### PR TITLE
fix(settings): silently drop unprefixed .env keys instead of raising extra_forbidden

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1] - 2026-05-05
+
 ### Fixed
 
 - **`MemorySettings(...)` no longer raises `extra_forbidden` for unrelated `.env` keys.** pydantic-settings 2.x leaks `.env` keys outside the configured `env_prefix` into the validation payload, which collided with `MemorySettings`'s `extra="forbid"` (used to catch code-level typos). Common symptoms: instantiating `MemorySettings(neo4j={...})` failed with `extra_forbidden` on `neo4j_uri` / `neo4j_password` / `openai_api_key` whenever the user's `.env` contained the unprefixed equivalents (e.g. `NEO4J_URI=...` from a Docker setup, or `OPENAI_API_KEY=...` for an unrelated tool). `MemorySettings.settings_customise_sources` now wraps the dotenv source to drop keys that aren't top-level model fields. `NAM_*`-prefixed nested loads (e.g. `NAM_NEO4J__URI`) are unchanged, and the typo guard for kwargs (`MemorySettings(schema=...)`) still raises. New `TestDotEnvFiltering` regression tests in `tests/unit/test_config.py`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`MemorySettings(...)` no longer raises `extra_forbidden` for unrelated `.env` keys.** pydantic-settings 2.x leaks `.env` keys outside the configured `env_prefix` into the validation payload, which collided with `MemorySettings`'s `extra="forbid"` (used to catch code-level typos). Common symptoms: instantiating `MemorySettings(neo4j={...})` failed with `extra_forbidden` on `neo4j_uri` / `neo4j_password` / `openai_api_key` whenever the user's `.env` contained the unprefixed equivalents (e.g. `NEO4J_URI=...` from a Docker setup, or `OPENAI_API_KEY=...` for an unrelated tool). `MemorySettings.settings_customise_sources` now wraps the dotenv source to drop keys that aren't top-level model fields. `NAM_*`-prefixed nested loads (e.g. `NAM_NEO4J__URI`) are unchanged, and the typo guard for kwargs (`MemorySettings(schema=...)`) still raises. New `TestDotEnvFiltering` regression tests in `tests/unit/test_config.py`.
+
 ## [0.2.0] - 2026-05-04
 
 The v0.2 feature drop. Headline feature is **adopting an existing Neo4j graph** as long-term memory; the rest are production-readiness primitives.

--- a/docs/modules/ROOT/pages/faq.adoc
+++ b/docs/modules/ROOT/pages/faq.adoc
@@ -1046,7 +1046,7 @@ neo4j_uri
 
 …even though you only passed `neo4j={...}` as a kwarg. The cause is unrelated keys in your `.env` file (e.g. plain `NEO4J_URI=...` from a Docker setup, or `OPENAI_API_KEY=...` for a different tool). pydantic-settings 2.x leaks unmatched `.env` keys into the validation payload regardless of `env_prefix`, and `MemorySettings` uses `extra="forbid"` to catch code-level typos.
 
-**Fix:** upgrade to neo4j-agent-memory 0.2.x or later -- `MemorySettings` filters non-`NAM_`-matching keys before they reach validation. No code change needed.
+**Fix:** upgrade to the next `0.2.x` patch release of `neo4j-agent-memory` (not `0.2.0`) or later -- `MemorySettings` filters non-`NAM_`-matching keys before they reach validation. No code change needed.
 
 **On older versions:** subclass `MemorySettings` (or your own settings class) with `extra="ignore"`:
 

--- a/docs/modules/ROOT/pages/faq.adoc
+++ b/docs/modules/ROOT/pages/faq.adoc
@@ -1032,6 +1032,39 @@ GLiNER has a context window limit. For large texts:
 . Process chunks separately
 . Merge and deduplicate results
 
