### PR TITLE
fix: self-terminate orphaned stdio MCP servers when parent dies

### DIFF
--- a/src/neo4j_agent_memory/cli/main.py
+++ b/src/neo4j_agent_memory/cli/main.py
@@ -758,6 +758,22 @@ def mcp():
     default=False,
     help="Disable automatic preference detection.",
 )
+@click.option(
+    "--no-parent-death-check",
+    is_flag=True,
+    default=False,
+    help=(
+        "Disable parent-death detection on stdio transport. By default, "
+        "the server self-terminates if its parent process exits (avoids "
+        "orphaned servers when an MCP client crashes)."
+    ),
+)
+@click.option(
+    "--parent-death-poll-interval",
+    type=float,
+    default=5.0,
+    help="Seconds between parent-process checks (default: 5.0).",
+)
 def mcp_serve(
     uri: str,
     user: str,
@@ -771,6 +787,8 @@ def mcp_serve(
     user_id: str | None,
     observation_threshold: int,
     no_auto_preferences: bool,
+    no_parent_death_check: bool,
+    parent_death_poll_interval: float,
 ):
     """Start the MCP server for Claude Desktop and other MCP hosts.
 
@@ -820,6 +838,8 @@ def mcp_serve(
             user_id=user_id,
             observation_threshold=observation_threshold,
             auto_preferences=not no_auto_preferences,
+            parent_death_check=not no_parent_death_check,
+            parent_death_poll_interval=parent_death_poll_interval,
         )
     )
 

--- a/src/neo4j_agent_memory/mcp/_lifecycle.py
+++ b/src/neo4j_agent_memory/mcp/_lifecycle.py
@@ -1,0 +1,131 @@
+"""Lifecycle helpers for MCP servers running over stdio.
+
+When an MCP client (e.g. Claude Code, Claude Desktop, Cursor) crashes or is
+killed without closing its end of the stdio pipe, the spawned server is
+reparented to ``init``/``launchd`` (PID 1) and keeps holding the Neo4j
+connection, file handles, and memory indefinitely. This module provides a
+lightweight watchdog that detects that condition and lets the server exit
+cleanly so the lifespan can release its resources.
+
+The watchdog is only meaningful for the stdio transport. For network
+transports (SSE/HTTP) the server is intended to outlive its starter, so
+``run_with_watchdog`` should not be used.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+import os
+import signal
+import sys
+from collections.abc import Awaitable
+
+logger = logging.getLogger(__name__)
+
+
+def _is_windows() -> bool:
+    return sys.platform == "win32"
+
+
+async def _parent_death_loop(poll_interval: float) -> None:
+    """Return when the parent process has exited.
+
+    ``getppid()`` returns 1 on Unix once the original parent dies and the
+    process is reparented to init/launchd. A value of 0 is treated the same
+    way for safety on platforms that report it that way under unusual
+    conditions.
+    """
+    initial_ppid = os.getppid()
+    logger.debug("MCP parent-death watcher started (initial ppid=%d)", initial_ppid)
+    while True:
+        await asyncio.sleep(poll_interval)
+        ppid = os.getppid()
+        if ppid in (0, 1):
+            logger.warning(
+                "MCP parent process exited (ppid=%d); initiating self-termination",
+                ppid,
+            )
+            return
+
+
+def _install_cancel_signal_handlers(
+    loop: asyncio.AbstractEventLoop,
+    target: asyncio.Task[object],
+) -> None:
+    """Cancel ``target`` on SIGTERM/SIGHUP/SIGPIPE so the lifespan can clean up."""
+    if _is_windows():
+        return
+    for sig in (signal.SIGTERM, signal.SIGHUP, signal.SIGPIPE):
+        try:
+            loop.add_signal_handler(sig, target.cancel)
+        except (NotImplementedError, RuntimeError, ValueError):
+            # Some environments (subinterpreters, non-main threads) can't install
+            # signal handlers. The watchdog still provides parent-death coverage.
+            logger.debug("Could not install handler for signal %s", sig)
+
+
+async def run_with_watchdog(
+    server_coro: Awaitable[None],
+    *,
+    poll_interval: float = 5.0,
+    install_signals: bool = True,
+) -> None:
+    """Run ``server_coro`` alongside a parent-death watchdog.
+
+    Returns when either:
+
+    * the server coroutine completes (normal exit or exception), or
+    * the parent process dies (``getppid()`` becomes 1 / 0), in which case
+      the server task is cancelled and the surrounding lifespan exits cleanly.
+
+    On Windows or when running outside a usable event-loop signal context,
+    parts of the watchdog degrade to no-ops; the server coroutine still runs.
+    """
+    if _is_windows():
+        # Parent-death detection via getppid() is unreliable on Windows.
+        # Run the server coroutine unchanged.
+        await server_coro
+        return
+
+    server_task: asyncio.Task[object] = asyncio.create_task(_await(server_coro), name="mcp-server")
+    watchdog_task: asyncio.Task[None] = asyncio.create_task(
+        _parent_death_loop(poll_interval), name="mcp-parent-death-watchdog"
+    )
+
+    if install_signals:
+        loop = asyncio.get_running_loop()
+        _install_cancel_signal_handlers(loop, server_task)
+
+    try:
+        done, pending = await asyncio.wait(
+            {server_task, watchdog_task},
+            return_when=asyncio.FIRST_COMPLETED,
+        )
+    except BaseException:
+        server_task.cancel()
+        watchdog_task.cancel()
+        raise
+
+    for task in pending:
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
+
+    if watchdog_task in done and server_task not in done:
+        logger.info("MCP server self-terminated: parent process is gone")
+        return
+
+    # Server completed (normally or with an error). Propagate exceptions.
+    for task in done:
+        if task is watchdog_task:
+            continue
+        exc = task.exception()
+        if exc is not None:
+            raise exc
+
+
+async def _await(coro: Awaitable[None]) -> None:
+    """Tiny shim so ``asyncio.create_task`` accepts a generic Awaitable."""
+    await coro

--- a/src/neo4j_agent_memory/mcp/server.py
+++ b/src/neo4j_agent_memory/mcp/server.py
@@ -215,6 +215,8 @@ try:
         user_id: str | None = None,
         observation_threshold: int = 30000,
         auto_preferences: bool = True,
+        parent_death_check: bool = True,
+        parent_death_poll_interval: float = 5.0,
     ) -> None:
         """Run the MCP server with Neo4j connection.
 
@@ -233,6 +235,12 @@ try:
             user_id: User identifier for session strategies.
             observation_threshold: Token threshold for observer compression.
             auto_preferences: Whether to auto-detect preferences.
+            parent_death_check: When True (default) and using the stdio
+                transport, the server self-terminates if its parent process
+                exits (reparented to PID 1). Has no effect for SSE/HTTP
+                transports, which are expected to outlive their starter.
+            parent_death_poll_interval: Seconds between parent-process checks.
+                Only used when ``parent_death_check`` is True.
         """
         from pydantic import SecretStr
 
