### PR TITLE
Vercel AI SDK Integration — Phase 1: Python HTTP API

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,13 @@ fuzzy = ["rapidfuzz>=3.0.0"]
 # CLI tools
 cli = ["click>=8.0.0", "rich>=13.0.0"]
 
+# HTTP API server
+server = [
+    "fastapi>=0.104.0",
+    "uvicorn[standard]>=0.24.0",
+    "sse-starlette>=1.6.0",
+]
+
 # Observability
 opentelemetry = [
     "opentelemetry-api>=1.20.0",

--- a/src/neo4j_agent_memory/__init__.py
+++ b/src/neo4j_agent_memory/__init__.py
@@ -104,6 +104,29 @@ class MemoryGraph(BaseModel):
     )
 
 
+class StructuredContext(BaseModel):
+    """Structured context combining all memory types with both formatted text and raw data."""
+
+    context_text: str = Field(
+        default="", description="Pre-formatted context string for LLM prompt injection"
+    )
+    messages: list[Any] = Field(
+        default_factory=list, description="Raw Message objects from short-term memory"
+    )
+    entities: list[Any] = Field(
+        default_factory=list, description="Raw Entity objects from long-term memory"
+    )
+    preferences: list[Any] = Field(
+        default_factory=list, description="Raw Preference objects from long-term memory"
+    )
+    traces: list[Any] = Field(
+        default_factory=list, description="Raw ReasoningTrace objects from reasoning memory"
+    )
+    stats: dict[str, int] = Field(default_factory=dict, description="Counts per memory type")
+
+    model_config = {"arbitrary_types_allowed": True}
+
+
 from neo4j_agent_memory.graph.client import Neo4jClient
 from neo4j_agent_memory.graph.schema import SchemaManager
 from neo4j_agent_memory.memory.long_term import (
@@ -192,6 +215,8 @@ __all__ = [
     "GraphNode",
     "GraphRelationship",
     "MemoryGraph",
+    # Structured Context
+    "StructuredContext",
     # Exceptions
     "MemoryError",
     "ConnectionError",
@@ -456,6 +481,86 @@ class MemoryClient:
                 parts.append(f"## Similar Past Tasks\n{reasoning_context}")
 
         return "\n\n".join(parts)
+
+    async def get_context_structured(
+        self,
+        query: str,
+        *,
+        session_id: str | None = None,
+        include_short_term: bool = True,
+        include_long_term: bool = True,
+        include_reasoning: bool = True,
+        max_items: int = 10,
+    ) -> StructuredContext:
+        """
+        Get structured context from all memory types for an API response.
+
+        Unlike ``get_context()`` which returns only a formatted string, this method
+        returns both the formatted text and the raw data objects from each memory type.
+        Designed for the HTTP API's POST /context endpoint.
+
+        Args:
+            query: The query to search for relevant context
+            session_id: Optional session ID for short-term filtering
+            include_short_term: Whether to include conversation history
+            include_long_term: Whether to include entities and preferences
+            include_reasoning: Whether to include similar task traces
+            max_items: Maximum items per memory type
+
+        Returns:
+            StructuredContext with formatted text and raw data from each memory type
+        """
+        messages: list = []
+        entities: list = []
+        preferences: list = []
+        traces: list = []
+
+        if include_short_term:
+            if session_id:
+                conversation = await self.short_term.get_conversation(
+                    session_id=session_id, limit=max_items
+                )
+                messages = list(conversation.messages[-max_items:])
+            if query:
+                searched = await self.short_term.search_messages(
+                    query, session_id=session_id, limit=max_items
+                )
+                # Merge: add searched messages not already in conversation messages
+                existing_ids = {m.id for m in messages}
+                for msg in searched:
+                    if msg.id not in existing_ids:
+                        messages.append(msg)
+
+        if include_long_term:
+            entities = await self.long_term.search_entities(query, limit=max_items)
+            preferences = await self.long_term.search_preferences(query, limit=max_items)
+
+        if include_reasoning:
+            traces = await self.reasoning.get_similar_traces(query, limit=max(1, max_items // 2))
+
+        # Build the formatted text using the existing get_context() method
+        context_text = await self.get_context(
+            query,
+            session_id=session_id,
+            include_short_term=include_short_term,
+            include_long_term=include_long_term,
+            include_reasoning=include_reasoning,
+            max_items=max_items,
+        )
+
+        return StructuredContext(
+            context_text=context_text,
+            messages=messages,
+            entities=entities,
+            preferences=preferences,
+            traces=traces,
+            stats={
+                "messages": len(messages),
+                "entities": len(entities),
+                "preferences": len(preferences),
+                "traces": len(traces),
+            },
+        )
 
     async def get_stats(self) -> dict:
         """

--- a/src/neo4j_agent_memory/cli/main.py
+++ b/src/neo4j_agent_memory/cli/main.py
@@ -665,6 +665,65 @@ def stats(format: str, uri: str, user: str, password: str | None):
             console.print(table)
 
 
+@cli.command()
+@click.option("--host", default="0.0.0.0", help="Host to bind to.")
+@click.option("--port", default=8000, type=int, help="Port to bind to.")
+@click.option("--reload", is_flag=True, help="Enable auto-reload for development.")
+@click.option("--api-key", default=None, help="API key for authentication.")
+@click.option("--cors-origins", default="*", help="Comma-separated CORS origins.")
+def serve(host: str, port: int, reload: bool, api_key: str | None, cors_origins: str):
+    """Start the memory API server.
+
+    Requires the [server] extra: pip install neo4j-agent-memory[server]
+
+    Examples:
+
+        neo4j-memory serve
+
+        neo4j-memory serve --port 8321 --api-key mykey
+
+        neo4j-memory serve --reload --cors-origins "http://localhost:3000"
+    """
+    try:
+        import uvicorn
+    except ImportError:
+        error_console.print(
+            "[red]Error:[/red] Server dependencies not installed. "
+            "Install with: pip install neo4j-agent-memory[server]"
+        )
+        sys.exit(1)
+
+    import os
+
+    # Pass config via environment so create_app() can pick them up
+    os.environ.setdefault("NAM_SERVER__HOST", host)
+    os.environ.setdefault("NAM_SERVER__PORT", str(port))
+    if api_key:
+        os.environ["NAM_SERVER__API_KEY"] = api_key
+        os.environ["NAM_SERVER__AUTH_ENABLED"] = "true"
+    if cors_origins != "*":
+        os.environ["NAM_SERVER__CORS_ORIGINS"] = cors_origins
+
+    console.print(
+        Panel(
+            f"[cyan]Host:[/cyan] {host}\n"
+            f"[cyan]Port:[/cyan] {port}\n"
+            f"[cyan]Auth:[/cyan] {'enabled' if api_key else 'disabled'}\n"
+            f"[cyan]CORS:[/cyan] {cors_origins}\n"
+            f"[cyan]Reload:[/cyan] {'enabled' if reload else 'disabled'}",
+            title="Neo4j Agent Memory API Server",
+        )
+    )
+
+    uvicorn.run(
+        "neo4j_agent_memory.server:create_app",
+        factory=True,
+        host=host,
+        port=port,
+        reload=reload,
+    )
+
+
 def main():
     """Entry point for the CLI."""
     cli()

--- a/src/neo4j_agent_memory/config/__init__.py
+++ b/src/neo4j_agent_memory/config/__init__.py
@@ -15,6 +15,7 @@ from neo4j_agent_memory.config.settings import (
     ResolutionConfig,
     ResolverStrategy,
     SearchConfig,
+    ServerConfig,
 )
 
 __all__ = [
@@ -32,4 +33,5 @@ __all__ = [
     "LLMProvider",
     "ExtractorType",
     "ResolverStrategy",
+    "ServerConfig",
 ]

--- a/src/neo4j_agent_memory/config/settings.py
+++ b/src/neo4j_agent_memory/config/settings.py
@@ -365,6 +365,24 @@ class EnrichmentConfig(BaseModel):
     )
 
 
+class ServerConfig(BaseModel):
+    """Configuration for the HTTP API server.
+
+    Only used when running ``neo4j-memory serve`` or the FastAPI app directly.
+    """
+
+    host: str = Field(default="0.0.0.0", description="Host to bind to")
+    port: int = Field(default=8000, description="Port to bind to")
+    cors_origins: list[str] = Field(default=["*"], description="Allowed CORS origins")
+    cors_origin_regex: str | None = Field(
+        default=None, description="Regex pattern for allowed CORS origins"
+    )
+    auth_enabled: bool = Field(default=False, description="Enable API key authentication")
+    api_key: SecretStr | None = Field(default=None, description="API key for authentication")
+    api_prefix: str = Field(default="/api/v1", description="API route prefix")
+    debug: bool = Field(default=False, description="Enable debug mode")
+
+
 class MemorySettings(BaseSettings):
     """
     Main configuration class for neo4j-agent-memory.
@@ -398,6 +416,9 @@ class MemorySettings(BaseSettings):
     search: SearchConfig = Field(default_factory=SearchConfig)
     geocoding: GeocodingConfig = Field(default_factory=GeocodingConfig)
     enrichment: EnrichmentConfig = Field(default_factory=EnrichmentConfig)
+
+    # Server configuration (only used when running the HTTP API server)
+    server: ServerConfig | None = Field(default=None, description="HTTP API server configuration")
 
     @classmethod
     def from_dict(cls, config: dict[str, Any]) -> "MemorySettings":

--- a/src/neo4j_agent_memory/server/__init__.py
+++ b/src/neo4j_agent_memory/server/__init__.py
@@ -1,0 +1,118 @@
+"""Neo4j Agent Memory HTTP API server.
+
+Provides a FastAPI application that exposes the MemoryClient over REST.
+
+Usage::
+
+    pip install neo4j-agent-memory[server]
+    neo4j-memory serve --port 8000
+
+Or programmatically::
+
+    from neo4j_agent_memory.server import create_app
+    app = create_app()
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from typing import Any
+
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+
+from neo4j_agent_memory import MemoryClient, MemorySettings
+from neo4j_agent_memory.server.config import ServerConfig
+from neo4j_agent_memory.server.models import HealthResponse
+from neo4j_agent_memory.server.routes import create_api_router
+
+logger = logging.getLogger(__name__)
+
+_PACKAGE_VERSION = "0.0.2"
+
+
+def create_app(
+    settings: MemorySettings | None = None,
+    *,
+    server_config: ServerConfig | None = None,
+    api_key: str | None = None,
+    cors_origins: list[str] | None = None,
+) -> FastAPI:
+    """Create and configure the FastAPI application.
+
+    Args:
+        settings: MemorySettings for the MemoryClient. If ``None``, settings
+            are loaded from environment variables.
+        server_config: Server-specific configuration. If ``None``, defaults are
+            used.
+        api_key: Optional API key to enable authentication. Overrides
+            ``server_config.api_key``.
+        cors_origins: Optional list of CORS origins. Overrides
+            ``server_config.cors_origins``.
+    """
+    if server_config is None:
+        server_config = ServerConfig()
+
+    effective_origins = cors_origins or server_config.cors_origins
+
+    # Resolve API key (explicit param > config)
+    effective_api_key: str | None = api_key
+    if effective_api_key is None and server_config.api_key is not None:
+        effective_api_key = server_config.api_key.get_secret_value()
+
+    @asynccontextmanager
+    async def lifespan(app: FastAPI) -> AsyncIterator[None]:
+        """Manage MemoryClient lifecycle."""
+        memory_settings = settings or MemorySettings()
+        client = MemoryClient(memory_settings)
+        try:
+            await client.connect()
+            app.state.memory_client = client
+            logger.info("Memory client connected")
+            yield
+        finally:
+            await client.close()
+            app.state.memory_client = None
+            logger.info("Memory client closed")
+
+    app = FastAPI(
+        title="Neo4j Agent Memory API",
+        description="REST API for Neo4j Agent Memory — short-term, long-term, and reasoning memory for AI agents.",
+        version=_PACKAGE_VERSION,
+        lifespan=lifespan,
+    )
+
+    # CORS
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=effective_origins,
+        allow_origin_regex=server_config.cors_origin_regex,
+        allow_credentials=True,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
+
+    # Auth middleware (opt-in)
+    if effective_api_key:
+        from neo4j_agent_memory.server.auth import APIKeyMiddleware
+
+        app.add_middleware(APIKeyMiddleware, api_key=effective_api_key)
+
+    # Routes
+    api_router = create_api_router()
+    app.include_router(api_router, prefix=server_config.api_prefix)
+
+    # Health check (outside API prefix)
+    @app.get("/health", response_model=HealthResponse, tags=["meta"])
+    async def health_check() -> HealthResponse:
+        """Health check endpoint."""
+        client: MemoryClient | None = getattr(app.state, "memory_client", None)
+        return HealthResponse(
+            status="healthy" if client and client.is_connected else "degraded",
+            memory_connected=bool(client and client.is_connected),
+            version=_PACKAGE_VERSION,
+        )
+
+    return app

--- a/src/neo4j_agent_memory/server/auth.py
+++ b/src/neo4j_agent_memory/server/auth.py
@@ -1,0 +1,34 @@
+"""API key authentication middleware for the Neo4j Agent Memory server."""
+
+from __future__ import annotations
+
+from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
+from starlette.requests import Request
+from starlette.responses import JSONResponse, Response
+
+# Paths that bypass authentication
+_PUBLIC_PATHS = frozenset({"/health", "/docs", "/openapi.json", "/redoc"})
+
+
+class APIKeyMiddleware(BaseHTTPMiddleware):
+    """Middleware that validates an ``X-API-Key`` header on every request.
+
+    Public paths (health check, docs) are excluded from authentication.
+    """
+
+    def __init__(self, app: object, api_key: str) -> None:
+        super().__init__(app)  # type: ignore[arg-type]
+        self._api_key = api_key
+
+    async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:
+        if request.url.path in _PUBLIC_PATHS:
+            return await call_next(request)
+
+        provided_key = request.headers.get("X-API-Key")
+        if provided_key != self._api_key:
+            return JSONResponse(
+                status_code=401,
+                content={"detail": "Invalid or missing API key"},
+            )
+
+        return await call_next(request)

--- a/src/neo4j_agent_memory/server/config.py
+++ b/src/neo4j_agent_memory/server/config.py
@@ -1,0 +1,9 @@
+"""Server configuration for the Neo4j Agent Memory HTTP API.
+
+Re-exports ``ServerConfig`` from the central settings module so that
+``from neo4j_agent_memory.server.config import ServerConfig`` works.
+"""
+
+from neo4j_agent_memory.config.settings import ServerConfig
+
+__all__ = ["ServerConfig"]

--- a/src/neo4j_agent_memory/server/dependencies.py
+++ b/src/neo4j_agent_memory/server/dependencies.py
@@ -1,0 +1,24 @@
+"""FastAPI dependencies for the Neo4j Agent Memory server."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from fastapi import HTTPException, Request
+
+if TYPE_CHECKING:
+    from neo4j_agent_memory import MemoryClient
+
+
+async def get_memory_client(request: Request) -> "MemoryClient":
+    """FastAPI dependency that retrieves the MemoryClient singleton.
+
+    The client is stored on ``app.state`` during the lifespan context.
+
+    Raises:
+        HTTPException: 503 if the memory client is not available or not connected.
+    """
+    client: MemoryClient | None = getattr(request.app.state, "memory_client", None)
+    if client is None or not client.is_connected:
+        raise HTTPException(status_code=503, detail="Memory service unavailable")
+    return client

--- a/src/neo4j_agent_memory/server/models.py
+++ b/src/neo4j_agent_memory/server/models.py
@@ -1,0 +1,487 @@
+"""Request and response models for the Neo4j Agent Memory HTTP API."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+from uuid import UUID
+
+from pydantic import BaseModel, Field
+
+# ---------------------------------------------------------------------------
+# Request models
+# ---------------------------------------------------------------------------
+
+
+class ContextRequest(BaseModel):
+    """Request body for POST /context."""
+
+    query: str = Field(description="Query to search for relevant context")
+    session_id: str | None = Field(default=None, description="Session ID for short-term filtering")
+    include_short_term: bool = Field(default=True, description="Include conversation history")
+    include_long_term: bool = Field(default=True, description="Include entities and preferences")
+    include_reasoning: bool = Field(default=True, description="Include reasoning traces")
+    max_items: int = Field(default=10, ge=1, le=100, description="Max items per memory type")
+
+
+class AddMessageRequest(BaseModel):
+    """Request body for POST /sessions/{session_id}/messages."""
+
+    role: str = Field(description="Message role: user, assistant, system, or tool")
+    content: str = Field(description="Message content")
+    conversation_id: str | None = Field(default=None, description="Parent conversation ID")
+    extract_entities: bool = Field(default=True, description="Extract entities from message")
+    generate_embedding: bool = Field(default=True, description="Generate embedding for search")
+    metadata: dict[str, Any] | None = Field(default=None, description="Additional metadata")
+
+
+class SearchMessagesRequest(BaseModel):
+    """Request body for POST /messages/search."""
+
+    query: str = Field(description="Search query")
+    session_id: str | None = Field(default=None, description="Filter by session ID")
+    limit: int = Field(default=10, ge=1, le=100, description="Maximum results")
+    threshold: float = Field(default=0.7, ge=0.0, le=1.0, description="Similarity threshold")
+
+
+class AddEntityRequest(BaseModel):
+    """Request body for POST /entities."""
+
+    name: str = Field(description="Entity name")
+    entity_type: str = Field(
+        description="Entity type (PERSON, OBJECT, LOCATION, EVENT, ORGANIZATION)"
+    )
+    subtype: str | None = Field(default=None, description="Entity subtype")
+    description: str | None = Field(default=None, description="Entity description")
+    aliases: list[str] | None = Field(default=None, description="Alternative names")
+    attributes: dict[str, Any] | None = Field(default=None, description="Additional attributes")
+    metadata: dict[str, Any] | None = Field(default=None, description="Additional metadata")
+
+
+class SearchEntitiesRequest(BaseModel):
+    """Request body for POST /entities/search."""
+
+    query: str = Field(description="Search query")
+    entity_types: list[str] | None = Field(default=None, description="Filter by entity types")
+    limit: int = Field(default=10, ge=1, le=100, description="Maximum results")
+    threshold: float = Field(default=0.7, ge=0.0, le=1.0, description="Similarity threshold")
+
+
+class AddPreferenceRequest(BaseModel):
+    """Request body for POST /preferences."""
+
+    category: str = Field(description="Preference category")
+    preference: str = Field(description="The preference statement")
+    context: str | None = Field(default=None, description="When/where preference applies")
+    confidence: float = Field(default=1.0, ge=0.0, le=1.0, description="Confidence score")
+
+
+class SearchPreferencesRequest(BaseModel):
+    """Request body for POST /preferences/search."""
+
+    query: str = Field(description="Search query")
+    category: str | None = Field(default=None, description="Filter by category")
+    limit: int = Field(default=10, ge=1, le=100, description="Maximum results")
+    threshold: float = Field(default=0.7, ge=0.0, le=1.0, description="Similarity threshold")
+
+
+class AddRelationshipRequest(BaseModel):
+    """Request body for POST /relationships."""
+
+    source_id: str = Field(description="Source entity ID")
+    target_id: str = Field(description="Target entity ID")
+    relationship_type: str = Field(description="Relationship type")
+    description: str | None = Field(default=None, description="Relationship description")
+    confidence: float = Field(default=1.0, ge=0.0, le=1.0, description="Confidence score")
+
+
+class StartTraceRequest(BaseModel):
+    """Request body for POST /traces."""
+
+    session_id: str = Field(description="Session identifier")
+    task: str = Field(description="Task description")
+    metadata: dict[str, Any] | None = Field(default=None, description="Additional metadata")
+
+
+class AddStepRequest(BaseModel):
+    """Request body for POST /traces/{trace_id}/steps."""
+
+    thought: str | None = Field(default=None, description="Agent's thought/reasoning")
+    action: str | None = Field(default=None, description="Action taken")
+    observation: str | None = Field(default=None, description="Observation from action")
+
+
+class CompleteTraceRequest(BaseModel):
+    """Request body for POST /traces/{trace_id}/complete."""
+
+    outcome: str | None = Field(default=None, description="Final outcome")
+    success: bool | None = Field(default=None, description="Whether task succeeded")
+
+
+class RecordToolCallRequest(BaseModel):
+    """Request body for POST /tool-calls."""
+
+    step_id: str = Field(description="Parent reasoning step ID")
+    tool_name: str = Field(description="Name of the tool")
+    arguments: dict[str, Any] = Field(description="Tool arguments")
+    result: Any | None = Field(default=None, description="Tool result")
+    status: str = Field(default="success", description="Call status")
+    duration_ms: int | None = Field(default=None, description="Duration in milliseconds")
+    error: str | None = Field(default=None, description="Error message if failed")
+
+
+class SearchTracesRequest(BaseModel):
+    """Request body for POST /traces/search."""
+
+    query: str = Field(description="Task description to search for")
+    limit: int = Field(default=5, ge=1, le=50, description="Maximum results")
+    success_only: bool = Field(default=True, description="Only return successful traces")
+    threshold: float = Field(default=0.7, ge=0.0, le=1.0, description="Similarity threshold")
+
+
+# ---------------------------------------------------------------------------
+# Response models
+# ---------------------------------------------------------------------------
+
+
+def _str_id(val: UUID | str | None) -> str | None:
+    """Convert UUID to string, pass through strings, return None for None."""
+    if val is None:
+        return None
+    return str(val)
+
+
+class MessageResponse(BaseModel):
+    """A message in a conversation."""
+
+    id: str = Field(description="Message ID")
+    role: str = Field(description="Message role")
+    content: str = Field(description="Message content")
+    conversation_id: str | None = Field(default=None, description="Parent conversation ID")
+    tool_calls: list[dict[str, Any]] | None = Field(default=None, description="Tool calls")
+    created_at: datetime = Field(description="Creation time")
+    metadata: dict[str, Any] = Field(default_factory=dict, description="Metadata")
+
+    @classmethod
+    def from_domain(cls, msg: Any) -> MessageResponse:
+        return cls(
+            id=str(msg.id),
+            role=msg.role.value if hasattr(msg.role, "value") else str(msg.role),
+            content=msg.content,
+            conversation_id=_str_id(msg.conversation_id),
+            tool_calls=msg.tool_calls,
+            created_at=msg.created_at,
+            metadata=msg.metadata or {},
+        )
+
+
+class SessionResponse(BaseModel):
+    """Summary of a conversation session."""
+
+    session_id: str = Field(description="Session identifier")
+    title: str | None = Field(default=None, description="Session title")
+    created_at: datetime = Field(description="Creation time")
+    updated_at: datetime | None = Field(default=None, description="Last update time")
+    message_count: int = Field(default=0, description="Number of messages")
+    first_message_preview: str | None = Field(default=None, description="First message preview")
+    last_message_preview: str | None = Field(default=None, description="Last message preview")
+
+    @classmethod
+    def from_domain(cls, session: Any) -> SessionResponse:
+        return cls(
+            session_id=session.session_id,
+            title=session.title,
+            created_at=session.created_at,
+            updated_at=session.updated_at,
+            message_count=session.message_count,
+            first_message_preview=session.first_message_preview,
+            last_message_preview=session.last_message_preview,
+        )
+
+
+class ConversationResponse(BaseModel):
+    """A conversation with its messages."""
+
+    id: str = Field(description="Conversation ID")
+    session_id: str = Field(description="Session identifier")
+    title: str | None = Field(default=None, description="Conversation title")
+    messages: list[MessageResponse] = Field(default_factory=list, description="Messages")
+    created_at: datetime = Field(description="Creation time")
+    updated_at: datetime | None = Field(default=None, description="Last update time")
+
+    @classmethod
+    def from_domain(cls, conv: Any) -> ConversationResponse:
+        return cls(
+            id=str(conv.id),
+            session_id=conv.session_id,
+            title=conv.title,
+            messages=[MessageResponse.from_domain(m) for m in conv.messages],
+            created_at=conv.created_at,
+            updated_at=conv.updated_at,
+        )
+
+
+class ConversationSummaryResponse(BaseModel):
+    """Summary of a conversation."""
+
+    session_id: str = Field(description="Session identifier")
+    summary: str = Field(description="Generated summary text")
+    message_count: int = Field(description="Number of messages summarized")
+    key_entities: list[str] = Field(default_factory=list, description="Key entities")
+    key_topics: list[str] = Field(default_factory=list, description="Key topics")
+    generated_at: datetime = Field(description="When summary was generated")
+
+    @classmethod
+    def from_domain(cls, s: Any) -> ConversationSummaryResponse:
+        return cls(
+            session_id=s.session_id,
+            summary=s.summary,
+            message_count=s.message_count,
+            key_entities=s.key_entities,
+            key_topics=s.key_topics,
+            generated_at=s.generated_at,
+        )
+
+
+class EntityResponse(BaseModel):
+    """An entity from the knowledge graph."""
+
+    id: str = Field(description="Entity ID")
+    name: str = Field(description="Entity name")
+    canonical_name: str | None = Field(default=None, description="Resolved canonical name")
+    type: str = Field(description="Entity type")
+    subtype: str | None = Field(default=None, description="Entity subtype")
+    description: str | None = Field(default=None, description="Entity description")
+    confidence: float = Field(description="Confidence score")
+    aliases: list[str] = Field(default_factory=list, description="Alternative names")
+    attributes: dict[str, Any] = Field(default_factory=dict, description="Additional attributes")
+    created_at: datetime = Field(description="Creation time")
+    metadata: dict[str, Any] = Field(default_factory=dict, description="Metadata")
+
+    @classmethod
+    def from_domain(cls, entity: Any) -> EntityResponse:
+        entity_type = entity.type.value if hasattr(entity.type, "value") else str(entity.type)
+        return cls(
+            id=str(entity.id),
+            name=entity.name,
+            canonical_name=entity.canonical_name,
+            type=entity_type,
+            subtype=entity.subtype,
+            description=entity.description,
+            confidence=entity.confidence,
+            aliases=entity.aliases or [],
+            attributes=entity.attributes or {},
+            created_at=entity.created_at,
+            metadata=entity.metadata or {},
+        )
+
+
+class DeduplicationResultResponse(BaseModel):
+    """Result of entity deduplication."""
+
+    is_duplicate: bool = Field(description="Whether entity was a duplicate")
+    action: str = Field(description="Action taken: none, merged, or flagged")
+    matched_entity_id: str | None = Field(default=None, description="Matched entity ID")
+    matched_entity_name: str | None = Field(default=None, description="Matched entity name")
+    similarity_score: float = Field(description="Similarity score")
+    match_type: str | None = Field(default=None, description="Type of match")
+
+    @classmethod
+    def from_domain(cls, result: Any) -> DeduplicationResultResponse:
+        return cls(
+            is_duplicate=result.is_duplicate,
+            action=result.action,
+            matched_entity_id=_str_id(result.matched_entity_id),
+            matched_entity_name=result.matched_entity_name,
+            similarity_score=result.similarity_score,
+            match_type=result.match_type,
+        )
+
+
+class AddEntityResponse(BaseModel):
+    """Response for adding an entity, includes deduplication info."""
+
+    entity: EntityResponse = Field(description="The created or matched entity")
+    deduplication: DeduplicationResultResponse = Field(description="Deduplication result")
+
+
+class RelationshipResponse(BaseModel):
+    """A relationship between entities."""
+
+    id: str = Field(description="Relationship ID")
+    source_id: str = Field(description="Source entity ID")
+    target_id: str = Field(description="Target entity ID")
+    type: str = Field(description="Relationship type")
+    description: str | None = Field(default=None, description="Relationship description")
+    confidence: float = Field(description="Confidence score")
+    created_at: datetime = Field(description="Creation time")
+
+    @classmethod
+    def from_domain(cls, rel: Any) -> RelationshipResponse:
+        return cls(
+            id=str(rel.id),
+            source_id=str(rel.source_id),
+            target_id=str(rel.target_id),
+            type=rel.type,
+            description=rel.description,
+            confidence=rel.confidence,
+            created_at=rel.created_at,
+        )
+
+
+class PreferenceResponse(BaseModel):
+    """A user preference."""
+
+    id: str = Field(description="Preference ID")
+    category: str = Field(description="Preference category")
+    preference: str = Field(description="The preference statement")
+    context: str | None = Field(default=None, description="When/where preference applies")
+    confidence: float = Field(description="Confidence score")
+    created_at: datetime = Field(description="Creation time")
+
+    @classmethod
+    def from_domain(cls, pref: Any) -> PreferenceResponse:
+        return cls(
+            id=str(pref.id),
+            category=pref.category,
+            preference=pref.preference,
+            context=pref.context,
+            confidence=pref.confidence,
+            created_at=pref.created_at,
+        )
+
+
+class ToolCallResponse(BaseModel):
+    """A tool call made during reasoning."""
+
+    id: str = Field(description="Tool call ID")
+    tool_name: str = Field(description="Tool name")
+    arguments: dict[str, Any] = Field(default_factory=dict, description="Tool arguments")
+    result: Any | None = Field(default=None, description="Tool result")
+    status: str = Field(description="Call status")
+    duration_ms: int | None = Field(default=None, description="Duration in milliseconds")
+    error: str | None = Field(default=None, description="Error message")
+
+    @classmethod
+    def from_domain(cls, tc: Any) -> ToolCallResponse:
+        return cls(
+            id=str(tc.id),
+            tool_name=tc.tool_name,
+            arguments=tc.arguments or {},
+            result=tc.result,
+            status=tc.status.value if hasattr(tc.status, "value") else str(tc.status),
+            duration_ms=tc.duration_ms,
+            error=tc.error,
+        )
+
+
+class StepResponse(BaseModel):
+    """A reasoning step."""
+
+    id: str = Field(description="Step ID")
+    trace_id: str = Field(description="Parent trace ID")
+    step_number: int = Field(description="Step number in sequence")
+    thought: str | None = Field(default=None, description="Agent's thought")
+    action: str | None = Field(default=None, description="Action taken")
+    observation: str | None = Field(default=None, description="Observation")
+    tool_calls: list[ToolCallResponse] = Field(default_factory=list, description="Tool calls")
+    created_at: datetime = Field(description="Creation time")
+
+    @classmethod
+    def from_domain(cls, step: Any) -> StepResponse:
+        return cls(
+            id=str(step.id),
+            trace_id=str(step.trace_id),
+            step_number=step.step_number,
+            thought=step.thought,
+            action=step.action,
+            observation=step.observation,
+            tool_calls=[ToolCallResponse.from_domain(tc) for tc in (step.tool_calls or [])],
+            created_at=step.created_at,
+        )
+
+
+class TraceResponse(BaseModel):
+    """A reasoning trace."""
+
+    id: str = Field(description="Trace ID")
+    session_id: str = Field(description="Session identifier")
+    task: str = Field(description="Task description")
+    steps: list[StepResponse] = Field(default_factory=list, description="Reasoning steps")
+    outcome: str | None = Field(default=None, description="Final outcome")
+    success: bool | None = Field(default=None, description="Whether task succeeded")
+    started_at: datetime = Field(description="Start time")
+    completed_at: datetime | None = Field(default=None, description="Completion time")
+
+    @classmethod
+    def from_domain(cls, trace: Any) -> TraceResponse:
+        return cls(
+            id=str(trace.id),
+            session_id=trace.session_id,
+            task=trace.task,
+            steps=[StepResponse.from_domain(s) for s in (trace.steps or [])],
+            outcome=trace.outcome,
+            success=trace.success,
+            started_at=trace.started_at,
+            completed_at=trace.completed_at,
+        )
+
+
+class ToolStatsResponse(BaseModel):
+    """Tool usage statistics."""
+
+    name: str = Field(description="Tool name")
+    description: str | None = Field(default=None, description="Tool description")
+    total_calls: int = Field(default=0, description="Total calls")
+    successful_calls: int = Field(default=0, description="Successful calls")
+    failed_calls: int = Field(default=0, description="Failed calls")
+    success_rate: float = Field(default=0.0, description="Success rate")
+    avg_duration_ms: float | None = Field(default=None, description="Average duration in ms")
+    last_used_at: datetime | None = Field(default=None, description="Last usage time")
+
+    @classmethod
+    def from_domain(cls, stats: Any) -> ToolStatsResponse:
+        return cls(
+            name=stats.name,
+            description=stats.description,
+            total_calls=stats.total_calls,
+            successful_calls=stats.successful_calls,
+            failed_calls=stats.failed_calls,
+            success_rate=stats.success_rate,
+            avg_duration_ms=stats.avg_duration_ms,
+            last_used_at=stats.last_used_at,
+        )
+
+
+class ContextResponse(BaseModel):
+    """Unified context response combining all memory types."""
+
+    context_text: str = Field(description="Pre-formatted context for system prompt injection")
+    messages: list[MessageResponse] = Field(default_factory=list, description="Recent messages")
+    entities: list[EntityResponse] = Field(default_factory=list, description="Relevant entities")
+    preferences: list[PreferenceResponse] = Field(
+        default_factory=list, description="Relevant preferences"
+    )
+    traces: list[TraceResponse] = Field(
+        default_factory=list, description="Relevant reasoning traces"
+    )
+    stats: dict[str, int] = Field(default_factory=dict, description="Counts per memory type")
+
+
+class HealthResponse(BaseModel):
+    """Health check response."""
+
+    status: str = Field(description="Server status")
+    memory_connected: bool = Field(description="Whether memory client is connected")
+    version: str = Field(description="Package version")
+
+
+class StatsResponse(BaseModel):
+    """Memory statistics."""
+
+    conversations: int = Field(default=0, description="Number of conversations")
+    messages: int = Field(default=0, description="Number of messages")
+    entities: int = Field(default=0, description="Number of entities")
+    preferences: int = Field(default=0, description="Number of preferences")
+    facts: int = Field(default=0, description="Number of facts")
+    traces: int = Field(default=0, description="Number of reasoning traces")

--- a/src/neo4j_agent_memory/server/routes/__init__.py
+++ b/src/neo4j_agent_memory/server/routes/__init__.py
@@ -1,0 +1,20 @@
+"""Route aggregation for the Neo4j Agent Memory server."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter
+
+from neo4j_agent_memory.server.routes.context import router as context_router
+from neo4j_agent_memory.server.routes.long_term import router as long_term_router
+from neo4j_agent_memory.server.routes.reasoning import router as reasoning_router
+from neo4j_agent_memory.server.routes.short_term import router as short_term_router
+
+
+def create_api_router() -> APIRouter:
+    """Create the aggregate API router with all sub-routers."""
+    api_router = APIRouter()
+    api_router.include_router(context_router)
+    api_router.include_router(short_term_router)
+    api_router.include_router(long_term_router)
+    api_router.include_router(reasoning_router)
+    return api_router

--- a/src/neo4j_agent_memory/server/routes/context.py
+++ b/src/neo4j_agent_memory/server/routes/context.py
@@ -1,0 +1,75 @@
+"""Unified context and stats endpoints."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends
+from fastapi.responses import PlainTextResponse
+
+from neo4j_agent_memory import MemoryClient
+from neo4j_agent_memory.server.dependencies import get_memory_client
+from neo4j_agent_memory.server.models import (
+    ContextRequest,
+    ContextResponse,
+    EntityResponse,
+    MessageResponse,
+    PreferenceResponse,
+    StatsResponse,
+    TraceResponse,
+)
+
+router = APIRouter(tags=["context"])
+
+
+@router.post("/context", response_model=ContextResponse)
+async def get_context(
+    request: ContextRequest,
+    memory: MemoryClient = Depends(get_memory_client),
+) -> ContextResponse:
+    """Get assembled context from all three memory types.
+
+    Returns both a pre-formatted text string suitable for LLM prompt injection
+    and the structured data (messages, entities, preferences, traces) that
+    composed it.
+    """
+    result = await memory.get_context_structured(
+        query=request.query,
+        session_id=request.session_id,
+        include_short_term=request.include_short_term,
+        include_long_term=request.include_long_term,
+        include_reasoning=request.include_reasoning,
+        max_items=request.max_items,
+    )
+    return ContextResponse(
+        context_text=result.context_text,
+        messages=[MessageResponse.from_domain(m) for m in result.messages],
+        entities=[EntityResponse.from_domain(e) for e in result.entities],
+        preferences=[PreferenceResponse.from_domain(p) for p in result.preferences],
+        traces=[TraceResponse.from_domain(t) for t in result.traces],
+        stats=result.stats,
+    )
+
+
+@router.post("/context/text")
+async def get_context_text(
+    request: ContextRequest,
+    memory: MemoryClient = Depends(get_memory_client),
+) -> PlainTextResponse:
+    """Get context as plain text only, suitable for direct prompt injection."""
+    text = await memory.get_context(
+        query=request.query,
+        session_id=request.session_id,
+        include_short_term=request.include_short_term,
+        include_long_term=request.include_long_term,
+        include_reasoning=request.include_reasoning,
+        max_items=request.max_items,
+    )
+    return PlainTextResponse(content=text)
+
+
+@router.get("/stats", response_model=StatsResponse)
+async def get_stats(
+    memory: MemoryClient = Depends(get_memory_client),
+) -> StatsResponse:
+    """Get memory statistics (counts for each memory type)."""
+    stats = await memory.get_stats()
+    return StatsResponse(**stats)

--- a/src/neo4j_agent_memory/server/routes/long_term.py
+++ b/src/neo4j_agent_memory/server/routes/long_term.py
@@ -1,0 +1,178 @@
+"""Long-term memory endpoints: entities, preferences, and relationships."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+
+from neo4j_agent_memory import MemoryClient
+from neo4j_agent_memory.server.dependencies import get_memory_client
+from neo4j_agent_memory.server.models import (
+    AddEntityRequest,
+    AddEntityResponse,
+    AddPreferenceRequest,
+    AddRelationshipRequest,
+    DeduplicationResultResponse,
+    EntityResponse,
+    PreferenceResponse,
+    RelationshipResponse,
+    SearchEntitiesRequest,
+    SearchPreferencesRequest,
+)
+
+router = APIRouter(tags=["long-term"])
+
+
+# ---------------------------------------------------------------------------
+# Entities
+# ---------------------------------------------------------------------------
+
+
+@router.post("/entities", response_model=AddEntityResponse, status_code=201)
+async def add_entity(
+    request: AddEntityRequest,
+    memory: MemoryClient = Depends(get_memory_client),
+) -> AddEntityResponse:
+    """Create or upsert an entity in the knowledge graph."""
+    entity, dedup_result = await memory.long_term.add_entity(
+        name=request.name,
+        entity_type=request.entity_type,
+        subtype=request.subtype,
+        description=request.description,
+        aliases=request.aliases,
+        attributes=request.attributes,
+        metadata=request.metadata,
+    )
+    return AddEntityResponse(
+        entity=EntityResponse.from_domain(entity),
+        deduplication=DeduplicationResultResponse.from_domain(dedup_result),
+    )
+
+
+@router.post("/entities/search", response_model=list[EntityResponse])
+async def search_entities(
+    request: SearchEntitiesRequest,
+    memory: MemoryClient = Depends(get_memory_client),
+) -> list[EntityResponse]:
+    """Search entities using semantic similarity."""
+    entities = await memory.long_term.search_entities(
+        query=request.query,
+        entity_types=request.entity_types,
+        limit=request.limit,
+        threshold=request.threshold,
+    )
+    return [EntityResponse.from_domain(e) for e in entities]
+
+
+@router.get("/entities/{name}", response_model=EntityResponse)
+async def get_entity_by_name(
+    name: str,
+    memory: MemoryClient = Depends(get_memory_client),
+) -> EntityResponse:
+    """Get an entity by name."""
+    entity = await memory.long_term.get_entity_by_name(name)
+    if entity is None:
+        raise HTTPException(status_code=404, detail=f"Entity '{name}' not found")
+    return EntityResponse.from_domain(entity)
+
+
+@router.get("/entities/{entity_id}/related")
+async def get_related_entities(
+    entity_id: str,
+    depth: int = Query(default=1, ge=1, le=3),
+    memory: MemoryClient = Depends(get_memory_client),
+) -> list[dict]:
+    """Get entities related to a given entity via graph traversal."""
+    # First look up the entity by name or ID
+    entity = await memory.long_term.get_entity_by_name(entity_id)
+    if entity is None:
+        raise HTTPException(status_code=404, detail=f"Entity '{entity_id}' not found")
+
+    related = await memory.long_term.get_related_entities(entity, depth=depth)
+    return [
+        {
+            "entity": EntityResponse.from_domain(ent).model_dump(),
+            "relationship": RelationshipResponse.from_domain(rel).model_dump(),
+        }
+        for ent, rel in related
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Preferences
+# ---------------------------------------------------------------------------
+
+
+@router.post("/preferences", response_model=PreferenceResponse, status_code=201)
+async def add_preference(
+    request: AddPreferenceRequest,
+    memory: MemoryClient = Depends(get_memory_client),
+) -> PreferenceResponse:
+    """Add a user preference."""
+    pref = await memory.long_term.add_preference(
+        category=request.category,
+        preference=request.preference,
+        context=request.context,
+        confidence=request.confidence,
+    )
+    return PreferenceResponse.from_domain(pref)
+
+
+@router.post("/preferences/search", response_model=list[PreferenceResponse])
+async def search_preferences(
+    request: SearchPreferencesRequest,
+    memory: MemoryClient = Depends(get_memory_client),
+) -> list[PreferenceResponse]:
+    """Search preferences using semantic similarity."""
+    prefs = await memory.long_term.search_preferences(
+        query=request.query,
+        category=request.category,
+        limit=request.limit,
+        threshold=request.threshold,
+    )
+    return [PreferenceResponse.from_domain(p) for p in prefs]
+
+
+@router.get("/preferences/category/{category}", response_model=list[PreferenceResponse])
+async def get_preferences_by_category(
+    category: str,
+    limit: int = Query(default=100, ge=1, le=500),
+    memory: MemoryClient = Depends(get_memory_client),
+) -> list[PreferenceResponse]:
+    """Get preferences by category."""
+    prefs = await memory.long_term.get_preferences_by_category(category=category, limit=limit)
+    return [PreferenceResponse.from_domain(p) for p in prefs]
+
+
+# ---------------------------------------------------------------------------
+# Relationships
+# ---------------------------------------------------------------------------
+
+
+@router.post("/relationships", response_model=RelationshipResponse, status_code=201)
+async def add_relationship(
+    request: AddRelationshipRequest,
+    memory: MemoryClient = Depends(get_memory_client),
+) -> RelationshipResponse:
+    """Create a relationship between two entities."""
+    # Look up entities by name to get the Entity objects
+    source = await memory.long_term.get_entity_by_name(request.source_id)
+    target = await memory.long_term.get_entity_by_name(request.target_id)
+    if source is None:
+        raise HTTPException(
+            status_code=404, detail=f"Source entity '{request.source_id}' not found"
+        )
+    if target is None:
+        raise HTTPException(
+            status_code=404, detail=f"Target entity '{request.target_id}' not found"
+        )
+
+    rel = await memory.long_term.add_relationship(
+        source=source,
+        target=target,
+        relationship_type=request.relationship_type,
+        description=request.description,
+        confidence=request.confidence,
+    )
+    return RelationshipResponse.from_domain(rel)

--- a/src/neo4j_agent_memory/server/routes/reasoning.py
+++ b/src/neo4j_agent_memory/server/routes/reasoning.py
@@ -1,0 +1,162 @@
+"""Reasoning memory endpoints: traces, steps, and tool calls."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+
+from neo4j_agent_memory import MemoryClient
+from neo4j_agent_memory.memory.reasoning import ToolCallStatus
+from neo4j_agent_memory.server.dependencies import get_memory_client
+from neo4j_agent_memory.server.models import (
+    AddStepRequest,
+    CompleteTraceRequest,
+    RecordToolCallRequest,
+    SearchTracesRequest,
+    StartTraceRequest,
+    StepResponse,
+    ToolCallResponse,
+    ToolStatsResponse,
+    TraceResponse,
+)
+
+router = APIRouter(tags=["reasoning"])
+
+
+# ---------------------------------------------------------------------------
+# Traces
+# ---------------------------------------------------------------------------
+
+
+@router.get("/traces", response_model=list[TraceResponse])
+async def list_traces(
+    session_id: str | None = None,
+    success_only: bool | None = None,
+    limit: int = Query(default=50, ge=1, le=500),
+    offset: int = Query(default=0, ge=0),
+    order_by: str = Query(default="started_at"),
+    order_dir: str = Query(default="desc"),
+    memory: MemoryClient = Depends(get_memory_client),
+) -> list[TraceResponse]:
+    """List reasoning traces with optional filtering."""
+    traces = await memory.reasoning.list_traces(
+        session_id=session_id,
+        success_only=success_only,
+        limit=limit,
+        offset=offset,
+        order_by=order_by,
+        order_dir=order_dir,
+    )
+    return [TraceResponse.from_domain(t) for t in traces]
+
+
+@router.post("/traces", response_model=TraceResponse, status_code=201)
+async def start_trace(
+    request: StartTraceRequest,
+    memory: MemoryClient = Depends(get_memory_client),
+) -> TraceResponse:
+    """Start a new reasoning trace."""
+    trace = await memory.reasoning.start_trace(
+        session_id=request.session_id,
+        task=request.task,
+        metadata=request.metadata,
+    )
+    return TraceResponse.from_domain(trace)
+
+
+@router.get("/traces/{trace_id}", response_model=TraceResponse)
+async def get_trace(
+    trace_id: str,
+    memory: MemoryClient = Depends(get_memory_client),
+) -> TraceResponse:
+    """Get a reasoning trace with all its steps and tool calls."""
+    trace = await memory.reasoning.get_trace(UUID(trace_id))
+    if trace is None:
+        raise HTTPException(status_code=404, detail="Trace not found")
+    return TraceResponse.from_domain(trace)
+
+
+@router.post("/traces/{trace_id}/complete", response_model=TraceResponse)
+async def complete_trace(
+    trace_id: str,
+    request: CompleteTraceRequest,
+    memory: MemoryClient = Depends(get_memory_client),
+) -> TraceResponse:
+    """Complete a reasoning trace with an outcome."""
+    trace = await memory.reasoning.complete_trace(
+        trace_id=UUID(trace_id),
+        outcome=request.outcome,
+        success=request.success,
+    )
+    return TraceResponse.from_domain(trace)
+
+
+@router.post("/traces/{trace_id}/steps", response_model=StepResponse, status_code=201)
+async def add_step(
+    trace_id: str,
+    request: AddStepRequest,
+    memory: MemoryClient = Depends(get_memory_client),
+) -> StepResponse:
+    """Add a reasoning step to a trace."""
+    step = await memory.reasoning.add_step(
+        trace_id=UUID(trace_id),
+        thought=request.thought,
+        action=request.action,
+        observation=request.observation,
+    )
+    return StepResponse.from_domain(step)
+
+
+@router.post("/traces/search", response_model=list[TraceResponse])
+async def search_traces(
+    request: SearchTracesRequest,
+    memory: MemoryClient = Depends(get_memory_client),
+) -> list[TraceResponse]:
+    """Find similar past reasoning traces."""
+    traces = await memory.reasoning.get_similar_traces(
+        task=request.query,
+        limit=request.limit,
+        success_only=request.success_only,
+        threshold=request.threshold,
+    )
+    return [TraceResponse.from_domain(t) for t in traces]
+
+
+# ---------------------------------------------------------------------------
+# Tool calls
+# ---------------------------------------------------------------------------
+
+
+@router.post("/tool-calls", response_model=ToolCallResponse, status_code=201)
+async def record_tool_call(
+    request: RecordToolCallRequest,
+    memory: MemoryClient = Depends(get_memory_client),
+) -> ToolCallResponse:
+    """Record a tool call for a reasoning step."""
+    # Map status string to enum
+    try:
+        status = ToolCallStatus(request.status)
+    except ValueError:
+        status = ToolCallStatus.SUCCESS
+
+    tc = await memory.reasoning.record_tool_call(
+        step_id=UUID(request.step_id),
+        tool_name=request.tool_name,
+        arguments=request.arguments,
+        result=request.result,
+        status=status,
+        duration_ms=request.duration_ms,
+        error=request.error,
+    )
+    return ToolCallResponse.from_domain(tc)
+
+
+@router.get("/tool-stats", response_model=list[ToolStatsResponse])
+async def get_tool_stats(
+    tool_name: str | None = None,
+    memory: MemoryClient = Depends(get_memory_client),
+) -> list[ToolStatsResponse]:
+    """Get tool usage statistics."""
+    stats = await memory.reasoning.get_tool_stats(tool_name=tool_name)
+    return [ToolStatsResponse.from_domain(s) for s in stats]

--- a/src/neo4j_agent_memory/server/routes/short_term.py
+++ b/src/neo4j_agent_memory/server/routes/short_term.py
@@ -1,0 +1,140 @@
+"""Short-term memory endpoints: sessions and messages."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+
+from neo4j_agent_memory import MemoryClient
+from neo4j_agent_memory.server.dependencies import get_memory_client
+from neo4j_agent_memory.server.models import (
+    AddMessageRequest,
+    ConversationResponse,
+    ConversationSummaryResponse,
+    MessageResponse,
+    SearchMessagesRequest,
+    SessionResponse,
+)
+
+router = APIRouter(tags=["short-term"])
+
+
+# ---------------------------------------------------------------------------
+# Sessions
+# ---------------------------------------------------------------------------
+
+
+@router.get("/sessions", response_model=list[SessionResponse])
+async def list_sessions(
+    prefix: str | None = None,
+    limit: int = Query(default=100, ge=1, le=500),
+    offset: int = Query(default=0, ge=0),
+    order_by: str = Query(default="updated_at"),
+    order_dir: str = Query(default="desc"),
+    memory: MemoryClient = Depends(get_memory_client),
+) -> list[SessionResponse]:
+    """List conversation sessions."""
+    sessions = await memory.short_term.list_sessions(
+        prefix=prefix,
+        limit=limit,
+        offset=offset,
+        order_by=order_by,
+        order_dir=order_dir,
+    )
+    return [SessionResponse.from_domain(s) for s in sessions]
+
+
+@router.get("/sessions/{session_id}", response_model=ConversationResponse)
+async def get_session(
+    session_id: str,
+    limit: int | None = None,
+    memory: MemoryClient = Depends(get_memory_client),
+) -> ConversationResponse:
+    """Get a conversation session with its messages."""
+    conversation = await memory.short_term.get_conversation(session_id=session_id, limit=limit)
+    return ConversationResponse.from_domain(conversation)
+
+
+@router.delete("/sessions/{session_id}")
+async def delete_session(
+    session_id: str,
+    memory: MemoryClient = Depends(get_memory_client),
+) -> dict[str, str]:
+    """Clear all data for a session."""
+    await memory.short_term.clear_session(session_id)
+    return {"status": "deleted", "session_id": session_id}
+
+
+# ---------------------------------------------------------------------------
+# Messages
+# ---------------------------------------------------------------------------
+
+
+@router.post("/sessions/{session_id}/messages", response_model=MessageResponse, status_code=201)
+async def add_message(
+    session_id: str,
+    request: AddMessageRequest,
+    memory: MemoryClient = Depends(get_memory_client),
+) -> MessageResponse:
+    """Add a message to a session."""
+    conversation_id = UUID(request.conversation_id) if request.conversation_id else None
+    message = await memory.short_term.add_message(
+        session_id=session_id,
+        role=request.role,
+        content=request.content,
+        conversation_id=conversation_id,
+        extract_entities=request.extract_entities,
+        generate_embedding=request.generate_embedding,
+        metadata=request.metadata,
+    )
+    return MessageResponse.from_domain(message)
+
+
+@router.get("/sessions/{session_id}/messages", response_model=list[MessageResponse])
+async def get_messages(
+    session_id: str,
+    limit: int | None = None,
+    memory: MemoryClient = Depends(get_memory_client),
+) -> list[MessageResponse]:
+    """Get messages for a session."""
+    conversation = await memory.short_term.get_conversation(session_id=session_id, limit=limit)
+    return [MessageResponse.from_domain(m) for m in conversation.messages]
+
+
+@router.get("/sessions/{session_id}/summary", response_model=ConversationSummaryResponse)
+async def get_session_summary(
+    session_id: str,
+    memory: MemoryClient = Depends(get_memory_client),
+) -> ConversationSummaryResponse:
+    """Get a summary of a conversation session."""
+    summary = await memory.short_term.get_conversation_summary(session_id)
+    return ConversationSummaryResponse.from_domain(summary)
+
+
+@router.post("/messages/search", response_model=list[MessageResponse])
+async def search_messages(
+    request: SearchMessagesRequest,
+    memory: MemoryClient = Depends(get_memory_client),
+) -> list[MessageResponse]:
+    """Search messages using semantic similarity."""
+    messages = await memory.short_term.search_messages(
+        query=request.query,
+        session_id=request.session_id,
+        limit=request.limit,
+        threshold=request.threshold,
+    )
+    return [MessageResponse.from_domain(m) for m in messages]
+
+
+@router.delete("/messages/{message_id}")
+async def delete_message(
+    message_id: str,
+    cascade: bool = Query(default=True),
+    memory: MemoryClient = Depends(get_memory_client),
+) -> dict[str, str]:
+    """Delete a specific message."""
+    deleted = await memory.short_term.delete_message(message_id, cascade=cascade)
+    if not deleted:
+        raise HTTPException(status_code=404, detail="Message not found")
+    return {"status": "deleted", "message_id": message_id}

--- a/tests/unit/server/test_server_app.py
+++ b/tests/unit/server/test_server_app.py
@@ -1,0 +1,618 @@
+"""Tests for the Neo4j Agent Memory HTTP API server.
+
+Uses FastAPI TestClient with a mocked MemoryClient to verify
+endpoint routing, request validation, and response models without
+requiring a live Neo4j instance.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from datetime import datetime
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from neo4j_agent_memory.server import create_app
+from neo4j_agent_memory.server.config import ServerConfig
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_message(role="user", content="Hello", session_id="test-session"):
+    """Create a mock Message object."""
+    msg = MagicMock()
+    msg.id = uuid4()
+    msg.role = MagicMock(value=role)
+    msg.content = content
+    msg.conversation_id = None
+    msg.tool_calls = None
+    msg.created_at = datetime(2025, 1, 1, 12, 0, 0)
+    msg.updated_at = None
+    msg.metadata = {}
+    return msg
+
+
+def _make_entity(name="Acme Corp", entity_type="ORGANIZATION"):
+    """Create a mock Entity object."""
+    ent = MagicMock()
+    ent.id = uuid4()
+    ent.name = name
+    ent.canonical_name = None
+    ent.type = entity_type
+    ent.subtype = None
+    ent.description = f"A test entity: {name}"
+    ent.confidence = 0.95
+    ent.aliases = []
+    ent.attributes = {}
+    ent.created_at = datetime(2025, 1, 1, 12, 0, 0)
+    ent.metadata = {}
+    return ent
+
+
+def _make_preference(category="food", preference="Likes pizza"):
+    """Create a mock Preference object."""
+    pref = MagicMock()
+    pref.id = uuid4()
+    pref.category = category
+    pref.preference = preference
+    pref.context = None
+    pref.confidence = 1.0
+    pref.created_at = datetime(2025, 1, 1, 12, 0, 0)
+    return pref
+
+
+def _make_trace(task="Find restaurants", success=True):
+    """Create a mock ReasoningTrace object."""
+    trace = MagicMock()
+    trace.id = uuid4()
+    trace.session_id = "test-session"
+    trace.task = task
+    trace.steps = []
+    trace.outcome = "Found 3 restaurants"
+    trace.success = success
+    trace.started_at = datetime(2025, 1, 1, 12, 0, 0)
+    trace.completed_at = datetime(2025, 1, 1, 12, 0, 5)
+    return trace
+
+
+def _make_session(session_id="test-session"):
+    """Create a mock SessionInfo object."""
+    session = MagicMock()
+    session.session_id = session_id
+    session.title = None
+    session.created_at = datetime(2025, 1, 1, 12, 0, 0)
+    session.updated_at = datetime(2025, 1, 1, 12, 5, 0)
+    session.message_count = 5
+    session.first_message_preview = "Hello"
+    session.last_message_preview = "Goodbye"
+    return session
+
+
+def _make_conversation(session_id="test-session"):
+    """Create a mock Conversation object."""
+    conv = MagicMock()
+    conv.id = uuid4()
+    conv.session_id = session_id
+    conv.title = None
+    conv.messages = [_make_message(), _make_message(role="assistant", content="Hi there!")]
+    conv.created_at = datetime(2025, 1, 1, 12, 0, 0)
+    conv.updated_at = datetime(2025, 1, 1, 12, 5, 0)
+    return conv
+
+
+def _make_dedup_result():
+    """Create a mock DeduplicationResult."""
+    result = MagicMock()
+    result.is_duplicate = False
+    result.action = "none"
+    result.matched_entity_id = None
+    result.matched_entity_name = None
+    result.similarity_score = 0.0
+    result.match_type = None
+    return result
+
+
+def _make_tool_stats(name="search_web"):
+    """Create a mock ToolStats object."""
+    stats = MagicMock()
+    stats.name = name
+    stats.description = "Web search tool"
+    stats.total_calls = 10
+    stats.successful_calls = 8
+    stats.failed_calls = 2
+    stats.success_rate = 0.8
+    stats.avg_duration_ms = 150.0
+    stats.last_used_at = datetime(2025, 1, 1, 12, 0, 0)
+    return stats
+
+
+def _create_mock_memory_client():
+    """Create a comprehensive mock MemoryClient."""
+    client = MagicMock()
+    client.is_connected = True
+
+    # Short-term
+    client.short_term = MagicMock()
+    client.short_term.list_sessions = AsyncMock(return_value=[_make_session()])
+    client.short_term.get_conversation = AsyncMock(return_value=_make_conversation())
+    client.short_term.add_message = AsyncMock(return_value=_make_message())
+    client.short_term.search_messages = AsyncMock(return_value=[_make_message()])
+    client.short_term.clear_session = AsyncMock(return_value=None)
+    client.short_term.delete_message = AsyncMock(return_value=True)
+    client.short_term.get_conversation_summary = AsyncMock(
+        return_value=MagicMock(
+            session_id="test-session",
+            summary="A test conversation",
+            message_count=5,
+            key_entities=["Acme"],
+            key_topics=["food"],
+            generated_at=datetime(2025, 1, 1, 12, 0, 0),
+        )
+    )
+
+    # Long-term
+    client.long_term = MagicMock()
+    client.long_term.add_entity = AsyncMock(return_value=(_make_entity(), _make_dedup_result()))
+    client.long_term.search_entities = AsyncMock(return_value=[_make_entity()])
+    client.long_term.get_entity_by_name = AsyncMock(return_value=_make_entity())
+    client.long_term.get_related_entities = AsyncMock(return_value=[])
+    client.long_term.add_preference = AsyncMock(return_value=_make_preference())
+    client.long_term.search_preferences = AsyncMock(return_value=[_make_preference()])
+    client.long_term.get_preferences_by_category = AsyncMock(return_value=[_make_preference()])
+    client.long_term.add_relationship = AsyncMock(
+        return_value=MagicMock(
+            id=uuid4(),
+            source_id=uuid4(),
+            target_id=uuid4(),
+            type="WORKS_AT",
+            description=None,
+            confidence=1.0,
+            created_at=datetime(2025, 1, 1, 12, 0, 0),
+        )
+    )
+
+    # Reasoning
+    client.reasoning = MagicMock()
+    client.reasoning.list_traces = AsyncMock(return_value=[_make_trace()])
+    client.reasoning.start_trace = AsyncMock(return_value=_make_trace())
+    client.reasoning.get_trace = AsyncMock(return_value=_make_trace())
+    client.reasoning.complete_trace = AsyncMock(return_value=_make_trace())
+    client.reasoning.add_step = AsyncMock(
+        return_value=MagicMock(
+            id=uuid4(),
+            trace_id=uuid4(),
+            step_number=1,
+            thought="Thinking...",
+            action="search",
+            observation="Found results",
+            tool_calls=[],
+            created_at=datetime(2025, 1, 1, 12, 0, 0),
+        )
+    )
+    client.reasoning.get_similar_traces = AsyncMock(return_value=[_make_trace()])
+    client.reasoning.record_tool_call = AsyncMock(
+        return_value=MagicMock(
+            id=uuid4(),
+            tool_name="search_web",
+            arguments={"q": "test"},
+            result="results",
+            status=MagicMock(value="success"),
+            duration_ms=100,
+            error=None,
+            created_at=datetime(2025, 1, 1, 12, 0, 0),
+        )
+    )
+    client.reasoning.get_tool_stats = AsyncMock(return_value=[_make_tool_stats()])
+
+    # Top-level
+    client.get_context = AsyncMock(return_value="## Context\nSome context text")
+    client.get_context_structured = AsyncMock(
+        return_value=MagicMock(
+            context_text="## Context\nSome context text",
+            messages=[_make_message()],
+            entities=[_make_entity()],
+            preferences=[_make_preference()],
+            traces=[_make_trace()],
+            stats={"messages": 1, "entities": 1, "preferences": 1, "traces": 1},
+        )
+    )
+    client.get_stats = AsyncMock(
+        return_value={
+            "conversations": 1,
+            "messages": 5,
+            "entities": 3,
+            "preferences": 2,
+            "facts": 0,
+            "traces": 1,
+        }
+    )
+
+    return client
+
+
+def _create_test_app(mock_client, *, api_key: str | None = None):
+    """Create a FastAPI app with mocked lifespan for testing."""
+    from fastapi.middleware.cors import CORSMiddleware
+
+    from neo4j_agent_memory.server.models import HealthResponse
+    from neo4j_agent_memory.server.routes import create_api_router
+
+    @asynccontextmanager
+    async def mock_lifespan(app: FastAPI) -> AsyncIterator[None]:
+        app.state.memory_client = mock_client
+        yield
+
+    app = FastAPI(title="Test", lifespan=mock_lifespan)
+
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=["*"],
+        allow_credentials=True,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
+
+    if api_key:
+        from neo4j_agent_memory.server.auth import APIKeyMiddleware
+
+        app.add_middleware(APIKeyMiddleware, api_key=api_key)
+
+    api_router = create_api_router()
+    app.include_router(api_router, prefix="/api/v1")
+
+    @app.get("/health", response_model=HealthResponse, tags=["meta"])
+    async def health_check() -> HealthResponse:
+        client = getattr(app.state, "memory_client", None)
+        return HealthResponse(
+            status="healthy" if client and client.is_connected else "degraded",
+            memory_connected=bool(client and client.is_connected),
+            version="test",
+        )
+
+    return app
+
+
+@pytest.fixture
+def mock_client():
+    return _create_mock_memory_client()
+
+
+@pytest.fixture
+def test_client(mock_client):
+    """Create a TestClient with a mocked MemoryClient."""
+    app = _create_test_app(mock_client)
+    with TestClient(app) as client:
+        yield client
+
+
+# ---------------------------------------------------------------------------
+# Health endpoint
+# ---------------------------------------------------------------------------
+
+
+class TestHealthEndpoint:
+    def test_health(self, test_client):
+        resp = test_client.get("/health")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["status"] == "healthy"
+        assert data["memory_connected"] is True
+        assert "version" in data
+
+
+# ---------------------------------------------------------------------------
+# Context endpoints
+# ---------------------------------------------------------------------------
+
+
+class TestContextEndpoints:
+    def test_post_context(self, test_client):
+        resp = test_client.post(
+            "/api/v1/context",
+            json={"query": "restaurant recommendations"},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "context_text" in data
+        assert "messages" in data
+        assert "entities" in data
+        assert "preferences" in data
+        assert "traces" in data
+        assert "stats" in data
+        assert isinstance(data["messages"], list)
+        assert isinstance(data["entities"], list)
+
+    def test_post_context_text(self, test_client):
+        resp = test_client.post(
+            "/api/v1/context/text",
+            json={"query": "test"},
+        )
+        assert resp.status_code == 200
+        assert "Context" in resp.text
+
+    def test_get_stats(self, test_client):
+        resp = test_client.get("/api/v1/stats")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["messages"] == 5
+        assert data["entities"] == 3
+
+
+# ---------------------------------------------------------------------------
+# Short-term endpoints
+# ---------------------------------------------------------------------------
+
+
+class TestShortTermEndpoints:
+    def test_list_sessions(self, test_client):
+        resp = test_client.get("/api/v1/sessions")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data) == 1
+        assert data[0]["session_id"] == "test-session"
+
+    def test_get_session(self, test_client):
+        resp = test_client.get("/api/v1/sessions/test-session")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["session_id"] == "test-session"
+        assert len(data["messages"]) == 2
+
+    def test_delete_session(self, test_client):
+        resp = test_client.delete("/api/v1/sessions/test-session")
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "deleted"
+
+    def test_add_message(self, test_client):
+        resp = test_client.post(
+            "/api/v1/sessions/test-session/messages",
+            json={"role": "user", "content": "Hello!"},
+        )
+        assert resp.status_code == 201
+        data = resp.json()
+        assert data["role"] == "user"
+        assert data["content"] == "Hello"  # from mock
+
+    def test_get_messages(self, test_client):
+        resp = test_client.get("/api/v1/sessions/test-session/messages")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data) == 2
+
+    def test_search_messages(self, test_client):
+        resp = test_client.post(
+            "/api/v1/messages/search",
+            json={"query": "restaurant"},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data) == 1
+
+    def test_delete_message(self, test_client):
+        resp = test_client.delete(f"/api/v1/messages/{uuid4()}")
+        assert resp.status_code == 200
+
+    def test_get_session_summary(self, test_client):
+        resp = test_client.get("/api/v1/sessions/test-session/summary")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["session_id"] == "test-session"
+        assert "summary" in data
+
+
+# ---------------------------------------------------------------------------
+# Long-term endpoints
+# ---------------------------------------------------------------------------
+
+
+class TestLongTermEndpoints:
+    def test_add_entity(self, test_client):
+        resp = test_client.post(
+            "/api/v1/entities",
+            json={"name": "Acme Corp", "entity_type": "ORGANIZATION"},
+        )
+        assert resp.status_code == 201
+        data = resp.json()
+        assert "entity" in data
+        assert "deduplication" in data
+        assert data["entity"]["name"] == "Acme Corp"
+        assert data["deduplication"]["is_duplicate"] is False
+
+    def test_search_entities(self, test_client):
+        resp = test_client.post(
+            "/api/v1/entities/search",
+            json={"query": "Acme"},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data) == 1
+
+    def test_get_entity_by_name(self, test_client):
+        resp = test_client.get("/api/v1/entities/Acme Corp")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["name"] == "Acme Corp"
+
+    def test_add_preference(self, test_client):
+        resp = test_client.post(
+            "/api/v1/preferences",
+            json={"category": "food", "preference": "Likes pizza"},
+        )
+        assert resp.status_code == 201
+        data = resp.json()
+        assert data["category"] == "food"
+
+    def test_search_preferences(self, test_client):
+        resp = test_client.post(
+            "/api/v1/preferences/search",
+            json={"query": "food"},
+        )
+        assert resp.status_code == 200
+        assert len(resp.json()) == 1
+
+    def test_get_preferences_by_category(self, test_client):
+        resp = test_client.get("/api/v1/preferences/category/food")
+        assert resp.status_code == 200
+        assert len(resp.json()) == 1
+
+    def test_add_relationship(self, test_client):
+        resp = test_client.post(
+            "/api/v1/relationships",
+            json={
+                "source_id": "John",
+                "target_id": "Acme Corp",
+                "relationship_type": "WORKS_AT",
+            },
+        )
+        assert resp.status_code == 201
+        data = resp.json()
+        assert data["type"] == "WORKS_AT"
+
+
+# ---------------------------------------------------------------------------
+# Reasoning endpoints
+# ---------------------------------------------------------------------------
+
+
+class TestReasoningEndpoints:
+    def test_list_traces(self, test_client):
+        resp = test_client.get("/api/v1/traces")
+        assert resp.status_code == 200
+        assert len(resp.json()) == 1
+
+    def test_start_trace(self, test_client):
+        resp = test_client.post(
+            "/api/v1/traces",
+            json={"session_id": "test-session", "task": "Find restaurants"},
+        )
+        assert resp.status_code == 201
+        data = resp.json()
+        assert data["task"] == "Find restaurants"
+
+    def test_get_trace(self, test_client):
+        trace_id = str(uuid4())
+        resp = test_client.get(f"/api/v1/traces/{trace_id}")
+        assert resp.status_code == 200
+
+    def test_complete_trace(self, test_client):
+        trace_id = str(uuid4())
+        resp = test_client.post(
+            f"/api/v1/traces/{trace_id}/complete",
+            json={"outcome": "Found 3 restaurants", "success": True},
+        )
+        assert resp.status_code == 200
+
+    def test_add_step(self, test_client):
+        trace_id = str(uuid4())
+        resp = test_client.post(
+            f"/api/v1/traces/{trace_id}/steps",
+            json={"thought": "Thinking...", "action": "search"},
+        )
+        assert resp.status_code == 201
+
+    def test_search_traces(self, test_client):
+        resp = test_client.post(
+            "/api/v1/traces/search",
+            json={"query": "restaurant"},
+        )
+        assert resp.status_code == 200
+        assert len(resp.json()) == 1
+
+    def test_record_tool_call(self, test_client):
+        resp = test_client.post(
+            "/api/v1/tool-calls",
+            json={
+                "step_id": str(uuid4()),
+                "tool_name": "search_web",
+                "arguments": {"q": "restaurants"},
+            },
+        )
+        assert resp.status_code == 201
+
+    def test_get_tool_stats(self, test_client):
+        resp = test_client.get("/api/v1/tool-stats")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data) == 1
+        assert data[0]["name"] == "search_web"
+
+
+# ---------------------------------------------------------------------------
+# Auth middleware
+# ---------------------------------------------------------------------------
+
+
+class TestAuthMiddleware:
+    def test_no_auth_by_default(self, test_client):
+        """Without API key config, all endpoints should be accessible."""
+        resp = test_client.get("/health")
+        assert resp.status_code == 200
+
+    def test_auth_rejects_without_key(self):
+        """With API key config, requests without key should be rejected."""
+        app = _create_test_app(_create_mock_memory_client(), api_key="test-secret-key")
+        with TestClient(app) as client:
+            # Health should still work (public path)
+            resp = client.get("/health")
+            assert resp.status_code == 200
+
+            # API endpoint should be rejected
+            resp = client.get("/api/v1/sessions")
+            assert resp.status_code == 401
+
+    def test_auth_accepts_with_key(self):
+        """With correct API key, requests should succeed."""
+        app = _create_test_app(_create_mock_memory_client(), api_key="test-secret-key")
+        with TestClient(app) as client:
+            resp = client.get(
+                "/api/v1/sessions",
+                headers={"X-API-Key": "test-secret-key"},
+            )
+            assert resp.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# Request validation
+# ---------------------------------------------------------------------------
+
+
+class TestRequestValidation:
+    def test_context_requires_query(self, test_client):
+        resp = test_client.post("/api/v1/context", json={})
+        assert resp.status_code == 422
+
+    def test_add_message_requires_role_and_content(self, test_client):
+        resp = test_client.post(
+            "/api/v1/sessions/test/messages",
+            json={"role": "user"},
+        )
+        assert resp.status_code == 422
+
+    def test_add_entity_requires_name_and_type(self, test_client):
+        resp = test_client.post("/api/v1/entities", json={"name": "Acme"})
+        assert resp.status_code == 422
+
+    def test_start_trace_requires_session_and_task(self, test_client):
+        resp = test_client.post("/api/v1/traces", json={"session_id": "test"})
+        assert resp.status_code == 422
+
+    def test_max_items_validation(self, test_client):
+        resp = test_client.post(
+            "/api/v1/context",
+            json={"query": "test", "max_items": 0},
+        )
+        assert resp.status_code == 422
+
+        resp = test_client.post(
+            "/api/v1/context",
+            json={"query": "test", "max_items": 200},
+        )
+        assert resp.status_code == 422

--- a/uv.lock
+++ b/uv.lock
@@ -172,6 +172,15 @@ wheels = [
 ]
 
 [[package]]
+name = "annotated-doc"
+version = "0.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/ba/046ceea27344560984e26a590f90bc7f4a75b06701f653222458922b558c/annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4", size = 7288, upload-time = "2025-11-10T22:07:42.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320", size = 5303, upload-time = "2025-11-10T22:07:40.673Z" },
+]
+
+[[package]]
 name = "annotated-types"
 version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1367,6 +1376,22 @@ wheels = [
 [package.optional-dependencies]
 lua = [
     { name = "lupa" },
+]
+
+[[package]]
+name = "fastapi"
+version = "0.128.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "pydantic" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/02/d4/811e7283aaaa84f1e7bd55fb642b58f8c01895e4884a9b7628cb55e00d63/fastapi-0.128.5.tar.gz", hash = "sha256:a7173579fc162d6471e3c6fbd9a4b7610c7a3b367bcacf6c4f90d5d022cab711", size = 374636, upload-time = "2026-02-08T10:22:30.493Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e4/e0/511972dba23ee76c0e9d09d1ae95e916fc8ebce5322b2b8b65a481428b10/fastapi-0.128.5-py3-none-any.whl", hash = "sha256:bceec0de8aa6564599c5bcc0593b0d287703562c848271fca8546fd2c87bf4dd", size = 103677, upload-time = "2026-02-08T10:22:28.919Z" },
 ]
 
 [[package]]
@@ -3543,6 +3568,11 @@ pydantic-ai = [
 sentence-transformers = [
     { name = "sentence-transformers" },
 ]
+server = [
+    { name = "fastapi" },
+    { name = "sse-starlette" },
+    { name = "uvicorn", extra = ["standard"] },
+]
 spacy = [
     { name = "spacy" },
 ]
@@ -3570,6 +3600,7 @@ requires-dist = [
     { name = "anthropic", marker = "extra == 'anthropic'", specifier = ">=0.20.0" },
     { name = "click", marker = "extra == 'cli'", specifier = ">=8.0.0" },
     { name = "crewai", marker = "extra == 'crewai'", specifier = ">=0.50.0" },
+    { name = "fastapi", marker = "extra == 'server'", specifier = ">=0.104.0" },
     { name = "gliner", marker = "extra == 'extraction'", specifier = ">=0.2.0" },
     { name = "gliner", marker = "extra == 'gliner'", specifier = ">=0.2.0" },
     { name = "langchain-core", marker = "extra == 'langchain'", specifier = ">=0.2.0" },
@@ -3593,8 +3624,10 @@ requires-dist = [
     { name = "sentence-transformers", marker = "extra == 'sentence-transformers'", specifier = ">=2.2.0" },
     { name = "spacy", marker = "extra == 'extraction'", specifier = ">=3.7.0" },
     { name = "spacy", marker = "extra == 'spacy'", specifier = ">=3.7.0" },
+    { name = "sse-starlette", marker = "extra == 'server'", specifier = ">=1.6.0" },
+    { name = "uvicorn", extras = ["standard"], marker = "extra == 'server'", specifier = ">=0.24.0" },
 ]
-provides-extras = ["openai", "anthropic", "sentence-transformers", "spacy", "gliner", "extraction", "fuzzy", "cli", "opentelemetry", "opik", "observability", "langchain", "llamaindex", "pydantic-ai", "crewai", "openai-agents", "all", "full"]
+provides-extras = ["openai", "anthropic", "sentence-transformers", "spacy", "gliner", "extraction", "fuzzy", "cli", "server", "opentelemetry", "opik", "observability", "langchain", "llamaindex", "pydantic-ai", "crewai", "openai-agents", "all", "full"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -7107,6 +7140,10 @@ dependencies = [
     { name = "typing-extensions" },
 ]
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/e3/ea/304cf7afb744aa626fa9855245526484ee55aba610d9973a0521c552a843/torch-2.10.0-1-cp310-none-macosx_11_0_arm64.whl", hash = "sha256:c37fc46eedd9175f9c81814cc47308f1b42cfe4987e532d4b423d23852f2bf63", size = 79411450, upload-time = "2026-02-06T17:37:35.75Z" },
+    { url = "https://files.pythonhosted.org/packages/25/d8/9e6b8e7df981a1e3ea3907fd5a74673e791da483e8c307f0b6ff012626d0/torch-2.10.0-1-cp311-none-macosx_11_0_arm64.whl", hash = "sha256:f699f31a236a677b3118bc0a3ef3d89c0c29b5ec0b20f4c4bf0b110378487464", size = 79423460, upload-time = "2026-02-06T17:37:39.657Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/2f/0b295dd8d199ef71e6f176f576473d645d41357b7b8aa978cc6b042575df/torch-2.10.0-1-cp312-none-macosx_11_0_arm64.whl", hash = "sha256:6abb224c2b6e9e27b592a1c0015c33a504b00a0e0938f1499f7f514e9b7bfb5c", size = 79498197, upload-time = "2026-02-06T17:37:27.627Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/1b/af5fccb50c341bd69dc016769503cb0857c1423fbe9343410dfeb65240f2/torch-2.10.0-1-cp313-none-macosx_11_0_arm64.whl", hash = "sha256:7350f6652dfd761f11f9ecb590bfe95b573e2961f7a242eccb3c8e78348d26fe", size = 79498248, upload-time = "2026-02-06T17:37:31.982Z" },
     { url = "https://files.pythonhosted.org/packages/0c/1a/c61f36cfd446170ec27b3a4984f072fd06dab6b5d7ce27e11adb35d6c838/torch-2.10.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:5276fa790a666ee8becaffff8acb711922252521b28fbce5db7db5cf9cb2026d", size = 145992962, upload-time = "2026-01-21T16:24:14.04Z" },
     { url = "https://files.pythonhosted.org/packages/b5/60/6662535354191e2d1555296045b63e4279e5a9dbad49acf55a5d38655a39/torch-2.10.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:aaf663927bcd490ae971469a624c322202a2a1e68936eb952535ca4cd3b90444", size = 915599237, upload-time = "2026-01-21T16:23:25.497Z" },
     { url = "https://files.pythonhosted.org/packages/40/b8/66bbe96f0d79be2b5c697b2e0b187ed792a15c6c4b8904613454651db848/torch-2.10.0-cp310-cp310-win_amd64.whl", hash = "sha256:a4be6a2a190b32ff5c8002a0977a25ea60e64f7ba46b1be37093c141d9c49aeb", size = 113720931, upload-time = "2026-01-21T16:24:23.743Z" },


### PR DESCRIPTION
Overview

This is the first phase of a three-layer integration that will bridge `neo4j-agent-memory` (Python) with the Vercel AI SDK ecosystem (TypeScript). The full architecture:

1. **Layer 1: Python HTTP API** (this PR) — FastAPI server exposing MemoryClient over REST
2. **Layer 2: TypeScript HTTP Client** (`@neo4j-labs/agent-memory-client`) — auto-generated from OpenAPI spec
3. **Layer 3: Vercel AI SDK Integration** (`@neo4j-labs/ai-sdk-memory`) — implements Vercel AI SDK memory provider interface

This PR implements Layer 1: a new `neo4j-agent-memory[server]` optional module that wraps the entire MemoryClient API in a production-ready FastAPI server with auto-generated OpenAPI 3.1 spec, API key authentication, and CORS support.

### What's Included

**New server module** (`src/neo4j_agent_memory/server/`) with 25 REST endpoints covering all three memory layers:

- **Context** — `POST /api/v1/context` returns both formatted context text and structured data (messages, entities, preferences, traces) in a single call; `POST /api/v1/context/text` for plain text; `GET /api/v1/stats`
- **Short-term memory** — Full CRUD for sessions and messages, conversation summaries, semantic message search
- **Long-term memory** — Entity management with deduplication results, preference CRUD by category, relationship creation, semantic search
- **Reasoning** — Trace lifecycle (start/step/complete), tool call recording, tool usage statistics, semantic trace search

**New `MemoryClient.get_context_structured()` method** — The existing `get_context()` only returns a formatted string. The new method returns a `StructuredContext` object with both the text and raw domain objects, enabling the critical `POST /context` endpoint that Layer 2 clients will depend on.

**`[server]` optional dependency group** — `fastapi`, `uvicorn[standard]`, `sse-starlette` are only required when using the server module. The core library remains dependency-light.

**CLI `serve` command** — `neo4j-memory serve --port 8000 --api-key <key>` starts the server. Uses lazy imports so the server dependencies aren't required for other CLI commands.

**API key authentication** — Opt-in `X-API-Key` header middleware, configurable via `--api-key` flag or `ServerConfig`.

**35 unit tests** with mocked MemoryClient covering all endpoints, auth middleware, and request validation.

### Key Design Decisions

- **Thin API response models** with `from_domain()` classmethods — exclude embedding vectors, serialize UUIDs as strings, separate from domain models
- **App-scoped MemoryClient singleton** via FastAPI lifespan context manager + `Depends(get_memory_client)`
- **`ServerConfig` lives in `config/settings.py`** (not `server/config.py`) to avoid requiring FastAPI as an import for the core config module
- **`add_entity` returns entity + deduplication result** since `LongTermMemory.add_entity()` returns a tuple

### Stats

```
18 files changed, 2097 insertions(+), 1 deletion(-)
```

### How to Test

```bash
# Install with server extras
pip install -e ".[server]"

# Start the server (requires Neo4j)
neo4j-memory serve --port 8321

# Health check
curl http://localhost:8321/health

# Browse OpenAPI docs
open http://localhost:8321/docs

# Query context
curl -X POST http://localhost:8321/api/v1/context \
  -H 'Content-Type: application/json' \
  -d '{"query": "test", "session_id": "sess-1"}'

# Run tests (no Neo4j required)
pytest tests/unit/server/