### PR TITLE
remote timeout in llamaindex

### DIFF
--- a/src/neo4j_agent_memory/integrations/llamaindex/memory.py
+++ b/src/neo4j_agent_memory/integrations/llamaindex/memory.py
@@ -72,7 +72,7 @@ try:
                 nest_asyncio.apply()
                 return self._loop.run_until_complete(coro)
             future = asyncio.run_coroutine_threadsafe(coro, self._loop)
-            return future.result(timeout=30)
+            return future.result()
 
         @staticmethod
         def _parse_role(role_value: str) -> MessageRole:


### PR DESCRIPTION
LLM extraction can take forever and easily go over timeout