### PR TITLE
allow MemorySettings.llm=None for non-LLM pipelines

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -327,6 +327,7 @@ jobs:
             tests/examples/test_llamaindex_example.py \
             tests/examples/test_aws_financial_advisor.py \
             tests/examples/test_domain_schemas.py \
+            tests/examples/test_no_llm_example.py \
             -v \
             --tb=short \
             --timeout=60

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Optional LLM (`llm=None`)**: `MemorySettings.llm` is now `Optional[LLMConfig]`. Pass `llm=None` to construct a fully working `MemoryClient` without any LLM provider — useful for air-gapped environments, deployments without an `OPENAI_API_KEY`, and deterministic local-only extraction. A new `examples/no_llm/` example and a "Run Without an LLM" how-to guide demonstrate the spaCy/GLiNER-only setup.
+
+### Changed
+
+- **Validator on `MemorySettings`**: setting `llm=None` together with `extraction.extractor_type=ExtractorType.LLM` or `extraction.enable_llm_fallback=True` now raises a `ValidationError` at construction time, naming both fields and suggesting the minimal fix. Omitting the `llm` field entirely preserves the historical default of auto-filling an `LLMConfig` when an LLM stage is enabled, so existing code is unaffected.
+
 ## [0.1.1] - 2026-04-23
 
 ### Added

--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -17,6 +17,7 @@
 *** xref:how-to/preferences.adoc[Manage Preferences]
 *** xref:how-to/reasoning-traces.adoc[Record Reasoning Traces]
 *** xref:how-to/entity-extraction.adoc[Configure Entity Extraction]
+*** xref:how-to/running-without-an-llm.adoc[Run Without an LLM]
 *** xref:how-to/batch-processing.adoc[Batch Processing]
 *** xref:how-to/deduplication.adoc[Handle Duplicates]
 *** Integrations

--- a/docs/modules/ROOT/pages/how-to/index.adoc
+++ b/docs/modules/ROOT/pages/how-to/index.adoc
@@ -47,6 +47,9 @@ Automatically extract entities and relationships to populate your context graph 
 | xref:how-to/entity-extraction.adoc[Configure Entity Extraction]
 | Set up spaCy, GLiNER, or LLM extractors. Create custom domain schemas for financial services, ecommerce, or any industry. Build multi-stage pipelines.
 
+| xref:how-to/running-without-an-llm.adoc[Run Without an LLM]
+| Use spaCy/GLiNER-only extraction with `llm=None`. Run in air-gapped environments or without an OpenAI key.
+
 | xref:how-to/batch-processing.adoc[Process Documents in Batch]
 | Extract entities from large document collections efficiently. Handle streaming for long documents. Import product catalogs or financial reports.
 

