### PR TITLE
fix llamaindex final message drop

### DIFF
--- a/src/neo4j_agent_memory/integrations/llamaindex/memory.py
+++ b/src/neo4j_agent_memory/integrations/llamaindex/memory.py
@@ -72,7 +72,7 @@ try:
                 nest_asyncio.apply()
                 return self._loop.run_until_complete(coro)
             future = asyncio.run_coroutine_threadsafe(coro, self._loop)
-            return future.result(timeout=30)
+            return future.result(timeout=60)
 
         @staticmethod
         def _parse_role(role_value: str) -> MessageRole:
@@ -356,20 +356,6 @@ try:
             await self._client.short_term.add_message(
                 self._session_id, role_str, content, metadata=metadata
             )
-
-        async def aput_messages(self, messages: list[ChatMessage]) -> None:
-            """Store a batch of ChatMessages in memory.
-
-            Overrides BaseMemory's default which dispatches via
-            ``asyncio.to_thread(self.put_messages, ...)``. That default path
-            bridges back to the original event loop via
-            ``run_coroutine_threadsafe`` and can silently drop the final
-            message at end-of-run (loop shutting down, timeout, or a
-            mismatched loop). Writing directly with ``await`` avoids the
-            thread hop entirely.
-            """
-            for msg in messages:
-                await self.aput(msg)
 
         async def aget_all(self) -> list[ChatMessage]:
             return await self.aget(input=None)

--- a/src/neo4j_agent_memory/integrations/llamaindex/memory.py
+++ b/src/neo4j_agent_memory/integrations/llamaindex/memory.py
@@ -348,9 +348,28 @@ try:
             if role_str == "tool" and content:
                 content = self._extract_mcp_text(content)
 
+            # Assistant messages with only tool_calls may have no text content;
+            # store an empty string so the message (and its metadata) is preserved.
+            if content is None:
+                content = ""
+
             await self._client.short_term.add_message(
                 self._session_id, role_str, content, metadata=metadata
             )
+
+        async def aput_messages(self, messages: list[ChatMessage]) -> None:
+            """Store a batch of ChatMessages in memory.
+
+            Overrides BaseMemory's default which dispatches via
+            ``asyncio.to_thread(self.put_messages, ...)``. That default path
+            bridges back to the original event loop via
+            ``run_coroutine_threadsafe`` and can silently drop the final
+            message at end-of-run (loop shutting down, timeout, or a
+            mismatched loop). Writing directly with ``await`` avoids the
+            thread hop entirely.
+            """
+            for msg in messages:
+                await self.aput(msg)
 
         async def aget_all(self) -> list[ChatMessage]:
             return await self.aget(input=None)


### PR DESCRIPTION
Override aput_messages to await aput directly instead of inheriting BaseMemory's asyncio.to_thread + run_coroutine_threadsafe bridge, which could silently drop the final message at end-of-run. Also store content-less assistant tool_call messages as empty string.