### PR TITLE
Add CORS support, stateless HTTP mode, and CLI flags to MCP server

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -1,0 +1,111 @@
+# MCP Server Quick Start
+
+## Quick Start
+
+```bash
+git clone https://github.com/neo4j-labs/agent-memory.git
+cd agent-memory
+uv sync --extra mcp && uv pip install uvicorn starlette
+make neo4j-start && make neo4j-wait
+export OPENAI_API_KEY=sk-...
+uv run python -m neo4j_agent_memory.mcp.server \
+  --transport streamable-http --port 5000 --neo4j-password test-password
+```
+
+> **Note:** `OPENAI_API_KEY` is required for embedding-based search (`memory_search`, `memory_store`). You can also pass it inline:
+>
+> ```bash
+> OPENAI_API_KEY=sk-... uv run python -m neo4j_agent_memory.mcp.server \
+>   --transport streamable-http --port 5000 --neo4j-password test-password
+> ```
+>
+> Or use the `--openai-api-key` flag instead of the environment variable.
+
+Server runs at `http://localhost:5000/mcp`. All CORS origins allowed by default.
+
+## Transports
+
+### Streamable HTTP (recommended)
+
+```bash
+uv run python -m neo4j_agent_memory.mcp.server \
+  --transport streamable-http --port 5000 --neo4j-password test-password
+```
+
+Endpoint: `http://localhost:5000/mcp` — POST JSON-RPC, get JSON back.
+
+### SSE
+
+```bash
+uv run python -m neo4j_agent_memory.mcp.server \
+  --transport sse --port 5000 --neo4j-password test-password
+```
+
+Endpoint: `http://localhost:5000/sse`, messages to `/messages`.
+
+### stdio (Claude Desktop)
+
+```bash
+uv run python -m neo4j_agent_memory.mcp.server --neo4j-password test-password
+```
+
+Claude Desktop config (`~/Library/Application Support/Claude/claude_desktop_config.json`):
+
+```json
+{
+  "mcpServers": {
+    "neo4j-memory": {
+      "command": "uv",
+      "args": [
+        "--directory", "/path/to/agent-memory",
+        "run", "python", "-m", "neo4j_agent_memory.mcp.server",
+        "--neo4j-password", "test-password"
+      ]
+    }
+  }
+}
+```
+
+## CORS
+
+All origins allowed by default. To restrict:
+
+```bash
+uv run python -m neo4j_agent_memory.mcp.server \
+  --transport streamable-http --port 5000 --neo4j-password test-password \
+  --allow-origin https://app.example.com \
+  --allow-origin https://admin.example.com
+```
+
+## Tools
+
+| Tool | Description |
+|------|-------------|
+| `memory_search` | Hybrid vector + graph search |
+| `memory_store` | Store messages, facts, preferences |
+| `entity_lookup` | Get entity with relationships |
+| `conversation_history` | Get session history |
+| `graph_query` | Read-only Cypher queries |
+
+## All flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--transport` | `stdio` | `stdio`, `sse`, or `streamable-http` |
+| `--port` | `8080` | Port for HTTP transports |
+| `--host` | `127.0.0.1` | Bind address (`0.0.0.0` for external) |
+| `--neo4j-uri` | `bolt://localhost:7687` | Neo4j URI |
+| `--neo4j-user` | `neo4j` | Neo4j username |
+| `--neo4j-password` | _(required)_ | Neo4j password |
+| `--neo4j-database` | `neo4j` | Neo4j database |
+| `--allow-origin` | `*` | CORS origin (repeatable) |
+| `--openai-api-key` | `$OPENAI_API_KEY` | OpenAI API key |
+
+## Troubleshooting
+
+| Error | Fix |
+|-------|-----|
+| `No module named 'mcp'` | `uv sync --extra mcp` |
+| `SSE transport requires additional dependencies` | `uv pip install uvicorn starlette` |
+| Neo4j connection refused | `make neo4j-start && make neo4j-wait` |
+| Browser client: no tools | Switch to `--transport streamable-http` |

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -5,18 +5,18 @@
 ```bash
 git clone https://github.com/neo4j-labs/agent-memory.git
 cd agent-memory
-uv sync --extra mcp && uv pip install uvicorn starlette
+uv sync --extra mcp
 make neo4j-start && make neo4j-wait
 export OPENAI_API_KEY=sk-...
 uv run python -m neo4j_agent_memory.mcp.server \
-  --transport streamable-http --port 5000 --neo4j-password test-password
+  --transport http --port 5000 --neo4j-password test-password
 ```
 
 > **Note:** `OPENAI_API_KEY` is required for embedding-based search (`memory_search`, `memory_store`). You can also pass it inline:
 >
 > ```bash
 > OPENAI_API_KEY=sk-... uv run python -m neo4j_agent_memory.mcp.server \
->   --transport streamable-http --port 5000 --neo4j-password test-password
+>   --transport http --port 5000 --neo4j-password test-password
 > ```
 >
 > Or use the `--openai-api-key` flag instead of the environment variable.
