### PR TITLE
feat: add Ollama embedding provider support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ wheels/
 .env
 .env.local
 .env.*.local
+scripts/backup-config.env
 
 # IDE and editor files
 .idea/

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -13,6 +13,7 @@ services:
       - NEO4J_apoc_import_file_use__neo4j__config=true
       - NEO4J_dbms_security_procedures_unrestricted=apoc.*
       - NEO4J_dbms_security_procedures_allowlist=apoc.*
+      - NEO4J_dbms_usage__report_enabled=false
     healthcheck:
       test:
         [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ dependencies = [
 [project.optional-dependencies]
 # Embedding providers
 openai = ["openai>=1.0.0"]
+ollama = ["openai>=1.0.0"]
 anthropic = ["anthropic>=0.20.0"]
 sentence-transformers = ["sentence-transformers>=2.2.0"]
 vertex-ai = ["google-cloud-aiplatform>=1.38.0"]

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,122 @@
+# Sauvegarde Neo4j vers OwnCloud
+
+Système de sauvegarde automatique des données Neo4j vers OwnCloud via WebDAV.
+
+## Fichiers
+
+- `backup-neo4j-to-owncloud.sh` - Script principal de sauvegarde
+- `backup-config.env` - Configuration des credentials OwnCloud
+- `neo4j-backup.service` - Service systemd pour la sauvegarde
+- `neo4j-backup.timer` - Timer systemd pour les sauvegardes récurrentes
+
+## Installation
+
+### 1. Configuration
+
+Éditez le fichier `backup-config.env` avec vos credentials OwnCloud :
+
+```bash
+# URL OwnCloud WebDAV
+OWNCLOUD_URL="https://your-owncloud-instance.com/remote.php/webdav"
+
+# Credentials OwnCloud
+OWNCLOUD_USER="your-username"
+OWNCLOUD_PASSWORD="your-password"
+
+# Répertoire de sauvegarde sur OwnCloud
+OWNCLOUD_BACKUP_DIR="/Neo4j-Backups"
+```
+
+### 2. Installation systemd
+
+Copiez les fichiers systemd vers le répertoire système :
+
+```bash
+sudo cp neo4j-backup.service /etc/systemd/system/
+sudo cp neo4j-backup.timer /etc/systemd/system/
+sudo systemctl daemon-reload
+```
+
+### 3. Activation du timer
+
+Activez et démarrez le timer pour les sauvegardes automatiques :
+
+```bash
+sudo systemctl enable neo4j-backup.timer
+sudo systemctl start neo4j-backup.timer
+```
+
+## Utilisation manuelle
+
+Pour exécuter une sauvegarde manuelle :
+
+```bash
+./backup-neo4j-to-owncloud.sh
+```
+
+Ou via systemd :
+
+```bash
+sudo systemctl start neo4j-backup.service
+```
+
+## Personnalisation
+
+### Fréquence des sauvegardes
+
+Modifiez `neo4j-backup.timer` pour changer la fréquence :
+
+```ini
+# Quotidien (par défaut)
+OnCalendar=daily
+
+# Hebdomadaire
+OnCalendar=weekly
+
+# Toutes les 6 heures
+OnCalendar=*:00/6:00
+```
+
+### Rétention
+
+Le script conserve actuellement tous les backups. Pour implémenter une rétention automatique, ajoutez à la fin du script :
+
+```bash
+# Garder seulement les 7 derniers backups
+cd "${BACKUP_DIR}"
+ls -t neo4j-backup-*.tar.gz | tail -n +8 | xargs rm -f
+```
+
+## Sécurité
+
+- Le fichier `backup-config.env` contient des credentials sensibles
+- Assurez-vous que le fichier a les permissions appropriées : `chmod 600 backup-config.env`
+- Considérez l'utilisation de variables d'environnement ou de secrets pour les credentials en production
+
+## Logs
+
+Consultez les logs systemd :
+
+```bash
+journalctl -u neo4j-backup.service -f
+```
+
+## Dépannage
+
+### Erreur "Fichier de configuration non trouvé"
+Vérifiez que `backup-config.env` existe dans le même répertoire que le script.
+
+### Erreur WebDAV
+Vérifiez que l'URL OwnCloud est correcte et que les credentials sont valides.
+Testez manuellement avec curl :
+
+```bash
+curl -u "user:password" "https://your-owncloud-instance.com/remote.php/webdav/"
+```
+
+### Erreur Neo4j
+Vérifiez que le container Neo4j est en cours d'exécution :
+
+```bash
+docker ps | grep neo4j
+```

--- a/scripts/backup-neo4j-to-owncloud.sh
+++ b/scripts/backup-neo4j-to-owncloud.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+# Script de sauvegarde Neo4j vers OwnCloud via WebDAV
+# Auteur: Backup System
+# Date: 2026-04-10
+
+# Charger la configuration
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CONFIG_FILE="${SCRIPT_DIR}/backup-config.env"
+
+if [ ! -f "$CONFIG_FILE" ]; then
+    echo "Erreur: Fichier de configuration non trouvé: $CONFIG_FILE"
+    exit 1
+fi
+
+source "$CONFIG_FILE"
+
+# Variables
+TIMESTAMP=$(date +%Y%m%d_%H%M%S)
+BACKUP_FILE="neo4j-backup-${TIMESTAMP}.tar.gz"
+
+# Créer le répertoire de sauvegarde
+mkdir -p "${BACKUP_DIR}"
+
+# Nettoyer le répertoire de backup avant de créer le nouveau dump
+rm -rf "${BACKUP_DIR}/backup"
+
+# Arrêter Neo4j pour permettre un dump cohérent
+echo "Arrêt de Neo4j..."
+docker stop "${NEO4J_CONTAINER}"
+
+# Attendre que le container soit arrêté
+echo "Attente de l'arrêt complet..."
+sleep 5
+
+# Faire le dump Neo4j avec un container temporaire utilisant le même volume
+echo "Création du dump Neo4j avec container temporaire..."
+docker run --rm \
+    -v agent-memory_neo4j_test_data:/data \
+    -v "${BACKUP_DIR}:/backup" \
+    --entrypoint /var/lib/neo4j/bin/neo4j-admin \
+    neo4j:5.26-community \
+    database dump neo4j --to-path=/backup --overwrite-destination
+
+# Vérifier que le dump a été créé
+if [ ! -f "${BACKUP_DIR}/neo4j.dump" ]; then
+    echo "Erreur: Le dump n'a pas été créé correctement"
+    exit 1
+fi
+
+# Redémarrer Neo4j
+echo "Redémarrage de Neo4j..."
+docker start "${NEO4J_CONTAINER}"
+
+# Attendre que Neo4j soit prêt
+echo "Attente de Neo4j..."
+sleep 30
+
+# Compresser le backup
+echo "Compression du backup..."
+if ! tar -czf "${BACKUP_DIR}/${BACKUP_FILE}" -C "${BACKUP_DIR}" neo4j.dump; then
+    echo "Erreur: Échec de la compression"
+    exit 1
+fi
+
+# Vérifier que l'archive a été créée
+if [ ! -f "${BACKUP_DIR}/${BACKUP_FILE}" ]; then
+    echo "Erreur: L'archive n'a pas été créée"
+    exit 1
+fi
+
+# Créer le répertoire de sauvegarde sur OwnCloud s'il n'existe pas
+echo "Création du répertoire de sauvegarde sur OwnCloud..."
+curl -u "${OWNCLOUD_USER}:${OWNCLOUD_PASSWORD}" \
+     -X MKCOL \
+     "${OWNCLOUD_URL}${OWNCLOUD_BACKUP_DIR}" \
+     --fail --silent --show-error || echo "Le répertoire existe déjà ou erreur de création"
+
+# Upload vers OwnCloud via WebDAV
+echo "Upload vers OwnCloud..."
+if curl -u "${OWNCLOUD_USER}:${OWNCLOUD_PASSWORD}" \
+     -T "${BACKUP_DIR}/${BACKUP_FILE}" \
+     "${OWNCLOUD_URL}${OWNCLOUD_BACKUP_DIR}/${BACKUP_FILE}"; then
+    echo "Upload réussi"
+else
+    echo "Erreur: Échec de l'upload vers OwnCloud"
+    echo "L'archive est conservée localement: ${BACKUP_DIR}/${BACKUP_FILE}"
+    exit 1
+fi
+
+# Nettoyage local (optionnel - commenter pour garder les backups locaux)
+echo "Nettoyage..."
+rm -f "${BACKUP_DIR}/neo4j.dump"
+# rm "${BACKUP_DIR}/${BACKUP_FILE}"
+
+echo "Sauvegarde terminée: ${BACKUP_FILE}"

--- a/scripts/neo4j-backup.service
+++ b/scripts/neo4j-backup.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Neo4j Backup to OwnCloud
+After=network.target docker.service
+
+[Service]
+Type=oneshot
+WorkingDirectory=/home/imohamma/Documents/Dev/agent-memory/scripts
+ExecStart=/home/imohamma/Documents/Dev/agent-memory/scripts/backup-neo4j-to-owncloud.sh
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target

--- a/scripts/neo4j-backup.timer
+++ b/scripts/neo4j-backup.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Daily Neo4j Backup to OwnCloud
+
+[Timer]
+OnCalendar=daily
+Persistent=true
+AccuracySec=1h
+
+[Install]
+WantedBy=timers.target

--- a/src/neo4j_agent_memory/__init__.py
+++ b/src/neo4j_agent_memory/__init__.py
@@ -939,7 +939,17 @@ class MemoryClient:
             return OpenAIEmbedder(
                 model=config.model,
                 api_key=config.api_key.get_secret_value() if config.api_key else None,
-                dimensions=config.dimensions if config.dimensions != 1536 else None,
+                dimensions=config.dimensions if config.dimensions != 768 else None,
+                batch_size=config.batch_size,
+            )
+        elif config.provider == EmbeddingProvider.OLLAMA:
+            from neo4j_agent_memory.embeddings.ollama import OllamaEmbedder
+
+            return OllamaEmbedder(
+                model=config.model,
+                base_url=config.base_url or "http://localhost:11434",
+                api_key=config.api_key.get_secret_value() if config.api_key else None,
+                dimensions=config.dimensions if config.dimensions != 768 else None,
                 batch_size=config.batch_size,
             )
         elif config.provider == EmbeddingProvider.SENTENCE_TRANSFORMERS:

--- a/src/neo4j_agent_memory/config/settings.py
+++ b/src/neo4j_agent_memory/config/settings.py
@@ -15,6 +15,7 @@ class EmbeddingProvider(str, Enum):
     SENTENCE_TRANSFORMERS = "sentence_transformers"
     VERTEX_AI = "vertex_ai"
     BEDROCK = "bedrock"
+    OLLAMA = "ollama"
     CUSTOM = "custom"
 
 
@@ -105,7 +106,7 @@ class EmbeddingConfig(BaseModel):
         default=EmbeddingProvider.OPENAI, description="Embedding provider to use"
     )
     model: str = Field(default="text-embedding-3-small", description="Embedding model name")
-    dimensions: int = Field(default=1536, ge=1, description="Embedding dimensions")
+    dimensions: int = Field(default=768, ge=1, description="Embedding dimensions")
     api_key: SecretStr | None = Field(default=None, description="API key for embedding provider")
     batch_size: int = Field(default=100, ge=1, description="Batch size for embeddings")
     # Sentence Transformers specific
@@ -120,6 +121,8 @@ class EmbeddingConfig(BaseModel):
     # AWS Bedrock specific
     aws_region: str | None = Field(default=None, description="AWS region for Bedrock")
     aws_profile: str | None = Field(default=None, description="AWS credentials profile name")
+    # Ollama specific
+    base_url: str | None = Field(default=None, description="Ollama server URL (default: http://localhost:11434)")
 
 
 class LLMConfig(BaseModel):

--- a/src/neo4j_agent_memory/embeddings/__init__.py
+++ b/src/neo4j_agent_memory/embeddings/__init__.py
@@ -10,6 +10,7 @@ __all__ = [
     "VertexAIEmbedder",
     "BedrockEmbedder",
     "SentenceTransformerEmbedder",
+    "OllamaEmbedder",
 ]
 
 
@@ -29,4 +30,8 @@ def __getattr__(name: str):
         )
 
         return SentenceTransformerEmbedder