@@ -262,6 +270,13 @@ try:
             await server.run_async(transport="sse", host=host, port=port)
         elif transport == "http":
             await server.run_async(transport="http", host=host, port=port)
+        elif parent_death_check:
+            from neo4j_agent_memory.mcp._lifecycle import run_with_watchdog
+
+            await run_with_watchdog(
+                server.run_async(transport="stdio"),
+                poll_interval=parent_death_poll_interval,
+            )
         else:
             await server.run_async(transport="stdio")
 
@@ -358,6 +373,22 @@ def main() -> None:
         default=False,
         help="Disable automatic preference detection from user messages",
     )
+    parser.add_argument(
+        "--no-parent-death-check",
+        action="store_true",
+        default=False,
+        help=(
+            "Disable parent-death detection on stdio transport. "
+            "By default, the server self-terminates if its parent process "
+            "exits (avoids orphaned servers when an MCP client crashes)."
+        ),
+    )
+    parser.add_argument(
+        "--parent-death-poll-interval",
+        type=float,
+        default=5.0,
+        help="Seconds between parent-process checks (default: 5.0).",
+    )
 
     args = parser.parse_args()
 
@@ -375,6 +406,8 @@ def main() -> None:
             user_id=args.user_id,
             observation_threshold=args.observation_threshold,
             auto_preferences=not args.no_auto_preferences,
