### PR TITLE
fix: auto-link facts and preferences to entities on creation

### DIFF
--- a/src/neo4j_agent_memory/graph/queries.py
+++ b/src/neo4j_agent_memory/graph/queries.py
@@ -349,12 +349,32 @@ RETURN r
 GET_FACTS_BY_SUBJECT = """
 MATCH (f:Fact)
 WHERE f.subject = $subject
+  AND (f.valid_from IS NULL OR f.valid_from <= datetime())
+  AND (f.valid_until IS NULL OR f.valid_until >= datetime())
+RETURN f
+ORDER BY f.confidence DESC, f.created_at DESC
+LIMIT $limit
+"""
+
+GET_FACTS_BY_SUBJECT_WITH_EXPIRED = """
+MATCH (f:Fact)
+WHERE f.subject = $subject
 RETURN f
 ORDER BY f.confidence DESC, f.created_at DESC
 LIMIT $limit
 """
 
 SEARCH_FACTS_BY_EMBEDDING = """
+CALL db.index.vector.queryNodes('fact_embedding_idx', $limit, $embedding)
+YIELD node, score
+WHERE score >= $threshold
+  AND (node.valid_from IS NULL OR node.valid_from <= datetime())
+  AND (node.valid_until IS NULL OR node.valid_until >= datetime())
+RETURN node AS f, score
+ORDER BY score DESC
+"""
+
+SEARCH_FACTS_BY_EMBEDDING_WITH_EXPIRED = """
 CALL db.index.vector.queryNodes('fact_embedding_idx', $limit, $embedding)
 YIELD node, score
 WHERE score >= $threshold
@@ -420,6 +440,25 @@ MATCH (p:Preference {id: $preference_id})
 MATCH (e:Entity {id: $entity_id})
 MERGE (p)-[r:ABOUT]->(e)
 RETURN r
+"""
+
+LINK_FACT_TO_ENTITY = """
+MATCH (f:Fact {id: $fact_id})
+MATCH (e:Entity)
+WHERE e.name = $entity_name OR e.canonical_name = $entity_name
+   OR $entity_name IN COALESCE(e.aliases, [])
+WITH f, e LIMIT 1
+MERGE (f)-[r:ABOUT]->(e)
+RETURN r
+"""
+
+LINK_PREFERENCE_TO_ENTITIES_BY_TEXT = """
+MATCH (p:Preference {id: $preference_id})
+MATCH (e:Entity)
+WHERE $text CONTAINS e.name
+WITH p, e LIMIT 5
+MERGE (p)-[r:ABOUT]->(e)
+RETURN count(r) AS linked
 """
 
 # =============================================================================

--- a/src/neo4j_agent_memory/graph/queries.py
+++ b/src/neo4j_agent_memory/graph/queries.py
@@ -349,8 +349,8 @@ RETURN r
 GET_FACTS_BY_SUBJECT = """
 MATCH (f:Fact)
 WHERE f.subject = $subject
-  AND (f.valid_from IS NULL OR f.valid_from <= datetime())
-  AND (f.valid_until IS NULL OR f.valid_until >= datetime())
+  AND (f.valid_from IS NULL OR datetime(f.valid_from) <= datetime())
+  AND (f.valid_until IS NULL OR datetime(f.valid_until) >= datetime())
 RETURN f
 ORDER BY f.confidence DESC, f.created_at DESC
 LIMIT $limit

--- a/src/neo4j_agent_memory/memory/long_term.py
+++ b/src/neo4j_agent_memory/memory/long_term.py
@@ -1,6 +1,7 @@
 """Long-term memory for entities, preferences, and facts."""
 
 import json
+import logging
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime
@@ -308,6 +309,9 @@ class Fact(MemoryEntry):
         return (self.subject, self.predicate, self.object)
 
 
+logger = logging.getLogger(__name__)
+
+
 class LongTermMemory(BaseMemory[Entity]):
     """
     Long-term/Declarative memory stores facts, preferences, and entities.
@@ -594,6 +598,9 @@ class LongTermMemory(BaseMemory[Entity]):
             },
         )
 