+[[extra-forbidden-from-env]]
+=== Why does `MemorySettings(...)` raise `extra_forbidden` for `neo4j_uri` / `openai_api_key`?
+
+You see an error like:
+
+[source,text]
+----
+ValidationError: 1 validation error for MemorySettings
+neo4j_uri
+  Extra inputs are not permitted [type=extra_forbidden, input_value='neo4j://localhost:7687']
+----
+
+…even though you only passed `neo4j={...}` as a kwarg. The cause is unrelated keys in your `.env` file (e.g. plain `NEO4J_URI=...` from a Docker setup, or `OPENAI_API_KEY=...` for a different tool). pydantic-settings 2.x leaks unmatched `.env` keys into the validation payload regardless of `env_prefix`, and `MemorySettings` uses `extra="forbid"` to catch code-level typos.
+
+**Fix:** upgrade to neo4j-agent-memory 0.2.x or later -- `MemorySettings` filters non-`NAM_`-matching keys before they reach validation. No code change needed.
+
+**On older versions:** subclass `MemorySettings` (or your own settings class) with `extra="ignore"`:
+
+[source,python]
+----
+from pydantic_settings import SettingsConfigDict
+from neo4j_agent_memory import MemorySettings
+
+class MySettings(MemorySettings):
+    model_config = SettingsConfigDict(
+        env_prefix="NAM_",
+        env_nested_delimiter="__",
+        env_file=".env",
+        env_file_encoding="utf-8",
+        extra="ignore",
+    )
+----
+
 [[gliner-not-installed]]
 === ImportError: GLiNER not installed
 

--- a/docs/modules/ROOT/pages/getting-started.adoc
+++ b/docs/modules/ROOT/pages/getting-started.adoc
@@ -323,6 +323,11 @@ async with MemoryClient(settings) as memory:
     pass
 ----
 
+[NOTE]
+====
+Other env vars in your `.env` (e.g. plain `NEO4J_URI=...`, `OPENAI_API_KEY=...` for unrelated tools) are silently ignored by `MemorySettings` -- only `NAM_*`-prefixed vars are loaded. If you're on a pre-`0.2.x` release and see `extra_forbidden` errors, see xref:faq.adoc#extra-forbidden-from-env[the FAQ entry].
+====
+
 == Error Handling
 
 [source,python]

--- a/docs/modules/ROOT/pages/getting-started.adoc
+++ b/docs/modules/ROOT/pages/getting-started.adoc
@@ -325,7 +325,7 @@ async with MemoryClient(settings) as memory:
 
 [NOTE]
 ====
-Other env vars in your `.env` (e.g. plain `NEO4J_URI=...`, `OPENAI_API_KEY=...` for unrelated tools) are silently ignored by `MemorySettings` -- only `NAM_*`-prefixed vars are loaded. If you're on a pre-`0.2.x` release and see `extra_forbidden` errors, see xref:faq.adoc#extra-forbidden-from-env[the FAQ entry].
+Other env vars in your `.env` (e.g. plain `NEO4J_URI=...`, `OPENAI_API_KEY=...` for unrelated tools) are silently ignored by `MemorySettings` -- only `NAM_*`-prefixed vars are loaded. If you see `extra_forbidden` errors, upgrade to the next `0.2.x` patch release and see xref:faq.adoc#extra-forbidden-from-env[the FAQ entry].
 ====
 
 == Error Handling

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "neo4j-agent-memory"
-version = "0.2.0"
+version = "0.2.1"
 description = "A comprehensive memory system for AI agents using Neo4j"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/src/neo4j_agent_memory/__init__.py
+++ b/src/neo4j_agent_memory/__init__.py
@@ -187,7 +187,7 @@ from neo4j_agent_memory.memory.short_term import (
     ShortTermMemory,
 )
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"
 
 __all__ = [
     # Main client

--- a/src/neo4j_agent_memory/config/settings.py
+++ b/src/neo4j_agent_memory/config/settings.py
@@ -554,7 +554,12 @@ class MemorySettings(BaseSettings):
         dotenv_settings: PydanticBaseSettingsSource,  # noqa: ARG003 — required by pydantic-settings hook
         file_secret_settings: PydanticBaseSettingsSource,
     ) -> tuple[PydanticBaseSettingsSource, ...]:
-        return init_settings, env_settings, _FilteredDotEnvSource(settings_cls), file_secret_settings
+        return (
+            init_settings,
+            env_settings,
+            _FilteredDotEnvSource(settings_cls),
+            file_secret_settings,
+        )
 
     @classmethod
     def from_dict(cls, config: dict[str, Any]) -> "MemorySettings":

