### PR TITLE
DO NOT MERGE: Add optional NeMo Flow integration

### DIFF
--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -32,6 +32,7 @@
 **** xref:how-to/integrations/aws-bedrock-embeddings.adoc[Amazon Bedrock Embeddings]
 **** xref:how-to/integrations/aws-hybrid-memory.adoc[AWS Hybrid Memory]
 **** xref:how-to/integrations/microsoft-agent.adoc[Microsoft Agent Framework]
+**** xref:how-to/integrations/nemo-flow.adoc[NeMo Flow]
 *** xref:how-to/create-context-graph-mcp.adoc[MCP + create-context-graph]
 
 ** Reference

--- a/docs/modules/ROOT/pages/how-to/integrations/index.adoc
+++ b/docs/modules/ROOT/pages/how-to/integrations/index.adoc
@@ -51,6 +51,10 @@ Neo4j Agent Memory provides official integrations for five popular agent framewo
 | xref:microsoft-agent.adoc[Microsoft Agent Framework]
 | Context providers, GDS algorithms, and graph-enhanced memory
 | ⚠️ Preview (API may change)
+
+| xref:how-to/integrations/nemo-flow.adoc[NeMo Flow]
+| Hidden LLM intercept layer for automatic recall, capture, and observability
+| ⚠️ Preview (API may change)
 |===
 
 == Quick Start
@@ -79,6 +83,9 @@ pip install neo4j-agent-memory[google,mcp]
 
 # AWS Strands Agents
 pip install neo4j-agent-memory[aws,strands]
+
+# NeMo Flow
+pip install "neo4j-agent-memory[nemo-flow]"
 
 # All frameworks
 pip install neo4j-agent-memory[all]
@@ -175,6 +182,20 @@ memory = Neo4jMicrosoftMemory(memory_client=client, session_id="user-123")
 agent = chat_client.as_agent(context_providers=[memory.context_provider])
 ----
 
+=== NeMo Flow
+
+[source,python]
+----
+from neo4j_agent_memory.integrations import nemo_flow
+
+handle = nemo_flow.install(memory_client)
+
+with nemo_flow.memory_scope(user_id="alex", thread_id="thread-123"):
+    result = await agent.ainvoke({"messages": messages})
+
+handle.uninstall()
+----
+
 == Choosing a Framework
 
 Not sure which integration to use? See the xref:explanation/framework-comparison.adoc[Framework Comparison Guide] for a detailed comparison of features, performance, and use cases.
@@ -216,6 +237,7 @@ Automatically extract entities from conversations:
 * xref:how-to/integrations/aws-strands.adoc[AWS Strands Integration] - Bedrock-powered agents with Context Graph
 * xref:how-to/integrations/aws-bedrock-embeddings.adoc[AWS Bedrock Embeddings] - Titan embedding configuration
 * xref:how-to/integrations/aws-hybrid-memory.adoc[AWS Hybrid Memory] - Combined memory providers
+* xref:how-to/integrations/nemo-flow.adoc[NeMo Flow Integration] - Hidden LLM intercept layer for recall and capture
 * xref:langchain.adoc[LangChain Integration] - Memory and retriever for chains
 * xref:pydantic-ai.adoc[PydanticAI Integration] - Type-safe agents with tracing
 * xref:llamaindex.adoc[LlamaIndex Integration] - RAG with TextNode support

--- a/docs/modules/ROOT/pages/how-to/integrations/nemo-flow.adoc
+++ b/docs/modules/ROOT/pages/how-to/integrations/nemo-flow.adoc
@@ -1,0 +1,258 @@
+= NeMo Flow Integration
+:page-product: agent-memory
+:page-pagination:
+:description: Use NeMo Flow as a hidden runtime layer for automatic Neo4j Agent Memory recall and capture around instrumented LLM calls.
+:keywords: nemo-flow, memory, llm intercept, agent memory, langgraph, observability
+
+Use the optional NeMo Flow integration to add Neo4j Agent Memory recall and capture around instrumented LLM calls.
+
+The integration is an adapter layer:
+
+* Neo4j Agent Memory owns memory identity, filtering, retrieval, formatting, and writes.
+* NeMo Flow owns the LLM execution interception point and observability lifecycle.
+
+Application code does not need to import NeMo Flow directly for the common path.
+
+== Install
+
+[source,bash]
+----
+pip install "neo4j-agent-memory[nemo-flow]"
+----
+
+The `nemo-flow` dependency is optional. Regular `neo4j-agent-memory` installs do not include it.
+
+== Basic Usage
+
+[source,python]
+----
+from neo4j_agent_memory import MemoryClient, MemorySettings
+from neo4j_agent_memory.integrations import nemo_flow
+
+memory = MemoryClient(settings)
+handle = nemo_flow.install(memory)
+
+with nemo_flow.memory_scope(user_id="alex", thread_id="thread-123"):
+    result = await agent.ainvoke({"messages": messages})
+
+handle.uninstall()
+----
+
+`thread_id` is a LangGraph-friendly alias for `run_id`.
+
+The LLM call must flow through NeMo Flow instrumentation. The adapter cannot observe arbitrary model calls that never enter the NeMo Flow LLM execution pipeline.
+
+== Read Path
+
+Before the downstream LLM call, the intercept:
+
+. Resolves memory identity from a custom resolver, `memory_scope(...)`, or NeMo Flow scope metadata.
+. Extracts the latest user query from the LLM request.
+. Retrieves scoped memory context.
+. Injects formatted memory into a copied `LLMRequest`.
+. Calls the downstream provider with the mutated request.
+
+By default, recall includes:
+
+* current session history from `short_term.get_conversation(...)`
+* scoped semantic message search from `short_term.search_messages(...)`
+
+Optional recall sources:
+
+* `long_term.get_context(...)` when `include_long_term=True`
+* `reasoning.get_context(...)` when `include_reasoning=True`
+* `MemoryIntegration.get_context(...)` as a fallback when using the high-level wrapper
+
+Given:
+
+[source,python]
+----
+with nemo_flow.memory_scope(user_id="alex", thread_id="thread-123"):
+    ...
+----
+
+the adapter resolves:
+
+[source,python]
+----
+session_id = "alex:thread-123"
+
+metadata_filters = {
+    "user_id": "alex",
+    "run_id": "thread-123",
+    "session_id": "alex:thread-123",
+}
+----
+
+The filtering logic lives in the Neo4j adapter, not in NeMo Flow core.
+
+== Write Path
+
+After the downstream LLM call returns, the intercept:
+
+. Extracts the user message from the original request.
+. Extracts the assistant message from the response.
+. Stores the interaction in Neo4j Agent Memory.
+. Returns the original model response to the caller.
+
+The default capture path stores messages through:
+
+* `MemoryIntegration.store_message(...)` if the provided object has it
+* otherwise `client.short_term.add_message(...)`
+
+Capture stores conversational memory. It does not directly write long-term preferences, facts, or entities. Entity extraction may run indirectly if `short_term.add_message(..., extract_entities=True)` has an extractor configured, but the adapter does not currently observe extracted entity counts or deduplication results.
+
+== Observability
+
+The adapter emits both NeMo Flow scopes and mark events.
+
+Scopes are used for operations with duration:
+
+[cols="1,1,2", options="header"]
+|===
+| Scope | Type | Meaning
+
+| `neo4j_agent_memory.memory`
+| `Custom`
+| Lexical memory identity scope created by `memory_scope(...)`.
+
+| `neo4j_agent_memory.recall`
+| `Retriever`
+| Memory recall before the provider LLM call.
+
+| `neo4j_agent_memory.capture`
+| `Custom`
+| Interaction capture after the provider LLM call.
+|===
+
+Mark events are point-in-time state transitions attached to a scope:
+
+[cols="1,2", options="header"]
+|===
+| Event | Meaning
+
+| `neo4j_agent_memory.identity.resolved`
+| Memory identity was resolved for the intercepted LLM call.
+
+| `neo4j_agent_memory.recall.context_built`
+| Recall built context from one or more memory sources.
+
+| `neo4j_agent_memory.recall.injected`
+| Recall injected formatted memory context into the LLM request.
+
+| `neo4j_agent_memory.recall.skipped`
+| Recall did not mutate the LLM request.
+
+| `neo4j_agent_memory.recall.failed`
+| Recall raised an exception.
+
+| `neo4j_agent_memory.capture.extracted`
+| Capture extracted messages from the LLM request and response.
+
+| `neo4j_agent_memory.capture.message_stored`
+| Capture stored one message.
+
+| `neo4j_agent_memory.capture.stored`
+| Capture completed storage for the extracted interaction.
+
+| `neo4j_agent_memory.capture.skipped`
+| Capture did not store any interaction messages.
+
+| `neo4j_agent_memory.capture.failed`
+| Capture raised an exception.
+|===
+
+Typical successful flow:
+
+[source,text]
+----
+neo4j_agent_memory.memory
+  LLM scope
+    mark: neo4j_agent_memory.identity.resolved
+    neo4j_agent_memory.recall
+      mark: neo4j_agent_memory.recall.context_built
+      mark: neo4j_agent_memory.recall.injected
+    provider LLM call
+    neo4j_agent_memory.capture
+      mark: neo4j_agent_memory.capture.extracted
+      mark: neo4j_agent_memory.capture.message_stored
+      mark: neo4j_agent_memory.capture.message_stored
+      mark: neo4j_agent_memory.capture.stored
+----
+
+Scope and mark payloads avoid raw query text and memory text. They include operational metadata such as query length, source counts, context character counts, message counts, insertion index, roles, and storage status.
+
+== Public API
+
+[source,python]
+----
+from neo4j_agent_memory.integrations import nemo_flow
+
+handle = nemo_flow.install(
+    memory,
+    name="neo4j_agent_memory.memory",
+    priority=50,
+    auto_recall=True,
+    auto_capture=True,
+    max_items=10,
+    top_k=5,
+    threshold=0.7,
+    include_session_history=True,
+    include_user_messages=True,
+    include_long_term=False,
+    include_reasoning=False,
+    extract_entities=True,
+    extract_relations=True,
+    generate_embeddings=True,
+    metadata=None,
+    fail_open=True,
+    enable_observability=True,
+    emit_mark_events=True,
+    emit_identity_events=True,
+)
+
+with nemo_flow.memory_scope(
+    user_id="alex",
+    agent_id=None,
+    run_id=None,
+    thread_id="thread-123",
+    session_id=None,
+    filters=None,
+):
+    ...
+----
+
+Aliases are available:
+
+* `nemo_flow.memory_context`
+* `nemo_flow.neo4j_memory_context`
+* `nemo_flow.install_neo4j`
+
+== Customization
+
+Use custom hooks when a framework or provider has a non-standard request or response shape:
+
+[source,python]
+----
+handle = nemo_flow.install(
+    memory,
+    identity_resolver=my_identity_resolver,
+    query_extractor=my_query_extractor,
+    interaction_extractor=my_interaction_extractor,
+    context_builder=my_context_builder,
+    context_formatter=my_context_formatter,
+)
+----
+
+`context_builder` can return either a plain string or `NemoFlowRecallContext` when you want to provide source counts and other observability metadata.
+
+== Failure Behavior
+
+The adapter is fail-open by default. When `fail_open=True`, memory recall or capture errors are logged and the LLM call continues.
+
+Set `fail_open=False` when memory failures should fail the agent call.
+
+== Example
+
+See `examples/nemo_flow_memory.py` for a no-credentials smoke example. It uses a small in-memory object that implements the subset of `MemoryClient` methods used by the adapter and runs a real NeMo Flow LLM execution boundary.
+

