### PR TITLE
feat: expose metadata parameter on memory_add_fact MCP tool

### DIFF
--- a/src/neo4j_agent_memory/integration.py
+++ b/src/neo4j_agent_memory/integration.py
@@ -544,6 +544,7 @@ class MemoryIntegration:
                 valid_from=valid_from,
                 valid_until=valid_until,
                 generate_embedding=True,
+                metadata=metadata,
             )
             return {
                 "stored": True,

--- a/src/neo4j_agent_memory/mcp/_tools.py
+++ b/src/neo4j_agent_memory/mcp/_tools.py
@@ -254,11 +254,12 @@ def _register_core_tools(mcp: FastMCP) -> None:
         confidence: float = 1.0,
         valid_from: str | None = None,
         valid_until: str | None = None,
+        metadata: dict[str, Any] | None = None,
     ) -> str:
         """Store a subject-predicate-object fact triple.
 
         Records declarative knowledge as a structured triple with optional
-        temporal validity bounds.
+        temporal validity bounds and arbitrary metadata.
 
         Args:
             subject: The subject of the fact (e.g., 'Earth').
@@ -267,6 +268,7 @@ def _register_core_tools(mcp: FastMCP) -> None:
             confidence: Confidence score 0.0-1.0 (default: 1.0).
             valid_from: ISO date string for when this fact becomes valid.
             valid_until: ISO date string for when this fact expires.
+            metadata: Additional metadata (e.g., scope, stack_tags, temporality).
         """
         integration = get_integration(ctx)
         result = await integration.add_fact(
@@ -276,6 +278,7 @@ def _register_core_tools(mcp: FastMCP) -> None:
             confidence=confidence,
             valid_from=valid_from,
             valid_until=valid_until,
+            metadata=metadata,
         )
         return json.dumps(result, default=str)
 


### PR DESCRIPTION
## Summary

- Wire the existing `metadata` parameter through the MCP tool and integration layers for `memory_add_fact`
- `memory_add_entity` already exposes `metadata` at the MCP level, but `memory_add_fact` does not — despite the integration layer (`MemoryIntegration.add_fact`) and storage layer (`LongTermMemory.add_fact`) both accepting and handling it correctly
- This is a 2-file, non-breaking change (optional param, defaults to `None`)

## Changes

**`src/neo4j_agent_memory/mcp/_tools.py`**
- Add `metadata: dict[str, Any] | None = None` parameter to `memory_add_fact`
- Pass it through to `integration.add_fact()`

**`src/neo4j_agent_memory/integration.py`**
- Pass the `metadata` kwarg through to `client.long_term.add_fact()`

## Motivation

Facts and entities are both first-class knowledge primitives, but only entities can carry metadata through the MCP interface. This makes it impossible to tag facts with structured metadata (e.g., scope, confidence levels, technology tags) without dropping to direct Cypher — which `graph_query` blocks for writes.

## Test plan

- [x] Verified `LongTermMemory.add_fact()` already handles metadata (serializes via `_serialize_metadata`, stores on Fact node, deserializes on read)
- [x] Tested round-trip: add fact with metadata via integration layer → read back via Cypher → all fields preserved
- [x] Tested via live MCP server: `memory_add_fact` with metadata → `graph_query` read-back → cleanup via `memory_delete_fact`