@@ -25,11 +25,11 @@ Server runs at `http://localhost:5000/mcp`. All CORS origins allowed by default.
 
 ## Transports
 
-### Streamable HTTP (recommended)
+### HTTP (recommended)
 
 ```bash
 uv run python -m neo4j_agent_memory.mcp.server \
-  --transport streamable-http --port 5000 --neo4j-password test-password
+  --transport http --port 5000 --neo4j-password test-password
 ```
 
 Endpoint: `http://localhost:5000/mcp` — POST JSON-RPC, get JSON back.
@@ -72,7 +72,7 @@ All origins allowed by default. To restrict:
 
 ```bash
 uv run python -m neo4j_agent_memory.mcp.server \
-  --transport streamable-http --port 5000 --neo4j-password test-password \
+  --transport http --port 5000 --neo4j-password test-password \
   --allow-origin https://app.example.com \
   --allow-origin https://admin.example.com
 ```
@@ -91,7 +91,7 @@ uv run python -m neo4j_agent_memory.mcp.server \
 
 | Flag | Default | Description |
 |------|---------|-------------|
-| `--transport` | `stdio` | `stdio`, `sse`, or `streamable-http` |
+| `--transport` | `stdio` | `stdio`, `sse`, or `http` |
 | `--port` | `8080` | Port for HTTP transports |
 | `--host` | `127.0.0.1` | Bind address (`0.0.0.0` for external) |
 | `--neo4j-uri` | `bolt://localhost:7687` | Neo4j URI |
@@ -105,7 +105,6 @@ uv run python -m neo4j_agent_memory.mcp.server \
 
 | Error | Fix |
 |-------|-----|
-| `No module named 'mcp'` | `uv sync --extra mcp` |
-| `SSE transport requires additional dependencies` | `uv pip install uvicorn starlette` |
+| `No module named 'fastmcp'` | `uv sync --extra mcp` |
 | Neo4j connection refused | `make neo4j-start && make neo4j-wait` |
-| Browser client: no tools | Switch to `--transport streamable-http` |
+| Browser client: no tools | Switch to `--transport http` |

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -34,6 +34,13 @@ uv run python -m neo4j_agent_memory.mcp.server \
 
 Endpoint: `http://localhost:5000/mcp` — POST JSON-RPC, get JSON back.
 
+**Browser-based clients** require `--stateless` to disable session ID tracking:
+
+```bash
+uv run python -m neo4j_agent_memory.mcp.server \
+  --transport http --port 5000 --neo4j-password test-password --stateless
+```
+
 ### SSE
 
 ```bash
@@ -57,9 +64,14 @@ Claude Desktop config (`~/Library/Application Support/Claude/claude_desktop_conf
     "neo4j-memory": {
       "command": "uv",
       "args": [
-        "--directory", "/path/to/agent-memory",
-        "run", "python", "-m", "neo4j_agent_memory.mcp.server",
-        "--neo4j-password", "test-password"
+        "--directory",
+        "/path/to/agent-memory",
+        "run",
+        "python",
+        "-m",
+        "neo4j_agent_memory.mcp.server",
+        "--neo4j-password",
+        "test-password"
       ]
     }
   }
@@ -79,32 +91,33 @@ uv run python -m neo4j_agent_memory.mcp.server \
 
 ## Tools
 