--- a/examples/nemo_flow_memory.py
+++ b/examples/nemo_flow_memory.py
@@ -1,0 +1,151 @@
+"""Run Neo4j Agent Memory's NeMo Flow integration without external services.
+
+This example uses a tiny in-memory object with the subset of `MemoryClient`
+methods that the integration uses. Replace `DemoMemoryClient` with a connected
+`neo4j_agent_memory.MemoryClient` in a real application.
+
+Install the optional dependency before running:
+
+    pip install "neo4j-agent-memory[nemo-flow]"
+    python examples/nemo_flow_memory.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass
+class DemoMessage:
+    role: str
+    content: str
+
+
+@dataclass
+class DemoConversation:
+    messages: list[DemoMessage]
+
+
+class DemoShortTermMemory:
+    """Small in-memory short-term memory for a no-credentials smoke run."""
+
+    def __init__(self) -> None:
+        self.conversations: dict[str, list[DemoMessage]] = {
+            "alex:demo-thread": [
+                DemoMessage("user", "Alex prefers tea in the afternoon."),
+            ]
+        }
+        self.add_calls: list[dict[str, Any]] = []
+
+    async def get_conversation(
+        self, session_id: str, *, limit: int | None = None
+    ) -> DemoConversation:
+        messages = self.conversations.get(session_id, [])
+        if limit is not None:
+            messages = messages[-limit:]
+        return DemoConversation(messages=list(messages))
+
+    async def search_messages(self, query: str, **kwargs: Any) -> list[DemoMessage]:
+        return []
+
+    async def add_message(
+        self,
+        session_id: str,
+        role: str,
+        content: str,
+        *,
+        metadata: dict[str, Any] | None = None,
+        **kwargs: Any,
+    ) -> DemoMessage:
+        message = DemoMessage(role, content)
+        self.conversations.setdefault(session_id, []).append(message)
+        self.add_calls.append(
+            {
+                "session_id": session_id,
+                "role": role,
+                "content": content,
+                "metadata": metadata,
+            }
+        )
+        return message
+
+
+class DemoMemoryClient:
+    """Small Neo4j-agent-memory-compatible client for the smoke run."""
+
+    def __init__(self) -> None:
+        self.short_term = DemoShortTermMemory()
+
+
+async def run_demo() -> dict[str, Any]:
+    from neo4j_agent_memory.integrations import nemo_flow
+
+    memory = DemoMemoryClient()
+    handle = nemo_flow.install(
+        memory,
+        name="neo4j_agent_memory.example.nemo_flow",
+        include_user_messages=False,
+    )
+    provider_requests = []
+
+    async def demo_llm(request: Any) -> dict[str, Any]:
+        provider_requests.append(request.content)
+        system_context = "\n".join(
+            message["content"]
+            for message in request.content["messages"]
+            if message.get("role") == "system"
+            and "Relevant memory context:" in message.get("content", "")
+        )
+        return {
+            "choices": [
+                {
+                    "message": {
+                        "role": "assistant",
+                        "content": f"I found your memory: {system_context}",
+                    }
+                }
+            ]
+        }
+
+    try:
+        with nemo_flow.memory_scope(user_id="alex", thread_id="demo-thread"):
+            response = await _run_instrumented_framework_llm(
+                "demo-llm",
+                {
+                    "model": "demo-model",
+                    "messages": [{"role": "user", "content": "What do I like to drink?"}],
+                },
+                demo_llm,
+            )
+    finally:
+        handle.uninstall()
+
+    return {
+        "response": response,
+        "provider_requests": provider_requests,
+        "add_calls": memory.short_term.add_calls,
+    }
+
+
+async def _run_instrumented_framework_llm(
+    name: str,
+    content: dict[str, Any],
+    provider: Any,
+) -> dict[str, Any]:
+    """Simulate the LLM boundary that a patched framework would own."""
+
+    import nemo_flow
+
+    request = nemo_flow.LLMRequest({}, content)
+    return await nemo_flow.llm.execute(name, request, provider)
+
+
+def main() -> None:
+    print(json.dumps(asyncio.run(run_demo()), indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,6 +92,7 @@ pydantic-ai = ["pydantic-ai>=0.1.0"]
 crewai = ["crewai>=0.50.0"]
 openai-agents = ["openai>=1.0.0"]
 microsoft-agent = ["agent-framework>=1.0.0b260212"]
+nemo-flow = ["nemo-flow>=0.1.0rc5,<0.2.0; python_version >= '3.11'"]
 
 # MCP server
 mcp = ["fastmcp>=2.0.0,<3"]

--- a/src/neo4j_agent_memory/integrations/__init__.py
+++ b/src/neo4j_agent_memory/integrations/__init__.py
@@ -1,3 +1,5 @@
 """Agent framework integrations."""
 
-__all__: list[str] = []
+from . import nemo_flow
+
+__all__ = ["nemo_flow"]

--- a/src/neo4j_agent_memory/integrations/_nemo_flow_content.py
+++ b/src/neo4j_agent_memory/integrations/_nemo_flow_content.py
@@ -1,0 +1,260 @@
+"""Request, response, and context shaping for the NeMo Flow adapter."""
+
+from __future__ import annotations
+
+import copy
+from collections.abc import Mapping, Sequence
+from typing import TYPE_CHECKING, Any
+
+from neo4j_agent_memory.integrations._nemo_flow_types import (
+    MemoryInjection,
+    NemoFlowContextSource,
+    NemoFlowRecallContext,
+    StoredMessageResult,
+    string_or_none,
+)
+
+if TYPE_CHECKING:
+    import nemo_flow
+
+
+def context_text(context: Any) -> str:
+    if isinstance(context, Mapping):
+        return text_from_content(context.get("context")) or ""
+    return text_from_content(context) or ""
+
+
+def coerce_recall_context(
+    context: Any,
+    source: NemoFlowContextSource,
+    *,
+    metadata: Mapping[str, Any] | None = None,
+) -> NemoFlowRecallContext:
+    if isinstance(context, NemoFlowRecallContext):
+        if not metadata:
+            return context
+        return NemoFlowRecallContext(
+            text=context.text,
+            source_counts=context.source_counts,
+            source_chars=context.source_chars,
+            metadata={**dict(metadata), **dict(context.metadata)},
+        )
+
+    text = context_text(context)
+    event_metadata = dict(metadata or {})
+    if isinstance(context, Mapping) and "has_context" in context:
+        event_metadata["has_context"] = bool(context["has_context"])
+
+    if not text:
+        return NemoFlowRecallContext(text="", metadata=event_metadata)
+
+    return NemoFlowRecallContext(
+        text=text,
+        source_counts={source.value: 1},
+        source_chars={source.value: len(text)},
+        metadata=event_metadata,
+    )
+
+
+def message_count(messages: Any) -> int:
+    if isinstance(messages, Sequence) and not isinstance(messages, (str, bytes)):
+        return len(messages)
+    return 0
+
+
+def interaction_event_data(messages: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
+    roles: list[str] = []
+    role_counts: dict[str, int] = {}
+    content_chars_by_role: dict[str, int] = {}
+    content_chars = 0
+
+    for message in messages:
+        role = str(message.get("role", "unknown"))
+        text = text_from_content(message.get("content")) or ""
+        chars = len(text)
+        roles.append(role)
+        role_counts[role] = role_counts.get(role, 0) + 1
+        content_chars_by_role[role] = content_chars_by_role.get(role, 0) + chars
+        content_chars += chars
+
+    return {
+        "message_count": len(messages),
+        "roles": roles,
+        "role_counts": role_counts,
+        "content_chars": content_chars,
+        "content_chars_by_role": content_chars_by_role,
+    }
+
+
+def stored_message_result(role: str, content: str, result: Any) -> StoredMessageResult:
+    if isinstance(result, Mapping):
+        error = result.get("error")
+        if error is not None:
+            return StoredMessageResult(
+                role=role,
+                content_chars=len(content),
+                stored=False,
+                result_type=string_or_none(result.get("type")) or "message",
+                error=str(error),
+            )
+        return StoredMessageResult(
+            role=role,
+            content_chars=len(content),
+            stored=bool(result.get("stored", True)),
+            result_id=string_or_none(result.get("id")),
+            result_type=string_or_none(result.get("type")) or "message",
+        )
+
+    return StoredMessageResult(
+        role=role,
+        content_chars=len(content),
+        stored=True,
+        result_id=string_or_none(getattr(result, "id", None)),
+        result_type=result.__class__.__name__ if result is not None else "message",
+    )
+
+
+def format_conversation(conversation: Any, max_items: int) -> str:
+    messages = getattr(conversation, "messages", None)
+    if not messages:
+        return ""
+
+    lines = ["## Recent Conversation"]
+    for message in list(messages)[-max_items:]:
+        role = role_value(getattr(message, "role", "message"))
+        content = text_from_content(getattr(message, "content", None))
+        if content:
+            lines.append(f"**{role}**: {content}")
+    return "\n".join(lines) if len(lines) > 1 else ""
+
+
+def format_messages(messages: Any) -> str:
+    if not isinstance(messages, Sequence) or isinstance(messages, (str, bytes)) or not messages:
+        return ""
+
+    lines = ["## Relevant Past Messages"]
+    for message in messages:
+        role = role_value(getattr(message, "role", "message"))
+        content = text_from_content(getattr(message, "content", None))
+        if content:
+            lines.append(f"- [{role}] {content}")
+    return "\n".join(lines) if len(lines) > 1 else ""
+
+
+def role_value(role: Any) -> str:
+    value = getattr(role, "value", role)
+    return str(value)
+
+
+def default_query_extractor(request: nemo_flow.LLMRequest) -> str | None:
+    content = request.content
+    if not isinstance(content, Mapping):
+        return None
+
+    messages = content.get("messages")
+    if isinstance(messages, Sequence) and not isinstance(messages, (str, bytes)):
+        for message in reversed(messages):
+            if isinstance(message, Mapping) and message.get("role") == "user":
+                text = text_from_content(message.get("content"))
+                if text:
+                    return text
+
+    for key in ("input", "prompt", "query"):
+        text = text_from_content(content.get(key))
+        if text:
+            return text
+    return None
+
+
+def default_interaction_extractor(
+    request: nemo_flow.LLMRequest,
+    response: nemo_flow.Json,
+) -> Sequence[Mapping[str, Any]] | None:
+    user_text = default_query_extractor(request)
+    assistant_text = assistant_text_from_response(response)
+    if not user_text or not assistant_text:
+        return None
+    return (
+        {"role": "user", "content": user_text},
+        {"role": "assistant", "content": assistant_text},
+    )
+
+
+def assistant_text_from_response(response: Any) -> str | None:
+    if isinstance(response, str):
+        return response
+    if not isinstance(response, Mapping):
+        return text_from_content(getattr(response, "content", None))
+
+    choices = response.get("choices")
+    if isinstance(choices, Sequence) and not isinstance(choices, (str, bytes)) and choices:
+        first = choices[0]
+        if isinstance(first, Mapping):
+            message = first.get("message")
+            if isinstance(message, Mapping):
+                text = text_from_content(message.get("content"))
+                if text:
+                    return text
+            text = text_from_content(first.get("text"))
+            if text:
+                return text
+
+    for key in ("output_text", "text", "content", "response"):
+        text = text_from_content(response.get(key))
+        if text:
+            return text
+
+    output = response.get("output")
+    if isinstance(output, Sequence) and not isinstance(output, (str, bytes)):
+        return text_from_content(output)
+    return None
+
+
+def default_context_formatter(context: str) -> str:
+    return f"Relevant memory context:\n{context}" if context else ""
+
+
+def inject_memory_context(content: Any, memory_text: str) -> MemoryInjection:
+    if not isinstance(content, Mapping):
+        return MemoryInjection(content=content, mutated=False)
+
+    messages = content.get("messages")
+    if not isinstance(messages, Sequence) or isinstance(messages, (str, bytes)):
+        return MemoryInjection(content=content, mutated=False)
+
+    new_content = copy.deepcopy(dict(content))
+    new_messages = list(copy.deepcopy(messages))
+    insert_at = 0
+    while insert_at < len(new_messages):
+        message = new_messages[insert_at]
+        if not isinstance(message, Mapping) or message.get("role") != "system":
+            break
+        insert_at += 1
+
+    new_messages.insert(insert_at, {"role": "system", "content": memory_text})
+    new_content["messages"] = new_messages
+    return MemoryInjection(
+        content=new_content,
+        mutated=True,
+        message_count_before=len(messages),
+        message_count_after=len(new_messages),
+        insert_at=insert_at,
+    )
+
+
+def text_from_content(content: Any) -> str | None:
+    if content is None:
+        return None
+    if isinstance(content, str):
+        return content
+    if isinstance(content, Mapping):
+        for key in ("text", "content"):
+            text = text_from_content(content.get(key))
+            if text:
+                return text
+        return None
+    if isinstance(content, Sequence) and not isinstance(content, (str, bytes)):
+        parts = [text_from_content(item) for item in content]
+        text = "\n".join(part for part in parts if part)
+        return text or None
+    return str(content)

--- a/src/neo4j_agent_memory/integrations/_nemo_flow_intercept.py
+++ b/src/neo4j_agent_memory/integrations/_nemo_flow_intercept.py
@@ -1,0 +1,331 @@
+"""LLM execution intercept for the optional NeMo Flow integration."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any
+
+from neo4j_agent_memory.integrations._nemo_flow_content import (
+    default_context_formatter,
+    default_interaction_extractor,
+    default_query_extractor,
+    inject_memory_context,
+    interaction_event_data,
+    text_from_content,
+)
+from neo4j_agent_memory.integrations._nemo_flow_memory import Neo4jMemoryAccess
+from neo4j_agent_memory.integrations._nemo_flow_runtime import (
+    NemoFlowTelemetry,
+    capture_metadata,
+    coerce_identity,
+    current_scope_metadata,
+    identity_from_metadata,
+    identity_observability_metadata,
+    memory_identity,
+)
+from neo4j_agent_memory.integrations._nemo_flow_types import (
+    MemoryIdentity,
+    NemoFlowEvent,
+    NemoFlowIdentitySource,
+    NemoFlowNeo4jConfig,
+    NemoFlowRecallContext,
+    NemoFlowScope,
+    NemoFlowSkipReason,
+    NemoFlowTurnContext,
+    ResolvedMemoryIdentity,
+)
+
+if TYPE_CHECKING:
+    import nemo_flow
+
+logger = logging.getLogger(__name__)
+
+
+class Neo4jNemoFlowIntercept:
+    """Orchestrates memory recall and capture around a NeMo Flow LLM call."""
+
+    def __init__(self, memory: Any, config: NemoFlowNeo4jConfig, nemo_flow_module: Any):
+        self.memory = memory
+        self.config = config
+        self._nemo_flow = nemo_flow_module
+        self._memory_access = Neo4jMemoryAccess(memory, config)
+        self._telemetry = NemoFlowTelemetry(nemo_flow_module, config)
+
+    async def __call__(
+        self,
+        llm_name: str,
+        request: nemo_flow.LLMRequest,
+        next_call: Callable[[nemo_flow.LLMRequest], Any],
+    ) -> nemo_flow.Json:
+        resolved = self._resolve_identity(llm_name, request)
+        if resolved is None or not resolved.identity.has_scope():
+            return await next_call(request)
+
+        identity = resolved.identity
+        self._telemetry.emit_identity_resolved(identity, resolved.source)
+
+        request_for_call = request
+        if self.config.auto_recall:
+            try:
+                request_for_call = await self._recall(request, identity)
+            except Exception:
+                if not self.config.fail_open:
+                    raise
+                logger.warning("Neo4j memory recall failed in NeMo Flow intercept", exc_info=True)
+
+        response = await next_call(request_for_call)
+
+        if self.config.auto_capture:
+            try:
+                await self._capture(request, response, identity)
+            except Exception:
+                if not self.config.fail_open:
+                    raise
+                logger.warning("Neo4j memory capture failed in NeMo Flow intercept", exc_info=True)
+
+        return response
+
+    def _resolve_identity(
+        self, llm_name: str, request: nemo_flow.LLMRequest
+    ) -> ResolvedMemoryIdentity | None:
+        scope_metadata = current_scope_metadata(self._nemo_flow)
+        context = NemoFlowTurnContext(
+            llm_name=llm_name,
+            request=request,
+            scope_metadata=scope_metadata,
+        )
+
+        if self.config.identity_resolver is not None:
+            identity = coerce_identity(self.config.identity_resolver(context))
+            if identity is not None:
+                return ResolvedMemoryIdentity(
+                    identity,
+                    NemoFlowIdentitySource.IDENTITY_RESOLVER,
+                )
+
+        context_identity = memory_identity.get()
+        if context_identity is not None and context_identity.has_scope():
+            return ResolvedMemoryIdentity(context_identity, NemoFlowIdentitySource.MEMORY_SCOPE)
+
+        metadata_identity = identity_from_metadata(scope_metadata)
+        if metadata_identity is not None:
+            return ResolvedMemoryIdentity(
+                metadata_identity,
+                NemoFlowIdentitySource.SCOPE_METADATA,
+            )
+
+        return None
+
+    async def _recall(
+        self,
+        request: nemo_flow.LLMRequest,
+        identity: MemoryIdentity,
+    ) -> nemo_flow.LLMRequest:
+        query_extractor = self.config.query_extractor or default_query_extractor
+        query = query_extractor(request)
+        if not query:
+            self._telemetry.emit_event(
+                NemoFlowEvent.RECALL_SKIPPED,
+                data={"reason": NemoFlowSkipReason.EMPTY_QUERY.value},
+                metadata=identity_observability_metadata(identity),
+            )
+            return request
+
+        scope_handle = self._telemetry.start_scope(
+            NemoFlowScope.RECALL,
+            input={
+                "query_length": len(query),
+                "top_k": self.config.top_k,
+                "max_items": self.config.max_items,
+                "threshold": self.config.threshold,
+            },
+            metadata=identity_observability_metadata(identity),
+        )
+        scope_output: dict[str, Any] = {"context_chars": 0, "injected": False}
+
+        try:
+            context = await self._memory_access.build_context(query, identity)
+            if not context.text:
+                self._telemetry.emit_event(
+                    NemoFlowEvent.RECALL_SKIPPED,
+                    handle=scope_handle,
+                    data={"reason": NemoFlowSkipReason.NO_CONTEXT.value},
+                    metadata=identity_observability_metadata(identity),
+                )
+                return request
+
+            context_event_data = context.to_event_data()
+            self._telemetry.emit_event(
+                NemoFlowEvent.RECALL_CONTEXT_BUILT,
+                handle=scope_handle,
+                data=context_event_data,
+                metadata=identity_observability_metadata(identity),
+            )
+
+            memory_text = self._format_context(context)
+            scope_output = {
+                **context_event_data,
+                "formatted_context_chars": len(memory_text),
+                "injected": False,
+            }
+            if not memory_text:
+                self._telemetry.emit_event(
+                    NemoFlowEvent.RECALL_SKIPPED,
+                    handle=scope_handle,
+                    data={"reason": NemoFlowSkipReason.EMPTY_FORMATTED_CONTEXT.value},
+                    metadata=identity_observability_metadata(identity),
+                )
+                return request
+
+            injection = inject_memory_context(request.content, memory_text)
+            if not injection.mutated:
+                self._telemetry.emit_event(
+                    NemoFlowEvent.RECALL_SKIPPED,
+                    handle=scope_handle,
+                    data={"reason": NemoFlowSkipReason.UNSUPPORTED_REQUEST_CONTENT.value},
+                    metadata=identity_observability_metadata(identity),
+                )
+                return request
+
+            scope_output = {
+                **context_event_data,
+                "formatted_context_chars": len(memory_text),
+                "message_count_before": injection.message_count_before,
+                "message_count_after": injection.message_count_after,
+                "insertion_index": injection.insert_at,
+                "injected": True,
+            }
+            self._telemetry.emit_event(
+                NemoFlowEvent.RECALL_INJECTED,
+                handle=scope_handle,
+                data=scope_output,
+                metadata=identity_observability_metadata(identity),
+            )
+            return self._nemo_flow.LLMRequest(request.headers, injection.content)
+        except Exception as exc:
+            scope_output = {"error_type": type(exc).__name__}
+            self._telemetry.emit_event(
+                NemoFlowEvent.RECALL_FAILED,
+                handle=scope_handle,
+                data={"error_type": type(exc).__name__},
+                metadata=identity_observability_metadata(identity),
+            )
+            raise
+        finally:
+            self._telemetry.end_scope(scope_handle, output=scope_output)
+
+    async def _capture(
+        self,
+        request: nemo_flow.LLMRequest,
+        response: nemo_flow.Json,
+        identity: MemoryIdentity,
+    ) -> None:
+        session_id = identity.resolved_session_id()
+        if session_id is None:
+            self._telemetry.emit_event(
+                NemoFlowEvent.CAPTURE_SKIPPED,
+                data={"reason": NemoFlowSkipReason.NO_SESSION_ID.value},
+                metadata=identity_observability_metadata(identity),
+            )
+            return
+
+        interaction_extractor = self.config.interaction_extractor or default_interaction_extractor
+        messages = interaction_extractor(request, response)
+        if not messages:
+            self._telemetry.emit_event(
+                NemoFlowEvent.CAPTURE_SKIPPED,
+                data={"reason": NemoFlowSkipReason.NO_INTERACTION.value},
+                metadata=identity_observability_metadata(identity),
+            )
+            return
+
+        metadata = capture_metadata(identity, self.config.metadata)
+        extracted_event_data = interaction_event_data(messages)
+        scope_handle = self._telemetry.start_scope(
+            NemoFlowScope.CAPTURE,
+            input=extracted_event_data,
+            metadata=identity_observability_metadata(identity),
+        )
+        self._telemetry.emit_event(
+            NemoFlowEvent.CAPTURE_EXTRACTED,
+            handle=scope_handle,
+            data=extracted_event_data,
+            metadata=identity_observability_metadata(identity),
+        )
+        scope_output: dict[str, Any] = {**extracted_event_data, "stored": False}
+        try:
+            attempted_count = 0
+            stored_count = 0
+            skipped_empty_count = 0
+            for message in messages:
+                role = str(message.get("role", "user"))
+                content = text_from_content(message.get("content"))
+                if not content:
+                    skipped_empty_count += 1
+                    continue
+                attempted_count += 1
+                result = await self._memory_access.store_message(
+                    role, content, session_id, metadata
+                )
+                if result.error is not None:
+                    raise RuntimeError(result.error)
+                if result.stored:
+                    stored_count += 1
+                    self._telemetry.emit_event(
+                        NemoFlowEvent.CAPTURE_MESSAGE_STORED,
+                        handle=scope_handle,
+                        data={
+                            "role": result.role,
+                            "content_chars": result.content_chars,
+                            "result_id": result.result_id,
+                            "result_type": result.result_type,
+                            "extract_entities": self.config.extract_entities,
+                            "extract_relations": self.config.extract_relations,
+                            "generate_embeddings": self.config.generate_embeddings,
+                        },
+                        metadata=identity_observability_metadata(identity),
+                    )
+            scope_output = {
+                **extracted_event_data,
+                "attempted_count": attempted_count,
+                "stored_count": stored_count,
+                "skipped_empty_count": skipped_empty_count,
+                "stored": stored_count > 0,
+            }
+            if attempted_count == 0:
+                self._telemetry.emit_event(
+                    NemoFlowEvent.CAPTURE_SKIPPED,
+                    handle=scope_handle,
+                    data={
+                        **scope_output,
+                        "reason": NemoFlowSkipReason.EMPTY_CONTENT.value,
+                    },
+                    metadata=identity_observability_metadata(identity),
+                )
+                return
+            self._telemetry.emit_event(
+                NemoFlowEvent.CAPTURE_STORED,
+                handle=scope_handle,
+                data=scope_output,
+                metadata=identity_observability_metadata(identity),
+            )
+        except Exception as exc:
+            scope_output = {
+                **extracted_event_data,
+                "stored": False,
+                "error_type": type(exc).__name__,
+            }
+            self._telemetry.emit_event(
+                NemoFlowEvent.CAPTURE_FAILED,
+                handle=scope_handle,
+                data=scope_output,
+                metadata=identity_observability_metadata(identity),
+            )
+            raise
+        finally:
+            self._telemetry.end_scope(scope_handle, output=scope_output)
+
+    def _format_context(self, context: NemoFlowRecallContext) -> str:
+        formatter = self.config.context_formatter or default_context_formatter
+        return formatter(context.text)