+    if name == "OllamaEmbedder":
+        from neo4j_agent_memory.embeddings.ollama import OllamaEmbedder
+
+        return OllamaEmbedder
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/neo4j_agent_memory/embeddings/ollama.py
+++ b/src/neo4j_agent_memory/embeddings/ollama.py
@@ -1,0 +1,111 @@
+"""Ollama embedding provider (OpenAI-compatible API)."""
+
+from typing import TYPE_CHECKING
+
+from neo4j_agent_memory.core.exceptions import EmbeddingError
+from neo4j_agent_memory.embeddings.base import BaseEmbedder
+
+if TYPE_CHECKING:
+    from openai import AsyncOpenAI
+
+
+# Ollama model dimensions
+MODEL_DIMENSIONS = {
+    "nomic-embed-text": 768,
+    "nomic-embed-text:latest": 768,
+    "nomic-embed-text-v2-moe": 768,
+    "nomic-embed-text-v2-moe:latest": 768,
+}
+
+
+class OllamaEmbedder(BaseEmbedder):
+    """Ollama embedding provider using OpenAI-compatible API."""
+
+    def __init__(
+        self,
+        model: str = "nomic-embed-text",
+        *,
+        base_url: str = "http://localhost:11434",
+        api_key: str | None = None,
+        dimensions: int | None = None,
+        batch_size: int = 100,
+    ):
+        """
+        Initialize Ollama embedder.
+
+        Args:
+            model: Ollama embedding model name
+            base_url: Ollama server URL (default: http://localhost:11434)
+            api_key: Optional API key (Ollama typically doesn't require one)
+            dimensions: Optional dimension override
+            batch_size: Maximum texts per API call
+        """
+        self._model = model
+        self._base_url = base_url
+        self._api_key = api_key or "ollama"  # Ollama accepts any key
+        self._requested_dimensions = dimensions
+        self._batch_size = batch_size
+        self._client: AsyncOpenAI | None = None
+
+        # Determine dimensions
+        if dimensions is not None:
+            self._dimensions = dimensions
+        else:
+            self._dimensions = MODEL_DIMENSIONS.get(model, 768)
+
+    def _ensure_client(self) -> "AsyncOpenAI":
+        """Ensure the OpenAI client is initialized with Ollama endpoint."""
+        if self._client is None:
+            try:
+                from openai import AsyncOpenAI
+            except ImportError:
+                raise EmbeddingError(
+                    "OpenAI package not installed. Install with: pip install openai"
+                )
+            self._client = AsyncOpenAI(
+                api_key=self._api_key,
+                base_url=f"{self._base_url}/v1",
+            )
+        return self._client
+
+    @property
+    def dimensions(self) -> int:
+        """Return the embedding dimensions."""
+        return self._dimensions
+
+    async def embed(self, text: str) -> list[float]:
+        """Generate embedding for a single text."""
+        client = self._ensure_client()
+
+        try:
+            response = await client.embeddings.create(
+                input=text,
+                model=self._model,
+            )
+            return response.data[0].embedding
+        except Exception as e:
+            raise EmbeddingError(f"Failed to generate embedding: {e}") from e
+
+    async def embed_batch(self, texts: list[str]) -> list[list[float]]:
+        """Generate embeddings for multiple texts efficiently."""
+        if not texts:
+            return []
+
+        client = self._ensure_client()
+        all_embeddings: list[list[float]] = []
+
+        try:
+            # Process in batches
+            for i in range(0, len(texts), self._batch_size):
+                batch = texts[i : i + self._batch_size]
+                response = await client.embeddings.create(
+                    input=batch,
+                    model=self._model,
+                )
+                # Sort by index to maintain order
+                sorted_data = sorted(response.data, key=lambda x: x.index)
+                all_embeddings.extend([d.embedding for d in sorted_data])
+
+            return all_embeddings
+        except Exception as e:
+            raise EmbeddingError(f"Failed to generate embeddings: {e}") from e

