### PR TITLE
feat: add delete tools for facts, preferences, entities (extended profile)

### DIFF
--- a/src/neo4j_agent_memory/graph/queries.py
+++ b/src/neo4j_agent_memory/graph/queries.py
@@ -637,6 +637,24 @@ OPTIONAL MATCH (rs)-[:USES_TOOL]->(tc:ToolCall)
 DETACH DELETE c, m, rt, rs, tc
 """
 
+DELETE_FACT = """
+MATCH (f:Fact {id: $id})
+DETACH DELETE f
+RETURN true AS deleted
+"""
+
+DELETE_PREFERENCE = """
+MATCH (p:Preference {id: $id})
+DETACH DELETE p
+RETURN true AS deleted
+"""
+
+DELETE_ENTITY = """
+MATCH (e:Entity {id: $id})
+DETACH DELETE e
+RETURN true AS deleted
+"""
+
 GET_MEMORY_STATS = """
 OPTIONAL MATCH (c:Conversation) WITH count(c) AS conversations
 OPTIONAL MATCH (m:Message) WITH conversations, count(m) AS messages

--- a/src/neo4j_agent_memory/integration.py
+++ b/src/neo4j_agent_memory/integration.py
@@ -554,3 +554,18 @@ class MemoryIntegration:
         except Exception as e:
             logger.error(f"Error adding fact: {e}")
             return {"error": str(e)}
+
+    async def delete_fact(self, fact_id: str) -> dict[str, Any]:
+        """Delete a fact by ID."""
+        deleted = await self._client.long_term.delete_fact(fact_id)
+        return {"deleted": deleted, "id": fact_id}
+
+    async def delete_preference(self, preference_id: str) -> dict[str, Any]:
+        """Delete a preference by ID."""
+        deleted = await self._client.long_term.delete_preference(preference_id)
+        return {"deleted": deleted, "id": preference_id}
+
+    async def delete_entity(self, entity_id: str) -> dict[str, Any]:
+        """Delete an entity and its relationships by ID."""
+        deleted = await self._client.long_term.delete_entity(entity_id)
+        return {"deleted": deleted, "id": entity_id}

--- a/src/neo4j_agent_memory/mcp/_tools.py
+++ b/src/neo4j_agent_memory/mcp/_tools.py
@@ -782,6 +782,65 @@ def _register_extended_tools(mcp: FastMCP) -> None:
             logger.error(f"Error in graph_query: {e}")
             return json.dumps({"error": str(e)})
 
+    # ── Delete tools ──
+
+    _DELETE_ANNOTATIONS = {
+        "readOnlyHint": False,
+        "destructiveHint": True,
+        "idempotentHint": True,
+    }
+
+    @mcp.tool(annotations=_DELETE_ANNOTATIONS)
+    async def memory_delete_fact(ctx: Context, fact_id: str) -> str:
+        """Delete a fact by ID. Removes the fact and all its relationships.
+
+        Use memory_search to find fact IDs first.
+
+        Args:
+            fact_id: The UUID of the fact to delete.
+        """
+        integration = get_integration(ctx)
+        try:
+            result = await integration.delete_fact(fact_id)
+            return json.dumps(result, default=str)
+        except Exception as e:
+            logger.error(f"Error deleting fact: {e}")
+            return json.dumps({"error": str(e)})
+
+    @mcp.tool(annotations=_DELETE_ANNOTATIONS)
+    async def memory_delete_preference(ctx: Context, preference_id: str) -> str:
+        """Delete a preference by ID. Removes the preference and all its relationships.
+
+        Use memory_search to find preference IDs first.
+
+        Args:
+            preference_id: The UUID of the preference to delete.
+        """
+        integration = get_integration(ctx)
+        try:
+            result = await integration.delete_preference(preference_id)
+            return json.dumps(result, default=str)
+        except Exception as e:
+            logger.error(f"Error deleting preference: {e}")
+            return json.dumps({"error": str(e)})
+
+    @mcp.tool(annotations=_DELETE_ANNOTATIONS)
+    async def memory_delete_entity(ctx: Context, entity_id: str) -> str:
+        """Delete an entity by ID. Removes the entity and all its relationships.
+
+        Use memory_search to find entity IDs first.
+
+        Args:
+            entity_id: The UUID of the entity to delete.
+        """
+        integration = get_integration(ctx)
+        try:
+            result = await integration.delete_entity(entity_id)
+            return json.dumps(result, default=str)
+        except Exception as e:
+            logger.error(f"Error deleting entity: {e}")
+            return json.dumps({"error": str(e)})
+
 
 # ── Helpers ───────────────────────────────────────────────────────────
 

--- a/src/neo4j_agent_memory/memory/long_term.py
+++ b/src/neo4j_agent_memory/memory/long_term.py
@@ -720,6 +720,27 @@ class LongTermMemory(BaseMemory[Entity]):
 
         return relationship
 
+    async def delete_fact(self, fact_id: str) -> bool:
+        """Delete a fact and its relationships by ID."""
+        results = await self._client.execute_write(
+            queries.DELETE_FACT, {"id": fact_id}
+        )
+        return bool(results)
+
+    async def delete_preference(self, preference_id: str) -> bool:
+        """Delete a preference and its relationships by ID."""
+        results = await self._client.execute_write(
+            queries.DELETE_PREFERENCE, {"id": preference_id}
+        )
+        return bool(results)
+
+    async def delete_entity(self, entity_id: str) -> bool:
+        """Delete an entity and its relationships by ID."""
+        results = await self._client.execute_write(
+            queries.DELETE_ENTITY, {"id": entity_id}
+        )
+        return bool(results)
+
     async def get_entity_by_name(self, name: str) -> Entity | None:
         """
         Get an entity by name.


### PR DESCRIPTION
## Summary
- Adds `memory_delete_fact`, `memory_delete_preference`, and `memory_delete_entity` MCP tools to the extended profile.
- Uses `DETACH DELETE` to clean up all relationships when deleting a node.
- Tools are annotated with `destructiveHint=True` and `idempotentHint=True`.
- Core profile is unchanged.

## Motivation
The memory system is append-only — wrong facts, stale preferences, and outdated entities cannot be corrected through the MCP interface. The only workaround is raw Cypher via `graph_query`, which is read-only for safety. These tools provide a safe, structured way to clean up graph data.

## Files changed
- `queries.py` — `DELETE_FACT`, `DELETE_PREFERENCE`, `DELETE_ENTITY`
- `long_term.py` — `delete_fact()`, `delete_preference()`, `delete_entity()`
- `integration.py` — delegation methods
- `_tools.py` — 3 tools in `_register_extended_tools()`