--- a/docs/modules/ROOT/pages/how-to/running-without-an-llm.adoc
+++ b/docs/modules/ROOT/pages/how-to/running-without-an-llm.adoc
@@ -1,0 +1,99 @@
+= Run Without an LLM
+:page-product: agent-memory
+:page-pagination:
+:toc: right
+:toclevels: 3
+:sectanchors:
+:sectlinks:
+:icons: font
+:source-highlighter: highlight.js
+
+How to use `neo4j-agent-memory` with no LLM provider — useful for air-gapped deployments, environments without an `OPENAI_API_KEY`, or when you want fully deterministic, free, local extraction.
+
+== Overview
+
+`MemorySettings.llm` is `Optional[LLMConfig]`. Set it to `None` to opt out of all LLM construction. Combine that with a local embedder (sentence-transformers) and a local extractor (spaCy and/or GLiNER) to get a working `MemoryClient` that never imports `openai`.
+
+== Prerequisites
+
+[source,bash]
+----
+pip install "neo4j-agent-memory[extraction,sentence-transformers]"
+python -m spacy download en_core_web_sm
+----
+
+You also need a running Neo4j instance.
+
+== Configuration
+
+[source,python]
+----
+from pydantic import SecretStr
+
+from neo4j_agent_memory import MemoryClient, MemorySettings, Neo4jConfig
+from neo4j_agent_memory.config.settings import (
+    EmbeddingConfig, EmbeddingProvider,
+    ExtractionConfig, ExtractorType,
+)
+
+settings = MemorySettings(
+    neo4j=Neo4jConfig(uri="bolt://localhost:7687", password=SecretStr("password")),
+    llm=None,                                         # <1>
+    embedding=EmbeddingConfig(
+        provider=EmbeddingProvider.SENTENCE_TRANSFORMERS,
+        model="all-MiniLM-L6-v2",
+        dimensions=384,
+    ),
+    extraction=ExtractionConfig(
+        extractor_type=ExtractorType.PIPELINE,
+        enable_spacy=True,
+        enable_gliner=True,
+        enable_llm_fallback=False,                    # <2>
+    ),
+)
+
+async with MemoryClient(settings) as memory:
+    await memory.short_term.add_message("session-1", "user", "John works at Acme")
+    print(await memory.get_context("Tell me about John"))
+----
+<1> Explicit opt-out — no LLM client is ever constructed.
+<2> Required when `llm=None` — see <<validation>>.
+
+[[validation]]
+== Validation rules
+
+`MemorySettings` raises a `ValidationError` at construction time if you set `llm=None` together with extraction settings that require an LLM:
+
+* `extraction.extractor_type == ExtractorType.LLM`, or
+* `extraction.enable_llm_fallback is True`.
+
+The error message names both fields and points at the minimal fix.
+
+If you _omit_ the `llm` field altogether (rather than passing `None`), the package keeps its historical behavior of auto-filling a default `LLMConfig` when an LLM stage is enabled — so existing code that relies on the default doesn't break.
+
+== Default behavior summary
+
+[cols="2,1,3", options="header"]
+|===
+| Configuration | LLM constructed? | Notes
+
+| `llm=None` + `extractor_type=SPACY/GLINER/NONE`, `enable_llm_fallback=False`
+| No
+| Fully local; `openai` is never imported.
+
+| `llm=None` + LLM-dependent extractor
+| —
+| `ValidationError` at construction time.
+
+| `llm` omitted + default `ExtractionConfig` (LLM fallback on)
+| Yes (default `LLMConfig`)
+| Backwards-compatible default — same as before this change.
+
+| `llm` omitted + non-LLM extractor
+| No
+| Validator skips the auto-fill since no LLM stage is enabled.
+|===
+
+== Worked example
+
+A runnable script lives at `examples/no_llm/main.py` in the repository.

--- a/docs/modules/ROOT/pages/reference/configuration.adoc
+++ b/docs/modules/ROOT/pages/reference/configuration.adoc
@@ -483,7 +483,7 @@ NAM_RESOLUTION__SEMANTIC_THRESHOLD=0.9
 
 == LLM Configuration
 
-Settings for LLM-based operations.
+Settings for LLM-based operations. The `llm` field on `MemorySettings` is `Optional[LLMConfig]`. Set `llm=None` to opt out of all LLM construction — see xref:how-to/running-without-an-llm.adoc[Run Without an LLM].
 
 === Python Configuration
 
@@ -500,6 +500,11 @@ llm_config = LLMConfig(
     max_tokens=4096,
 )
 ----
+
+[NOTE]
+====
+If you set `MemorySettings(llm=None, ...)` together with `extraction.extractor_type=LLM` or `extraction.enable_llm_fallback=True`, `MemorySettings` raises a `ValidationError` at construction time. Either provide an `LLMConfig` or switch to a non-LLM extractor (`SPACY`, `GLINER`, `NONE`) and disable the LLM fallback.
+====
 
 === Environment Variables
 