+        # Link preference to entities mentioned in its text
+        await self._link_preference_to_entities(pref)
+
         return pref
 
     async def add_fact(
@@ -659,6 +666,9 @@ class LongTermMemory(BaseMemory[Entity]):
             },
         )
 
+        # Link fact to entities mentioned in subject/object
+        await self._link_fact_to_entities(fact)
+
         return fact
 
     async def add_relationship(
@@ -719,6 +729,32 @@ class LongTermMemory(BaseMemory[Entity]):
         )
 
         return relationship
+
+    async def _link_fact_to_entities(self, fact: Fact) -> None:
+        """Link a fact to entities matching its subject and object."""
+        for entity_name in (fact.subject, fact.object):
+            try:
+                await self._client.execute_write(
+                    queries.LINK_FACT_TO_ENTITY,
+                    {"fact_id": str(fact.id), "entity_name": entity_name},
+                )
+            except Exception:
+                # Entity may not exist — that's expected
+                pass
+
+    async def _link_preference_to_entities(self, pref: Preference) -> None:
+        """Link a preference to entities mentioned in its text."""
+        text = f"{pref.category} {pref.preference}"
+        if pref.context:
+            text += f" {pref.context}"
+        try:
+            await self._client.execute_write(
+                queries.LINK_PREFERENCE_TO_ENTITIES_BY_TEXT,
+                {"preference_id": str(pref.id), "text": text},
+            )
+        except Exception:
+            # No matching entities — that's expected
+            pass
 
     async def get_entity_by_name(self, name: str) -> Entity | None:
         """
@@ -1723,6 +1759,7 @@ class LongTermMemory(BaseMemory[Entity]):
         *,
         limit: int = 10,
         threshold: float = 0.7,
+        include_expired: bool = False,
     ) -> list[Fact]:
         """
         Search for facts by semantic similarity.
@@ -1731,6 +1768,7 @@ class LongTermMemory(BaseMemory[Entity]):
             query: Search query
             limit: Maximum results
             threshold: Minimum similarity threshold
+            include_expired: Include facts past their valid_until date
 
         Returns:
             List of matching facts
@@ -1740,8 +1778,14 @@ class LongTermMemory(BaseMemory[Entity]):
 
         query_embedding = await self._embedder.embed(query)
 
+        vector_query = (
+            queries.SEARCH_FACTS_BY_EMBEDDING_WITH_EXPIRED
+            if include_expired
+            else queries.SEARCH_FACTS_BY_EMBEDDING
+        )
+
         results = await self._client.execute_read(
-            queries.SEARCH_FACTS_BY_EMBEDDING,
+            vector_query,
             {
                 "embedding": query_embedding,
                 "limit": limit,


### PR DESCRIPTION
## Summary
- When a fact is created, its `subject` and `object` are matched against existing entity names/canonical_names/aliases. If a match is found, an `ABOUT` relationship is created automatically.
- Preferences are matched by checking if any entity name appears in the preference text.
- Both are fire-and-forget — missing entity matches do not cause errors.
- Also enforces temporal validity (`valid_from`/`valid_until`) on fact search queries. Expired facts are filtered by default; callers can pass `include_expired=True` to retrieve them.

## Motivation
`memory_health` reports orphaned facts and preferences (nodes without `ABOUT` relationships), but nothing in the creation flow prevents orphans from being created. This is the root cause — every `add_fact()` and `add_preference()` call creates disconnected nodes.

Existing graphs can be backfilled with:
```cypher
MATCH (f:Fact) WHERE NOT (f)-[:ABOUT]->()
MATCH (e:Entity) WHERE f.subject = e.name OR f.subject = e.canonical_name
MERGE (f)-[:ABOUT]->(e)
```

## Files changed
- `queries.py` — `LINK_FACT_TO_ENTITY`, `LINK_PREFERENCE_TO_ENTITIES_BY_TEXT`, TTL WHERE clauses
- `long_term.py` — `_link_fact_to_entities()`, `_link_preference_to_entities()`, `include_expired` param

Fixes #77, #91