### PR TITLE
fix: Inherit BaseMemoryService in Neo4jMemoryService for Google ADK compatibility

### DIFF
--- a/src/neo4j_agent_memory/integrations/google_adk/memory_service.py
+++ b/src/neo4j_agent_memory/integrations/google_adk/memory_service.py
@@ -17,6 +17,7 @@ from neo4j_agent_memory.integrations.google_adk.types import (
     preference_to_memory_entry,
     session_message_from_dict,
 )
+from google.adk.memory.base_memory_service import BaseMemoryService
 
 if TYPE_CHECKING:
     from neo4j_agent_memory import MemoryClient
@@ -24,7 +25,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-class Neo4jMemoryService:
+class Neo4jMemoryService(BaseMemoryService):
     """Neo4j-backed memory service for Google ADK agents.
 
     Implements the ADK MemoryService interface to provide:
@@ -51,7 +52,7 @@ class Neo4jMemoryService:
             await memory_service.add_session_to_memory(session)
 
             # Search memories
-            results = await memory_service.search_memories("project deadline")
+            results = await memory_service.search_memory("project deadline")
 
     Attributes:
         user_id: Optional user identifier for personalization.
@@ -77,6 +78,7 @@ class Neo4jMemoryService:
             include_preferences: Whether to include preferences in search.
             extract_on_store: Whether to extract entities when storing sessions.
         """
+        super().__init__()
         self._client = memory_client
         self._user_id = user_id
         self._include_entities = include_entities
@@ -143,7 +145,7 @@ class Neo4jMemoryService:
 
         logger.debug(f"Stored {len(messages)} messages for session {session_id}")
 
-    async def search_memories(
+    async def search_memory(
         self,
         query: str,
         *,

--- a/src/neo4j_agent_memory/integrations/google_adk/memory_service.py
+++ b/src/neo4j_agent_memory/integrations/google_adk/memory_service.py
@@ -17,7 +17,7 @@ from neo4j_agent_memory.integrations.google_adk.types import (
     preference_to_memory_entry,
     session_message_from_dict,
 )
-from google.adk.memory.base_memory_service import BaseMemoryService
+from google.adk.memory.base_memory_service import BaseMemoryService, SearchMemoryResponse
 
 if TYPE_CHECKING:
     from neo4j_agent_memory import MemoryClient
@@ -154,7 +154,7 @@ class Neo4jMemoryService(BaseMemoryService):
         limit: int = 10,
         threshold: float = 0.7,
         **kwargs: Any,
-    ) -> list[MemoryEntry]:
+    ) -> SearchMemoryResponse:
         """Search across all memory types.
 
         Performs hybrid vector + graph search across messages, entities,
@@ -206,7 +206,7 @@ class Neo4jMemoryService(BaseMemoryService):
 
         # Sort by score (descending) and limit
         results.sort(key=lambda x: x.score or 0, reverse=True)
-        return results[:limit]
+        return SearchMemoryResponse(memories=results[:limit])
 
     async def get_memories_for_session(
         self,


### PR DESCRIPTION
## Description
This PR fixes a critical Pydantic validation error that occurs when attempting to inject `Neo4jMemoryService` into a Google ADK `Runner`.

Currently, instantiating an ADK Runner with this memory service throws the following error:
`Input should be an instance of BaseMemoryService [type=is_instance_of, input_value=<neo4j_agent_memory.integ...>, input_type=Neo4jMemoryService]`

Because ADK uses strict Pydantic type validation, custom memory services must explicitly inherit from `google.adk.memory.base_memory_service.BaseMemoryService`. 

## Changes Made

**Inheritance added:** Imported `BaseMemoryService` and made `Neo4jMemoryService` inherit from it. Added `super().__init__()` to the constructor.
**Method signature aligned:** Renamed `search_memories` to `search_memory` to properly fulfill the abstract method requirements enforced by ADK's `BaseMemoryService`.
**Docstring updated:** Updated the Example docstring to reflect the `search_memory` naming change.


## Steps to Test

Create a Google ADK `LlmAgent`.
Initialize `Neo4jMemoryService`.
Pass the memory service into an ADK `Runner(..., memory_service=neo4j_memory_service)`.
The Runner will successfully initialize without raising a Pydantic `ValidationError`