-| Tool | Description |
-|------|-------------|
-| `memory_search` | Hybrid vector + graph search |
-| `memory_store` | Store messages, facts, preferences |
-| `entity_lookup` | Get entity with relationships |
-| `conversation_history` | Get session history |
-| `graph_query` | Read-only Cypher queries |
+| Tool                   | Description                        |
+| ---------------------- | ---------------------------------- |
+| `memory_search`        | Hybrid vector + graph search       |
+| `memory_store`         | Store messages, facts, preferences |
+| `entity_lookup`        | Get entity with relationships      |
+| `conversation_history` | Get session history                |
+| `graph_query`          | Read-only Cypher queries           |
 
 ## All flags
 
-| Flag | Default | Description |
-|------|---------|-------------|
-| `--transport` | `stdio` | `stdio`, `sse`, or `http` |
-| `--port` | `8080` | Port for HTTP transports |
-| `--host` | `127.0.0.1` | Bind address (`0.0.0.0` for external) |
-| `--neo4j-uri` | `bolt://localhost:7687` | Neo4j URI |
-| `--neo4j-user` | `neo4j` | Neo4j username |
-| `--neo4j-password` | _(required)_ | Neo4j password |
-| `--neo4j-database` | `neo4j` | Neo4j database |
-| `--allow-origin` | `*` | CORS origin (repeatable) |
-| `--openai-api-key` | `$OPENAI_API_KEY` | OpenAI API key |
+| Flag               | Default                 | Description                                                |
+| ------------------ | ----------------------- | ---------------------------------------------------------- |
+| `--transport`      | `stdio`                 | `stdio`, `sse`, or `http`                                  |
+| `--port`           | `8080`                  | Port for HTTP transports                                   |
+| `--host`           | `127.0.0.1`             | Bind address (`0.0.0.0` for external)                      |
+| `--neo4j-uri`      | `bolt://localhost:7687` | Neo4j URI                                                  |
+| `--neo4j-user`     | `neo4j`                 | Neo4j username                                             |
+| `--neo4j-password` | _(required)_            | Neo4j password                                             |
+| `--neo4j-database` | `neo4j`                 | Neo4j database                                             |
+| `--allow-origin`   | `*`                     | CORS origin (repeatable)                                   |
+| `--stateless`      | `false`                 | Disable session ID tracking (required for browser clients) |
+| `--openai-api-key` | `$OPENAI_API_KEY`       | OpenAI API key                                             |
 
 ## Troubleshooting
 
-| Error | Fix |
-|-------|-----|
-| `No module named 'fastmcp'` | `uv sync --extra mcp` |
-| Neo4j connection refused | `make neo4j-start && make neo4j-wait` |
-| Browser client: no tools | Switch to `--transport http` |
+| Error                       | Fix                                   |
+| --------------------------- | ------------------------------------- |
+| `No module named 'fastmcp'` | `uv sync --extra mcp`                 |
+| Neo4j connection refused    | `make neo4j-start && make neo4j-wait` |
+| Browser client: no tools    | Use `--transport http --stateless`    |