--- a/src/neo4j_agent_memory/graph/schema.py
+++ b/src/neo4j_agent_memory/graph/schema.py
@@ -10,7 +10,7 @@ if TYPE_CHECKING:
 
 
 # Default vector dimensions
-DEFAULT_VECTOR_DIMENSIONS = 1536
+DEFAULT_VECTOR_DIMENSIONS = 768
 
 
 class SchemaManager:

--- a/uv.lock
+++ b/uv.lock
@@ -4647,6 +4647,9 @@ observability = [
     { name = "opentelemetry-api" },
     { name = "opentelemetry-sdk" },
 ]
+ollama = [
+    { name = "openai" },
+]
 openai = [
     { name = "openai" },
 ]
@@ -4717,6 +4720,7 @@ requires-dist = [
     { name = "neo4j", specifier = ">=5.20.0" },
     { name = "neo4j-agent-memory", extras = ["all", "sentence-transformers", "spacy", "gliner"], marker = "extra == 'full'" },
     { name = "neo4j-agent-memory", extras = ["openai", "anthropic", "fuzzy", "langchain", "llamaindex", "pydantic-ai", "crewai", "openai-agents", "microsoft-agent"], marker = "extra == 'all'" },
+    { name = "openai", marker = "extra == 'ollama'", specifier = ">=1.0.0" },
     { name = "openai", marker = "extra == 'openai'", specifier = ">=1.0.0" },
     { name = "openai", marker = "extra == 'openai-agents'", specifier = ">=1.0.0" },
     { name = "opentelemetry-api", marker = "extra == 'observability'", specifier = ">=1.20.0" },
@@ -4735,7 +4739,7 @@ requires-dist = [
     { name = "spacy", marker = "extra == 'spacy'", specifier = ">=3.7.0" },
     { name = "strands-agents", marker = "extra == 'strands'", specifier = ">=0.1.0" },
 ]
-provides-extras = ["openai", "anthropic", "sentence-transformers", "vertex-ai", "bedrock", "google", "aws", "strands", "spacy", "gliner", "extraction", "fuzzy", "cli", "opentelemetry", "opik", "observability", "langchain", "llamaindex", "pydantic-ai", "crewai", "openai-agents", "microsoft-agent", "mcp", "google-adk", "all", "full"]
+provides-extras = ["openai", "ollama", "anthropic", "sentence-transformers", "vertex-ai", "bedrock", "google", "aws", "strands", "spacy", "gliner", "extraction", "fuzzy", "cli", "opentelemetry", "opik", "observability", "langchain", "llamaindex", "pydantic-ai", "crewai", "openai-agents", "microsoft-agent", "mcp", "google-adk", "all", "full"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
Add Ollama embedding provider using OpenAI-compatible API.

- Add OllamaEmbedder class
- Add ollama optional dependency
- Update default vector dimensions to 768 (nomic-embed-text)
- Add base_url config for Ollama server endpoint
- Update embeddings module to export OllamaEmbedder
- Add Ollama provider to EmbeddingConfig

This allows users to use local Ollama instances for embeddings instead of external providers.