+            parent_death_check=not args.no_parent_death_check,
+            parent_death_poll_interval=args.parent_death_poll_interval,
         )
     )
 

--- a/tests/unit/mcp/test_lifecycle.py
+++ b/tests/unit/mcp/test_lifecycle.py
@@ -1,0 +1,104 @@
+"""Unit tests for MCP server lifecycle / orphan-detection watchdog."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+
+import pytest
+
+from neo4j_agent_memory.mcp._lifecycle import (
+    _parent_death_loop,
+    run_with_watchdog,
+)
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="getppid() semantics differ on Windows")
+class TestParentDeathLoop:
+    """Tests for the parent-death detection coroutine."""
+
+    async def test_returns_when_ppid_becomes_one(self, monkeypatch):
+        """Loop should return when getppid() == 1 (orphaned to init/launchd)."""
+        readings = iter([os.getppid(), 1])
+        monkeypatch.setattr(os, "getppid", lambda: next(readings))
+        # Should return well within timeout since poll_interval is tiny.
+        await asyncio.wait_for(_parent_death_loop(0.01), timeout=1.0)
+
+    async def test_returns_when_ppid_is_zero(self, monkeypatch):
+        """Some platforms report ppid=0 for orphans — also treat as orphaned."""
+        readings = iter([os.getppid(), 0])
+        monkeypatch.setattr(os, "getppid", lambda: next(readings))
+        await asyncio.wait_for(_parent_death_loop(0.01), timeout=1.0)
+
+    async def test_keeps_polling_while_parent_alive(self, monkeypatch):
+        """Loop should keep polling while the parent is alive (ppid > 1)."""
+        monkeypatch.setattr(os, "getppid", lambda: 12345)
+        with pytest.raises(asyncio.TimeoutError):
+            await asyncio.wait_for(_parent_death_loop(0.01), timeout=0.1)
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="watchdog is a no-op passthrough on Windows")
+class TestRunWithWatchdog:
+    """Tests for the run_with_watchdog orchestrator."""
+
+    async def test_returns_normally_when_server_completes(self):
+        """If the server coroutine finishes, run_with_watchdog returns cleanly."""
+
+        async def fake_server() -> None:
+            await asyncio.sleep(0.01)
+
+        await asyncio.wait_for(
+            run_with_watchdog(fake_server(), poll_interval=10, install_signals=False),
+            timeout=1.0,
+        )
+
+    async def test_propagates_server_exceptions(self):
+        """Exceptions raised by the server must be surfaced, not swallowed."""
+
+        async def fake_server() -> None:
+            await asyncio.sleep(0.01)
+            raise RuntimeError("boom")
+
+        with pytest.raises(RuntimeError, match="boom"):
+            await asyncio.wait_for(
+                run_with_watchdog(fake_server(), poll_interval=10, install_signals=False),
+                timeout=1.0,
+            )
+
+    async def test_cancels_server_when_parent_dies(self, monkeypatch):
+        """When the watchdog detects an orphan, the server task is cancelled."""
+        cancelled = asyncio.Event()
+
+        async def fake_server() -> None:
+            try:
+                await asyncio.sleep(60)
+            except asyncio.CancelledError:
+                cancelled.set()
+                raise
+
+        readings = iter([os.getppid(), 1])
+        monkeypatch.setattr(os, "getppid", lambda: next(readings))
+
+        await asyncio.wait_for(
+            run_with_watchdog(fake_server(), poll_interval=0.01, install_signals=False),
+            timeout=1.0,
+        )
+        assert cancelled.is_set()
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="Windows-only passthrough check")
+class TestWindowsBehavior:
+    async def test_passthrough_on_windows(self):
+        """run_with_watchdog runs the server unchanged on Windows."""
+        ran = False
+
+        async def fake_server() -> None:
+            nonlocal ran
+            ran = True
+
+        await asyncio.wait_for(
+            run_with_watchdog(fake_server(), poll_interval=0.01),
+            timeout=1.0,
+        )
+        assert ran


### PR DESCRIPTION
## Problem

When an MCP client (Claude Code, Claude Desktop, Cursor, Zed, etc.) crashes or is killed without cleanly closing stdin, the spawned `mcp serve --transport stdio` process is reparented to PID 1 and keeps holding:

- a TLS connection to Neo4j
- file handles
- ~1.5 GB resident memory per orphan (POLE+O loaded model + driver state)

Multiple orphans accumulating across sessions caused 3+ GB of zombie memory in observed production usage:

```
PID  RSS    COMMAND
1532 1.65G  python3 .venv/bin/neo4j-agent-memory mcp serve ...  # 29h orphan
44020 1.55G python3 .venv/bin/neo4j-agent-memory mcp serve ...  # 29min orphan
55934  130M python3 .venv/bin/neo4j-agent-memory mcp serve ...  # current session (legitimate)
```

The MCP stdio protocol assumes the client owns server lifecycle. When the client closes stdin cleanly, the server reads EOF and exits. When the client dies abnormally, no EOF is delivered. The server is blocked on a network `recv()` to Neo4j and never observes that its parent is gone.

## Fix

A lightweight parent-death watchdog (`mcp/_lifecycle.py`) that polls `os.getppid()` every 5 s on the stdio transport. When ppid is 1 or 0, the watchdog cancels the server task; cancellation flows through FastMCP's existing lifespan, so the Neo4j driver closes cleanly.

```python
async def run_with_watchdog(server_coro, *, poll_interval=5.0, install_signals=True):
    server_task = asyncio.create_task(_await(server_coro), name="mcp-server")
    watchdog_task = asyncio.create_task(_parent_death_loop(poll_interval), ...)
    # First to complete cancels the other
    done, pending = await asyncio.wait({server_task, watchdog_task}, return_when=FIRST_COMPLETED)
    ...
```

## Behavior

| Transport | Watchdog |
|---|---|
| `stdio` | **On by default** (the bugfix). Disable with `--no-parent-death-check`; tune cadence with `--parent-death-poll-interval`. |
| `sse`, `http` | Unchanged — these are designed to outlive their starter (Cloud Run, daemonized deploys). |
| Windows | Passthrough — `getppid()` reparenting semantics differ. |

Also installs `SIGTERM`, `SIGHUP`, `SIGPIPE` handlers that route through the same cancel path so graceful kills close the lifespan cleanly.

## Tests

- Unit tests in `tests/unit/mcp/test_lifecycle.py` (6 active, 1 Windows-skipped) — cover polling loop, exception propagation, server cancellation on orphan, and Windows passthrough. Pass in 0.21 s.
- Mypy clean on the new module.
- **Runtime-verified**: spawned the venv Python under `start_new_session=True`, exited the parent, observed clean self-termination within ~1.5 s:

  ```
  [child 17:12:36] starting run_with_watchdog (poll=0.5s)
  [child 17:12:36] fake_server started; pid=62432 ppid=62431
  [child 17:12:38] MCP parent process exited (ppid=1); initiating self-termination
  [child 17:12:38] MCP server self-terminated: parent process is gone
  [child 17:12:38] run_with_watchdog returned after 1.51s (ppid now=1)
  ```

## Tradeoffs / non-goals

- **5 s default poll** — cheap (one syscall every 5 s); fast enough to prevent orphan accumulation without spamming.
- **Idle-timeout** (exit if no JSON-RPC traffic for N s) deferred to a follow-up. Parent-death detection alone solves the actual reported issue.
- **Wrapper-launched servers** (e.g. `uv run`, `npx`) — the watchdog only sees the wrapper as parent. For `neo4j-agent-memory` this is fine: clients invoke the venv Python directly. A "watchdog proxy" mode for wrappers is out of scope.
- **No new dependencies.**

## Backwards compatibility

- Default behavior change: stdio servers self-terminate on parent death (this is the fix).
- All other surfaces unchanged.
- Two new CLI flags (`--no-parent-death-check`, `--parent-death-poll-interval`) opt-in only.
- `run_server()` API gains two kwargs with defaults; existing callers unaffected.

## Test plan

- [x] Unit tests for parent-death loop, watchdog orchestration, exception propagation
- [x] Mypy clean on new module
- [x] Runtime verification with orphaned subprocess
- [ ] Maintainer testing with their preferred MCP client