--- a/examples/no_llm/README.md
+++ b/examples/no_llm/README.md
@@ -1,0 +1,46 @@
+# Running without an LLM
+
+This example shows how to use `neo4j-agent-memory` with no LLM provider — useful for:
+
+- Air-gapped or offline environments
+- Deployments without an `OPENAI_API_KEY`
+- Deterministic, free, fully-local extraction
+
+The key configuration is:
+
+```python
+settings = MemorySettings(
+    neo4j=Neo4jConfig(...),
+    llm=None,                                # explicit opt-out
+    embedding=EmbeddingConfig(
+        provider=EmbeddingProvider.SENTENCE_TRANSFORMERS,
+        model="all-MiniLM-L6-v2",
+        dimensions=384,
+    ),
+    extraction=ExtractionConfig(
+        extractor_type=ExtractorType.PIPELINE,
+        enable_spacy=True,
+        enable_gliner=True,
+        enable_llm_fallback=False,           # required when llm=None
+    ),
+)
+```
+
+If you set `llm=None` together with an LLM-dependent extractor (`extractor_type=LLM` or `enable_llm_fallback=True`), `MemorySettings` raises a `ValidationError` at construction time naming both fields.
+
+## Setup
+
+```bash
+pip install "neo4j-agent-memory[extraction,sentence-transformers]"
+python -m spacy download en_core_web_sm
+```
+
+Start Neo4j however you like (Docker, Aura, local). Set `NEO4J_URI` / `NEO4J_PASSWORD` if not using `bolt://localhost:7687` with the default `password`.
+
+## Run
+
+```bash
+python main.py
+```
+
+You should see a printed memory context with no calls to OpenAI and no need for any API key.

--- a/examples/no_llm/main.py
+++ b/examples/no_llm/main.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Run neo4j-agent-memory with no LLM provider.
+
+This example shows how to use neo4j-agent-memory in air-gapped environments,
+or when you simply don't want to call an LLM:
+
+- ``llm=None`` on ``MemorySettings`` — no OpenAI client is ever constructed.
+- A local embedder (sentence-transformers) — no embeddings API is called.
+- A local extractor pipeline (spaCy + GLiNER) with the LLM fallback disabled.
+
+Requirements:
+
+    pip install "neo4j-agent-memory[extraction,sentence-transformers]"
+    python -m spacy download en_core_web_sm
+
+Set ``NEO4J_URI`` / ``NEO4J_PASSWORD`` if you're not using ``bolt://localhost:7687``
+with the default ``password``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+
+from pydantic import SecretStr
+
+from neo4j_agent_memory import MemoryClient, MemorySettings, Neo4jConfig
+from neo4j_agent_memory.config.settings import (
+    EmbeddingConfig,
+    EmbeddingProvider,
+    ExtractionConfig,
+    ExtractorType,
+)
+
+
+def build_settings() -> MemorySettings:
+    return MemorySettings(
+        neo4j=Neo4jConfig(
+            uri=os.getenv("NEO4J_URI", "bolt://localhost:7687"),
+            username=os.getenv("NEO4J_USERNAME", "neo4j"),
+            password=SecretStr(os.getenv("NEO4J_PASSWORD", "password")),
+        ),
+        # Explicit opt-out: never construct an LLM client.
+        llm=None,
+        embedding=EmbeddingConfig(
+            provider=EmbeddingProvider.SENTENCE_TRANSFORMERS,
+            model="all-MiniLM-L6-v2",
+            dimensions=384,
+        ),
+        # Local extraction only. enable_llm_fallback=False is required when
+        # llm=None — otherwise MemorySettings raises a ValidationError.
+        extraction=ExtractionConfig(
+            extractor_type=ExtractorType.PIPELINE,
+            enable_spacy=True,
+            enable_gliner=True,
+            enable_llm_fallback=False,
+        ),
+    )
+
+
+async def main() -> None:
+    settings = build_settings()
+    assert settings.llm is None, "expected llm=None to be preserved"
+
+    async with MemoryClient(settings) as memory:
+        session_id = "no-llm-demo"
+
+        await memory.short_term.add_message(
+            session_id, "user", "John Smith works at Acme Corp in New York."
+        )
+        await memory.short_term.add_message(
+            session_id, "assistant", "Got it — I'll remember John and Acme Corp."
+        )
+
+        context = await memory.get_context("What do we know about John?", session_id=session_id)
+        print(context)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/src/neo4j_agent_memory/config/settings.py
+++ b/src/neo4j_agent_memory/config/settings.py
@@ -446,7 +446,8 @@ class MemorySettings(BaseSettings):
                     f"extractor_type={ext.extractor_type.value}, "
                     f"enable_llm_fallback={ext.enable_llm_fallback}. "
                     "Either provide an LLMConfig, or set extractor_type to "
