### PR TITLE
feat: deduplicate facts and preferences on creation

### DIFF
--- a/src/neo4j_agent_memory/graph/queries.py
+++ b/src/neo4j_agent_memory/graph/queries.py
@@ -362,6 +362,34 @@ RETURN node AS f, score
 ORDER BY score DESC
 """
 
+FIND_DUPLICATE_FACTS = """
+CALL db.index.vector.queryNodes('fact_embedding_idx', $limit, $embedding)
+YIELD node, score
+WHERE score >= $threshold
+  AND node.subject = $subject
+  AND node.predicate = $predicate
+RETURN node AS f, score
+ORDER BY score DESC
+"""
+
+UPDATE_FACT_CONFIDENCE = """
+MATCH (f:Fact {id: $id})
+SET f.confidence = CASE
+    WHEN $confidence > f.confidence THEN $confidence ELSE f.confidence END,
+    f.object = CASE
+    WHEN $confidence > f.confidence THEN $object ELSE f.object END
+RETURN f
+"""
+
+FIND_DUPLICATE_PREFERENCES = """
+CALL db.index.vector.queryNodes('preference_embedding_idx', $limit, $embedding)
+YIELD node, score
+WHERE score >= $threshold
+  AND node.category = $category
+RETURN node AS p, score
+ORDER BY score DESC
+"""
+
 GET_ENTITY_RELATIONSHIPS = """
 MATCH (e:Entity {id: $entity_id})-[r:RELATED_TO]-(other:Entity)
 RETURN e, r, other

--- a/src/neo4j_agent_memory/memory/long_term.py
+++ b/src/neo4j_agent_memory/memory/long_term.py
@@ -548,7 +548,11 @@ class LongTermMemory(BaseMemory[Entity]):
         metadata: dict[str, Any] | None = None,
     ) -> Preference:
         """
-        Add a user preference.
+        Add a user preference with deduplication.
+
+        If a preference in the same category already exists with high
+        semantic similarity, returns the existing one instead of creating
+        a duplicate.
 
         Args:
             category: Preference category (food, music, communication, etc.)
@@ -559,7 +563,7 @@ class LongTermMemory(BaseMemory[Entity]):
             metadata: Optional metadata
 
         Returns:
-            The created preference
+            The created or existing preference
         """
         # Generate embedding
         embedding = None
@@ -568,6 +572,26 @@ class LongTermMemory(BaseMemory[Entity]):
             if context:
                 text += f" ({context})"
             embedding = await self._embedder.embed(text)
+
+        # Check for duplicate preferences (same category, high similarity)
+        if self._deduplication.enabled and embedding is not None:
+            try:
+                dupes = await self._client.execute_read(
+                    queries.FIND_DUPLICATE_PREFERENCES,
+                    {
+                        "embedding": embedding,
+                        "limit": 3,
+                        "threshold": 0.95,
+                        "category": category,
+                    },
+                )
+                if dupes:
+                    existing_data = dict(dupes[0]["p"])
+                    existing = self._parse_preference(existing_data)
+                    existing.metadata["deduplicated"] = True
+                    return existing
+            except Exception:
+                pass  # Vector index may not exist yet
 
         # Create preference
         pref = Preference(
@@ -609,7 +633,11 @@ class LongTermMemory(BaseMemory[Entity]):
         metadata: dict[str, Any] | None = None,
     ) -> Fact:
         """
-        Add a declarative fact.
+        Add a declarative fact with deduplication.
+
+        If a fact with the same subject and predicate already exists
+        with high semantic similarity, updates the existing fact's
+        confidence instead of creating a duplicate.
 
         Args:
             subject: Fact subject
@@ -622,13 +650,42 @@ class LongTermMemory(BaseMemory[Entity]):
             metadata: Optional metadata
 
         Returns:
-            The created fact
+            The created or existing fact
         """
         # Generate embedding
         embedding = None
         if generate_embedding and self._embedder is not None:
             text = f"{subject} {predicate} {obj}"
             embedding = await self._embedder.embed(text)
+
+        # Check for duplicate facts (same subject+predicate, high similarity)
+        if self._deduplication.enabled and embedding is not None:
+            try:
+                dupes = await self._client.execute_read(
+                    queries.FIND_DUPLICATE_FACTS,
+                    {
+                        "embedding": embedding,
+                        "limit": 3,
+                        "threshold": 0.95,
+                        "subject": subject,
+                        "predicate": predicate,
+                    },
+                )
+                if dupes:
+                    existing_data = dict(dupes[0]["f"])
+                    await self._client.execute_write(
+                        queries.UPDATE_FACT_CONFIDENCE,
+                        {
+                            "id": existing_data["id"],
+                            "confidence": confidence,
+                            "object": obj,
+                        },
+                    )
+                    existing = self._parse_fact(existing_data)
+                    existing.metadata["deduplicated"] = True
+                    return existing
+            except Exception:
+                pass  # Vector index may not exist yet; proceed with creation
 
         # Create fact
         fact = Fact(


### PR DESCRIPTION
## Summary
- Before creating a fact, searches for existing facts with same subject+predicate and >0.95 embedding similarity. If found, updates confidence on the existing fact and returns it with `metadata["deduplicated"] = True`.
- Same logic for preferences: same category + >0.95 similarity returns the existing preference.
- Gated behind the existing `DeduplicationConfig.enabled` flag (default: `True`), which was previously defined but unused for facts and preferences.

## Motivation
Entity resolution prevents duplicate entities, but facts and preferences had no deduplication. Storing "prefers Rust over Python" three times across sessions creates three nodes. This wires up the existing `fact_deduplication_enabled` config that was already `True` but had no implementation.

## Files changed
- `queries.py` — `FIND_DUPLICATE_FACTS`, `UPDATE_FACT_CONFIDENCE`, `FIND_DUPLICATE_PREFERENCES`
- `long_term.py` — dedup check before create in `add_fact()` and `add_preference()`