--- a/README.md
+++ b/README.md
@@ -1062,7 +1062,7 @@ agent = ChatAgent(
 
 ### MCP Server
 
-Expose memory capabilities via Model Context Protocol for AI platforms:
+Expose memory capabilities via Model Context Protocol for AI platforms. See the **[MCP Server Quick Start](QUICKSTART.md)** to get up and running in under a minute.
 
 ```bash
 # Run the MCP server

--- a/src/neo4j_agent_memory/mcp/server.py
+++ b/src/neo4j_agent_memory/mcp/server.py
@@ -16,6 +16,31 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+
+def _build_cors_middleware(allow_origins: list[str] | None = None) -> list[Any]:
+    """Build Starlette CORS middleware list for FastMCP.
+
+    Args:
+        allow_origins: Allowed origins. Defaults to ["*"].
+
+    Returns:
+        List of Starlette Middleware instances.
+    """
+    from starlette.middleware import Middleware
+    from starlette.middleware.cors import CORSMiddleware
+
+    origins = allow_origins or ["*"]
+    return [
+        Middleware(
+            CORSMiddleware,
+            allow_origins=origins,
+            allow_methods=["GET", "POST", "DELETE", "OPTIONS"],
+            allow_headers=["*"],
+            expose_headers=["Mcp-Session-Id"],
+        )
+    ]
+
+
 try:
     from fastmcp import FastMCP
 
@@ -130,14 +155,47 @@ try:
             """Run the MCP server using stdio transport."""
             await self._mcp.run_async(transport="stdio")
 
-        async def run_sse(self, host: str = "127.0.0.1", port: int = 8080) -> None:
+        async def run_sse(
+            self,
+            host: str = "127.0.0.1",
+            port: int = 8080,
+            allow_origins: list[str] | None = None,
+        ) -> None:
             """Run the MCP server using SSE transport.
 
             Args:
                 host: Host to bind to.
                 port: Port to listen on.
+                allow_origins: CORS allowed origins (defaults to ["*"]).
             """
-            await self._mcp.run_async(transport="sse", host=host, port=port)
+            middleware = _build_cors_middleware(allow_origins)
+            await self._mcp.run_async(
+                transport="sse", host=host, port=port, middleware=middleware
+            )
+
+        async def run_http(
+            self,
+            host: str = "127.0.0.1",
+            port: int = 8080,
+            allow_origins: list[str] | None = None,
+        ) -> None:
+            """Run the MCP server using HTTP transport.
+
+            Clients POST JSON-RPC messages and receive responses as JSON
+            or SSE streams.
+
+            Args:
+                host: Host to bind to.
+                port: Port to listen on.
+                allow_origins: CORS allowed origins (defaults to ["*"]).
+            """
+            middleware = _build_cors_middleware(allow_origins)
+            await self._mcp.run_async(
+                transport="http",
+                host=host,
+                port=port,
+                middleware=middleware,
+            )
 
     async def run_server(
         neo4j_uri: str,
@@ -147,6 +205,7 @@ try:
         transport: str = "stdio",
         host: str = "127.0.0.1",
         port: int = 8080,
+        allow_origins: list[str] | None = None,
     ) -> None:
         """Run the MCP server with Neo4j connection.
 
@@ -160,6 +219,7 @@ try:
             transport: Transport type (stdio, sse, or http).
             host: Host for network transports.
             port: Port for network transports.
+            allow_origins: CORS allowed origins for HTTP transports.
         """
         from pydantic import SecretStr
 
@@ -177,10 +237,14 @@ try:
 
         server = create_mcp_server(settings, server_name="neo4j-agent-memory")
 
-        if transport == "sse":
-            await server.run_async(transport="sse", host=host, port=port)
-        elif transport == "http":
-            await server.run_async(transport="http", host=host, port=port)
+        if transport in ("sse", "http"):
+            middleware = _build_cors_middleware(allow_origins)
+            await server.run_async(
+                transport=transport,
+                host=host,
+                port=port,
+                middleware=middleware,
+            )
         else:
             await server.run_async(transport="stdio")
 
@@ -235,7 +299,7 @@ def main() -> None:
         "--transport",
         choices=["stdio", "sse", "http"],
         default="stdio",
-        help="MCP transport type",
+        help="MCP transport type (http uses Streamable HTTP, recommended for browser clients)",
     )
     parser.add_argument(
         "--host",
@@ -248,8 +312,23 @@ def main() -> None:
         default=8080,
         help="Port for network transports",
     )
+    parser.add_argument(
+        "--allow-origin",
+        action="append",
+        dest="allow_origins",
+        help="Allowed CORS origin (repeatable, defaults to '*'). "
+        "Example: --allow-origin https://example.com --allow-origin https://app.example.com",
+    )
+    parser.add_argument(
+        "--openai-api-key",
+        default=os.environ.get("OPENAI_API_KEY", ""),
+        help="OpenAI API key (for embeddings/extraction)",
+    )
 
     args = parser.parse_args()
+
+    if args.openai_api_key:
+        os.environ["OPENAI_API_KEY"] = args.openai_api_key
 
     asyncio.run(
         run_server(
@@ -260,6 +339,7 @@ def main() -> None:
             transport=args.transport,
             host=args.host,
             port=args.port,
+            allow_origins=args.allow_origins,
         )
     )
 

--- a/src/neo4j_agent_memory/mcp/server.py
+++ b/src/neo4j_agent_memory/mcp/server.py
@@ -169,15 +169,14 @@ try:
                 allow_origins: CORS allowed origins (defaults to ["*"]).
             """
             middleware = _build_cors_middleware(allow_origins)
-            await self._mcp.run_async(
-                transport="sse", host=host, port=port, middleware=middleware
-            )
+            await self._mcp.run_async(transport="sse", host=host, port=port, middleware=middleware)
 
         async def run_http(
             self,
             host: str = "127.0.0.1",
             port: int = 8080,
             allow_origins: list[str] | None = None,
+            stateless_http: bool = False,
         ) -> None:
             """Run the MCP server using HTTP transport.
 
@@ -188,6 +187,9 @@ try:
                 host: Host to bind to.
                 port: Port to listen on.
                 allow_origins: CORS allowed origins (defaults to ["*"]).
+                stateless_http: If True, disable session ID tracking.
+                    Required for browser-based MCP clients that don't
+                    forward the Mcp-Session-Id header.
             """
             middleware = _build_cors_middleware(allow_origins)
             await self._mcp.run_async(
@@ -195,6 +197,7 @@ try:
                 host=host,
                 port=port,
                 middleware=middleware,
+                stateless_http=stateless_http,
             )
 
     async def run_server(
@@ -206,6 +209,7 @@ try:
         host: str = "127.0.0.1",
         port: int = 8080,
         allow_origins: list[str] | None = None,
+        stateless_http: bool = False,
     ) -> None:
         """Run the MCP server with Neo4j connection.
 
@@ -220,6 +224,8 @@ try:
             host: Host for network transports.
             port: Port for network transports.
             allow_origins: CORS allowed origins for HTTP transports.
+            stateless_http: If True, disable session ID tracking for HTTP
+                transport. Required for browser-based MCP clients.
         """
         from pydantic import SecretStr
 
@@ -244,6 +250,7 @@ try:
                 host=host,
                 port=port,
                 middleware=middleware,
+                stateless_http=stateless_http,
             )
         else:
             await server.run_async(transport="stdio")
@@ -320,6 +327,14 @@ def main() -> None:
         "Example: --allow-origin https://example.com --allow-origin https://app.example.com",
     )
     parser.add_argument(
+        "--stateless",
+        action="store_true",
+        default=False,
+        help="Disable session ID tracking for HTTP transport. "
+        "Required for browser-based MCP clients that "
+        "don't forward the Mcp-Session-Id header.",
+    )
+    parser.add_argument(
         "--openai-api-key",
         default=os.environ.get("OPENAI_API_KEY", ""),
         help="OpenAI API key (for embeddings/extraction)",
@@ -340,6 +355,7 @@ def main() -> None:
             host=args.host,
             port=args.port,
             allow_origins=args.allow_origins,
+            stateless_http=args.stateless,
         )
     )
 


### PR DESCRIPTION
Adds CORS middleware to HTTP/SSE transports, stateless HTTP mode for browser-based MCP clients, and new CLI flags for easier configuration.

### Changes

- **CORS middleware**: Both `--transport http` and `--transport sse` now include configurable CORS via `--allow-origin` (repeatable, defaults to `*`). Exposes `Mcp-Session-Id` header for HTTP transport compatibility.
- **`--stateless` CLI flag**: Disables session ID tracking for HTTP transport. Required for browser-based MCP clients that don't forward the `Mcp-Session-Id` header — without this, `tools/list` and other requests after `initialize` fail with `400 Bad Request: Missing session ID`.
- **`run_http()` method**: Added to `Neo4jMemoryMCPServer` for programmatic HTTP transport usage with CORS and `stateless_http` support
- **`run_sse()` updated**: Now accepts `allow_origins` parameter for CORS configuration
- **`--allow-origin` CLI flag**: Repeatable flag to restrict CORS origins
- **`--openai-api-key` CLI flag**: Sets `OPENAI_API_KEY` env var for embeddings/extraction
- **`run_server()` updated**: Passes `allow_origins` and `stateless_http` through to transport middleware
- **QUICKSTART.md updated**: Reflects new flags, browser client usage, and updated troubleshooting

### Usage

```bash
# HTTP with CORS (all origins)
neo4j-memory mcp serve --transport http --port 8080

# Browser-based clients (e.g., introspecting tools)
neo4j-memory mcp serve --transport http --port 8080 --stateless

# Restricted CORS origins
neo4j-memory mcp serve --transport http --port 8080 \
  --allow-origin https://app.example.com \
  --allow-origin https://admin.example.com

# With OpenAI key
neo4j-memory mcp serve --transport http --port 8080 --openai-api-key sk-...
```