-                    "ExtractorType.SPACY/GLINER/NONE and enable_llm_fallback=False."
+                    "ExtractorType.SPACY/GLINER/PIPELINE/NONE and "
+                    "enable_llm_fallback=False."
                 )
             # Lenient fallback preserves pre-0.2 default behavior when the user
             # didn't explicitly opt out.

--- a/src/neo4j_agent_memory/config/settings.py
+++ b/src/neo4j_agent_memory/config/settings.py
@@ -3,7 +3,7 @@
 from enum import Enum
 from typing import Any
 
-from pydantic import BaseModel, Field, SecretStr
+from pydantic import BaseModel, Field, SecretStr, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -123,7 +123,13 @@ class EmbeddingConfig(BaseModel):
 
 
 class LLMConfig(BaseModel):
-    """LLM provider configuration for extraction."""
+    """LLM provider configuration for extraction.
+
+    This config is optional on `MemorySettings`. Set ``MemorySettings.llm=None``
+    to run without any LLM provider (e.g. spaCy/GLiNER-only extraction in
+    air-gapped or no-API-key environments). See the "Running without an LLM"
+    how-to and ``examples/no_llm/`` for a worked example.
+    """
 
     provider: LLMProvider = Field(default=LLMProvider.OPENAI, description="LLM provider to use")
     model: str = Field(default="gpt-4o-mini", description="LLM model name")
@@ -419,7 +425,7 @@ class MemorySettings(BaseSettings):
 
     neo4j: Neo4jConfig = Field(default_factory=lambda: Neo4jConfig(password=SecretStr("")))
     embedding: EmbeddingConfig = Field(default_factory=EmbeddingConfig)
-    llm: LLMConfig = Field(default_factory=LLMConfig)
+    llm: LLMConfig | None = Field(default=None)
     schema_config: SchemaConfig = Field(default_factory=SchemaConfig)
     extraction: ExtractionConfig = Field(default_factory=ExtractionConfig)
     resolution: ResolutionConfig = Field(default_factory=ResolutionConfig)
@@ -427,6 +433,25 @@ class MemorySettings(BaseSettings):
     search: SearchConfig = Field(default_factory=SearchConfig)
     geocoding: GeocodingConfig = Field(default_factory=GeocodingConfig)
     enrichment: EnrichmentConfig = Field(default_factory=EnrichmentConfig)
+
+    @model_validator(mode="after")
+    def _validate_llm_consistency(self) -> "MemorySettings":
+        ext = self.extraction
+        needs_llm = ext.extractor_type == ExtractorType.LLM or ext.enable_llm_fallback
+        if needs_llm and self.llm is None:
+            # Distinguish explicit `llm=None` (strict) from "user didn't mention llm".
+            if "llm" in self.model_fields_set:
+                raise ValueError(
+                    "llm=None is incompatible with extraction settings: "
+                    f"extractor_type={ext.extractor_type.value}, "
+                    f"enable_llm_fallback={ext.enable_llm_fallback}. "
+                    "Either provide an LLMConfig, or set extractor_type to "
+                    "ExtractorType.SPACY/GLINER/NONE and enable_llm_fallback=False."
+                )
+            # Lenient fallback preserves pre-0.2 default behavior when the user
+            # didn't explicitly opt out.
+            self.llm = LLMConfig()
+        return self
 
     @classmethod
     def from_dict(cls, config: dict[str, Any]) -> "MemorySettings":

--- a/src/neo4j_agent_memory/config/settings.py
+++ b/src/neo4j_agent_memory/config/settings.py
@@ -437,7 +437,13 @@ class MemorySettings(BaseSettings):
     @model_validator(mode="after")
     def _validate_llm_consistency(self) -> "MemorySettings":
         ext = self.extraction
