### PR TITLE
fix: ABOUT entity linking for facts/preferences + logger fix

### DIFF
--- a/src/neo4j_agent_memory/graph/queries.py
+++ b/src/neo4j_agent_memory/graph/queries.py
@@ -246,7 +246,10 @@ RETURN e
 
 GET_ENTITY_BY_NAME = """
 MATCH (e:Entity)
-WHERE e.name = $name OR e.canonical_name = $name OR $name IN COALESCE(e.aliases, [])
+WHERE e.name = $name
+   OR toLower(e.name) = toLower($name)
+   OR e.canonical_name = toLower($name)
+   OR $name IN COALESCE(e.aliases, [])
 RETURN e
 LIMIT 1
 """
@@ -419,6 +422,14 @@ LINK_PREFERENCE_TO_ENTITY = """
 MATCH (p:Preference {id: $preference_id})
 MATCH (e:Entity {id: $entity_id})
 MERGE (p)-[r:ABOUT]->(e)
+RETURN r
+"""
+
+LINK_FACT_TO_ENTITY = """
+MATCH (f:Fact {id: $fact_id})
+MATCH (e:Entity {id: $entity_id})
+MERGE (f)-[r:ABOUT]->(e)
+ON CREATE SET r.role = $role
 RETURN r
 """
 

--- a/src/neo4j_agent_memory/mcp/_tools.py
+++ b/src/neo4j_agent_memory/mcp/_tools.py
@@ -411,11 +411,24 @@ def _register_extended_tools(mcp: FastMCP) -> None:
         client = get_client(ctx)
 
         try:
+            from neo4j_agent_memory.graph import queries as q
+
             entities = await client.long_term.search_entities(
                 query=name,
                 entity_types=[entity_type] if entity_type else None,
                 limit=1,
             )
+
+            # Fallback: name-based lookup if vector search found nothing
+            if not entities:
+                records = await client.graph.execute_read(
+                    q.GET_ENTITY_BY_NAME,
+                    {"name": name},
+                )
+                if records:
+                    entity_data = dict(records[0]["e"])
+                    if not (entity_type and entity_data.get("type") != entity_type):
+                        entities = [client.long_term._parse_entity(entity_data)]
 
             if not entities:
                 return json.dumps({"found": False, "name": name})
@@ -438,6 +451,13 @@ def _register_extended_tools(mcp: FastMCP) -> None:
             if include_neighbors:
                 neighbors = await _get_entity_neighbors(client, str(entity.id), max_hops)
                 result["neighbors"] = neighbors
+
+            # Include linked facts and preferences
+            linked = await _get_entity_facts_and_preferences(client, str(entity.id))
+            if linked.get("facts"):
+                result["facts"] = linked["facts"]
+            if linked.get("preferences"):
+                result["preferences"] = linked["preferences"]
 
             return json.dumps(result, default=str)
 
@@ -784,6 +804,36 @@ def _register_extended_tools(mcp: FastMCP) -> None:
 
 
 # ── Helpers ───────────────────────────────────────────────────────────
+
+
+async def _get_entity_facts_and_preferences(
+    client: Any,
+    entity_id: str,
+) -> dict[str, list[dict[str, Any]]]:
+    """Get facts and preferences linked to an entity via ABOUT relationships."""
+    query = """
+    MATCH (e:Entity {id: $entity_id})
+    OPTIONAL MATCH (f:Fact)-[:ABOUT]->(e)
+    OPTIONAL MATCH (p:Preference)-[:ABOUT]->(e)
+    WITH e,
+         collect(DISTINCT {type: 'fact', subject: f.subject,
+                 predicate: f.predicate, object: f.object}) AS facts,
+         collect(DISTINCT {type: 'preference', category: p.category,
+                 preference: p.preference}) AS preferences
+    RETURN facts, preferences
+    """
+    try:
+        records = await client.graph.execute_read(query, {"entity_id": entity_id})
+        if not records:
+            return {"facts": [], "preferences": []}
+
+        record = records[0]
+        facts = [f for f in record.get("facts", []) if f.get("subject") is not None]
+        preferences = [p for p in record.get("preferences", []) if p.get("category") is not None]
+        return {"facts": facts, "preferences": preferences}
+    except Exception as e:
+        logger.debug(f"Error getting facts/preferences for entity: {e}")
+        return {"facts": [], "preferences": []}
 
 
 async def _get_entity_neighbors(

--- a/src/neo4j_agent_memory/memory/long_term.py
+++ b/src/neo4j_agent_memory/memory/long_term.py
@@ -1,6 +1,7 @@
 """Long-term memory for entities, preferences, and facts."""
 
 import json
+import logging
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime
@@ -13,6 +14,8 @@ from pydantic import Field
 from neo4j_agent_memory.core.memory import BaseMemory, MemoryEntry
 from neo4j_agent_memory.graph import queries
 from neo4j_agent_memory.graph.query_builder import build_create_entity_query
+
+logger = logging.getLogger(__name__)
 
 # =============================================================================
 # DEDUPLICATION CONFIGURATION
@@ -594,6 +597,9 @@ class LongTermMemory(BaseMemory[Entity]):
             },
         )
 