--- a/src/neo4j_agent_memory/integrations/_nemo_flow_memory.py
+++ b/src/neo4j_agent_memory/integrations/_nemo_flow_memory.py
@@ -1,0 +1,234 @@
+"""Neo4j Agent Memory access used by the NeMo Flow intercept."""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+from collections.abc import Callable, Mapping
+from typing import Any
+
+from neo4j_agent_memory.integrations._nemo_flow_content import (
+    coerce_recall_context,
+    format_conversation,
+    format_messages,
+    message_count,
+    stored_message_result,
+)
+from neo4j_agent_memory.integrations._nemo_flow_types import (
+    MemoryIdentity,
+    NemoFlowContextSource,
+    NemoFlowNeo4jConfig,
+    NemoFlowRecallContext,
+    StoredMessageResult,
+)
+
+
+class Neo4jMemoryAccess:
+    """Provider-facing memory operations behind the NeMo Flow adapter."""
+
+    def __init__(self, memory: Any, config: NemoFlowNeo4jConfig):
+        self.memory = memory
+        self.config = config
+
+    async def build_context(self, query: str, identity: MemoryIdentity) -> NemoFlowRecallContext:
+        if self.config.context_builder is not None:
+            context = await self.invoke(self.config.context_builder, self.memory, query, identity)
+            return coerce_recall_context(context, NemoFlowContextSource.CUSTOM)
+
+        client = client_for_memory(self.memory)
+        session_id = identity.resolved_session_id()
+        parts: list[str] = []
+        source_counts: dict[str, int] = {}
+        source_chars: dict[str, int] = {}
+
+        def add_part(source: NemoFlowContextSource, text: str, count: int = 1) -> None:
+            if not text:
+                return
+            source_key = source.value
+            parts.append(text)
+            source_counts[source_key] = source_counts.get(source_key, 0) + count
+            source_chars[source_key] = source_chars.get(source_key, 0) + len(text)
+
+        short_term = getattr(client, "short_term", None)
+        if short_term is not None:
+            if self.config.include_session_history and session_id is not None:
+                get_conversation = getattr(short_term, "get_conversation", None)
+                if get_conversation is not None:
+                    conversation = await self.invoke(
+                        get_conversation,
+                        session_id,
+                        limit=self.config.max_items,
+                    )
+                    conversation_context = format_conversation(conversation, self.config.max_items)
+                    if conversation_context:
+                        add_part(
+                            NemoFlowContextSource.SESSION_HISTORY,
+                            conversation_context,
+                            message_count(getattr(conversation, "messages", None)),
+                        )
+
+            if self.config.include_user_messages:
+                search_messages = getattr(short_term, "search_messages", None)
+                if search_messages is not None:
+                    search_kwargs: dict[str, Any] = {
+                        "limit": self.config.top_k,
+                        "metadata_filters": identity.metadata(),
+                    }
+                    if self.config.threshold is not None:
+                        search_kwargs["threshold"] = self.config.threshold
+                    messages = await self.invoke(search_messages, query, **search_kwargs)
+                    messages_context = format_messages(messages)
+                    if messages_context:
+                        add_part(
+                            NemoFlowContextSource.USER_MESSAGES,
+                            messages_context,
+                            message_count(messages),
+                        )
+
+        long_term = getattr(client, "long_term", None)
+        if (
+            self.config.include_long_term
+            and long_term is not None
+            and hasattr(long_term, "get_context")
+        ):
+            context = await self.invoke(
+                long_term.get_context,
+                query,
+                max_items=self.config.max_items,
+            )
+            if context:
+                add_part(
+                    NemoFlowContextSource.LONG_TERM,
+                    f"## Relevant Knowledge\n{context}",
+                )
+
+        reasoning = getattr(client, "reasoning", None)
+        if (
+            self.config.include_reasoning
+            and reasoning is not None
+            and hasattr(reasoning, "get_context")
+        ):
+            context = await self.invoke(
+                reasoning.get_context,
+                query,
+                max_traces=max(1, self.config.max_items // 2),
+            )
+            if context:
+                add_part(
+                    NemoFlowContextSource.REASONING,
+                    f"## Similar Past Tasks\n{context}",
+                )
+
+        if not parts and hasattr(self.memory, "get_context"):
+            context = await self._invoke_get_context(
+                self.memory.get_context,
+                query,
+                session_id=session_id,
+            )
+            return coerce_recall_context(
+                context,
+                NemoFlowContextSource.MEMORY_INTEGRATION,
+                metadata={"fallback_used": True},
+            )
+
+        return NemoFlowRecallContext(
+            text="\n\n".join(parts),
+            source_counts=source_counts,
+            source_chars=source_chars,
+        )
+
+    async def store_message(
+        self,
+        role: str,
+        content: str,
+        session_id: str,
+        metadata: Mapping[str, Any],
+    ) -> StoredMessageResult:
+        if hasattr(self.memory, "store_message"):
+            result = await self.invoke(
+                self.memory.store_message,
+                role,
+                content,
+                session_id=session_id,
+                metadata=dict(metadata),
+            )
+            return stored_message_result(role, content, result)
+
+        client = client_for_memory(self.memory)
+        result = await self.invoke(
+            client.short_term.add_message,
+            session_id=session_id,
+            role=role,
+            content=content,
+            metadata=dict(metadata),
+            extract_entities=self.config.extract_entities,
+            extract_relations=self.config.extract_relations,
+            generate_embedding=self.config.generate_embeddings,
+        )
+        return stored_message_result(role, content, result)
+
+    async def invoke(self, method: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
+        supported_kwargs = supported_kwargs_for(method, kwargs)
+        if inspect.iscoroutinefunction(method):
+            return await method(*args, **supported_kwargs)
+        if self.config.run_sync_in_thread:
+            return await asyncio.to_thread(method, *args, **supported_kwargs)
+        result = method(*args, **supported_kwargs)
+        if inspect.isawaitable(result):
+            return await result
+        return result
+
+    async def _invoke_get_context(
+        self,
+        method: Callable[..., Any],
+        query: str,
+        *,
+        session_id: str | None,
+    ) -> Any:
+        kwargs = {
+            "session_id": session_id,
+            "include_short_term": self.config.include_session_history,
+            "include_long_term": self.config.include_long_term,
+            "include_reasoning": self.config.include_reasoning,
+            "max_items": self.config.max_items,
+        }
+        if accepts_positional_query(method):
+            return await self.invoke(method, query, **kwargs)
+        return await self.invoke(method, query=query, **kwargs)
+
+
+def client_for_memory(memory: Any) -> Any:
+    try:
+        return memory.client
+    except Exception:
+        return memory
+
+
+def supported_kwargs_for(method: Callable[..., Any], kwargs: Mapping[str, Any]) -> dict[str, Any]:
+    if not kwargs:
+        return {}
+    try:
+        signature = inspect.signature(method)
+    except (TypeError, ValueError):
+        return dict(kwargs)
+
+    if any(param.kind == inspect.Parameter.VAR_KEYWORD for param in signature.parameters.values()):
+        return dict(kwargs)
+    return {key: value for key, value in kwargs.items() if key in signature.parameters}
+
+
+def accepts_positional_query(method: Callable[..., Any]) -> bool:
+    try:
+        signature = inspect.signature(method)
+    except (TypeError, ValueError):
+        return True
+
+    for param in signature.parameters.values():
+        if param.kind in (
+            inspect.Parameter.POSITIONAL_ONLY,
+            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+        ):
+            return True
+        if param.kind == inspect.Parameter.VAR_POSITIONAL:
+            return True
+    return False

--- a/src/neo4j_agent_memory/integrations/_nemo_flow_runtime.py
+++ b/src/neo4j_agent_memory/integrations/_nemo_flow_runtime.py
@@ -1,0 +1,243 @@
+"""NeMo Flow runtime, identity, and observability helpers."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Mapping
+from contextvars import ContextVar
+from typing import Any
+
+from neo4j_agent_memory.integrations._nemo_flow_types import (
+    IDENTITY_KEYS,
+    NEMO_FLOW_EVENT_REGISTRY,
+    NEMO_FLOW_SCOPE_REGISTRY,
+    MemoryIdentity,
+    NemoFlowEvent,
+    NemoFlowIdentitySource,
+    NemoFlowNeo4jConfig,
+    NemoFlowScope,
+)
+
+logger = logging.getLogger(__name__)
+
+memory_identity: ContextVar[MemoryIdentity | None] = ContextVar(
+    "neo4j_agent_memory_nemo_flow_identity",
+    default=None,
+)
+
+
+def load_nemo_flow() -> Any:
+    try:
+        import nemo_flow
+
+        return nemo_flow
+    except ImportError as exc:
+        raise ImportError(
+            "neo4j_agent_memory.integrations.nemo_flow requires NeMo Flow. "
+            "Install it with `neo4j-agent-memory[nemo-flow]` before calling install()."
+        ) from exc
+
+
+def maybe_load_nemo_flow() -> Any | None:
+    try:
+        return load_nemo_flow()
+    except ImportError:
+        return None
+
+
+def activate_runtime_module(nemo_flow_module: Any) -> None:
+    try:
+        nemo_flow_module.get_scope_stack()
+    except Exception:
+        logger.debug("Failed to activate NeMo Flow scope stack", exc_info=True)
+
+
+def push_memory_context_scope(nemo_flow_module: Any, identity: MemoryIdentity) -> Any | None:
+    activate_runtime_module(nemo_flow_module)
+    try:
+        definition = NEMO_FLOW_SCOPE_REGISTRY[NemoFlowScope.MEMORY]
+        return nemo_flow_module.scope.push(
+            definition.name.value,
+            getattr(nemo_flow_module.ScopeType, definition.scope_type_name),
+            metadata={
+                "integration": "neo4j_agent_memory",
+                "neo4j_agent_memory": identity_scope_metadata(identity),
+            },
+        )
+    except Exception:
+        logger.debug("Failed to push NeMo Flow Neo4j memory context scope", exc_info=True)
+        return None
+
+
+def pop_memory_context_scope(nemo_flow_module: Any | None, handle: Any | None) -> None:
+    if nemo_flow_module is None or handle is None:
+        return
+
+    try:
+        nemo_flow_module.scope.pop(handle)
+    except Exception:
+        logger.debug("Failed to pop NeMo Flow Neo4j memory context scope", exc_info=True)
+
+
+def current_scope_metadata(nemo_flow_module: Any) -> Mapping[str, Any] | None:
+    try:
+        handle = nemo_flow_module.scope.get_handle()
+    except Exception:
+        return None
+    metadata = getattr(handle, "metadata", None) if handle is not None else None
+    return metadata if isinstance(metadata, Mapping) else None
+
+
+def identity_from_metadata(metadata: Mapping[str, Any] | None) -> MemoryIdentity | None:
+    if metadata is None:
+        return None
+
+    neo4j_metadata = metadata.get("neo4j_agent_memory")
+    if isinstance(neo4j_metadata, Mapping):
+        return MemoryIdentity.from_mapping(neo4j_metadata)
+
+    shorthand_metadata = metadata.get("neo4j")
+    if isinstance(shorthand_metadata, Mapping):
+        return MemoryIdentity.from_mapping(shorthand_metadata)
+
+    memory_metadata = metadata.get("memory")
+    if isinstance(memory_metadata, Mapping) and memory_metadata.get("provider") in (
+        None,
+        "neo4j",
+        "neo4j_agent_memory",
+    ):
+        return MemoryIdentity.from_mapping(memory_metadata)
+
+    if any(key in metadata for key in IDENTITY_KEYS) or "thread_id" in metadata:
+        return MemoryIdentity.from_mapping(metadata)
+
+    return None
+
+
+def coerce_identity(identity: MemoryIdentity | Mapping[str, Any] | None) -> MemoryIdentity | None:
+    if identity is None or isinstance(identity, MemoryIdentity):
+        return identity
+    if isinstance(identity, Mapping):
+        return MemoryIdentity.from_mapping(identity)
+    raise TypeError("identity_resolver must return MemoryIdentity, mapping, or None")
+
+
+def capture_metadata(
+    identity: MemoryIdentity, metadata: Mapping[str, Any] | None
+) -> dict[str, Any]:
+    captured = dict(metadata or {})
+    for key, value in identity.metadata().items():
+        captured.setdefault(key, value)
+    return captured
+
+
+def resolve_run_id(*, run_id: str | None, thread_id: str | None) -> str | None:
+    if run_id is not None and thread_id is not None and run_id != thread_id:
+        raise ValueError("run_id and thread_id cannot both be set to different values")
+    return run_id if run_id is not None else thread_id
+
+
+def identity_scope_metadata(identity: MemoryIdentity) -> dict[str, Any]:
+    metadata: dict[str, Any] = {}
+    if identity.user_id is not None:
+        metadata["user_id"] = identity.user_id
+    if identity.agent_id is not None:
+        metadata["agent_id"] = identity.agent_id
+    if identity.run_id is not None:
+        metadata["run_id"] = identity.run_id
+    if identity.session_id is not None:
+        metadata["session_id"] = identity.session_id
+    if identity.filters:
+        metadata["filters"] = dict(identity.filters)
+    return metadata
+
+
+def identity_observability_metadata(identity: MemoryIdentity) -> dict[str, Any]:
+    metadata = identity.metadata()
+    return {
+        "filter_keys": sorted(metadata),
+        "has_user_id": identity.user_id is not None,
+        "has_agent_id": identity.agent_id is not None,
+        "has_run_id": identity.run_id is not None,
+        "has_session_id": identity.session_id is not None,
+    }
+
+
+class NemoFlowTelemetry:
+    """Small wrapper around NeMo Flow's scope and mark APIs."""
+
+    def __init__(self, nemo_flow_module: Any, config: NemoFlowNeo4jConfig):
+        self._nemo_flow = nemo_flow_module
+        self._config = config
+
+    def emit_identity_resolved(
+        self,
+        identity: MemoryIdentity,
+        source: NemoFlowIdentitySource,
+    ) -> None:
+        if not self._config.emit_identity_events:
+            return
+
+        self.emit_event(
+            NemoFlowEvent.IDENTITY_RESOLVED,
+            data={
+                "source": source.value,
+                "has_scope": identity.has_scope(),
+                "filter_count": len(identity.metadata()),
+            },
+            metadata=identity_observability_metadata(identity),
+        )
+
+    def start_scope(
+        self,
+        scope: NemoFlowScope,
+        *,
+        input: Mapping[str, Any] | None = None,
+        metadata: Mapping[str, Any] | None = None,
+    ) -> Any | None:
+        if not self._config.enable_observability:
+            return None
+
+        try:
+            definition = NEMO_FLOW_SCOPE_REGISTRY[scope]
+            scope_type = getattr(self._nemo_flow.ScopeType, definition.scope_type_name)
+            return self._nemo_flow.scope.push(
+                definition.name.value,
+                scope_type,
+                input=dict(input or {}),
+                metadata={"integration": "neo4j_agent_memory", **dict(metadata or {})},
+            )
+        except Exception:
+            logger.debug("Failed to start NeMo Flow Neo4j memory scope", exc_info=True)
+            return None
+
+    def end_scope(self, handle: Any | None, *, output: Mapping[str, Any] | None = None) -> None:
+        if handle is None:
+            return
+
+        try:
+            self._nemo_flow.scope.pop(handle, output=dict(output or {}))
+        except Exception:
+            logger.debug("Failed to end NeMo Flow Neo4j memory scope", exc_info=True)
+
+    def emit_event(
+        self,
+        event: NemoFlowEvent,
+        *,
+        handle: Any | None = None,
+        data: Mapping[str, Any] | None = None,
+        metadata: Mapping[str, Any] | None = None,
+    ) -> None:
+        if not self._config.enable_observability or not self._config.emit_mark_events:
+            return
+
+        try:
+            definition = NEMO_FLOW_EVENT_REGISTRY[event]
+            self._nemo_flow.scope.event(
+                definition.name.value,
+                handle=handle,
+                data=dict(data or {}),
+                metadata={"integration": "neo4j_agent_memory", **dict(metadata or {})},
+            )
+        except Exception:
+            logger.debug("Failed to emit NeMo Flow Neo4j memory mark event", exc_info=True)

--- a/src/neo4j_agent_memory/integrations/_nemo_flow_types.py
+++ b/src/neo4j_agent_memory/integrations/_nemo_flow_types.py
@@ -1,0 +1,322 @@
+"""Shared types for the optional NeMo Flow integration."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    import nemo_flow
+
+
+IDENTITY_KEYS = ("user_id", "agent_id", "run_id", "session_id")
+RESERVED_IDENTITY_KEYS = {"filters", "provider", "thread_id"}
+
+
+def string_or_none(value: Any) -> str | None:
+    if value is None:
+        return None
+    return str(value)
+
+
+class NemoFlowScope(str, Enum):
+    """Named NeMo Flow scopes emitted by the integration."""
+
+    MEMORY = "neo4j_agent_memory.memory"
+    RECALL = "neo4j_agent_memory.recall"
+    CAPTURE = "neo4j_agent_memory.capture"
+
+
+class NemoFlowEvent(str, Enum):
+    """Named NeMo Flow mark events emitted by the integration."""
+
+    IDENTITY_RESOLVED = "neo4j_agent_memory.identity.resolved"
+    RECALL_SKIPPED = "neo4j_agent_memory.recall.skipped"
+    RECALL_CONTEXT_BUILT = "neo4j_agent_memory.recall.context_built"
+    RECALL_INJECTED = "neo4j_agent_memory.recall.injected"
+    RECALL_FAILED = "neo4j_agent_memory.recall.failed"
+    CAPTURE_SKIPPED = "neo4j_agent_memory.capture.skipped"
+    CAPTURE_EXTRACTED = "neo4j_agent_memory.capture.extracted"
+    CAPTURE_MESSAGE_STORED = "neo4j_agent_memory.capture.message_stored"
+    CAPTURE_STORED = "neo4j_agent_memory.capture.stored"
+    CAPTURE_FAILED = "neo4j_agent_memory.capture.failed"
+
+
+class NemoFlowIdentitySource(str, Enum):
+    """Where memory identity came from for an intercepted LLM call."""
+
+    IDENTITY_RESOLVER = "identity_resolver"
+    MEMORY_SCOPE = "memory_scope"
+    SCOPE_METADATA = "scope_metadata"
+
+
+class NemoFlowContextSource(str, Enum):
+    """Context sources the adapter can observe during recall."""
+
+    SESSION_HISTORY = "session_history"
+    USER_MESSAGES = "user_messages"
+    LONG_TERM = "long_term"
+    REASONING = "reasoning"
+    MEMORY_INTEGRATION = "memory_integration"
+    CUSTOM = "custom"
+
+
+class NemoFlowSkipReason(str, Enum):
+    """Known reasons a recall or capture operation was skipped."""
+
+    EMPTY_QUERY = "empty_query"
+    NO_CONTEXT = "no_context"
+    EMPTY_FORMATTED_CONTEXT = "empty_formatted_context"
+    UNSUPPORTED_REQUEST_CONTENT = "unsupported_request_content"
+    NO_SESSION_ID = "no_session_id"
+    NO_INTERACTION = "no_interaction"
+    EMPTY_CONTENT = "empty_content"
+
+
+@dataclass(frozen=True)
+class NemoFlowScopeDefinition:
+    """Registry entry describing a NeMo Flow scope."""
+
+    name: NemoFlowScope
+    scope_type_name: str
+    description: str
+
+
+@dataclass(frozen=True)
+class NemoFlowEventDefinition:
+    """Registry entry describing a NeMo Flow mark event."""
+
+    name: NemoFlowEvent
+    description: str
+
+
+NEMO_FLOW_SCOPE_REGISTRY: Mapping[NemoFlowScope, NemoFlowScopeDefinition] = {
+    NemoFlowScope.MEMORY: NemoFlowScopeDefinition(
+        NemoFlowScope.MEMORY,
+        "Custom",
+        "Lexical scope carrying Neo4j Agent Memory identity.",
+    ),
+    NemoFlowScope.RECALL: NemoFlowScopeDefinition(
+        NemoFlowScope.RECALL,
+        "Retriever",
+        "Recall memory context before the provider LLM call.",
+    ),
+    NemoFlowScope.CAPTURE: NemoFlowScopeDefinition(
+        NemoFlowScope.CAPTURE,
+        "Custom",
+        "Capture the user/assistant interaction after the provider LLM call.",
+    ),
+}
+
+NEMO_FLOW_EVENT_REGISTRY: Mapping[NemoFlowEvent, NemoFlowEventDefinition] = {
+    NemoFlowEvent.IDENTITY_RESOLVED: NemoFlowEventDefinition(
+        NemoFlowEvent.IDENTITY_RESOLVED,
+        "Memory identity was resolved for an intercepted LLM call.",
+    ),
+    NemoFlowEvent.RECALL_SKIPPED: NemoFlowEventDefinition(
+        NemoFlowEvent.RECALL_SKIPPED,
+        "Recall did not mutate the LLM request.",
+    ),
+    NemoFlowEvent.RECALL_CONTEXT_BUILT: NemoFlowEventDefinition(
+        NemoFlowEvent.RECALL_CONTEXT_BUILT,
+        "Recall built context from one or more memory sources.",
+    ),
+    NemoFlowEvent.RECALL_INJECTED: NemoFlowEventDefinition(
+        NemoFlowEvent.RECALL_INJECTED,
+        "Recall injected formatted memory context into the LLM request.",
+    ),
+    NemoFlowEvent.RECALL_FAILED: NemoFlowEventDefinition(
+        NemoFlowEvent.RECALL_FAILED,
+        "Recall raised an exception.",
+    ),
+    NemoFlowEvent.CAPTURE_SKIPPED: NemoFlowEventDefinition(
+        NemoFlowEvent.CAPTURE_SKIPPED,
+        "Capture did not store any interaction messages.",
+    ),
+    NemoFlowEvent.CAPTURE_EXTRACTED: NemoFlowEventDefinition(
+        NemoFlowEvent.CAPTURE_EXTRACTED,
+        "Capture extracted messages from the LLM request and response.",
+    ),
+    NemoFlowEvent.CAPTURE_MESSAGE_STORED: NemoFlowEventDefinition(
+        NemoFlowEvent.CAPTURE_MESSAGE_STORED,
+        "Capture stored one message.",
+    ),
+    NemoFlowEvent.CAPTURE_STORED: NemoFlowEventDefinition(
+        NemoFlowEvent.CAPTURE_STORED,
+        "Capture completed storage for the extracted interaction.",
+    ),
+    NemoFlowEvent.CAPTURE_FAILED: NemoFlowEventDefinition(
+        NemoFlowEvent.CAPTURE_FAILED,
+        "Capture raised an exception.",
+    ),
+}
+
+
+@dataclass(frozen=True)
+class MemoryIdentity:
+    """Neo4j memory scope used by the NeMo Flow intercept."""
+
+    user_id: str | None = None
+    agent_id: str | None = None
+    run_id: str | None = None
+    session_id: str | None = None
+    filters: Mapping[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_mapping(cls, value: Mapping[str, Any]) -> MemoryIdentity:
+        """Build identity from user metadata or NeMo Flow scope metadata."""
+        filters: dict[str, Any] = {}
+        nested_filters = value.get("filters")
+        if isinstance(nested_filters, Mapping):
+            filters.update(
+                {str(key): item for key, item in nested_filters.items() if item is not None}
+            )
+
+        for key, item in value.items():
+            if key in IDENTITY_KEYS or key in RESERVED_IDENTITY_KEYS or item is None:
+                continue
+            filters[str(key)] = item
+
+        run_id = value.get("run_id", value.get("thread_id"))
+        return cls(
+            user_id=string_or_none(value.get("user_id")),
+            agent_id=string_or_none(value.get("agent_id")),
+            run_id=string_or_none(run_id),
+            session_id=string_or_none(value.get("session_id")),
+            filters=filters,
+        )
+
+    def resolved_session_id(self) -> str | None:
+        """Resolve the Neo4j short-term memory session ID."""
+        if self.session_id:
+            return self.session_id
+        if self.user_id and self.run_id:
+            return f"{self.user_id}:{self.run_id}"
+        if self.agent_id and self.run_id:
+            return f"{self.agent_id}:{self.run_id}"
+        if self.run_id:
+            return self.run_id
+        if self.user_id:
+            return self.user_id
+        if self.agent_id:
+            return self.agent_id
+        return None
+
+    def metadata(self) -> dict[str, Any]:
+        """Metadata stored on captured messages and used for scoped search."""
+        metadata = dict(self.filters)
+        if self.user_id is not None:
+            metadata["user_id"] = self.user_id
+        if self.agent_id is not None:
+            metadata["agent_id"] = self.agent_id
+        if self.run_id is not None:
+            metadata["run_id"] = self.run_id
+        session_id = self.resolved_session_id()
+        if session_id is not None:
+            metadata["session_id"] = session_id
+        return metadata
+
+    def has_scope(self) -> bool:
+        """Return whether enough identity exists to scope Neo4j memory."""
+        return self.resolved_session_id() is not None
+
+
+@dataclass(frozen=True)
+class NemoFlowRecallContext:
+    """Recall context text plus observable source statistics."""
+
+    text: str
+    source_counts: Mapping[str, int] = field(default_factory=dict)
+    source_chars: Mapping[str, int] = field(default_factory=dict)
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    @property
+    def context_chars(self) -> int:
+        """Number of characters in the assembled context text."""
+        return len(self.text)
+
+    def to_event_data(self) -> dict[str, Any]:
+        """Convert context statistics into NeMo Flow mark-event data."""
+        return {
+            "context_chars": self.context_chars,
+            "sources": sorted(self.source_counts),
+            "source_counts": dict(self.source_counts),
+            "source_chars": dict(self.source_chars),
+            **dict(self.metadata),
+        }
+
+
+@dataclass(frozen=True)
+class ResolvedMemoryIdentity:
+    identity: MemoryIdentity
+    source: NemoFlowIdentitySource
+
+
+@dataclass(frozen=True)
+class StoredMessageResult:
+    role: str
+    content_chars: int
+    stored: bool
+    result_id: str | None = None
+    result_type: str | None = None
+    error: str | None = None
+
+
+@dataclass(frozen=True)
+class MemoryInjection:
+    content: Any
+    mutated: bool
+    message_count_before: int = 0
+    message_count_after: int = 0
+    insert_at: int | None = None
+
+
+@dataclass(frozen=True)
+class NemoFlowTurnContext:
+    """Context passed to a custom identity resolver."""
+
+    llm_name: str
+    request: nemo_flow.LLMRequest
+    scope_metadata: Mapping[str, Any] | None
+
+
+IdentityResolver = Callable[[NemoFlowTurnContext], MemoryIdentity | Mapping[str, Any] | None]
+QueryExtractor = Callable[["nemo_flow.LLMRequest"], str | None]
+InteractionExtractor = Callable[
+    ["nemo_flow.LLMRequest", "nemo_flow.Json"], Sequence[Mapping[str, Any]] | None
+]
+ContextBuilder = Callable[[Any, str, MemoryIdentity], Any]
+ContextFormatter = Callable[[str], str]
+
+
+@dataclass(frozen=True)
+class NemoFlowNeo4jConfig:
+    """Configuration for the Neo4j Agent Memory NeMo Flow intercept."""
+
+    name: str = "neo4j_agent_memory.memory"
+    priority: int = 50
+    auto_recall: bool = True
+    auto_capture: bool = True
+    max_items: int = 10
+    top_k: int = 5
+    threshold: float | None = 0.7
+    include_session_history: bool = True
+    include_user_messages: bool = True
+    include_long_term: bool = False
+    include_reasoning: bool = False
+    extract_entities: bool = True
+    extract_relations: bool = True
+    generate_embeddings: bool = True
+    metadata: Mapping[str, Any] | None = None
+    fail_open: bool = True
+    enable_observability: bool = True
+    emit_mark_events: bool = True
+    emit_identity_events: bool = True
+    run_sync_in_thread: bool = False
+    identity_resolver: IdentityResolver | None = None
+    query_extractor: QueryExtractor | None = None
+    interaction_extractor: InteractionExtractor | None = None
+    context_builder: ContextBuilder | None = None
+    context_formatter: ContextFormatter | None = None

--- a/src/neo4j_agent_memory/integrations/nemo_flow.py
+++ b/src/neo4j_agent_memory/integrations/nemo_flow.py
@@ -1,0 +1,228 @@
+"""Optional NeMo Flow integration for Neo4j Agent Memory.
+
+This module is intentionally the public facade. The implementation lives in
+private modules so the user-facing API stays small and stable.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterator, Mapping
+from contextlib import contextmanager
+from typing import TYPE_CHECKING, Any
+
+from neo4j_agent_memory.integrations._nemo_flow_intercept import Neo4jNemoFlowIntercept
+from neo4j_agent_memory.integrations._nemo_flow_runtime import (
+    activate_runtime_module,
+    load_nemo_flow,
+    maybe_load_nemo_flow,
+    memory_identity,
+    pop_memory_context_scope,
+    push_memory_context_scope,
+    resolve_run_id,
+)
+from neo4j_agent_memory.integrations._nemo_flow_types import (
+    NEMO_FLOW_EVENT_REGISTRY,
+    NEMO_FLOW_SCOPE_REGISTRY,
+    ContextBuilder,
+    ContextFormatter,
+    IdentityResolver,
+    InteractionExtractor,
+    MemoryIdentity,
+    NemoFlowContextSource,
+    NemoFlowEvent,
+    NemoFlowEventDefinition,
+    NemoFlowIdentitySource,
+    NemoFlowNeo4jConfig,
+    NemoFlowRecallContext,
+    NemoFlowScope,
+    NemoFlowScopeDefinition,
+    NemoFlowSkipReason,
+    NemoFlowTurnContext,
+    QueryExtractor,
+)
+
+if TYPE_CHECKING:
+    import nemo_flow
+
+
+class NemoFlowNeo4jHandle:
+    """Registration handle returned by `install`."""
+
+    def __init__(
+        self,
+        name: str,
+        nemo_flow_module: Any,
+        intercept: Neo4jNemoFlowIntercept,
+    ):
+        self.name = name
+        self._nemo_flow = nemo_flow_module
+        self._intercept = intercept
+        self._active = True
+
+    @property
+    def active(self) -> bool:
+        return self._active
+
+    @property
+    def intercept(
+        self,
+    ) -> Callable[
+        [str, nemo_flow.LLMRequest, Callable[[nemo_flow.LLMRequest], Any]],
+        Any,
+    ]:
+        return self._intercept
+
+    def uninstall(self) -> bool:
+        """Deregister the NeMo Flow execution intercept."""
+        if not self._active:
+            return False
+        removed = self._nemo_flow.intercepts.deregister_llm_execution(self.name)
+        self._active = False
+        return bool(removed)
+
+
+@contextmanager
+def memory_scope(
+    user_id: str | None = None,
+    *,
+    agent_id: str | None = None,
+    run_id: str | None = None,
+    thread_id: str | None = None,
+    session_id: str | None = None,
+    filters: Mapping[str, Any] | None = None,
+    activate_runtime: bool = True,
+) -> Iterator[MemoryIdentity]:
+    """Set Neo4j memory identity for framework calls in the current scope.
+
+    If NeMo Flow is installed, this also pushes a NeMo Flow scope so
+    instrumented LLM calls can find the same identity without application code
+    importing NeMo Flow directly. ``thread_id`` is a LangGraph-friendly alias
+    for ``run_id``.
+    """
+    run_id = resolve_run_id(run_id=run_id, thread_id=thread_id)
+    identity = MemoryIdentity(
+        user_id=user_id,
+        agent_id=agent_id,
+        run_id=run_id,
+        session_id=session_id,
+        filters=filters or {},
+    )
+    token = memory_identity.set(identity)
+    nemo_flow_module = maybe_load_nemo_flow() if activate_runtime else None
+    scope_handle = (
+        push_memory_context_scope(nemo_flow_module, identity)
+        if nemo_flow_module is not None and identity.has_scope()
+        else None
+    )
+    try:
+        yield identity
+    finally:
+        pop_memory_context_scope(nemo_flow_module, scope_handle)
+        memory_identity.reset(token)
+
+
+memory_context = memory_scope
+neo4j_memory_context = memory_scope
+
+
+def install(
+    memory: Any,
+    *,
+    name: str = "neo4j_agent_memory.memory",
+    priority: int = 50,
+    auto_recall: bool = True,
+    auto_capture: bool = True,
+    max_items: int = 10,
+    top_k: int = 5,
+    threshold: float | None = 0.7,
+    include_session_history: bool = True,
+    include_user_messages: bool = True,
+    include_long_term: bool = False,
+    include_reasoning: bool = False,
+    extract_entities: bool = True,
+    extract_relations: bool = True,
+    generate_embeddings: bool = True,
+    metadata: Mapping[str, Any] | None = None,
+    fail_open: bool = True,
+    enable_observability: bool = True,
+    emit_mark_events: bool = True,
+    emit_identity_events: bool = True,
+    activate_runtime: bool = True,
+    run_sync_in_thread: bool = False,
+    identity_resolver: IdentityResolver | None = None,
+    query_extractor: QueryExtractor | None = None,
+    interaction_extractor: InteractionExtractor | None = None,
+    context_builder: ContextBuilder | None = None,
+    context_formatter: ContextFormatter | None = None,
+) -> NemoFlowNeo4jHandle:
+    """Register Neo4j Agent Memory on NeMo Flow's LLM execution path."""
+    nemo_flow_module = load_nemo_flow()
+    if activate_runtime:
+        activate_runtime_module(nemo_flow_module)
+    config = NemoFlowNeo4jConfig(
+        name=name,
+        priority=priority,
+        auto_recall=auto_recall,
+        auto_capture=auto_capture,
+        max_items=max_items,
+        top_k=top_k,
+        threshold=threshold,
+        include_session_history=include_session_history,
+        include_user_messages=include_user_messages,
+        include_long_term=include_long_term,
+        include_reasoning=include_reasoning,
+        extract_entities=extract_entities,
+        extract_relations=extract_relations,
+        generate_embeddings=generate_embeddings,
+        metadata=metadata,
+        fail_open=fail_open,
+        enable_observability=enable_observability,
+        emit_mark_events=emit_mark_events,
+        emit_identity_events=emit_identity_events,
+        run_sync_in_thread=run_sync_in_thread,
+        identity_resolver=identity_resolver,
+        query_extractor=query_extractor,
+        interaction_extractor=interaction_extractor,
+        context_builder=context_builder,
+        context_formatter=context_formatter,
+    )
+    intercept = Neo4jNemoFlowIntercept(memory, config, nemo_flow_module)
+    nemo_flow_module.intercepts.register_llm_execution(name, priority, intercept)
+    return NemoFlowNeo4jHandle(name, nemo_flow_module, intercept)
+
+
+install_neo4j = install
+
+
+def activate_runtime() -> None:
+    """Activate NeMo Flow in the current context without exposing its API."""
+    activate_runtime_module(load_nemo_flow())
+
+
+__all__ = [
+    "ContextBuilder",
+    "ContextFormatter",
+    "IdentityResolver",
+    "InteractionExtractor",
+    "MemoryIdentity",
+    "NEMO_FLOW_EVENT_REGISTRY",
+    "NEMO_FLOW_SCOPE_REGISTRY",
+    "NemoFlowContextSource",
+    "NemoFlowEvent",
+    "NemoFlowEventDefinition",
+    "NemoFlowIdentitySource",
+    "NemoFlowNeo4jConfig",
+    "NemoFlowNeo4jHandle",
+    "NemoFlowRecallContext",
+    "NemoFlowScope",
+    "NemoFlowScopeDefinition",
+    "NemoFlowSkipReason",
+    "NemoFlowTurnContext",
+    "QueryExtractor",
+    "activate_runtime",
+    "install",
+    "install_neo4j",
+    "memory_context",
+    "memory_scope",
+    "neo4j_memory_context",
+]

--- a/tests/examples/test_nemo_flow_memory.py
+++ b/tests/examples/test_nemo_flow_memory.py
@@ -1,0 +1,62 @@
+"""Smoke test for the NeMo Flow memory example."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+nemo_flow = pytest.importorskip(
+    "nemo_flow", reason="nemo-flow optional dependency is not installed"
+)
+
+
+def _load_example_module():
+    path = Path(__file__).resolve().parents[2] / "examples" / "nemo_flow_memory.py"
+    spec = importlib.util.spec_from_file_location("neo4j_nemo_flow_memory_example", path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.mark.asyncio
+async def test_nemo_flow_memory_example_smoke() -> None:
+    module = _load_example_module()
+
+    result = await module.run_demo()
+
+    assert result["provider_requests"][0]["messages"][0]["role"] == "system"
+    assert (
+        "Alex prefers tea in the afternoon."
+        in result["provider_requests"][0]["messages"][0]["content"]
+    )
+    assert result["add_calls"] == [
+        {
+            "session_id": "alex:demo-thread",
+            "role": "user",
+            "content": "What do I like to drink?",
+            "metadata": {
+                "user_id": "alex",
+                "run_id": "demo-thread",
+                "session_id": "alex:demo-thread",
+            },
+        },
+        {
+            "session_id": "alex:demo-thread",
+            "role": "assistant",
+            "content": (
+                "I found your memory: Relevant memory context:\n"
+                "## Recent Conversation\n"
+                "**user**: Alex prefers tea in the afternoon."
+            ),
+            "metadata": {
+                "user_id": "alex",
+                "run_id": "demo-thread",
+                "session_id": "alex:demo-thread",
+            },
+        },
+    ]

--- a/tests/integration/test_nemo_flow_integration.py
+++ b/tests/integration/test_nemo_flow_integration.py
@@ -1,0 +1,76 @@
+"""Live integration smoke for Neo4j Agent Memory with NeMo Flow."""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+
+pytest.importorskip("nemo_flow", reason="nemo-flow optional dependency is not installed")
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_nemo_flow_recall_and_capture_with_real_memory_client(memory_client) -> None:
+    """Exercise the adapter through real NeMo Flow and real Neo4j memory APIs."""
+    import nemo_flow as nemo_flow_runtime
+
+    from neo4j_agent_memory.integrations import nemo_flow
+
+    user_id = f"test-nemo-user-{uuid4()}"
+    thread_id = f"test-nemo-thread-{uuid4()}"
+    session_id = f"{user_id}:{thread_id}"
+
+    await memory_client.short_term.add_message(
+        session_id,
+        "user",
+        "Alex prefers jasmine tea in the afternoon.",
+        metadata={
+            "user_id": user_id,
+            "run_id": thread_id,
+            "session_id": session_id,
+        },
+        extract_entities=False,
+        generate_embedding=False,
+    )
+
+    handle = nemo_flow.install(
+        memory_client,
+        name=f"neo4j_agent_memory.integration.{uuid4()}",
+        include_user_messages=False,
+        extract_entities=False,
+        generate_embeddings=False,
+    )
+    provider_requests = []
+
+    async def provider(request):
+        provider_requests.append(request.content)
+        return {"choices": [{"message": {"content": "Jasmine tea."}}]}
+
+    try:
+        with nemo_flow.memory_scope(user_id=user_id, thread_id=thread_id):
+            response = await nemo_flow_runtime.llm.execute(
+                "neo4j-agent-memory-live-smoke",
+                nemo_flow_runtime.LLMRequest(
+                    {},
+                    {
+                        "model": "local-smoke",
+                        "messages": [{"role": "user", "content": "What do I prefer to drink?"}],
+                    },
+                ),
+                provider,
+            )
+    finally:
+        handle.uninstall()
+
+    assert response == {"choices": [{"message": {"content": "Jasmine tea."}}]}
+    assert provider_requests
+    messages = provider_requests[0]["messages"]
+    assert messages[0]["role"] == "system"
+    assert "Relevant memory context:" in messages[0]["content"]
+    assert "Alex prefers jasmine tea in the afternoon." in messages[0]["content"]
+
+    conversation = await memory_client.short_term.get_conversation(session_id)
+    stored_contents = [message.content for message in conversation.messages]
+    assert "What do I prefer to drink?" in stored_contents
+    assert "Jasmine tea." in stored_contents

--- a/tests/unit/integrations/test_nemo_flow.py
+++ b/tests/unit/integrations/test_nemo_flow.py
@@ -1,0 +1,511 @@
+"""Unit tests for the optional NeMo Flow integration."""
+
+from __future__ import annotations
+
+import sys
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from neo4j_agent_memory.integrations import nemo_flow
+
+
+class FakeLLMRequest:
+    def __init__(self, headers: dict[str, Any], content: dict[str, Any]):
+        self.headers = dict(headers)
+        self.content = dict(content)
+
+
+class FakeInterceptors:
+    def __init__(self) -> None:
+        self.registered: dict[str, dict[str, Any]] = {}
+        self.deregistered: list[str] = []
+
+    def register_llm_execution(self, name: str, priority: int, callback: Any) -> None:
+        self.registered[name] = {"priority": priority, "callback": callback}
+
+    def deregister_llm_execution(self, name: str) -> bool:
+        self.deregistered.append(name)
+        return self.registered.pop(name, None) is not None
+
+
+class FakeScope:
+    def __init__(self) -> None:
+        self.handle: Any | None = None
+        self.stack: list[Any] = []
+        self.pushed: list[dict[str, Any]] = []
+        self.popped: list[dict[str, Any]] = []
+        self.events: list[dict[str, Any]] = []
+
+    def get_handle(self) -> Any | None:
+        return self.handle
+
+    def push(
+        self,
+        name: str,
+        scope_type: str,
+        *,
+        input: dict[str, Any] | None = None,
+        metadata: dict[str, Any] | None = None,
+        **kwargs: Any,
+    ) -> Any:
+        handle = SimpleNamespace(name=name, scope_type=scope_type, input=input, metadata=metadata)
+        self.stack.append(handle)
+        self.handle = handle
+        self.pushed.append(
+            {
+                "name": name,
+                "scope_type": scope_type,
+                "input": input,
+                "metadata": metadata,
+                "handle": handle,
+            }
+        )
+        return handle
+
+    def pop(self, handle: Any, *, output: dict[str, Any] | None = None) -> None:
+        self.popped.append({"name": handle.name, "output": output, "handle": handle})
+        if self.stack and self.stack[-1] is handle:
+            self.stack.pop()
+        elif handle in self.stack:
+            self.stack.remove(handle)
+        self.handle = self.stack[-1] if self.stack else None
+
+    def event(
+        self,
+        name: str,
+        *,
+        handle: Any | None = None,
+        data: dict[str, Any] | None = None,
+        metadata: dict[str, Any] | None = None,
+        **kwargs: Any,
+    ) -> None:
+        self.events.append(
+            {
+                "name": name,
+                "handle": handle,
+                "data": data,
+                "metadata": metadata,
+            }
+        )
+
+
+class FakeShortTermMemory:
+    def __init__(self) -> None:
+        self.get_conversation_calls: list[dict[str, Any]] = []
+        self.search_messages_calls: list[dict[str, Any]] = []
+        self.add_message_calls: list[dict[str, Any]] = []
+        self.conversations: dict[str, list[Any]] = {
+            "user-1:thread-1": [
+                SimpleNamespace(role="user", content="Alex prefers tea in the afternoon.")
+            ],
+            "scope-session": [SimpleNamespace(role="assistant", content="Stored scope context.")],
+        }
+
+    async def get_conversation(self, session_id: str, *, limit: int | None = None) -> Any:
+        self.get_conversation_calls.append({"session_id": session_id, "limit": limit})
+        messages = self.conversations.get(session_id, [])
+        if limit is not None:
+            messages = messages[-limit:]
+        return SimpleNamespace(messages=messages)
+
+    async def search_messages(self, query: str, **kwargs: Any) -> list[Any]:
+        self.search_messages_calls.append({"query": query, "kwargs": kwargs})
+        return [SimpleNamespace(role="user", content="Past memory: Alex also likes green tea.")]
+
+    async def add_message(
+        self,
+        session_id: str,
+        role: str,
+        content: str,
+        *,
+        metadata: dict[str, Any] | None = None,
+        extract_entities: bool = True,
+        extract_relations: bool = True,
+        generate_embedding: bool = True,
+    ) -> Any:
+        self.add_message_calls.append(
+            {
+                "session_id": session_id,
+                "role": role,
+                "content": content,
+                "metadata": metadata,
+                "extract_entities": extract_entities,
+                "extract_relations": extract_relations,
+                "generate_embedding": generate_embedding,
+            }
+        )
+        return SimpleNamespace(id=f"message-{len(self.add_message_calls)}")
+
+
+class FakeLongTermMemory:
+    def __init__(self) -> None:
+        self.get_context_calls: list[dict[str, Any]] = []
+
+    async def get_context(self, query: str, **kwargs: Any) -> str:
+        self.get_context_calls.append({"query": query, "kwargs": kwargs})
+        return "### User Preferences\n- [drink] Alex prefers jasmine tea."
+
+
+class FakeMemoryClient:
+    def __init__(self) -> None:
+        self.short_term = FakeShortTermMemory()
+        self.long_term = FakeLongTermMemory()
+        self.reasoning = SimpleNamespace()
+
+
+class FakeMemoryIntegration:
+    def __init__(self) -> None:
+        self.client = FakeMemoryClient()
+        self.store_message_calls: list[dict[str, Any]] = []
+
+    async def store_message(
+        self,
+        role: str,
+        content: str,
+        *,
+        session_id: str | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        self.store_message_calls.append(
+            {
+                "role": role,
+                "content": content,
+                "session_id": session_id,
+                "metadata": metadata,
+            }
+        )
+        return {"stored": True}
+
+
+@pytest.fixture
+def fake_nemo_flow(monkeypatch: pytest.MonkeyPatch) -> Any:
+    intercepts = FakeInterceptors()
+    scope = FakeScope()
+    module = SimpleNamespace(
+        LLMRequest=FakeLLMRequest,
+        Json=dict,
+        ScopeType=SimpleNamespace(Agent="agent", Retriever="retriever", Custom="custom"),
+        intercepts=intercepts,
+        scope=scope,
+        get_scope_stack=lambda: SimpleNamespace(),
+    )
+    monkeypatch.setitem(sys.modules, "nemo_flow", module)
+    return module
+
+
+def test_install_registers_and_uninstalls_execution_intercept(fake_nemo_flow: Any) -> None:
+    memory = FakeMemoryClient()
+
+    handle = nemo_flow.install(memory, name="neo4j.test", priority=12)
+
+    assert handle.active is True
+    assert fake_nemo_flow.intercepts.registered["neo4j.test"]["priority"] == 12
+    assert fake_nemo_flow.intercepts.registered["neo4j.test"]["callback"] is handle.intercept
+    assert handle.uninstall() is True
+    assert handle.active is False
+    assert handle.uninstall() is False
+    assert fake_nemo_flow.intercepts.deregistered == ["neo4j.test"]
+
+
+@pytest.mark.asyncio
+async def test_context_identity_recalls_and_captures_with_memory_client(
+    fake_nemo_flow: Any,
+) -> None:
+    memory = FakeMemoryClient()
+    nemo_flow.install(memory, name="neo4j.context")
+    intercept = fake_nemo_flow.intercepts.registered["neo4j.context"]["callback"]
+    seen_requests = []
+    request = fake_nemo_flow.LLMRequest(
+        {"x-trace": "abc"},
+        {
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "What should I drink?"}],
+        },
+    )
+
+    async def next_call(next_request: Any) -> dict[str, Any]:
+        seen_requests.append(next_request)
+        return {"choices": [{"message": {"content": "Drink tea."}}]}
+
+    with nemo_flow.memory_scope(user_id="user-1", thread_id="thread-1"):
+        response = await intercept("gpt-test", request, next_call)
+
+    assert response == {"choices": [{"message": {"content": "Drink tea."}}]}
+    assert len(seen_requests) == 1
+    assert isinstance(seen_requests[0], FakeLLMRequest)
+    assert seen_requests[0] is not request
+    assert seen_requests[0].headers == {"x-trace": "abc"}
+
+    messages = seen_requests[0].content["messages"]
+    assert messages[0]["role"] == "system"
+    assert "Relevant memory context:" in messages[0]["content"]
+    assert "Alex prefers tea in the afternoon." in messages[0]["content"]
+    assert "Past memory: Alex also likes green tea." in messages[0]["content"]
+
+    assert memory.short_term.get_conversation_calls == [
+        {"session_id": "user-1:thread-1", "limit": 10}
+    ]
+    assert memory.short_term.search_messages_calls == [
+        {
+            "query": "What should I drink?",
+            "kwargs": {
+                "limit": 5,
+                "metadata_filters": {
+                    "user_id": "user-1",
+                    "run_id": "thread-1",
+                    "session_id": "user-1:thread-1",
+                },
+                "threshold": 0.7,
+            },
+        }
+    ]
+    assert memory.short_term.add_message_calls == [
+        {
+            "session_id": "user-1:thread-1",
+            "role": "user",
+            "content": "What should I drink?",
+            "metadata": {
+                "user_id": "user-1",
+                "run_id": "thread-1",
+                "session_id": "user-1:thread-1",
+            },
+            "extract_entities": True,
+            "extract_relations": True,
+            "generate_embedding": True,
+        },
+        {
+            "session_id": "user-1:thread-1",
+            "role": "assistant",
+            "content": "Drink tea.",
+            "metadata": {
+                "user_id": "user-1",
+                "run_id": "thread-1",
+                "session_id": "user-1:thread-1",
+            },
+            "extract_entities": True,
+            "extract_relations": True,
+            "generate_embedding": True,
+        },
+    ]
+    assert [item["name"] for item in fake_nemo_flow.scope.pushed] == [
+        nemo_flow.NemoFlowScope.MEMORY.value,
+        nemo_flow.NemoFlowScope.RECALL.value,
+        nemo_flow.NemoFlowScope.CAPTURE.value,
+    ]
+    assert [item["name"] for item in fake_nemo_flow.scope.popped] == [
+        nemo_flow.NemoFlowScope.RECALL.value,
+        nemo_flow.NemoFlowScope.CAPTURE.value,
+        nemo_flow.NemoFlowScope.MEMORY.value,
+    ]
+    assert [item["name"] for item in fake_nemo_flow.scope.events] == [
+        nemo_flow.NemoFlowEvent.IDENTITY_RESOLVED.value,
+        nemo_flow.NemoFlowEvent.RECALL_CONTEXT_BUILT.value,
+        nemo_flow.NemoFlowEvent.RECALL_INJECTED.value,
+        nemo_flow.NemoFlowEvent.CAPTURE_EXTRACTED.value,
+        nemo_flow.NemoFlowEvent.CAPTURE_MESSAGE_STORED.value,
+        nemo_flow.NemoFlowEvent.CAPTURE_MESSAGE_STORED.value,
+        nemo_flow.NemoFlowEvent.CAPTURE_STORED.value,
+    ]
+    expected_context_chars = len(
+        "## Recent Conversation\n"
+        "**user**: Alex prefers tea in the afternoon.\n\n"
+        "## Relevant Past Messages\n"
+        "- [user] Past memory: Alex also likes green tea."
+    )
+    assert fake_nemo_flow.scope.events[0]["data"] == {
+        "source": nemo_flow.NemoFlowIdentitySource.MEMORY_SCOPE.value,
+        "has_scope": True,
+        "filter_count": 3,
+    }
+    assert fake_nemo_flow.scope.events[1]["data"]["context_chars"] == expected_context_chars
+    assert fake_nemo_flow.scope.events[1]["data"]["source_counts"] == {
+        nemo_flow.NemoFlowContextSource.SESSION_HISTORY.value: 1,
+        nemo_flow.NemoFlowContextSource.USER_MESSAGES.value: 1,
+    }
+    assert fake_nemo_flow.scope.events[2]["data"]["context_chars"] == expected_context_chars
+    assert fake_nemo_flow.scope.events[2]["data"]["message_count_before"] == 1
+    assert fake_nemo_flow.scope.events[2]["data"]["message_count_after"] == 2
+    assert fake_nemo_flow.scope.events[3]["data"] == {
+        "message_count": 2,
+        "roles": ["user", "assistant"],
+        "role_counts": {"user": 1, "assistant": 1},
+        "content_chars": 30,
+        "content_chars_by_role": {"user": 20, "assistant": 10},
+    }
+    assert fake_nemo_flow.scope.events[4]["data"]["role"] == "user"
+    assert fake_nemo_flow.scope.events[4]["data"]["result_id"] == "message-1"
+    assert fake_nemo_flow.scope.events[5]["data"]["role"] == "assistant"
+    assert fake_nemo_flow.scope.events[5]["data"]["result_id"] == "message-2"
+    assert fake_nemo_flow.scope.events[6]["data"] == {
+        "message_count": 2,
+        "roles": ["user", "assistant"],
+        "role_counts": {"user": 1, "assistant": 1},
+        "content_chars": 30,
+        "content_chars_by_role": {"user": 20, "assistant": 10},
+        "attempted_count": 2,
+        "stored_count": 2,
+        "skipped_empty_count": 0,
+        "stored": True,
+    }
+
+
+@pytest.mark.asyncio
+async def test_scope_metadata_can_supply_neo4j_identity(fake_nemo_flow: Any) -> None:
+    memory = FakeMemoryClient()
+    nemo_flow.install(memory, name="neo4j.scope", include_user_messages=False)
+    intercept = fake_nemo_flow.intercepts.registered["neo4j.scope"]["callback"]
+    fake_nemo_flow.scope.handle = SimpleNamespace(
+        metadata={"neo4j_agent_memory": {"session_id": "scope-session", "user_id": "scope-user"}}
+    )
+    request = fake_nemo_flow.LLMRequest(
+        {},
+        {"messages": [{"role": "user", "content": "Remember this?"}]},
+    )
+
+    async def next_call(next_request: Any) -> dict[str, str]:
+        return {"content": "I will remember."}
+
+    await intercept("gpt-test", request, next_call)
+
+    assert memory.short_term.get_conversation_calls == [
+        {"session_id": "scope-session", "limit": 10}
+    ]
+    assert memory.short_term.add_message_calls[0]["session_id"] == "scope-session"
+    assert memory.short_term.add_message_calls[0]["metadata"] == {
+        "user_id": "scope-user",
+        "session_id": "scope-session",
+    }
+
+
+@pytest.mark.asyncio
+async def test_no_identity_skips_neo4j_and_calls_next_with_original_request(
+    fake_nemo_flow: Any,
+) -> None:
+    memory = FakeMemoryClient()
+    nemo_flow.install(memory, name="neo4j.no_identity")
+    intercept = fake_nemo_flow.intercepts.registered["neo4j.no_identity"]["callback"]
+    request = fake_nemo_flow.LLMRequest({}, {"messages": [{"role": "user", "content": "Hi"}]})
+    seen_requests = []
+
+    async def next_call(next_request: Any) -> dict[str, str]:
+        seen_requests.append(next_request)
+        return {"content": "Hello"}
+
+    assert await intercept("gpt-test", request, next_call) == {"content": "Hello"}
+    assert seen_requests == [request]
+    assert memory.short_term.get_conversation_calls == []
+    assert memory.short_term.search_messages_calls == []
+    assert memory.short_term.add_message_calls == []
+    assert fake_nemo_flow.scope.pushed == []
+    assert fake_nemo_flow.scope.popped == []
+    assert fake_nemo_flow.scope.events == []
+
+
+@pytest.mark.asyncio
+async def test_memory_integration_capture_uses_store_message(fake_nemo_flow: Any) -> None:
+    integration = FakeMemoryIntegration()
+    nemo_flow.install(
+        integration,
+        name="neo4j.integration",
+        include_user_messages=False,
+        extract_entities=False,
+    )
+    intercept = fake_nemo_flow.intercepts.registered["neo4j.integration"]["callback"]
+    request = fake_nemo_flow.LLMRequest(
+        {},
+        {"messages": [{"role": "user", "content": "What do I drink?"}]},
+    )
+
+    async def next_call(next_request: Any) -> dict[str, str]:
+        return {"content": "Tea."}
+
+    with nemo_flow.memory_scope(session_id="explicit-session", user_id="alex"):
+        await intercept("gpt-test", request, next_call)
+
+    assert integration.store_message_calls == [
+        {
+            "role": "user",
+            "content": "What do I drink?",
+            "session_id": "explicit-session",
+            "metadata": {"user_id": "alex", "session_id": "explicit-session"},
+        },
+        {
+            "role": "assistant",
+            "content": "Tea.",
+            "session_id": "explicit-session",
+            "metadata": {"user_id": "alex", "session_id": "explicit-session"},
+        },
+    ]
+
+
+@pytest.mark.asyncio
+async def test_long_term_recall_is_opt_in(fake_nemo_flow: Any) -> None:
+    memory = FakeMemoryClient()
+    nemo_flow.install(
+        memory,
+        name="neo4j.long_term",
+        include_session_history=False,
+        include_user_messages=False,
+        include_long_term=True,
+    )
+    intercept = fake_nemo_flow.intercepts.registered["neo4j.long_term"]["callback"]
+    seen_requests = []
+    request = fake_nemo_flow.LLMRequest(
+        {},
+        {"messages": [{"role": "user", "content": "What tea do I like?"}]},
+    )
+
+    async def next_call(next_request: Any) -> dict[str, str]:
+        seen_requests.append(next_request)
+        return {"content": "Jasmine tea."}
+
+    with nemo_flow.memory_scope(user_id="alex", run_id="run-1"):
+        await intercept("gpt-test", request, next_call)
+
+    assert memory.long_term.get_context_calls == [
+        {"query": "What tea do I like?", "kwargs": {"max_items": 10}}
+    ]
+    assert "Alex prefers jasmine tea" in seen_requests[0].content["messages"][0]["content"]
+
+
+def test_legacy_names_remain_available() -> None:
+    assert nemo_flow.memory_context is nemo_flow.memory_scope
+    assert nemo_flow.neo4j_memory_context is nemo_flow.memory_scope
+    assert nemo_flow.install_neo4j is nemo_flow.install
+
+
+def test_scope_and_event_registries_are_public() -> None:
+    assert nemo_flow.NEMO_FLOW_SCOPE_REGISTRY[nemo_flow.NemoFlowScope.MEMORY].scope_type_name == (
+        "Custom"
+    )
+    assert nemo_flow.NEMO_FLOW_SCOPE_REGISTRY[nemo_flow.NemoFlowScope.RECALL].scope_type_name == (
+        "Retriever"
+    )
+    assert (
+        nemo_flow.NEMO_FLOW_EVENT_REGISTRY[nemo_flow.NemoFlowEvent.RECALL_INJECTED].name.value
+        == "neo4j_agent_memory.recall.injected"
+    )
+    assert (
+        nemo_flow.NEMO_FLOW_EVENT_REGISTRY[nemo_flow.NemoFlowEvent.RECALL_CONTEXT_BUILT].description
+        == "Recall built context from one or more memory sources."
+    )
+    assert (
+        nemo_flow.NEMO_FLOW_EVENT_REGISTRY[nemo_flow.NemoFlowEvent.CAPTURE_STORED].name.value
+        == "neo4j_agent_memory.capture.stored"
+    )
+    assert (
+        nemo_flow.NEMO_FLOW_EVENT_REGISTRY[
+            nemo_flow.NemoFlowEvent.CAPTURE_MESSAGE_STORED
+        ].description
+        == "Capture stored one message."
+    )
+
+
+def test_thread_id_conflict_is_rejected() -> None:
+    with (
+        pytest.raises(ValueError, match="run_id and thread_id"),
+        nemo_flow.memory_scope(user_id="user-1", run_id="run-1", thread_id="thread-1"),
+    ):
+        pass

--- a/uv.lock
+++ b/uv.lock
@@ -4554,6 +4554,18 @@ wheels = [
 ]
 
 [[package]]
+name = "nemo-flow"
+version = "0.1.0"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5e/2e/2ccd2c9cccea62abafb135ce4f04ad5d3210f63b50d6d12e5ce9347cd13c/nemo_flow-0.1.0-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:2763690978b94ea84b4cdb8d137c88376ff24420e5959d2eba315bbcd949a03e", size = 4013568, upload-time = "2026-05-01T21:47:20.217Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/33/d251565cdbabf80ab0dd28f3f485bacf4782928ba5dcc56fc69dd2898a73/nemo_flow-0.1.0-cp311-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b437788cea723d5d7271c8001359b73962543253a28710b82a35a19f0abe0671", size = 3599365, upload-time = "2026-05-01T21:47:22.318Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/ca/3de7ff316aba0fdee0f077d1e7642e10d9dc87840f4737053047ec00a9ad/nemo_flow-0.1.0-cp311-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b4b44b9ffd3b69744dbb37ca4a4813982f41ada79d28089191d77ce7f797b012", size = 3753371, upload-time = "2026-05-01T21:47:24.058Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/c6/20c2a95c60cde60fc11d90d4523f8e9a57312a60b64dafc46fefa241e6e0/nemo_flow-0.1.0-cp311-abi3-win_amd64.whl", hash = "sha256:ee17c893f543304a32d4a3c8fa6f0892f27c92f068f0ea3d7108853cee13674f", size = 3677742, upload-time = "2026-05-01T21:47:25.895Z" },
+    { url = "https://files.pythonhosted.org/packages/04/2a/81ae22a63db2fd1635a83043ebe671fc18327b9c0873601efbfb1526ca14/nemo_flow-0.1.0-cp311-abi3-win_arm64.whl", hash = "sha256:5e20f3eba98f485dd0b3aacd59a71368137648f9315d60ed17bc0cb7ba0e3ec0", size = 3489671, upload-time = "2026-05-01T21:47:27.967Z" },
+]
+
+[[package]]
 name = "neo4j"
 version = "6.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -4643,6 +4655,9 @@ mcp = [
 microsoft-agent = [
     { name = "agent-framework" },
 ]
+nemo-flow = [
+    { name = "nemo-flow", marker = "python_full_version >= '3.11'" },
+]
 observability = [
     { name = "opentelemetry-api" },
     { name = "opentelemetry-sdk" },
@@ -4714,6 +4729,7 @@ requires-dist = [
     { name = "google-cloud-aiplatform", marker = "extra == 'vertex-ai'", specifier = ">=1.38.0" },
     { name = "langchain-core", marker = "extra == 'langchain'", specifier = ">=0.2.0" },
     { name = "llama-index-core", marker = "extra == 'llamaindex'", specifier = ">=0.10.0" },
+    { name = "nemo-flow", marker = "python_full_version >= '3.11' and extra == 'nemo-flow'", specifier = ">=0.1.0rc5,<0.2.0" },
     { name = "neo4j", specifier = ">=5.20.0" },
     { name = "neo4j-agent-memory", extras = ["all", "sentence-transformers", "spacy", "gliner"], marker = "extra == 'full'" },
     { name = "neo4j-agent-memory", extras = ["openai", "anthropic", "fuzzy", "langchain", "llamaindex", "pydantic-ai", "crewai", "openai-agents", "microsoft-agent"], marker = "extra == 'all'" },
@@ -4735,7 +4751,7 @@ requires-dist = [
     { name = "spacy", marker = "extra == 'spacy'", specifier = ">=3.7.0" },
     { name = "strands-agents", marker = "extra == 'strands'", specifier = ">=0.1.0" },
 ]
-provides-extras = ["openai", "anthropic", "sentence-transformers", "vertex-ai", "bedrock", "google", "aws", "strands", "spacy", "gliner", "extraction", "fuzzy", "cli", "opentelemetry", "opik", "observability", "langchain", "llamaindex", "pydantic-ai", "crewai", "openai-agents", "microsoft-agent", "mcp", "google-adk", "all", "full"]
+provides-extras = ["openai", "anthropic", "sentence-transformers", "vertex-ai", "bedrock", "google", "aws", "strands", "spacy", "gliner", "extraction", "fuzzy", "cli", "opentelemetry", "opik", "observability", "langchain", "llamaindex", "pydantic-ai", "crewai", "openai-agents", "microsoft-agent", "nemo-flow", "mcp", "google-adk", "all", "full"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## DO NOT MERGE

This is a draft PR for design review and live validation only. Please do not merge until the NeMo Flow integration shape, event contract, and memory provider boundaries have been reviewed.

## What This Adds

Adds an optional NeMo Flow integration for Neo4j Agent Memory. The integration uses NeMo Flow as the hidden runtime/intercept layer while Neo4j Agent Memory owns memory identity, filtering, retrieval, formatting, and storage.

The intended user-facing DX is:

```python
from neo4j_agent_memory import MemoryClient
from neo4j_agent_memory.integrations import nemo_flow

memory = MemoryClient(settings)
handle = nemo_flow.install(memory)

with nemo_flow.memory_scope(user_id="alex", thread_id="thread-123"):
    result = await agent.ainvoke({"messages": messages})

handle.uninstall()
```

Application code does not need to import NeMo Flow directly for the common path, as long as the agent/framework LLM boundary is already flowing through NeMo Flow instrumentation.

## Integration Behavior

Before an LLM call, the intercept:

- resolves memory identity from a custom resolver, `memory_scope(...)`, or NeMo Flow scope metadata
- extracts the latest user query from the request
- recalls scoped short-term memory context
- optionally includes long-term and reasoning context
- injects formatted memory into a copied NeMo Flow `LLMRequest`

After the LLM call, the intercept:

- extracts the user and assistant messages
- stores them through `MemoryIntegration.store_message(...)` when available
- otherwise stores them through `client.short_term.add_message(...)`
- returns the original model response to the caller

## Architecture

The public module is kept intentionally small:

- `integrations/nemo_flow.py`: public facade, install/uninstall handle, memory scope
- `_nemo_flow_intercept.py`: LLM execution orchestration
- `_nemo_flow_memory.py`: Neo4j Agent Memory access and storage
- `_nemo_flow_runtime.py`: lazy NeMo Flow import, scope identity, telemetry helpers
- `_nemo_flow_content.py`: request/response extraction and request mutation
- `_nemo_flow_types.py`: config, enums, registries, shared dataclasses

## Observability

The adapter emits NeMo Flow scopes for duration-bearing operations:

- `neo4j_agent_memory.memory`
- `neo4j_agent_memory.recall`
- `neo4j_agent_memory.capture`

It also emits mark events for state transitions:

- `neo4j_agent_memory.identity.resolved`
- `neo4j_agent_memory.recall.context_built`
- `neo4j_agent_memory.recall.injected`
- `neo4j_agent_memory.recall.skipped`
- `neo4j_agent_memory.recall.failed`
- `neo4j_agent_memory.capture.extracted`
- `neo4j_agent_memory.capture.message_stored`
- `neo4j_agent_memory.capture.stored`
- `neo4j_agent_memory.capture.skipped`
- `neo4j_agent_memory.capture.failed`

Scope and event payloads avoid raw user query text and recalled memory text. They include operational metadata such as counts, character lengths, insertion index, roles, and storage status.

## Included Artifacts

- Optional dependency extra: `neo4j-agent-memory[nemo-flow]`
- Public integration API
- Unit tests with a fake NeMo Flow runtime
- Example smoke test without external services
- Live integration smoke test using the existing Neo4j fixture/testcontainer path
- Integration docs page and nav/index entries

## Validation

Ran:

```bash
env UV_CACHE_DIR=/tmp/uv-cache uv run ruff check src/neo4j_agent_memory/integrations/nemo_flow.py src/neo4j_agent_memory/integrations/_nemo_flow_types.py src/neo4j_agent_memory/integrations/_nemo_flow_content.py src/neo4j_agent_memory/integrations/_nemo_flow_runtime.py src/neo4j_agent_memory/integrations/_nemo_flow_memory.py src/neo4j_agent_memory/integrations/_nemo_flow_intercept.py tests/unit/integrations/test_nemo_flow.py tests/examples/test_nemo_flow_memory.py tests/integration/test_nemo_flow_integration.py
env UV_CACHE_DIR=/tmp/uv-cache uv run ruff format --check src/neo4j_agent_memory/integrations/nemo_flow.py src/neo4j_agent_memory/integrations/_nemo_flow_types.py src/neo4j_agent_memory/integrations/_nemo_flow_content.py src/neo4j_agent_memory/integrations/_nemo_flow_runtime.py src/neo4j_agent_memory/integrations/_nemo_flow_memory.py src/neo4j_agent_memory/integrations/_nemo_flow_intercept.py tests/unit/integrations/test_nemo_flow.py tests/examples/test_nemo_flow_memory.py tests/integration/test_nemo_flow_integration.py
env UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/unit/integrations/test_nemo_flow.py tests/examples/test_nemo_flow_memory.py tests/integration/test_nemo_flow_integration.py -q
```

Result: `11 passed`, Ruff clean.

## Known Limitations / Review Items

- Non-streaming LLM execution path only
- No direct tool-call memory capture yet
- Long-term and reasoning recall are opt-in
- Capture writes conversational short-term memory by default
- Entity extraction may run indirectly through short-term memory storage, but this adapter does not yet observe extraction/deduplication counts
- Needs manual observability review with a real NeMo Flow subscriber/exporter setup before merge