-        needs_llm = ext.extractor_type == ExtractorType.LLM or ext.enable_llm_fallback
+        needs_llm = (
+            ext.extractor_type == ExtractorType.LLM
+            or (
+                ext.extractor_type == ExtractorType.PIPELINE
+                and ext.enable_llm_fallback
+            )
+        )
         if needs_llm and self.llm is None:
             # Distinguish explicit `llm=None` (strict) from "user didn't mention llm".
             if "llm" in self.model_fields_set:

--- a/src/neo4j_agent_memory/config/settings.py
+++ b/src/neo4j_agent_memory/config/settings.py
@@ -437,12 +437,8 @@ class MemorySettings(BaseSettings):
     @model_validator(mode="after")
     def _validate_llm_consistency(self) -> "MemorySettings":
         ext = self.extraction
-        needs_llm = (
-            ext.extractor_type == ExtractorType.LLM
-            or (
-                ext.extractor_type == ExtractorType.PIPELINE
-                and ext.enable_llm_fallback
-            )
+        needs_llm = ext.extractor_type == ExtractorType.LLM or (
+            ext.extractor_type == ExtractorType.PIPELINE and ext.enable_llm_fallback
         )
         if needs_llm and self.llm is None:
             # Distinguish explicit `llm=None` (strict) from "user didn't mention llm".

--- a/tests/examples/test_no_llm_example.py
+++ b/tests/examples/test_no_llm_example.py
@@ -1,0 +1,83 @@
+"""Smoke tests for the no_llm example (T7).
+
+Validates structure, imports, and the configuration produced by
+``examples/no_llm/main.py``. This test does NOT require Neo4j and runs in
+CI's ``example-tests-quick`` job.
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+EXAMPLES_DIR = Path(__file__).parent.parent.parent / "examples"
+NO_LLM_DIR = EXAMPLES_DIR / "no_llm"
+
+
+class TestNoLLMExample:
+    def test_example_file_exists(self):
+        assert (NO_LLM_DIR / "main.py").exists()
+        assert (NO_LLM_DIR / "README.md").exists()
+
+    def test_example_compiles(self):
+        """The example must be syntactically valid Python."""
+        source = (NO_LLM_DIR / "main.py").read_text()
+        ast.parse(source)
+
+    def test_example_imports_work(self):
+        """All imports referenced by the example must resolve."""
+        from neo4j_agent_memory import MemoryClient, MemorySettings, Neo4jConfig
+        from neo4j_agent_memory.config.settings import (
+            EmbeddingConfig,
+            EmbeddingProvider,
+            ExtractionConfig,
+            ExtractorType,
+        )
+
+        assert MemoryClient is not None
+        assert MemorySettings is not None
+        assert Neo4jConfig is not None
+        assert EmbeddingConfig is not None
+        assert EmbeddingProvider.SENTENCE_TRANSFORMERS is not None
+        assert ExtractionConfig is not None
+        assert ExtractorType.PIPELINE is not None
+
+    def test_build_settings_produces_llm_none(self, monkeypatch):
+        """The example's build_settings() must produce a settings object with llm=None."""
+        # Avoid relying on a live Neo4j — `build_settings()` only constructs the
+        # config object, no connection is made here.
+        monkeypatch.setenv("NEO4J_URI", "bolt://localhost:7687")
+        monkeypatch.setenv("NEO4J_USERNAME", "neo4j")
+        monkeypatch.setenv("NEO4J_PASSWORD", "password")
+
+        spec = importlib.util.spec_from_file_location("no_llm_example_main", NO_LLM_DIR / "main.py")
+        assert spec is not None and spec.loader is not None
+        module = importlib.util.module_from_spec(spec)
+        # Don't keep the module around in sys.modules across tests.
+        try:
+            spec.loader.exec_module(module)
+            settings = module.build_settings()
+            assert settings.llm is None
+            assert settings.extraction.enable_llm_fallback is False
+            assert settings.embedding.provider.value == "sentence_transformers"
+        finally:
+            sys.modules.pop("no_llm_example_main", None)
+
+    def test_example_uses_explicit_llm_none(self):
+        """Sanity check: the example demonstrates the ``llm=None`` opt-out."""
+        source = (NO_LLM_DIR / "main.py").read_text()
+        assert "llm=None" in source
+        assert "enable_llm_fallback=False" in source
+
+    @pytest.mark.requires_neo4j
+    def test_example_runs_end_to_end(self):
+        """End-to-end run requires Neo4j; gated behind the requires_neo4j marker."""
+        # Intentionally a placeholder; the integration suite covers the
+        # round-trip in tests/integration/test_memory_client_no_llm.py. We
+        # mark this test so the example-tests CI job (which has Neo4j) can
+        # opt in if desired without forcing the quick job to spin one up.
+        pytest.skip("Covered by tests/integration/test_memory_client_no_llm.py")

--- a/tests/integration/test_memory_client_no_llm.py
+++ b/tests/integration/test_memory_client_no_llm.py
@@ -1,0 +1,127 @@
+"""Integration tests for running MemoryClient with no LLM provider.
+
+Validates the optional-LLM path end-to-end:
+
+- T5: a freshly constructed MemoryClient with `llm=None` and a non-OpenAI
+  embedder must not import the `openai` module along the LLM-extraction path.
+  We assert this in a subprocess to avoid false positives from other tests
+  that may have already imported `openai` in the parent process.
+- T6: `get_context` works end-to-end with `llm=None`. Today none of the
+  `get_context` paths call an LLM, so this test documents the current
+  behavior. If reasoning summarization is added later, that feature will
+  gain its own guard and a corresponding test.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import textwrap
+
+import pytest
+from pydantic import SecretStr
+
+from neo4j_agent_memory import MemoryClient, MemorySettings, Neo4jConfig
+from neo4j_agent_memory.config.settings import (
+    EmbeddingConfig,
+    EmbeddingProvider,
+    ExtractionConfig,
+    ExtractorType,
+)
+
+
+def _build_settings(neo4j_connection_info) -> MemorySettings:
+    return MemorySettings(
+        neo4j=Neo4jConfig(
+            uri=neo4j_connection_info["uri"],
+            username=neo4j_connection_info["username"],
+            password=SecretStr(neo4j_connection_info["password"]),
+        ),
+        llm=None,
+        embedding=EmbeddingConfig(
+            provider=EmbeddingProvider.SENTENCE_TRANSFORMERS,
+            model="all-MiniLM-L6-v2",
+            dimensions=384,
+        ),
+        extraction=ExtractionConfig(
+            extractor_type=ExtractorType.NONE,
+            enable_llm_fallback=False,
+        ),
+    )
+
+
+@pytest.mark.integration
+class TestMemoryClientNoLLM:
+    @pytest.mark.asyncio
+    async def test_get_context_works_without_llm(
+        self, neo4j_connection_info, mock_embedder, session_id
+    ):
+        """T6: end-to-end add_message + get_context with llm=None succeeds."""
+        settings = _build_settings(neo4j_connection_info)
+
+        async with MemoryClient(settings, embedder=mock_embedder) as client:
+            assert client._settings.llm is None
+
+            await client.short_term.add_message(session_id, "user", "John works at Acme in NYC")
+            context = await client.get_context("Tell me about John")
+            assert isinstance(context, str)
+
+    def test_no_openai_import_with_llm_none(self, neo4j_connection_info):
+        """T5: constructing+connecting a client with llm=None must not import openai."""
+        script = textwrap.dedent(
+            f"""
+            import asyncio, sys
+            from pydantic import SecretStr
+            from neo4j_agent_memory import MemoryClient, MemorySettings, Neo4jConfig
+            from neo4j_agent_memory.config.settings import (
+                EmbeddingConfig, EmbeddingProvider,
+                ExtractionConfig, ExtractorType,
+            )
+
+            settings = MemorySettings(
+                neo4j=Neo4jConfig(
+                    uri={neo4j_connection_info["uri"]!r},
+                    username={neo4j_connection_info["username"]!r},
+                    password=SecretStr({neo4j_connection_info["password"]!r}),
+                ),
+                llm=None,
+                embedding=EmbeddingConfig(
+                    provider=EmbeddingProvider.SENTENCE_TRANSFORMERS,
+                    model="all-MiniLM-L6-v2",
+                    dimensions=384,
+                ),
+                extraction=ExtractionConfig(
+                    extractor_type=ExtractorType.NONE,
+                    enable_llm_fallback=False,
+                ),
+            )
+
+            async def main():
+                async with MemoryClient(settings) as client:
+                    await client.short_term.add_message(
+                        "no-llm-smoke", "user", "Hello"
+                    )
+
+            asyncio.run(main())
+
+            # Subprocess assertion: no openai SDK module loaded along this path.
+            offenders = [m for m in sys.modules if m == "openai" or m.startswith("openai.")]
+            if offenders:
+                print("OPENAI_LOADED:" + ",".join(sorted(offenders)))
+                sys.exit(1)
+            print("OK")
+            """
+        )
+
+        result = subprocess.run(
+            [sys.executable, "-c", script],
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+        if result.returncode != 0:
+            pytest.fail(
+                f"no-llm subprocess failed:\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+            )
+        assert "OK" in result.stdout
+        assert "OPENAI_LOADED" not in result.stdout

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,6 +1,7 @@
 """Unit tests for configuration."""
 
-from pydantic import SecretStr
+import pytest
+from pydantic import SecretStr, ValidationError
 
 from neo4j_agent_memory.config.settings import (
     EmbeddingConfig,
@@ -9,6 +10,7 @@ from neo4j_agent_memory.config.settings import (
     ExtractorType,
     GeocodingConfig,
     GeocodingProvider,
+    LLMConfig,
     MemorySettings,
     Neo4jConfig,
     ResolutionConfig,
@@ -224,3 +226,94 @@ class TestMemorySettings:
         assert settings.geocoding.enabled is True
         assert settings.geocoding.provider == GeocodingProvider.GOOGLE
         assert settings.geocoding.api_key.get_secret_value() == "google-api-key"
+
+
+class TestMemorySettingsOptionalLLM:
+    """Tests for the optional `llm` field on MemorySettings."""
+
+    def test_llm_none_with_spacy_only_extractor(self):
+        """T1: explicit llm=None with a non-LLM extractor is accepted."""
+        settings = MemorySettings(
+            neo4j=Neo4jConfig(password=SecretStr("test")),
+            llm=None,
+            extraction=ExtractionConfig(
+                extractor_type=ExtractorType.SPACY,
+                enable_llm_fallback=False,
+            ),
+        )
+        assert settings.llm is None
+
+    def test_default_settings_auto_fill_llm(self):
+        """T2: omitting `llm` preserves the historical default LLMConfig.
+
+        The default ExtractionConfig has enable_llm_fallback=True, so the
+        validator's lenient branch fills in a default LLMConfig.
+        """
+        settings = MemorySettings(neo4j=Neo4jConfig(password=SecretStr("test")))
+        assert isinstance(settings.llm, LLMConfig)
+
+    def test_default_llm_skipped_when_not_needed(self):
+        """T2b: omitting `llm` and using a non-LLM extractor leaves llm=None.
+
+        No auto-fill when no LLM stage is enabled — avoids surprise OpenAI
+        client construction in air-gapped/no-key environments.
+        """
+        settings = MemorySettings(
+            neo4j=Neo4jConfig(password=SecretStr("test")),
+            extraction=ExtractionConfig(
+                extractor_type=ExtractorType.SPACY,
+                enable_llm_fallback=False,
+            ),
+        )
+        assert settings.llm is None
+
+    def test_llm_none_with_llm_extractor_raises(self):
+        """T3: llm=None + extractor_type=LLM is a ValidationError."""
+        with pytest.raises(ValidationError) as excinfo:
+            MemorySettings(
+                neo4j=Neo4jConfig(password=SecretStr("test")),
+                llm=None,
+                extraction=ExtractionConfig(extractor_type=ExtractorType.LLM),
+            )
+        msg = str(excinfo.value)
+        assert "llm" in msg
+        assert "extractor_type" in msg or "LLM" in msg
+
+    def test_llm_none_with_fallback_enabled_raises(self):
+        """T4: llm=None + enable_llm_fallback=True is a ValidationError."""
+        with pytest.raises(ValidationError) as excinfo:
+            MemorySettings(
+                neo4j=Neo4jConfig(password=SecretStr("test")),
+                llm=None,
+                extraction=ExtractionConfig(
+                    extractor_type=ExtractorType.PIPELINE,
+                    enable_llm_fallback=True,
+                ),
+            )
+        msg = str(excinfo.value)
+        assert "llm" in msg
+        assert "enable_llm_fallback" in msg
+
+    def test_llm_none_with_pipeline_no_fallback_ok(self):
+        """T4b: pipeline with LLM fallback disabled accepts llm=None."""
+        settings = MemorySettings(
+            neo4j=Neo4jConfig(password=SecretStr("test")),
+            llm=None,
+            extraction=ExtractionConfig(
+                extractor_type=ExtractorType.PIPELINE,
+                enable_spacy=True,
+                enable_gliner=True,
+                enable_llm_fallback=False,
+            ),
+        )
+        assert settings.llm is None
+        assert settings.extraction.enable_llm_fallback is False
+
+    def test_explicit_llm_config_passes_through(self):
+        """User-provided LLMConfig is preserved verbatim."""
+        custom = LLMConfig(model="gpt-4o", api_key=SecretStr("sk-test"))
+        settings = MemorySettings(
+            neo4j=Neo4jConfig(password=SecretStr("test")),
+            llm=custom,
+        )
+        assert settings.llm is custom

--- a/uv.lock
+++ b/uv.lock
@@ -4567,7 +4567,7 @@ wheels = [
 
 [[package]]
 name = "neo4j-agent-memory"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "neo4j" },


### PR DESCRIPTION
## Summary

- `MemorySettings.llm` is now `Optional[LLMConfig]` (default `None`), letting users construct a fully working `MemoryClient` without any LLM provider — for air-gapped deployments, environments without an `OPENAI_API_KEY`, or deterministic local-only extraction.
- A new `@model_validator(mode="after")` distinguishes explicit `llm=None` (strict — raises `ValidationError` if the extraction config still requires an LLM, naming both fields) from "user didn't mention `llm`" (lenient — auto-fills a default `LLMConfig` only when an LLM stage is enabled). Existing callers are unaffected.
- New `examples/no_llm/` walkthrough (sentence-transformers + spaCy + GLiNER, `enable_llm_fallback=False`) plus a "Run Without an LLM" how-to in the docs.

Closes the bug reported in `johnymontana/agent-memory-example-no-llm` (`reproduce_bug.py`): users can now pass `llm=None` without hitting `Input should be a valid dictionary or instance of LLMConfig`.

## Test plan

- [x] `make lint` / `ruff format --check` — clean on all touched files.
- [x] `mypy src/neo4j_agent_memory/config/settings.py` — clean (no new errors anywhere in `src`).
- [x] `pytest tests/unit` — 907 passed, 3 skipped. Includes 7 new cases under `TestMemorySettingsOptionalLLM` (T1–T4 + permissive/strict variants).
- [x] `pytest tests/examples/test_no_llm_example.py` — 5 passed, 1 skipped (the skipped end-to-end case is covered by the integration suite).
- [ ] `pytest tests/integration/test_memory_client_no_llm.py` — covers T5 (subprocess asserts `openai` is never imported with `llm=None`) and T6 (`get_context` round-trip succeeds). Requires Neo4j; runs in the `example-tests` / `integration-test` CI jobs.
- [ ] Manual smoke: `unset OPENAI_API_KEY && uv run python examples/no_llm/main.py` against a local Neo4j — expect a printed context string with no exceptions and no OpenAI client construction.
- [ ] Re-run the user-supplied `reproduce_bug.py` against this branch — expect it to succeed.