+        # Link preference to matching entities by category name
+        await self._link_to_entity_by_name(pref.category, str(pref.id), "preference")
+
         return pref
 
     async def add_fact(
@@ -659,7 +665,47 @@ class LongTermMemory(BaseMemory[Entity]):
             },
         )
 
+        # Link fact to matching entities (subject and object)
+        await self._link_to_entity_by_name(fact.subject, str(fact.id), "fact", role="subject")
+        await self._link_to_entity_by_name(fact.object, str(fact.id), "fact", role="object")
+
         return fact
+
+    async def _link_to_entity_by_name(
+        self,
+        name: str,
+        node_id: str,
+        node_type: str,
+        *,
+        role: str = "subject",
+    ) -> None:
+        """Link a Fact or Preference to a matching Entity via an ABOUT relationship.
+
+        Looks up the entity by name (case-insensitive). If found, creates
+        the appropriate ABOUT edge. Silently skips if no match is found.
+        """
+        try:
+            records = await self._client.execute_read(
+                queries.GET_ENTITY_BY_NAME,
+                {"name": name},
+            )
+            if not records:
+                return
+
+            entity_id = records[0]["e"]["id"]
+
+            if node_type == "preference":
+                await self._client.execute_write(
+                    queries.LINK_PREFERENCE_TO_ENTITY,
+                    {"preference_id": node_id, "entity_id": entity_id},
+                )
+            elif node_type == "fact":
+                await self._client.execute_write(
+                    queries.LINK_FACT_TO_ENTITY,
+                    {"fact_id": node_id, "entity_id": entity_id, "role": role},
+                )
+        except Exception as e:
+            logger.debug("Could not link %s to entity '%s': %s", node_type, name, e)
 
     async def add_relationship(
         self,

--- a/tests/integration/test_about_relationships.py
+++ b/tests/integration/test_about_relationships.py
@@ -1,0 +1,148 @@
+"""Integration tests for ABOUT relationships between Facts/Preferences and Entities.
+
+Verifies that add_fact() and add_preference() create ABOUT relationships
+linking to matching entities in the knowledge graph. These tests directly
+validate the fix for https://github.com/neo4j-labs/agent-memory/issues/77.
+"""
+
+import pytest
+
+from neo4j_agent_memory.memory.long_term import EntityType
+
+
+@pytest.mark.integration
+class TestAboutRelationships:
+    """Test ABOUT relationships between Facts/Preferences and Entities."""
+
+    @pytest.mark.asyncio
+    async def test_fact_linked_to_entity_via_about_subject(self, clean_memory_client):
+        """Adding a fact whose subject matches an entity creates ABOUT with role=subject."""
+        entity, _ = await clean_memory_client.long_term.add_entity(
+            name="Alice",
+            entity_type=EntityType.PERSON,
+            resolve=False,
+            generate_embedding=False,
+        )
+
+        fact = await clean_memory_client.long_term.add_fact(
+            subject="Alice",
+            predicate="works_at",
+            obj="Acme Corp",
+            generate_embedding=False,
+        )
+
+        result = await clean_memory_client._client.execute_read(
+            """
+            MATCH (f:Fact {id: $fact_id})-[r:ABOUT]->(e:Entity {id: $entity_id})
+            RETURN r.role AS role
+            """,
+            {"fact_id": str(fact.id), "entity_id": str(entity.id)},
+        )
+
+        assert len(result) == 1, "ABOUT relationship not created for subject"
+        assert result[0]["role"] == "subject"
+
+    @pytest.mark.asyncio
+    async def test_fact_linked_to_entity_via_about_object(self, clean_memory_client):
+        """Adding a fact whose object matches an entity creates ABOUT with role=object."""
+        entity, _ = await clean_memory_client.long_term.add_entity(
+            name="Acme Corp",
+            entity_type=EntityType.ORGANIZATION,
+            resolve=False,
+            generate_embedding=False,
+        )
+
+        fact = await clean_memory_client.long_term.add_fact(
+            subject="Bob",
+            predicate="works_at",
+            obj="Acme Corp",
+            generate_embedding=False,
+        )
+
+        result = await clean_memory_client._client.execute_read(
+            """
+            MATCH (f:Fact {id: $fact_id})-[r:ABOUT]->(e:Entity {id: $entity_id})
+            RETURN r.role AS role
+            """,
+            {"fact_id": str(fact.id), "entity_id": str(entity.id)},
+        )
+
+        assert len(result) == 1, "ABOUT relationship not created for object"
+        assert result[0]["role"] == "object"
+
+    @pytest.mark.asyncio
+    async def test_preference_linked_to_entity_via_about(self, clean_memory_client):
+        """Adding a preference whose category matches an entity creates ABOUT."""
+        entity, _ = await clean_memory_client.long_term.add_entity(
+            name="Python",
+            entity_type="OBJECT",
+            resolve=False,
+            generate_embedding=False,
+        )
+
+        pref = await clean_memory_client.long_term.add_preference(
+            category="Python",
+            preference="Prefers Python for data science",
+            generate_embedding=False,
+        )
+
+        result = await clean_memory_client._client.execute_read(
+            """
+            MATCH (p:Preference {id: $pref_id})-[r:ABOUT]->(e:Entity {id: $entity_id})
+            RETURN r
+            """,
+            {"pref_id": str(pref.id), "entity_id": str(entity.id)},
+        )
+
+        assert len(result) == 1, "ABOUT relationship not created for preference"
+
+    @pytest.mark.asyncio
+    async def test_fact_no_matching_entity_no_error(self, clean_memory_client):
+        """Adding a fact with no matching entity should not crash and create no ABOUT."""
+        fact = await clean_memory_client.long_term.add_fact(
+            subject="NonExistentPerson",
+            predicate="likes",
+            obj="NonExistentThing",
+            generate_embedding=False,
+        )
+
+        assert fact is not None
+        assert fact.subject == "NonExistentPerson"
+
+        result = await clean_memory_client._client.execute_read(
+            """
+            MATCH (f:Fact {id: $fact_id})-[r:ABOUT]->()
+            RETURN r
+            """,
+            {"fact_id": str(fact.id)},
+        )
+
+        assert len(result) == 0
+
+    @pytest.mark.asyncio
+    async def test_fact_case_insensitive_linking(self, clean_memory_client):
+        """Entity linking should be case-insensitive."""
+        entity, _ = await clean_memory_client.long_term.add_entity(
+            name="Rust",
+            entity_type="OBJECT",
+            resolve=False,
+            generate_embedding=False,
+        )
+
+        fact = await clean_memory_client.long_term.add_fact(
+            subject="rust",
+            predicate="is_a",
+            obj="programming language",
+            generate_embedding=False,
+        )
+
+        result = await clean_memory_client._client.execute_read(
+            """
+            MATCH (f:Fact {id: $fact_id})-[r:ABOUT]->(e:Entity {id: $entity_id})
+            RETURN r.role AS role
+            """,
+            {"fact_id": str(fact.id), "entity_id": str(entity.id)},
+        )
+
+        assert len(result) == 1, "Case-insensitive ABOUT relationship not created"
+        assert result[0]["role"] == "subject"


### PR DESCRIPTION
## Summary

- Adds `_link_to_entity_by_name()` to `LongTermMemory` that automatically creates `ABOUT` relationships between Facts/Preferences and matching Entities when `add_fact()` or `add_preference()` is called
- Adds `LINK_FACT_TO_ENTITY` query constant and enhances `GET_ENTITY_BY_NAME` with case-insensitive matching (`toLower()`, `canonical_name`, aliases)
- Adds fallback name-based entity lookup in MCP `memory_get_entity` tool when vector search returns nothing
- Adds `_get_entity_facts_and_preferences()` helper to include linked facts/preferences in entity results
- **Fixes missing `import logging` in `long_term.py`** that caused a `NameError` in the except handler, silently breaking all entity linking when called through the MCP server

## How It Works

When a fact is added with `add_fact(subject="Rust", predicate="USED_FOR", obj="edge binary")`:
1. The fact is stored in Neo4j (existing behavior)
2. `_link_to_entity_by_name("Rust", fact_id, "fact", role="subject")` is called
3. It looks up an entity named "Rust" (case-insensitive)
4. If found, creates `(fact)-[:ABOUT {role: "subject"}]->(entity)`
5. Same for the object: looks up "edge binary" entity

Preferences link by category name: `add_preference(category="Python", ...)` links to an entity named "Python".

## Bug Context

Without this fix, `add_fact()` and `add_preference()` create isolated nodes with zero relationships to entities — making the knowledge *graph* effectively a flat key-value store. The `memory_get_context` tool cannot traverse from entities to related facts, and `memory_get_entity` returns no linked knowledge.

The missing `import logging` (#87) caused a cascading failure: any exception during linking triggered `NameError` instead of the actual error, making the root cause invisible through the MCP server.

## Test Plan

5 new integration tests in `tests/integration/test_about_relationships.py`:

- [x] `test_fact_linked_to_entity_via_about_subject` — entity + fact with matching subject → ABOUT with role=subject
- [x] `test_fact_linked_to_entity_via_about_object` — entity + fact with matching object → ABOUT with role=object
- [x] `test_preference_linked_to_entity_via_about` — entity + preference with matching category → ABOUT link
- [x] `test_fact_no_matching_entity_no_error` — fact with no matching entity → no crash, zero ABOUT links
- [x] `test_fact_case_insensitive_linking` — entity "Rust" + fact subject "rust" → still linked

All tests use `clean_memory_client` (real Neo4j via testcontainer), no external API calls.

Fixes #77
Fixes #87
Supersedes #78 (based on pre-v0.1.0 code)