--- a/src/neo4j_agent_memory/config/settings.py
+++ b/src/neo4j_agent_memory/config/settings.py
@@ -474,9 +474,16 @@ class EnrichmentConfig(BaseModel):
 
 
 class _FilteredDotEnvSource(DotEnvSettingsSource):
-    # Drops .env keys that aren't top-level model fields. Works around
-    # pydantic-settings 2.x DotEnvSettingsSource leaking non-prefix-matching
-    # keys into the validation payload when the model has extra='forbid'.
+    # Wraps an existing DotEnvSettingsSource instance, preserving all runtime
+    # overrides (e.g. _env_file=None or _env_file=some_path passed at
+    # MemorySettings instantiation time) while dropping .env keys that are not
+    # top-level model fields.  The original source is already configured with
+    # the correct env_file / env_file_encoding / env_prefix when it arrives in
+    # settings_customise_sources — copying its __dict__ is cheaper and safer
+    # than re-constructing from settings_cls alone.
+    def __init__(self, original: DotEnvSettingsSource) -> None:
+        self.__dict__.update(original.__dict__)
+
     def __call__(self) -> dict[str, Any]:
         data = super().__call__()
         valid = set(self.settings_cls.model_fields.keys())
@@ -551,13 +558,13 @@ class MemorySettings(BaseSettings):
         settings_cls: type[BaseSettings],
         init_settings: PydanticBaseSettingsSource,
         env_settings: PydanticBaseSettingsSource,
-        dotenv_settings: PydanticBaseSettingsSource,  # noqa: ARG003 — required by pydantic-settings hook
+        dotenv_settings: PydanticBaseSettingsSource,
         file_secret_settings: PydanticBaseSettingsSource,
     ) -> tuple[PydanticBaseSettingsSource, ...]:
         return (
             init_settings,
             env_settings,
-            _FilteredDotEnvSource(settings_cls),
+            _FilteredDotEnvSource(dotenv_settings),  # type: ignore[arg-type]
             file_secret_settings,
         )
 

--- a/src/neo4j_agent_memory/config/settings.py
+++ b/src/neo4j_agent_memory/config/settings.py
@@ -4,7 +4,8 @@ from enum import Enum
 from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, SecretStr, model_validator
-from pydantic_settings import BaseSettings, SettingsConfigDict
+from pydantic_settings import BaseSettings, PydanticBaseSettingsSource, SettingsConfigDict
+from pydantic_settings.sources import DotEnvSettingsSource
 
 # Strict config shared by every child config model. Misspelled fields raise
 # at construction time instead of being silently dropped.
@@ -472,6 +473,16 @@ class EnrichmentConfig(BaseModel):
     )
 
 
+class _FilteredDotEnvSource(DotEnvSettingsSource):
+    # Drops .env keys that aren't top-level model fields. Works around
+    # pydantic-settings 2.x DotEnvSettingsSource leaking non-prefix-matching
+    # keys into the validation payload when the model has extra='forbid'.
+    def __call__(self) -> dict[str, Any]:
+        data = super().__call__()
+        valid = set(self.settings_cls.model_fields.keys())
+        return {k: v for k, v in data.items() if k in valid}
+
+
 class MemorySettings(BaseSettings):
     """
     Main configuration class for neo4j-agent-memory.
@@ -494,9 +505,10 @@ class MemorySettings(BaseSettings):
         env_file_encoding="utf-8",
         # ``extra="forbid"`` rejects misspelled top-level fields (e.g.
         # ``schema=`` instead of ``schema_config=``) at construction time
-        # rather than silently dropping them. Pydantic still allows unknown
-        # *environment variables* with the same prefix to be ignored — that
-        # is the intent of the env loader, not a typo in code.
+        # rather than silently dropping them. Unrelated keys in a user's
+        # ``.env`` (e.g. plain ``NEO4J_URI=…`` or ``OPENAI_API_KEY=…`` for
+        # other tools) are filtered out by ``settings_customise_sources``
+        # below before they reach validation.
         extra="forbid",
     )
 
@@ -532,6 +544,17 @@ class MemorySettings(BaseSettings):
             # didn't explicitly opt out.
             self.llm = LLMConfig()
         return self
+
+    @classmethod
+    def settings_customise_sources(
+        cls,
+        settings_cls: type[BaseSettings],
+        init_settings: PydanticBaseSettingsSource,
+        env_settings: PydanticBaseSettingsSource,
+        dotenv_settings: PydanticBaseSettingsSource,  # noqa: ARG003 — required by pydantic-settings hook
+        file_secret_settings: PydanticBaseSettingsSource,
+    ) -> tuple[PydanticBaseSettingsSource, ...]:
+        return init_settings, env_settings, _FilteredDotEnvSource(settings_cls), file_secret_settings
 
     @classmethod
     def from_dict(cls, config: dict[str, Any]) -> "MemorySettings":

--- a/src/neo4j_agent_memory/config/settings.py
+++ b/src/neo4j_agent_memory/config/settings.py
@@ -555,7 +555,7 @@ class MemorySettings(BaseSettings):
     @classmethod
     def settings_customise_sources(
         cls,
-        settings_cls: type[BaseSettings],
+        settings_cls: type[BaseSettings],  # noqa: ARG003 — required by pydantic-settings hook
         init_settings: PydanticBaseSettingsSource,
         env_settings: PydanticBaseSettingsSource,
         dotenv_settings: PydanticBaseSettingsSource,

--- a/src/neo4j_agent_memory/config/settings.py
+++ b/src/neo4j_agent_memory/config/settings.py
@@ -481,7 +481,7 @@ class _FilteredDotEnvSource(DotEnvSettingsSource):
     # the correct env_file / env_file_encoding / env_prefix when it arrives in
     # settings_customise_sources — copying its __dict__ is cheaper and safer
     # than re-constructing from settings_cls alone.
-    def __init__(self, original: DotEnvSettingsSource) -> None:
+    def __init__(self, original: PydanticBaseSettingsSource) -> None:
         self.__dict__.update(original.__dict__)
 
     def __call__(self) -> dict[str, Any]:
@@ -564,7 +564,7 @@ class MemorySettings(BaseSettings):
         return (
             init_settings,
             env_settings,
-            _FilteredDotEnvSource(dotenv_settings),  # type: ignore[arg-type]
+            _FilteredDotEnvSource(dotenv_settings),
             file_secret_settings,
         )
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -432,9 +432,7 @@ class TestDotEnvFiltering:
 
         env_file = tmp_path / ".env"
         env_file.write_text(
-            "NAM_MY_APP=hello\n"
-            "MY_APP=ignored-without-prefix\n"
-            "OPENAI_API_KEY=sk-ignored\n"
+            "NAM_MY_APP=hello\nMY_APP=ignored-without-prefix\nOPENAI_API_KEY=sk-ignored\n"
         )
         monkeypatch.chdir(tmp_path)
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -452,7 +452,7 @@ class TestDotEnvFiltering:
 
         # Do NOT pass neo4j= as a kwarg — init_settings would take precedence
         # over dotenv_settings, masking whether the custom file was actually read.
-        settings = MemorySettings(_env_file=str(custom_env))
+        settings = MemorySettings(_env_file=custom_env)
         assert settings.neo4j.uri == "neo4j://custom:7687"
         assert settings.neo4j.password.get_secret_value() == "custompass"
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -438,3 +438,33 @@ class TestDotEnvFiltering:
 
         settings = ExtendedSettings(neo4j=Neo4jConfig(password=SecretStr("test")))
         assert settings.my_app == "hello"
+
+    def test_custom_env_file_path_respected(self, tmp_path, monkeypatch):
+        """_env_file= override must be forwarded to the wrapped DotEnv source."""
+        # No .env in cwd — if the wrong file were used we'd get defaults.
+        monkeypatch.chdir(tmp_path)
+
+        # Custom env file with NAM_-prefixed keys
+        custom_env = tmp_path / "custom.env"
+        custom_env.write_text(
+            "NAM_NEO4J__URI=neo4j://custom:7687\nNAM_NEO4J__PASSWORD=custompass\n"
+        )
+
+        # Do NOT pass neo4j= as a kwarg — init_settings would take precedence
+        # over dotenv_settings, masking whether the custom file was actually read.
+        settings = MemorySettings(_env_file=str(custom_env))
+        assert settings.neo4j.uri == "neo4j://custom:7687"
+        assert settings.neo4j.password.get_secret_value() == "custompass"
+
+    def test_env_file_none_disables_dotenv(self, tmp_path, monkeypatch):
+        """_env_file=None must prevent dotenv loading even if .env exists in cwd."""
+        env_file = tmp_path / ".env"
+        env_file.write_text(
+            "NAM_NEO4J__URI=neo4j://should-not-load:7687\nNAM_NEO4J__PASSWORD=blocked\n"
+        )
+        monkeypatch.chdir(tmp_path)
+
+        settings = MemorySettings(_env_file=None)
+        # URI must fall back to default, not read from the .env on disk.
+        assert settings.neo4j.uri == "bolt://localhost:7687"
+        assert settings.neo4j.password.get_secret_value() == ""

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -357,3 +357,86 @@ class TestStrictExtraFields:
     def test_unknown_field_rejected_on_geocoding_config(self):
         with pytest.raises(ValidationError):
             GeocodingConfig(provider_name="nominatim")  # type: ignore[call-arg]
+
+
+class TestDotEnvFiltering:
+    """Tests for `.env` keys outside ``NAM_`` prefix being silently ignored.
+
+    pydantic-settings 2.x leaks unmatched ``.env`` keys into the validation
+    payload even when ``env_prefix`` is set, which collides with
+    ``extra="forbid"``. ``MemorySettings.settings_customise_sources`` wraps
+    the dotenv source to filter to known top-level fields only.
+    """
+
+    def test_unprefixed_env_keys_ignored(self, tmp_path, monkeypatch):
+        """Plain ``NEO4J_URI`` / ``OPENAI_API_KEY`` in .env must not raise."""
+        env_file = tmp_path / ".env"
+        env_file.write_text(
+            "NEO4J_URI=neo4j://leaked:7687\n"
+            "NEO4J_USERNAME=leaked\n"
+            "NEO4J_PASSWORD=leaked\n"
+            "OPENAI_API_KEY=sk-leaked\n"
+        )
+        monkeypatch.chdir(tmp_path)
+
+        settings = MemorySettings(neo4j=Neo4jConfig(password=SecretStr("kwarg")))
+
+        # Unprefixed values must NOT bleed into the loaded settings.
+        assert settings.neo4j.uri == "bolt://localhost:7687"
+        assert settings.neo4j.username == "neo4j"
+        assert settings.neo4j.password.get_secret_value() == "kwarg"
+
+    def test_prefixed_env_keys_still_loaded(self, tmp_path, monkeypatch):
+        """Filter must not break the normal NAM_-prefixed nested load path."""
+        env_file = tmp_path / ".env"
+        env_file.write_text(
+            "NAM_NEO4J__URI=neo4j://example:7687\n"
+            "NAM_NEO4J__PASSWORD=fromenv\n"
+            "NEO4J_URI=should-be-ignored\n"
+        )
+        monkeypatch.chdir(tmp_path)
+
+        settings = MemorySettings()
+
+        assert settings.neo4j.uri == "neo4j://example:7687"
+        assert settings.neo4j.password.get_secret_value() == "fromenv"
+
+    def test_kwarg_typo_still_rejected_with_envfile_present(self, tmp_path, monkeypatch):
+        """Filter must not weaken the existing typo guard for code-level kwargs."""
+        from neo4j_agent_memory.config.settings import SchemaConfig
+
+        env_file = tmp_path / ".env"
+        env_file.write_text("NEO4J_URI=neo4j://noise:7687\n")
+        monkeypatch.chdir(tmp_path)
+
+        with pytest.raises(ValidationError) as excinfo:
+            MemorySettings(
+                neo4j=Neo4jConfig(password=SecretStr("test")),
+                schema=SchemaConfig(),  # type: ignore[call-arg]
+            )
+        assert "schema" in str(excinfo.value)
+
+    def test_subclass_field_survives_filter(self, tmp_path, monkeypatch):
+        """Subclasses adding new top-level fields must still receive prefixed env values."""
+        from pydantic_settings import SettingsConfigDict
+
+        class ExtendedSettings(MemorySettings):
+            model_config = SettingsConfigDict(
+                env_prefix="NAM_",
+                env_nested_delimiter="__",
+                env_file=".env",
+                env_file_encoding="utf-8",
+                extra="forbid",
+            )
+            my_app: str | None = None
+
+        env_file = tmp_path / ".env"
+        env_file.write_text(
+            "NAM_MY_APP=hello\n"
+            "MY_APP=ignored-without-prefix\n"
+            "OPENAI_API_KEY=sk-ignored\n"
+        )
+        monkeypatch.chdir(tmp_path)
+
+        settings = ExtendedSettings(neo4j=Neo4jConfig(password=SecretStr("test")))
+        assert settings.my_app == "hello"

--- a/uv.lock
+++ b/uv.lock
@@ -4567,7 +4567,7 @@ wheels = [
 
 [[package]]
 name = "neo4j-agent-memory"
-version = "0.1.2"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "neo4j" },

--- a/uv.lock
+++ b/uv.lock
@@ -4567,7 +4567,7 @@ wheels = [
 
 [[package]]
 name = "neo4j-agent-memory"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "neo4j" },


### PR DESCRIPTION
## Summary

`MemorySettings(neo4j={...})` was raising `ValidationError: extra_forbidden`
on `neo4j_uri` / `neo4j_password` / `openai_api_key` whenever the user's
`.env` happened to contain the unprefixed equivalents (e.g. `NEO4J_URI=...`
copied from a Docker setup, or `OPENAI_API_KEY=...` for a different tool).
Every example app in this repo carries an `extra="ignore"` workaround for
this — the friction was real and recurring.

**Root cause:** pydantic-settings 2.x's `DotEnvSettingsSource.__call__`
leaks `.env` keys outside the configured `env_prefix` into the validation
payload (see upstream
[`sources/providers/dotenv.py:137`](https://github.com/pydantic/pydantic-settings)).
That collided with `MemorySettings`'s `extra="forbid"` (kept intentionally
to catch code-level typos like `MemorySettings(schema=...)`). The inline
comment in `settings.py` claiming pydantic ignores non-prefix env vars was
factually wrong for current pydantic-settings.

**Fix:** `MemorySettings.settings_customise_sources` now wraps the dotenv
source with `_FilteredDotEnvSource`, which drops keys that aren't top-level
model fields after pydantic-settings has done its prefix-aware nested
resolution. Net effect:

- Unrelated `.env` keys (`NEO4J_URI`, `OPENAI_API_KEY`, …) are ignored
-  `NAM_*`-prefixed nested loads (`NAM_NEO4J__URI` → `neo4j.uri`) unchanged
-  Code-level kwargs typos (`MemorySettings(schema=...)`) still raise
-  Subclasses adding new fields get them respected by the filter

No public API change. The existing subclass-with-`extra="ignore"` pattern
keeps working for users who want it.

## Changes

- `src/neo4j_agent_memory/config/settings.py` — add `_FilteredDotEnvSource`
  + `settings_customise_sources` hook on `MemorySettings`; update the
  outdated comment block.
- `tests/unit/test_config.py` — new `TestDotEnvFiltering` class with 4
  regression cases (no `.env` coverage existed before).
- `docs/modules/ROOT/pages/faq.adoc` — new troubleshooting entry covering
  the symptom for users on pinned older versions.
- `docs/modules/ROOT/pages/getting-started.adoc` — one-line `NOTE` near the
  env-var example.
- `CHANGELOG.md` — `[Unreleased] / Fixed` entry.

## Test plan

- [x] `make test-unit` — all 962 unit tests pass, including the 4 new
      `TestDotEnvFiltering` cases
- [x] `ruff check` + `mypy` clean on changed files
- [x] Manual repro from the original report:
      ```python
      # .env contains: NEO4J_URI=neo4j://localhost:7687
      MemorySettings(neo4j={"uri": "bolt://localhost:7687",
                            "username": "neo4j",
                            "password": "neo4jpassword"})
      ```
      → previously raised `extra_forbidden`, now succeeds
- [x] Verified `MemorySettings(neo4j={"password": "x"}, schema=SchemaConfig())`
      still raises (typo guard intact)
- [x] Verified `NAM_NEO4J__URI` in `.env` still loads via nested resolution
- [ ] Smoke-test one example app (`make example-basic`) in CI
