### PR TITLE
Relocate TypeScript client, examples, and docs from agent-memory-tck repo

### DIFF
--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -1,10 +1,36 @@
-name: CI
+name: Python CI
 
 on:
   push:
     branches: [main]
+    paths:
+      - 'src/**'
+      - 'tests/**'
+      - 'benchmarks/**'
+      - 'examples/**'
+      - 'docs/**'
+      - 'scripts/**'
+      - 'pyproject.toml'
+      - 'uv.lock'
+      - 'Makefile'
+      - 'docker-compose.test.yml'
+      - 'codecov.yml'
+      - '.github/workflows/ci-python.yml'
   pull_request:
     branches: [main]
+    paths:
+      - 'src/**'
+      - 'tests/**'
+      - 'benchmarks/**'
+      - 'examples/**'
+      - 'docs/**'
+      - 'scripts/**'
+      - 'pyproject.toml'
+      - 'uv.lock'
+      - 'Makefile'
+      - 'docker-compose.test.yml'
+      - 'codecov.yml'
+      - '.github/workflows/ci-python.yml'
 
 jobs:
   lint:

--- a/.github/workflows/ci-typescript.yml
+++ b/.github/workflows/ci-typescript.yml
@@ -1,0 +1,53 @@
+name: TypeScript CI
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'typescript/**'
+      - '.github/workflows/ci-typescript.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'typescript/**'
+      - '.github/workflows/ci-typescript.yml'
+
+defaults:
+  run:
+    working-directory: typescript
+
+jobs:
+  lint-test:
+    name: Lint + Test (Node ${{ matrix.node }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node: ['20', '22']
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node }}
+          cache: 'npm'
+          cache-dependency-path: typescript/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Unit tests
+        run: npm run test:unit
+
+      - name: Integration tests
+        run: npm run test:integration
+
+      - name: Build
+        run: npm run build
+
+      - name: Verify packed artifact
+        run: npm pack --dry-run

--- a/.github/workflows/ci-typescript.yml
+++ b/.github/workflows/ci-typescript.yml
@@ -12,6 +12,9 @@ on:
       - 'typescript/**'
       - '.github/workflows/ci-typescript.yml'
 
+permissions:
+  contents: read
+
 defaults:
   run:
     working-directory: typescript

--- a/.github/workflows/ci-typescript.yml
+++ b/.github/workflows/ci-typescript.yml
@@ -15,14 +15,13 @@ on:
 permissions:
   contents: read
 
-defaults:
-  run:
-    working-directory: typescript
-
 jobs:
   lint-test:
     name: Lint + Test (Node ${{ matrix.node }})
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: typescript
     strategy:
       fail-fast: false
       matrix:
@@ -54,3 +53,35 @@ jobs:
 
       - name: Verify packed artifact
         run: npm pack --dry-run
+
+  type-check-examples:
+    name: Type-check example (${{ matrix.example }})
+    runs-on: ubuntu-latest
+    needs: lint-test
+    strategy:
+      fail-fast: false
+      matrix:
+        example: [langchain, mastra, mcp, strands, vercel-ai]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: typescript/package-lock.json
+
+      - name: Build SDK (populates typescript/dist for file: deps)
+        working-directory: typescript
+        run: |
+          npm ci
+          npm run build
+
+      - name: Install example dependencies
+        working-directory: typescript/examples/${{ matrix.example }}
+        run: npm install --no-package-lock
+
+      - name: Type-check example
+        working-directory: typescript/examples/${{ matrix.example }}
+        run: npx tsc --noEmit

--- a/.github/workflows/docs-typedoc.yml
+++ b/.github/workflows/docs-typedoc.yml
@@ -1,0 +1,60 @@
+name: TypeDoc
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'typescript/src/**'
+      - 'typescript/typedoc.json'
+      - 'typescript/package.json'
+      - '.github/workflows/docs-typedoc.yml'
+    tags:
+      - 'typescript-v*'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: 'typedoc'
+  cancel-in-progress: true
+
+jobs:
+  build-deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy.outputs.page_url }}
+    defaults:
+      run:
+        working-directory: typescript
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: typescript/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build TypeDoc
+        run: npm run docs:api
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload TypeDoc artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          # Matches `out` in typescript/typedoc.json
+          path: typescript/docs-api
+
+      - name: Deploy to GitHub Pages
+        id: deploy
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/e2e-typescript.yml
+++ b/.github/workflows/e2e-typescript.yml
@@ -1,0 +1,89 @@
+name: TypeScript E2E
+
+# Runs the TypeScript SDK's e2e suite (test/e2e/) against the live
+# NAMS hosted service.
+#
+# Mirrors nams-integration.yml on the Python side. Uses the same
+# MEMORY_API_KEY repo secret (set in repo Settings → Secrets and
+# variables → Actions). When the secret is absent (e.g. forks),
+# the workflow short-circuits cleanly to keep CI logs tidy — the
+# test files themselves also self-skip via `describe.skip` when
+# MEMORY_API_KEY is empty.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'typescript/**'
+      - '.github/workflows/e2e-typescript.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'typescript/**'
+      - '.github/workflows/e2e-typescript.yml'
+  schedule:
+    # 06:30 UTC — staggered 30 min after nams-integration.yml so the two
+    # don't hit the sandbox simultaneously.
+    - cron: "30 6 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    # Skip on PRs from forks (secrets are unavailable there).
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    timeout-minutes: 20
+    defaults:
+      run:
+        working-directory: typescript
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: typescript/package-lock.json
+
+      - name: Verify MEMORY_API_KEY is configured
+        env:
+          MEMORY_API_KEY: ${{ secrets.MEMORY_API_KEY }}
+        id: check-secret
+        run: |
+          if [ -z "$MEMORY_API_KEY" ]; then
+            echo "::warning::MEMORY_API_KEY secret is not set. TypeScript e2e tests will be skipped."
+            echo "skip_tests=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "MEMORY_API_KEY is set; running live e2e tests."
+          fi
+
+      - name: Install dependencies
+        if: steps.check-secret.outputs.skip_tests != 'true'
+        run: npm ci
+
+      - name: Build SDK
+        if: steps.check-secret.outputs.skip_tests != 'true'
+        run: npm run build
+
+      # Hosted-service suite — covers the full memory surface against
+      # NAMS. Individual tests self-skip on 403 when the key lacks a scope.
+      - name: Hosted service e2e
+        if: steps.check-secret.outputs.skip_tests != 'true'
+        env:
+          MEMORY_API_KEY: ${{ secrets.MEMORY_API_KEY }}
+          MEMORY_ENDPOINT: ${{ vars.MEMORY_ENDPOINT || 'https://memory.neo4jlabs.com/v1' }}
+        run: npx vitest run test/e2e/hosted-service.test.ts --reporter=verbose
+
+      # Strands integration e2e — exercises the conversation-manager,
+      # session-storage, and reasoning-hook plumbing against the live
+      # service. No OPENAI_API_KEY needed (uses mocked model wrapping).
+      - name: Strands integration e2e
+        if: steps.check-secret.outputs.skip_tests != 'true'
+        env:
+          MEMORY_API_KEY: ${{ secrets.MEMORY_API_KEY }}
+          MEMORY_ENDPOINT: ${{ vars.MEMORY_ENDPOINT || 'https://memory.neo4jlabs.com/v1' }}
+        run: npx vitest run test/e2e/strands.test.ts --reporter=verbose

--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -1,9 +1,9 @@
-name: Release
+name: Publish Python
 
 on:
   push:
     tags:
-      - "v*"
+      - "python-v*"
 
 permissions:
   contents: write

--- a/.github/workflows/publish-typescript.yml
+++ b/.github/workflows/publish-typescript.yml
@@ -1,0 +1,59 @@
+name: Publish TypeScript
+
+on:
+  push:
+    tags:
+      - "typescript-v*"
+
+defaults:
+  run:
+    working-directory: typescript
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment:
+      name: npm
+      url: https://www.npmjs.com/package/@neo4j-labs/agent-memory
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          registry-url: 'https://registry.npmjs.org'
+          cache: 'npm'
+          cache-dependency-path: typescript/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Test
+        run: npm test
+
+      - name: Build
+        run: npm run build
+
+      - name: Publish to npm with provenance
+        run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  github-release:
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          name: "TypeScript SDK ${{ github.ref_name }}"

--- a/.github/workflows/publish-typescript.yml
+++ b/.github/workflows/publish-typescript.yml
@@ -49,6 +49,8 @@ jobs:
   github-release:
     needs: publish
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/tck-conformance.yml
+++ b/.github/workflows/tck-conformance.yml
@@ -1,0 +1,75 @@
+name: TCK Conformance (Published Package)
+
+# Runs the agent-memory-tck Bronze conformance suite against the
+# *published* @neo4j-labs/agent-memory npm package. Distinct from the
+# in-tree typescript/test/tck/ suite (which runs in ci-typescript.yml) —
+# this verifies what users actually install.
+#
+# Activated only after the TCK-side companion PR lands and
+# clients/typescript-pkg-runner/ exists in the TCK repo (see Step 7 of
+# the relocation plan). Until then, run manually via workflow_dispatch.
+
+on:
+  schedule:
+    - cron: "0 6 * * *"  # 06:00 UTC, same slot as nams-integration.yml
+  workflow_dispatch:
+    inputs:
+      package_version:
+        description: 'npm version to test (default: latest)'
+        required: false
+        default: 'latest'
+
+jobs:
+  bronze:
+    runs-on: ubuntu-latest
+    # Until the TCK companion PR lands, default to manual-only
+    if: github.event_name == 'workflow_dispatch'
+    steps:
+      - name: Checkout TCK
+        uses: actions/checkout@v4
+        with:
+          repository: neo4j-labs/agent-memory-tck
+          path: tck
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Install TCK dependencies
+        working-directory: tck
+        run: uv sync --group dev
+
+      - name: Install published TS client
+        working-directory: tck/clients/typescript-pkg-runner
+        run: |
+          npm install @neo4j-labs/agent-memory@${{ github.event.inputs.package_version || 'latest' }}
+
+      - name: Start bridge server
+        working-directory: tck/clients/typescript-pkg-runner
+        run: |
+          npm run bridge &
+          sleep 5
+
+      - name: Run Bronze conformance suite
+        working-directory: tck
+        run: uv run pytest tests/ -m bronze --bridge-url http://localhost:3002
+
+      - name: File issue on failure
+        if: failure() && github.event_name == 'schedule'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: `TCK Bronze conformance failed against published @neo4j-labs/agent-memory@latest`,
+              body: `The nightly TCK conformance run failed. See [the run](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}).`,
+              labels: ['typescript', 'tck', 'bug']
+            })

--- a/.github/workflows/tck-conformance.yml
+++ b/.github/workflows/tck-conformance.yml
@@ -19,6 +19,10 @@ on:
         required: false
         default: 'latest'
 
+permissions:
+  contents: read
+  issues: write
+
 jobs:
   bronze:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,12 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 
+# TypeScript SDK (typescript/)
+typescript/node_modules/
+typescript/dist/
+typescript/.tsbuildinfo
+typescript/docs-api/
+
 # Build outputs
 *.log
 

--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,8 @@ typescript/node_modules/
 typescript/dist/
 typescript/.tsbuildinfo
 typescript/docs-api/
+typescript/examples/*/node_modules/
+typescript/examples/*/package-lock.json
 
 # Build outputs
 *.log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Repository
+
+- The repository at `neo4j-labs/agent-memory` is now polyglot. A
+  TypeScript SDK (`@neo4j-labs/agent-memory`, in `typescript/`) ships
+  alongside the Python SDK with the same memory model and the same NAMS
+  backend. _For the TypeScript SDK changelog see
+  [`typescript/CHANGELOG.md`](typescript/CHANGELOG.md)._
+- Python release tags are now namespaced as `python-v*` (e.g.
+  `python-v0.4.1`) so they cannot collide with TypeScript tags
+  (`typescript-v*`). The publish workflow has been renamed from
+  `release.yml` to `publish-python.yml`.
+- The CI workflow has been renamed from `ci.yml` to `ci-python.yml` and
+  is now path-filtered. TypeScript-only PRs no longer trigger the
+  Python test matrix.
+
 ## [0.4.0] - 2026-05-17
 
 The "hosted backend" release. Headline feature is **NAMS (Neo4j Agent Memory Service) backend support** — write once against `MemoryClient`, choose between local bolt-to-Neo4j or the hosted REST service at config time. The change is purely additive — existing v0.3.x code keeps working unchanged on bolt.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,73 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## Polyglot Layout
+
+This repository ships **two SDKs** with the same memory model and the
+same NAMS backend:
+
+- **Python SDK** (`neo4j-agent-memory` on PyPI) — lives at the repo
+  root: source in `src/neo4j_agent_memory/`, tests in `tests/`,
+  examples in `examples/`, build config in `pyproject.toml`.
+- **TypeScript SDK** (`@neo4j-labs/agent-memory` on npm) — lives at
+  `typescript/`: source, tests, examples, and `package.json` are all
+  contained inside that subtree.
+
+The two packages **share no build tooling**. There is no pnpm
+workspace, no Turborepo, no Nx, no `uv` workspace clause. Each package
+is built and released independently.
+
+### Release tagging
+
+Releases are tag-namespaced so they cannot collide:
+
+- `python-v*` (e.g. `python-v0.4.1`) → publishes to PyPI via
+  `.github/workflows/publish-python.yml`
+- `typescript-v*` (e.g. `typescript-v0.3.0`) → publishes to npm via
+  `.github/workflows/publish-typescript.yml`
+
+Plain `v*` tags do not trigger any publish.
+
+### CI is path-filtered
+
+- `.github/workflows/ci-python.yml` fires on changes under `src/**`,
+  `tests/**`, `benchmarks/**`, `examples/**`, `docs/**`, `scripts/**`,
+  and Python config files. **TypeScript-only PRs do not trigger Python
+  CI.**
+- `.github/workflows/ci-typescript.yml` fires on changes under
+  `typescript/**`. **Python-only PRs do not trigger TypeScript CI.**
+
+If you touch a cross-cutting file (e.g. `.gitignore`, top-level
+`README.md`), expect neither workflow to fire — surface the change in
+the PR description.
+
+### Working in the TypeScript subtree
+
+From the repo root:
+
+```bash
+make ts-install       # cd typescript && npm ci
+make ts-test          # cd typescript && npm test
+make ts-lint
+make ts-build
+make ts-conformance   # start the TCK bridge server (port 3001)
+```
+
+Or directly: `cd typescript && npm <script>`. The
+`typescript/package.json` `scripts` field is the source of truth for TS
+commands.
+
+### TCK conformance
+
+The cross-language behavioral spec lives in
+[`neo4j-labs/agent-memory-tck`](https://github.com/neo4j-labs/agent-memory-tck).
+The TCK certifies clients against Bronze, Silver, Gold, and Platinum
+tiers. After the relocation, the TCK consumes the published
+`@neo4j-labs/agent-memory` npm package as an external dependency. An
+in-tree TCK suite (`typescript/test/tck/`) runs in TS CI on every PR;
+the nightly `tck-conformance.yml` workflow runs the full TCK against
+the published package to catch packaging regressions.
+
 ## Project Overview
 
 `neo4j-agent-memory` is a Python package that provides a comprehensive memory system for AI agents using Neo4j as the backend. It implements a three-layer memory architecture:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -144,12 +144,13 @@ This project uses GitHub Actions for continuous integration and deployment.
 | Workflow | Trigger | Purpose |
 |----------|---------|---------|
 | **Python CI** (`ci-python.yml`) | Push to `main`, PRs touching `src/**`, `tests/**`, `docs/**`, etc. | Linting, type checking, tests, build validation |
-| **TypeScript CI** (`ci-typescript.yml`) | Push to `main`, PRs touching `typescript/**` | Lint, vitest (unit + integration), build, packed-artifact check |
+| **TypeScript CI** (`ci-typescript.yml`) | Push to `main`, PRs touching `typescript/**` | Lint, vitest (unit + integration), build, packed-artifact check, per-example type-check matrix |
+| **TypeScript E2E** (`e2e-typescript.yml`) | Push, PR, nightly | Run TypeScript SDK e2e suite against live NAMS sandbox (uses `MEMORY_API_KEY` secret) |
 | **Publish Python** (`publish-python.yml`) | Git tags `python-v*` | Build and publish to PyPI, create GitHub releases |
 | **Publish TypeScript** (`publish-typescript.yml`) | Git tags `typescript-v*` | Build and publish to npm with provenance |
 | **TypeDoc** (`docs-typedoc.yml`) | Push to `main` (TS docs paths) or `typescript-v*` tags | Build TypeDoc API reference, deploy to GitHub Pages |
 | **TCK Conformance** (`tck-conformance.yml`) | Nightly + workflow_dispatch | Run agent-memory-tck Bronze suite against the published `@neo4j-labs/agent-memory` package |
-| **NAMS Integration** (`nams-integration.yml`) | Push, PR, nightly | Run NAMS sandbox integration tests |
+| **NAMS Integration** (`nams-integration.yml`) | Push, PR, nightly | Run NAMS sandbox integration tests (Python side, uses `NAMS_SANDBOX_KEY` secret) |
 
 ### CI Jobs
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -143,8 +143,13 @@ This project uses GitHub Actions for continuous integration and deployment.
 
 | Workflow | Trigger | Purpose |
 |----------|---------|---------|
-| **CI** (`ci.yml`) | Push to `main`, PRs | Linting, type checking, tests, build validation |
-| **Release** (`release.yml`) | Git tags (`v*`) | Build and publish to PyPI, create GitHub releases |
+| **Python CI** (`ci-python.yml`) | Push to `main`, PRs touching `src/**`, `tests/**`, `docs/**`, etc. | Linting, type checking, tests, build validation |
+| **TypeScript CI** (`ci-typescript.yml`) | Push to `main`, PRs touching `typescript/**` | Lint, vitest (unit + integration), build, packed-artifact check |
+| **Publish Python** (`publish-python.yml`) | Git tags `python-v*` | Build and publish to PyPI, create GitHub releases |
+| **Publish TypeScript** (`publish-typescript.yml`) | Git tags `typescript-v*` | Build and publish to npm with provenance |
+| **TypeDoc** (`docs-typedoc.yml`) | Push to `main` (TS docs paths) or `typescript-v*` tags | Build TypeDoc API reference, deploy to GitHub Pages |
+| **TCK Conformance** (`tck-conformance.yml`) | Nightly + workflow_dispatch | Run agent-memory-tck Bronze suite against the published `@neo4j-labs/agent-memory` package |
+| **NAMS Integration** (`nams-integration.yml`) | Push, PR, nightly | Run NAMS sandbox integration tests |
 
 ### CI Jobs
 
@@ -196,15 +201,108 @@ All PRs must pass these checks before merging:
 5. Commit with descriptive messages
 6. Push and open a PR against `main`
 
-## Publishing to PyPI
+## Publishing
+
+This repo ships two independently versioned packages. Each has its own
+tag prefix and publish workflow.
+
+### Python (neo4j-agent-memory → PyPI)
 
 1. Update version in `pyproject.toml`
-2. Create and push a tag:
+2. Create and push a tag with the **`python-v`** prefix:
    ```bash
-   git tag v0.1.0
-   git push origin v0.1.0
+   git tag python-v0.4.1
+   git push origin python-v0.4.1
    ```
-3. GitHub Actions will automatically build and publish to PyPI
+3. `publish-python.yml` builds and publishes to PyPI, then creates a
+   GitHub Release.
+
+### TypeScript (@neo4j-labs/agent-memory → npm)
+
+1. Update version in `typescript/package.json`
+2. Update `typescript/CHANGELOG.md`
+3. Create and push a tag with the **`typescript-v`** prefix:
+   ```bash
+   git tag typescript-v0.3.0
+   git push origin typescript-v0.3.0
+   ```
+4. `publish-typescript.yml` builds and publishes to npm with provenance,
+   then creates a GitHub Release.
+
+> Tag prefixes are enforced by the publish workflows. Plain `v*` tags
+> will not trigger a publish.
+
+## TypeScript Contributions
+
+The TypeScript SDK lives at [`typescript/`](typescript/). It is a thin
+HTTP client over the NAMS REST API and ships five framework integrations
+(Vercel AI SDK, MCP, LangChain JS, Mastra, AWS Strands).
+
+### Setup
+
+Requires Node.js 20+.
+
+```bash
+cd typescript
+npm ci
+```
+
+### Common commands
+
+```bash
+# From the repo root
+make ts-install       # cd typescript && npm ci
+make ts-build         # cd typescript && npm run build
+make ts-test          # cd typescript && npm test
+make ts-test-unit     # cd typescript && npm run test:unit
+make ts-lint          # cd typescript && npm run lint
+make ts-docs          # cd typescript && npm run docs:api (TypeDoc)
+make ts-conformance   # cd typescript && npm run conformance:server (TCK bridge)
+
+# Or directly inside typescript/
+npm run lint
+npm run test:unit
+npm run test:integration
+npm run test:tck         # In-tree TCK Bronze conformance (RUN_TCK_BRIDGE=1)
+npm run build
+npm pack --dry-run       # Verify the publishable artifact
+```
+
+### TCK conformance
+
+The TypeScript SDK is verified against the cross-language
+[`agent-memory-tck`](https://github.com/neo4j-labs/agent-memory-tck)
+behavioral spec. The in-tree suite at `typescript/test/tck/` runs in
+`ci-typescript.yml` on every PR. A nightly job
+(`tck-conformance.yml`) runs the TCK against the **published** npm
+package to catch packaging regressions.
+
+To run the bridge server locally for cross-language testing:
+
+```bash
+make ts-conformance    # or: cd typescript && npm run conformance:server
+# Bridge listens on TCK_BRIDGE_PORT (default 3001)
+```
+
+### Code style (TypeScript)
+
+- **Formatter / Linter**: `tsc --noEmit` + `eslint src/` (run via
+  `npm run lint`)
+- **Tests**: vitest (`test/unit`, `test/integration`, `test/e2e`,
+  `test/tck`)
+- **Build**: tsup → `dist/` (CJS + ESM + type declarations)
+- **Engines**: Node 20+, but written to run on Bun, Deno, Cloudflare
+  Workers, and Vercel Edge
+
+### Adding a new framework integration
+
+1. Add `src/integrations/<name>.ts`
+2. Wire a subpath export in `typescript/package.json` under `exports`
+3. Add a runnable example at `typescript/examples/<name>/`
+4. Add a how-to guide at `docs/modules/ROOT/pages/how-to/typescript/<name>.adoc`
+5. Add a row to the integrations table in
+   `docs/modules/ROOT/pages/sdks/typescript.adoc` and in
+   `typescript/README.md`
 
 ## Documentation Guidelines (Diataxis Framework)
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help install install-all install-dev lint format typecheck test test-unit test-integration test-integration-mcp test-e2e test-all test-docker test-ci test-no-docker test-quick test-file test-match test-aws test-nams-unit test-nams-integration test-nams coverage coverage-all coverage-ci coverage-mcp test-examples test-examples-quick test-examples-no-neo4j test-docs test-docs-syntax test-docs-build test-docs-links neo4j-start neo4j-stop neo4j-logs clean build publish docs docs-diagrams-list docs-diagrams-status docs-diagrams-missing docs-diagrams-manifest docs-diagrams-add-refs docs-diagrams-generate example-basic example-resolution example-langchain example-pydantic examples chat-agent-install chat-agent-backend chat-agent-frontend chat-agent
+.PHONY: help install install-all install-dev lint format typecheck test test-unit test-integration test-integration-mcp test-e2e test-all test-docker test-ci test-no-docker test-quick test-file test-match test-aws test-nams-unit test-nams-integration test-nams coverage coverage-all coverage-ci coverage-mcp test-examples test-examples-quick test-examples-no-neo4j test-docs test-docs-syntax test-docs-build test-docs-links neo4j-start neo4j-stop neo4j-logs clean build publish docs docs-diagrams-list docs-diagrams-status docs-diagrams-missing docs-diagrams-manifest docs-diagrams-add-refs docs-diagrams-generate example-basic example-resolution example-langchain example-pydantic examples chat-agent-install chat-agent-backend chat-agent-frontend chat-agent ts-install ts-build ts-test ts-test-unit ts-test-integration ts-lint ts-docs ts-conformance ts-pack ts-clean
 
 # Default target
 help:
@@ -593,3 +593,53 @@ chat-agent:
 
 # Start Neo4j and run backend (convenience target)
 chat-agent-backend-with-neo4j: neo4j-start neo4j-wait chat-agent-backend
+
+# ============================================================================
+# TypeScript SDK (typescript/)
+#
+# The TypeScript SDK is a sibling package — @neo4j-labs/agent-memory on npm.
+# It has its own package.json, vitest config, and dependencies. These targets
+# delegate to npm scripts inside typescript/.
+# ============================================================================
+
+TS_DIR := typescript
+
+# Install TS dependencies (npm ci, reproducible from package-lock.json)
+ts-install:
+	cd $(TS_DIR) && npm ci
+
+# Build the TS package (tsup → dist/)
+ts-build:
+	cd $(TS_DIR) && npm run build
+
+# Run all TS tests (unit + integration)
+ts-test:
+	cd $(TS_DIR) && npm test
+
+# Run TS unit tests only (no Neo4j or NAMS sandbox required)
+ts-test-unit:
+	cd $(TS_DIR) && npm run test:unit
+
+# Run TS integration tests
+ts-test-integration:
+	cd $(TS_DIR) && npm run test:integration
+
+# Lint TS code (tsc --noEmit + eslint)
+ts-lint:
+	cd $(TS_DIR) && npm run lint
+
+# Build TypeDoc API reference (outputs to typescript/docs-api/)
+ts-docs:
+	cd $(TS_DIR) && npm run docs:api
+
+# Start the TCK bridge conformance server (default port 3001)
+ts-conformance:
+	cd $(TS_DIR) && npm run conformance:server
+
+# Inspect what would be published to npm
+ts-pack:
+	cd $(TS_DIR) && npm pack --dry-run
+
+# Remove TS build artifacts
+ts-clean:
+	rm -rf $(TS_DIR)/dist $(TS_DIR)/docs-api $(TS_DIR)/.tsbuildinfo

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help install install-all install-dev lint format typecheck test test-unit test-integration test-integration-mcp test-e2e test-all test-docker test-ci test-no-docker test-quick test-file test-match test-aws test-nams-unit test-nams-integration test-nams coverage coverage-all coverage-ci coverage-mcp test-examples test-examples-quick test-examples-no-neo4j test-docs test-docs-syntax test-docs-build test-docs-links neo4j-start neo4j-stop neo4j-logs clean build publish docs docs-diagrams-list docs-diagrams-status docs-diagrams-missing docs-diagrams-manifest docs-diagrams-add-refs docs-diagrams-generate example-basic example-resolution example-langchain example-pydantic examples chat-agent-install chat-agent-backend chat-agent-frontend chat-agent ts-install ts-build ts-test ts-test-unit ts-test-integration ts-lint ts-docs ts-conformance ts-pack ts-clean
+.PHONY: help install install-all install-dev lint format typecheck test test-unit test-integration test-integration-mcp test-e2e test-all test-docker test-ci test-no-docker test-quick test-file test-match test-aws test-nams-unit test-nams-integration test-nams coverage coverage-all coverage-ci coverage-mcp test-examples test-examples-quick test-examples-no-neo4j test-docs test-docs-syntax test-docs-build test-docs-links neo4j-start neo4j-stop neo4j-logs clean build publish docs docs-diagrams-list docs-diagrams-status docs-diagrams-missing docs-diagrams-manifest docs-diagrams-add-refs docs-diagrams-generate example-basic example-resolution example-langchain example-pydantic examples chat-agent-install chat-agent-backend chat-agent-frontend chat-agent ts-install ts-build ts-test ts-test-unit ts-test-integration ts-lint ts-docs ts-conformance ts-pack ts-clean ts-test-examples
 
 # Default target
 help:
@@ -643,3 +643,14 @@ ts-pack:
 # Remove TS build artifacts
 ts-clean:
 	rm -rf $(TS_DIR)/dist $(TS_DIR)/docs-api $(TS_DIR)/.tsbuildinfo
+
+# Type-check every TS example against the freshly built SDK. Catches
+# API drift between examples and the SDK without needing API keys.
+# Mirrors the ci-typescript.yml type-check-examples matrix.
+ts-test-examples:
+	cd $(TS_DIR) && npm ci && npm run build
+	@for ex in langchain mastra mcp strands vercel-ai; do \
+		echo "=== Type-checking $$ex ==="; \
+		(cd $(TS_DIR)/examples/$$ex && npm install --no-package-lock && npx tsc --noEmit) || exit 1; \
+	done
+	@echo "All TS examples type-check cleanly."

--- a/README.md
+++ b/README.md
@@ -5,8 +5,10 @@ A graph-native memory system for AI agents. Store conversations, build knowledge
 [![Neo4j Labs](https://img.shields.io/badge/Neo4j-Labs-6366F1?logo=neo4j)](https://neo4j.com/labs/)
 [![Status: Experimental](https://img.shields.io/badge/Status-Experimental-F59E0B)](https://neo4j.com/labs/)
 [![Community Supported](https://img.shields.io/badge/Support-Community-6B7280)](https://community.neo4j.com)
-[![CI](https://github.com/neo4j-labs/agent-memory/actions/workflows/ci.yml/badge.svg)](https://github.com/neo4j-labs/agent-memory/actions/workflows/ci.yml)
+[![Python CI](https://github.com/neo4j-labs/agent-memory/actions/workflows/ci-python.yml/badge.svg)](https://github.com/neo4j-labs/agent-memory/actions/workflows/ci-python.yml)
+[![TypeScript CI](https://github.com/neo4j-labs/agent-memory/actions/workflows/ci-typescript.yml/badge.svg)](https://github.com/neo4j-labs/agent-memory/actions/workflows/ci-typescript.yml)
 [![PyPI version](https://badge.fury.io/py/neo4j-agent-memory.svg)](https://badge.fury.io/py/neo4j-agent-memory)
+[![npm version](https://img.shields.io/npm/v/@neo4j-labs/agent-memory.svg)](https://www.npmjs.com/package/@neo4j-labs/agent-memory)
 [![Python versions](https://img.shields.io/pypi/pyversions/neo4j-agent-memory.svg)](https://pypi.org/project/neo4j-agent-memory/)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
@@ -27,6 +29,26 @@ A graph-native memory system for AI agents. Store conversations, build knowledge
 **New in v0.2** _(in development on the `adopt-existing-graph` branch)_: adopt an existing Neo4j graph as long-term memory (`client.schema.adopt_existing_graph(...)`), multi-tenant scoping (`user_identifier=`), fire-and-forget [buffered writes](examples/buffered-writes/) (`client.buffered.submit(...)`), [consolidation primitives](examples/audit-trail/) (`client.consolidation.dedupe_entities(...)`), an [eval harness](examples/eval-harness/) (`client.eval.run(suite)`), and explicit `:TOUCHED` audit edges from reasoning steps to entities.
 
 **New in v0.3** _(pluggable providers)_: bring your own model. `MemorySettings.embedding` and `MemorySettings.llm` now accept a provider-string shorthand (`"anthropic/claude-3-5-sonnet-latest"`, `"BAAI/bge-small-en-v1.5"`) or a Provider instance. Native adapters for OpenAI, Anthropic, Bedrock, Vertex AI, and sentence-transformers; LiteLLM universal fallback covers 100+ providers (Cohere, Voyage, Groq, Together, Mistral, Ollama, ...). Existing `EmbeddingConfig`/`LLMConfig` users keep working with a one-time deprecation warning — full migration guide at [migrate-to-v0.3](https://neo4j.com/labs/agent-memory/how-to/migrate-to-v0.3.html).
+
+## SDKs
+
+`neo4j-labs/agent-memory` ships two SDKs with the same memory model, both
+backed by the [NAMS](https://neo4j.com/labs/agent-memory/reference/rest-api)
+hosted service. Pick the one that matches your stack — mixed Python +
+TypeScript agents read and write the same memory.
+
+| Language | Package | Install | Docs |
+|---|---|---|---|
+| Python | [`neo4j-agent-memory`](https://pypi.org/project/neo4j-agent-memory/) | `pip install neo4j-agent-memory` | [Python SDK docs](https://neo4j.com/labs/agent-memory/sdks/python) |
+| TypeScript | [`@neo4j-labs/agent-memory`](https://www.npmjs.com/package/@neo4j-labs/agent-memory) | `npm install @neo4j-labs/agent-memory` | [TypeScript SDK docs](https://neo4j.com/labs/agent-memory/sdks/typescript) |
+
+The Python SDK lives at the repo root (`src/neo4j_agent_memory/`,
+`examples/`); the TypeScript SDK lives at `typescript/`. The two SDKs are
+versioned and released independently — `python-v*` tags publish to PyPI,
+`typescript-v*` tags publish to npm. Cross-language behavioral conformance
+is enforced by the
+[`agent-memory-tck`](https://github.com/neo4j-labs/agent-memory-tck)
+spec suite, which consumes both SDKs as external dependencies.
 
 ## Quick Start
 
@@ -252,4 +274,4 @@ Apache License 2.0
 
 ---
 
-This is a [Neo4j Labs](https://neo4j.com/labs/) project -- community supported, not officially backed by Neo4j. [Community Forum](https://community.neo4j.com) | [GitHub Issues](https://github.com/neo4j-labs/agent-memory/issues) | [Documentation](https://neo4j.com/labs/agent-memory/)
+This is a [Neo4j Labs](https://neo4j.com/labs/) project -- community supported, not officially backed by Neo4j. [Community Forum](https://community.neo4j.com) | [GitHub Issues](https://github.com/neo4j-labs/agent-memory/issues) | [Documentation](https://neo4j.com/labs/agent-memory/) | [TypeScript SDK](typescript/README.md)

--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -1,15 +1,23 @@
 * xref:index.adoc[Agent Memory]
 ** xref:getting-started.adoc[Getting Started]
 
+** SDKs
+*** xref:sdks/python.adoc[Python SDK — neo4j-agent-memory]
+*** xref:sdks/typescript.adoc[TypeScript SDK — @neo4j-labs/agent-memory]
+
 ** xref:tutorials/index.adoc[Tutorials]
-*** xref:tutorials/first-agent-memory.adoc[First Agent Memory]
-*** xref:tutorials/conversation-memory.adoc[Conversation Memory]
-*** xref:tutorials/knowledge-graph.adoc[Knowledge Graphs]
-*** xref:tutorials/anthropic-and-local-embeddings.adoc[Anthropic + Local Embeddings]
-*** xref:tutorials/strands-agent-quickstart.adoc[Strands Agent Quickstart]
-*** xref:tutorials/mcp-server.adoc[MCP Server for Claude Desktop]
-*** xref:tutorials/microsoft-agent-memory.adoc[Microsoft Agent Memory]
-*** xref:tutorials/nams-quickstart.adoc[NAMS Quickstart (v0.4)]
+*** Python
+**** xref:tutorials/first-agent-memory.adoc[First Agent Memory]
+**** xref:tutorials/conversation-memory.adoc[Conversation Memory]
+**** xref:tutorials/knowledge-graph.adoc[Knowledge Graphs]
+**** xref:tutorials/anthropic-and-local-embeddings.adoc[Anthropic + Local Embeddings]
+**** xref:tutorials/strands-agent-quickstart.adoc[Strands Agent Quickstart]
+**** xref:tutorials/mcp-server.adoc[MCP Server for Claude Desktop]
+**** xref:tutorials/microsoft-agent-memory.adoc[Microsoft Agent Memory]
+**** xref:tutorials/nams-quickstart.adoc[NAMS Quickstart (v0.4)]
+*** TypeScript
+**** xref:tutorials/first-agent-memory-typescript.adoc[First Agent Memory (TypeScript)]
+**** xref:tutorials/hosted-quickstart-typescript.adoc[Hosted Quickstart]
 
 ** xref:how-to/index.adoc[How-To Guides]
 
@@ -63,11 +71,25 @@
 **** xref:how-to/integrations/microsoft-agent.adoc[Microsoft Agent Framework]
 **** xref:how-to/create-context-graph-mcp.adoc[MCP + create-context-graph]
 
+*** TypeScript
+**** xref:how-to/typescript/edge-runtime.adoc[Edge Runtime Deployment]
+**** xref:how-to/typescript/vercel-ai.adoc[Vercel AI SDK]
+**** xref:how-to/typescript/mcp.adoc[MCP Tools]
+**** xref:how-to/typescript/langchain.adoc[LangChain JS]
+**** xref:how-to/typescript/mastra.adoc[Mastra]
+**** xref:how-to/typescript/strands.adoc[Strands Agents]
+**** xref:how-to/typescript/observability.adoc[Observability]
+**** xref:how-to/typescript/authenticate.adoc[Authentication]
+**** xref:how-to/typescript/handle-errors.adoc[Error Handling]
+**** xref:how-to/typescript/troubleshooting.adoc[Troubleshooting]
+**** xref:how-to/typescript/integrations-overview.adoc[Framework Integrations Overview]
+
 ** xref:reference/index.adoc[Reference]
 *** xref:reference/configuration.adoc[Configuration]
 *** xref:reference/environment-variables.adoc[Environment Variables]
 *** xref:reference/cli.adoc[CLI]
 *** xref:reference/mcp-tools.adoc[MCP Tools]
+*** xref:reference/rest-api.adoc[NAMS REST API]
 *** xref:reference/deployment.adoc[Deployment]
 *** xref:reference/extractors.adoc[Extractors]
 *** xref:reference/schemas.adoc[Schemas]
@@ -91,6 +113,7 @@
 *** xref:explanation/structured-extraction.adoc[Structured Extraction]
 *** xref:explanation/framework-comparison.adoc[Framework Comparison]
 *** xref:explanation/backends.adoc[Bolt vs NAMS (v0.4)]
+*** xref:explanation/multi-agent-sharing.adoc[Cross-Agent Memory Sharing]
 
 ** xref:glossary.adoc[Glossary]
 ** xref:faq.adoc[FAQ]

--- a/docs/modules/ROOT/pages/explanation/graph-architecture.adoc
+++ b/docs/modules/ROOT/pages/explanation/graph-architecture.adoc
@@ -398,4 +398,6 @@ However, most enterprise agent use cases benefit from the combination of graph, 
 * xref:explanation/memory-types.adoc[Understanding the Three Memory Types]
 * xref:explanation/poleo-model.adoc[The POLE+O Data Model]
 * xref:reference/configuration.adoc[Configuration Reference]
+* xref:reference/rest-api.adoc[NAMS REST API] - The hosted-service surface both SDKs target
 * xref:how-to/entity-extraction.adoc[Configure Entity Extraction]
+* link:https://github.com/neo4j-labs/agent-memory-tck/blob/main/docs/explanation/architecture.adoc[Architecture in the TCK spec] - The cross-language spec author's framing

--- a/docs/modules/ROOT/pages/explanation/memory-types.adoc
+++ b/docs/modules/ROOT/pages/explanation/memory-types.adoc
@@ -256,3 +256,5 @@ trace = await client.reasoning.start_trace(
 * xref:how-to/entities.adoc[Work with Entities] - Long-term memory operations
 * xref:how-to/reasoning-traces.adoc[Record Reasoning Traces] - Reasoning memory operations
 * xref:reference/api/memory-client.adoc[MemoryClient API] - Full API reference
+* xref:explanation/multi-agent-sharing.adoc[Cross-Agent Memory Sharing] - How multiple agents share one memory graph
+* link:https://github.com/neo4j-labs/agent-memory-tck/blob/main/docs/explanation/memory-model.adoc[Memory model in the TCK spec] - The cross-language spec author's framing

--- a/docs/modules/ROOT/pages/explanation/multi-agent-sharing.adoc
+++ b/docs/modules/ROOT/pages/explanation/multi-agent-sharing.adoc
@@ -1,141 +1,186 @@
 = Cross-Agent Memory Sharing
+:page-product: agent-memory
 :toc:
 :toclevels: 2
 
-One of the TCK's core goals is enabling agents written in different languages and frameworks to share the same Neo4j memory graph. This document explains how that works and why the TCK makes it possible.
+How multiple agents — written in different languages, using different frameworks, deployed as separate services — read and write the same memory graph.
 
-== The Problem
+[.lead]
+**Conversations are private. Knowledge is shared.** That's the design contract that makes Neo4j Agent Memory natural for multi-agent systems.
 
-Without a shared specification:
+== The capability in one sentence
 
-* A Python agent using PydanticAI writes entities with one property naming convention.
-* A TypeScript agent using Vercel AI SDK writes entities with a different convention.
-* A Go agent writes reasoning traces with an incompatible structure.
-* An R agent writes statistical traces with yet another format.
+If two agents point at the same backend (NAMS API key, or the same Neo4j cluster), an entity created by Agent A is queryable by Agent B as soon as the write returns — with no copy step, no message bus, no cache invalidation.
 
-When all three connect to the same Neo4j Aura instance, their writes are *silently incompatible*. The Python agent can't read what the TypeScript agent wrote.
+== The two namespaces
 
-== The Solution: Schema Compatibility via TCK
+Every memory operation lives in one of two namespaces:
 
-The TCK defines the *exact graph schema* that all implementations must produce:
-
-* Node labels: `Conversation`, `Message`, `Entity`, `Preference`, `Fact`, `ReasoningTrace`, `ReasoningStep`, `ToolCall`
-* Property names: `id`, `session_id`, `role`, `content`, `timestamp`, `entity_type`, `step_number`, etc.
-* Relationship types: `HAS_MESSAGE`, `NEXT_MESSAGE`, `WORKS_AT`, `KNOWS`, `HAS_STEP`, `HAS_TOOL_CALL`, etc.
-
-If two implementations both pass the TCK, their graph writes are guaranteed to be compatible.
-
-== Namespace Model
-
-The TCK supports two namespace concepts:
-
-=== Session Namespace (Per-Agent Isolation)
-
-Each agent uses its own session IDs:
-
-----
-Lenny: session_id = "lenny-task-001"
-Scout: session_id = "scout-search-042"
-Forge: session_id = "forge-enrich-007"
-Atlas: session_id = "atlas-synth-003"
-Sage:  session_id = "sage-audit-012"
-Rune:  session_id = "rune-analysis-001"
-----
-
-**Conversations and reasoning traces are isolated by session.** Lenny's conversation history is not visible when querying Scout's session.
-
-=== Entity Namespace (Shared Knowledge)
-
-Entities, preferences, and facts are *shared across all sessions*:
-
-----
-Lenny creates: Entity("Alice Johnson", PERSON)
-Scout can read: get_entity_by_name("Alice Johnson") → Entity found!
-Forge enriches: add_fact("Alice Johnson", "ROLE", "CTO")
-Atlas queries: search_entities("Alice") → Entity with all enrichments
-----
-
-This is the fundamental value proposition: **conversations are private, knowledge is shared.**
-
-== TCK Verification
-
-The Gold tier includes tests that verify this sharing model:
-
-[cols="1,3"]
+[cols="1,2,3", options="header"]
 |===
-|Test |What It Verifies
+|Namespace |Scoped by |What's in it
 
-|`test_entity_enriched_across_sessions`
-|Entity created in session A is retrievable from session B context
+|*Conversation namespace* (private)
+|`session_id` (and optionally `user_identifier=`)
+|`Conversation`, `Message`, `ReasoningTrace`, `ReasoningStep`, `ToolCall`. Each agent sees only the sessions it wrote to. One agent's chat history is invisible to another by default.
 
-|`test_reasoning_traces_isolated_by_session`
-|Traces are filterable by session — each agent sees only its own traces
-
-|`test_conversations_isolated_but_entities_shared`
-|Two sessions have separate conversations but both see the same entity
+|*Entity namespace* (shared)
+|Global (within a backend / workspace)
+|`Entity` (POLE+O), `Preference`, `Fact`, `Relationship` between entities. Any agent on the same backend reads what any other agent wrote.
 |===
 
-== The Multi-Agent Demo
+This split is the load-bearing design choice. It mirrors how human teams work: individual notebooks (conversations) plus a shared wiki (knowledge).
 
-The repository includes a six-agent demo proving this architecture:
+== Multi-tenant scoping with `user_identifier`
 
-[cols="1,1,1,2"]
+For SaaS-style deployments where one backend serves many end-users, every memory call accepts a `user_identifier=` kwarg:
+
+[source,python]
+----
+# Agent code, identical for every end-user
+async def handle_request(user_id: str, message: str):
+    async with MemoryClient() as memory:
+        await memory.short_term.add_message(
+            session_id=f"chat-{user_id}",
+            role="user",
+            content=message,
+            user_identifier=user_id,  # scopes the write
+        )
+        # Subsequent reads with the same user_identifier only see this user's data
+        prefs = await memory.long_term.search_preferences(
+            "communication style",
+            user_identifier=user_id,
+        )
+----
+
+`user_identifier` is stored as a property on every node and used as a WHERE filter on every read. See xref:how-to/multi-tenancy.adoc[Multi-tenant memory] for the full pattern.
+
+== Cross-language sharing: same contract, different SDKs
+
+The Python SDK (`neo4j-agent-memory`) and the TypeScript SDK (`@neo4j-labs/agent-memory`) both implement the same xref:reference/rest-api.adoc[NAMS REST contract]. So an agent in either language can read what an agent in the other wrote.
+
+Example: a Python ingestion agent and a TypeScript chat agent sharing entities:
+
+[source,python]
+----
+# ingestion-agent (Python) — runs on a cron, scrapes podcasts
+async with MemoryClient() as memory:
+    entity, _ = await memory.long_term.add_entity(
+        "Alice Johnson", "PERSON",
+        description="Former CTO of Acme, speaker on Lenny's podcast Ep. 42",
+    )
+----
+
+[source,typescript]
+----
+// chat-agent (TypeScript) — runs on Cloudflare Workers
+const memory = new MemoryClient();
+const matches = await memory.longTerm.searchEntities("Alice Johnson", { topK: 3 });
+// matches[0].description includes the entity the Python agent created.
+----
+
+Both SDKs write nodes with the same labels, property names, and relationship types. The graph doesn't know which language produced it.
+
+== A typical multi-agent architecture
+
+[cols="1,3", options="header"]
 |===
-|Agent |Language |Framework |Role
+|Layer |Responsibility
 
-|*Lenny*
+|*Backend* (NAMS or Neo4j)
+|Single source of truth for the memory graph. NAMS is the natural choice when you don't want to operate Neo4j; self-hosted Bolt is the choice when you need write-Cypher or geospatial features.
+
+|*Agents* (any language, any framework)
+|Each agent is a separate process or service. Each holds its own `MemoryClient` pointed at the same backend. Each owns its session IDs but reads the shared entity graph.
+
+|*Orchestrator* (optional)
+|A coordinating agent that reads all sub-agents' reasoning traces, queries the shared entity graph, and synthesizes a response. Can be a workflow engine (LangGraph, Mastra) or a simple supervisor agent.
+|===
+
+When agents are independent services (containerized, on different runtimes), NAMS removes the "who runs Neo4j?" question — every service just needs an API key.
+
+== Worked example: ingestion + chat + analytics
+
+Three agents that never talk to each other directly but cooperate via shared memory:
+
+[cols="1,1,1,3", options="header"]
+|===
+|Agent |Language |Framework |What it does
+
+|**Ingestion**
 |Python
 |PydanticAI
-|Podcast research — creates Person and Organization entities from transcripts
+|Cron job. Reads podcast transcripts, extracts `Person`/`Organization` entities, writes them to long-term memory.
 
-|*Scout*
+|**Chat**
 |TypeScript
-|Vercel AI SDK
-|Web search — reads shared entities, enriches with web results
+|Vercel AI SDK on Cloudflare Workers
+|User-facing chat. On every turn, reads relevant entities and preferences from the shared graph, persists the conversation in its own session namespace.
 
-|*Forge*
-|Go
-|Custom HTTP
-|Data pipeline — adds structured properties (role, company, domain) as facts
-
-|*Atlas*
+|**Analytics**
 |Python
-|LangGraph
-|Orchestrator — reads all agents' reasoning traces, produces cross-agent synthesis
-
-|*Sage*
-|C#
-|Semantic Kernel
-|Knowledge validation — detects conflicts, audits graph integrity
-
-|*Rune*
-|R
-|ellmer
-|Statistical analysis — runs regressions, correlations, clustering on graph entities
+|Plain script + `client.query.cypher(...)`
+|Nightly. Reads all entities, computes co-mention graphs, surfaces trends.
 |===
 
-=== Data Flow
+Each agent is its own deployment. None imports the others. They cooperate solely through reads and writes against the shared backend.
 
+== When agents collide: avoiding write conflicts
+
+Because the entity namespace is shared, two agents *can* try to create the same entity at the same time. Neo4j Agent Memory handles this with:
+
+* **Entity deduplication on ingest** — `add_entity()` checks for embedding-similar and fuzzy-name matches before creating a new node. Above the `auto_merge_threshold` (default 0.95), the new write merges into the existing node and the name is added as an alias.
+* **`SAME_AS` flagged pairs** — between `flag_threshold` (0.85) and the auto-merge threshold, the new entity is created but linked via a `SAME_AS` relationship for human review.
+* **Server-side dedup on NAMS** — the hosted backend performs dedup transparently.
+
+See xref:how-to/deduplication.adoc[Handle duplicates] for the configuration knobs.
+
+== Reasoning trace isolation
+
+While entities are shared, reasoning traces are per-session by design:
+
+[source,python]
 ----
-Lenny (Python) ──creates──> Entity("Alice Johnson", PERSON)
-                                    │
-Scout (TypeScript) ──reads──────────┤──enriches──> Fact("Alice Johnson", ENRICHED_BY, "...")
-                                    │
-Forge (Go) ──reads──────────────────┤──enriches──> Fact("Alice Johnson", ROLE, "CTO")
-                                    │
-Rune (R) ──reads────────────────────┤──analyzes───> ReasoningTrace(correlation r=0.72, p=0.028)
-                                    │
-Atlas (Python) ──reads all traces───┴──synthesizes──> Summary of all agents' work
+# Agent A starts a trace
+trace_a = await memory.reasoning.start_trace(
+    session_id="agent-a-session-1",
+    task="Plan a trip",
+)
+
+# Agent B in the same process — its traces don't show up in A's session
+trace_b = await memory.reasoning.start_trace(
+    session_id="agent-b-session-1",
+    task="Book a flight",
+)
+
+# A's get_session_traces returns only A's traces
+await memory.reasoning.get_session_traces("agent-a-session-1")
 ----
 
-Each agent runs as a separate service (Cloud Run or Docker container), all connecting to the same Neo4j instance. The TCK guarantees that Lenny's Python writes are readable by Scout's TypeScript reads, Forge's Go reads, Sage's C# reads, and Rune's R reads — because they all implement the same schema.
+But if an orchestrator wants cross-agent visibility for audit, it can query Cypher (Bolt) or the read-only Cypher endpoint (NAMS Platinum):
 
-== Why This Matters
+[source,cypher]
+----
+// All traces created in the last hour, across all sessions and agents
+MATCH (t:ReasoningTrace)
+WHERE t.created_at > datetime() - duration('PT1H')
+RETURN t.session_id, t.task, t.outcome, t.success
+ORDER BY t.created_at DESC
+----
 
-The polyglot memory architecture addresses the most common skepticism about multi-language agent systems:
+See xref:how-to/audit-reasoning.adoc[Audit reasoning with TOUCHED edges] for the full audit pattern.
 
-> "Will the TypeScript SDK really produce graph structures compatible with what the Python SDK writes?"
+== Why this matters for AI engineering
 
-The TCK's answer: **yes, by definition.** If both pass the TCK, they are compatible. The multi-agent demo proves it live.
+The hardest problem in multi-agent systems is not coordination — it's coherence. Two agents that "know" different things will give the user contradictory answers. A shared memory graph keeps every agent's worldview in sync without bolting on a separate state management layer.
 
-This is the same principle behind the openCypher TCK: a query written for one Cypher engine is portable to another because they both pass the same compatibility suite.
+The architecture also degrades gracefully: a single-agent prototype written against `MemoryClient` becomes a multi-agent system by adding more agents that point at the same backend. No refactor.
+
+== See Also
+
+* xref:explanation/memory-types.adoc[Understanding the Three Memory Types] — what conversations, entities, and traces are
+* xref:explanation/backends.adoc[Bolt vs NAMS] — which backend to pick
+* xref:how-to/multi-tenancy.adoc[Multi-tenant memory] — `user_identifier=` patterns
+* xref:how-to/use-nams.adoc[Use NAMS] — the hosted-service operational guide
+* xref:tutorials/nams-quickstart.adoc[NAMS Quickstart] — end-to-end deployment
+* xref:reference/rest-api.adoc[NAMS REST API] — the wire-level contract both SDKs implement

--- a/docs/modules/ROOT/pages/explanation/multi-agent-sharing.adoc
+++ b/docs/modules/ROOT/pages/explanation/multi-agent-sharing.adoc
@@ -1,0 +1,141 @@
+= Cross-Agent Memory Sharing
+:toc:
+:toclevels: 2
+
+One of the TCK's core goals is enabling agents written in different languages and frameworks to share the same Neo4j memory graph. This document explains how that works and why the TCK makes it possible.
+
+== The Problem
+
+Without a shared specification:
+
+* A Python agent using PydanticAI writes entities with one property naming convention.
+* A TypeScript agent using Vercel AI SDK writes entities with a different convention.
+* A Go agent writes reasoning traces with an incompatible structure.
+* An R agent writes statistical traces with yet another format.
+
+When all three connect to the same Neo4j Aura instance, their writes are *silently incompatible*. The Python agent can't read what the TypeScript agent wrote.
+
+== The Solution: Schema Compatibility via TCK
+
+The TCK defines the *exact graph schema* that all implementations must produce:
+
+* Node labels: `Conversation`, `Message`, `Entity`, `Preference`, `Fact`, `ReasoningTrace`, `ReasoningStep`, `ToolCall`
+* Property names: `id`, `session_id`, `role`, `content`, `timestamp`, `entity_type`, `step_number`, etc.
+* Relationship types: `HAS_MESSAGE`, `NEXT_MESSAGE`, `WORKS_AT`, `KNOWS`, `HAS_STEP`, `HAS_TOOL_CALL`, etc.
+
+If two implementations both pass the TCK, their graph writes are guaranteed to be compatible.
+
+== Namespace Model
+
+The TCK supports two namespace concepts:
+
+=== Session Namespace (Per-Agent Isolation)
+
+Each agent uses its own session IDs:
+
+----
+Lenny: session_id = "lenny-task-001"
+Scout: session_id = "scout-search-042"
+Forge: session_id = "forge-enrich-007"
+Atlas: session_id = "atlas-synth-003"
+Sage:  session_id = "sage-audit-012"
+Rune:  session_id = "rune-analysis-001"
+----
+
+**Conversations and reasoning traces are isolated by session.** Lenny's conversation history is not visible when querying Scout's session.
+
+=== Entity Namespace (Shared Knowledge)
+
+Entities, preferences, and facts are *shared across all sessions*:
+
+----
+Lenny creates: Entity("Alice Johnson", PERSON)
+Scout can read: get_entity_by_name("Alice Johnson") → Entity found!
+Forge enriches: add_fact("Alice Johnson", "ROLE", "CTO")
+Atlas queries: search_entities("Alice") → Entity with all enrichments
+----
+
+This is the fundamental value proposition: **conversations are private, knowledge is shared.**
+
+== TCK Verification
+
+The Gold tier includes tests that verify this sharing model:
+
+[cols="1,3"]
+|===
+|Test |What It Verifies
+
+|`test_entity_enriched_across_sessions`
+|Entity created in session A is retrievable from session B context
+
+|`test_reasoning_traces_isolated_by_session`
+|Traces are filterable by session — each agent sees only its own traces
+
+|`test_conversations_isolated_but_entities_shared`
+|Two sessions have separate conversations but both see the same entity
+|===
+
+== The Multi-Agent Demo
+
+The repository includes a six-agent demo proving this architecture:
+
+[cols="1,1,1,2"]
+|===
+|Agent |Language |Framework |Role
+
+|*Lenny*
+|Python
+|PydanticAI
+|Podcast research — creates Person and Organization entities from transcripts
+
+|*Scout*
+|TypeScript
+|Vercel AI SDK
+|Web search — reads shared entities, enriches with web results
+
+|*Forge*
+|Go
+|Custom HTTP
+|Data pipeline — adds structured properties (role, company, domain) as facts
+
+|*Atlas*
+|Python
+|LangGraph
+|Orchestrator — reads all agents' reasoning traces, produces cross-agent synthesis
+
+|*Sage*
+|C#
+|Semantic Kernel
+|Knowledge validation — detects conflicts, audits graph integrity
+
+|*Rune*
+|R
+|ellmer
+|Statistical analysis — runs regressions, correlations, clustering on graph entities
+|===
+
+=== Data Flow
+
+----
+Lenny (Python) ──creates──> Entity("Alice Johnson", PERSON)
+                                    │
+Scout (TypeScript) ──reads──────────┤──enriches──> Fact("Alice Johnson", ENRICHED_BY, "...")
+                                    │
+Forge (Go) ──reads──────────────────┤──enriches──> Fact("Alice Johnson", ROLE, "CTO")
+                                    │
+Rune (R) ──reads────────────────────┤──analyzes───> ReasoningTrace(correlation r=0.72, p=0.028)
+                                    │
+Atlas (Python) ──reads all traces───┴──synthesizes──> Summary of all agents' work
+----
+
+Each agent runs as a separate service (Cloud Run or Docker container), all connecting to the same Neo4j instance. The TCK guarantees that Lenny's Python writes are readable by Scout's TypeScript reads, Forge's Go reads, Sage's C# reads, and Rune's R reads — because they all implement the same schema.
+
+== Why This Matters
+
+The polyglot memory architecture addresses the most common skepticism about multi-language agent systems:
+
+> "Will the TypeScript SDK really produce graph structures compatible with what the Python SDK writes?"
+
+The TCK's answer: **yes, by definition.** If both pass the TCK, they are compatible. The multi-agent demo proves it live.
+
+This is the same principle behind the openCypher TCK: a query written for one Cypher engine is portable to another because they both pass the same compatibility suite.

--- a/docs/modules/ROOT/pages/getting-started.adoc
+++ b/docs/modules/ROOT/pages/getting-started.adoc
@@ -12,19 +12,109 @@
 :page-ad-underline-role: button
 :page-ad-underline: Enroll now
 
-This guide walks you through installing neo4j-agent-memory, connecting to Neo4j, and performing your first memory operations.
+This guide walks you through installing the Neo4j Agent Memory SDK, connecting to a backend, and performing your first memory operations.
 
-== Prerequisites
+[TIP]
+====
+*Two ways to run.* Pick the one that matches your goal:
 
-Before you begin, ensure you have:
+* **Hosted (NAMS)** — A managed REST service at link:https://memory.neo4jlabs.com[memory.neo4jlabs.com]. You provide an API key; Neo4j is operated for you. Fastest path to a working agent. Best for prototypes, demos, and multi-tenant SaaS deployments.
+* **Self-hosted (Bolt)** — Bring your own Neo4j (Aura, Desktop, or Docker). You get full schema control, write-Cypher access, geospatial features, and air-gapped operation. Best when you already operate Neo4j or need bolt-only features.
 
-* **Python 3.10+** installed
-* **Neo4j 5.20+** running (local or cloud)
-* **OpenAI API key** (optional, for embeddings and LLM extraction)
+The SDK surface is the same for both — `client.short_term`, `client.long_term`, `client.reasoning`. See xref:explanation/backends.adoc[Bolt vs NAMS] for the trade-offs and xref:how-to/migrate-to-nams.adoc[Migrate to NAMS] for porting between them.
+====
 
-== Installation
+== Path A: Hosted (NAMS) — fastest start
 
-=== Basic Installation
+If you don't already operate Neo4j, start here. There is nothing to install or run beyond the SDK and an API key.
+
+=== 1. Get an API key
+
+Sign up at link:https://memory.neo4jlabs.com[memory.neo4jlabs.com] and copy your `nams_...` key.
+
+=== 2. Install the SDK
+
+[tabs]
+======
+Python::
++
+[source,bash]
+----
+pip install neo4j-agent-memory
+export MEMORY_API_KEY=nams_...
+----
+
+TypeScript::
++
+[source,bash]
+----
+npm install @neo4j-labs/agent-memory
+export MEMORY_API_KEY=nams_...
+----
+======
+
+=== 3. First operations
+
+[tabs]
+======
+Python::
++
+[source,python]
+----
+import asyncio, os
+from neo4j_agent_memory import MemoryClient
+
+async def main():
+    # Reads MEMORY_API_KEY from env; backend auto-selects NAMS.
+    async with MemoryClient() as memory:
+        await memory.short_term.add_message(
+            session_id="user-123", role="user",
+            content="I love Italian food!",
+        )
+        await memory.long_term.add_preference(
+            category="food", preference="Loves Italian cuisine",
+        )
+        ctx = await memory.get_context(
+            "restaurant recommendation", session_id="user-123",
+        )
+        print(ctx)
+
+asyncio.run(main())
+----
+
+TypeScript::
++
+[source,typescript]
+----
+import { MemoryClient } from "@neo4j-labs/agent-memory";
+
+const memory = new MemoryClient();  // reads MEMORY_API_KEY
+
+const conv = await memory.shortTerm.createConversation({ userId: "alice" });
+await memory.shortTerm.addMessage(conv.id, "user", "I love Italian food!");
+
+await memory.longTerm.addPreference("food", {
+  preference: "Loves Italian cuisine",
+});
+
+const ctx = await memory.shortTerm.getContext(conv.id);
+console.log(ctx.recentMessages, ctx.observations, ctx.reflections);
+----
+======
+
+Then continue with xref:tutorials/nams-quickstart.adoc[NAMS Quickstart] (Python) or xref:tutorials/hosted-quickstart-typescript.adoc[Hosted Quickstart] (TypeScript).
+
+== Path B: Self-hosted Neo4j (Bolt)
+
+If you already run Neo4j or need bolt-only features (write-Cypher, geospatial, `adopt_existing_graph`), follow this path. _Python only — the TypeScript SDK is NAMS-only._
+
+=== Prerequisites
+
+* Python 3.10+
+* Neo4j 5.20+ (local or cloud)
+* Optional: OpenAI / Anthropic / Bedrock / Vertex key for embeddings and LLM extraction
+
+=== Basic install
 
 Install the core package with pip:
 
@@ -33,7 +123,7 @@ Install the core package with pip:
 pip install neo4j-agent-memory
 ----
 
-=== Installation with Extras
+=== Install with extras
 
 Choose the extras that match your needs:
 

--- a/docs/modules/ROOT/pages/how-to/index.adoc
+++ b/docs/modules/ROOT/pages/how-to/index.adoc
@@ -14,6 +14,45 @@ Practical guides for accomplishing specific tasks with neo4j-agent-memory.
 [.lead]
 How-to guides are *task-oriented*. They take you through the steps required to solve a real-world problem. They assume you already know the basics and focus on building your **context graph**—the personalized knowledge structure that makes your agents intelligent.
 
+== Deployment & Backend
+
+Decide how to run agent memory: hosted service or self-hosted Neo4j.
+
+[cols="1,2", options="header"]
+|===
+| Guide | What You'll Accomplish
+
+| xref:how-to/use-nams.adoc[Use NAMS (Hosted Service)]
+| Run agent memory with zero infrastructure. Get an API key, point `MemoryClient` at the hosted endpoint, and skip operating Neo4j entirely.
+
+| xref:how-to/migrate-to-nams.adoc[Migrate from Bolt to NAMS]
+| Port an existing self-hosted deployment to the hosted service. Includes the full `NotSupportedError` reference for bolt-only methods.
+
+| xref:how-to/multi-tenancy.adoc[Multi-Tenant Memory]
+| Use `user_identifier=` to scope writes and reads per end-user. Required for SaaS-style deployments where one backend serves many users.
+|===
+
+== Multi-Agent Patterns
+
+When two or more agents share a memory graph — whether across languages, frameworks, or services.
+
+[cols="1,2", options="header"]
+|===
+| Guide | What You'll Accomplish
+
+| xref:explanation/multi-agent-sharing.adoc[Cross-Agent Memory Sharing] _(concept)_
+| Understand the conversation-vs-entity namespace split, how Python and TypeScript agents share the same graph, and the typical multi-agent architecture.
+
+| xref:how-to/multi-tenancy.adoc[Scope by `user_identifier`]
+| The per-user scoping primitive that keeps tenants isolated on a shared backend.
+
+| xref:how-to/audit-reasoning.adoc[Audit Cross-Agent Reasoning]
+| Query `:TOUCHED` edges to answer "which agent affected which entity, and when?" One-hop traversal across the shared graph.
+
+| xref:how-to/create-context-graph-mcp.adoc[Wire MCP into Multi-Agent Stacks]
+| Expose the memory surface as MCP tools so any MCP-aware agent (Claude Desktop, Cursor, custom dispatchers) shares the same graph.
+|===
+
 == Core Context Graph Operations
 
 Build and query your context graph—the foundation for personalized agent interactions.
@@ -87,6 +126,45 @@ Connect neo4j-agent-memory to popular agent frameworks for persistent, shared co
 
 | xref:how-to/create-context-graph-mcp.adoc[Add MCP Server to create-context-graph Projects]
 | Connect Claude Desktop to scaffolded projects. Query domain-specific knowledge graphs through natural conversation.
+|===
+
+== TypeScript SDK (`@neo4j-labs/agent-memory`)
+
+The TypeScript SDK targets the hosted NAMS service. It runs on Node 20+, Bun, Deno, Cloudflare Workers, and Vercel Edge.
+
+[cols="1,2", options="header"]
+|===
+| Guide | What You'll Accomplish
+
+| xref:how-to/typescript/authenticate.adoc[Authenticate]
+| API key handling, OAuth refresh, scope management for the TypeScript SDK.
+
+| xref:how-to/typescript/edge-runtime.adoc[Deploy to Edge Runtimes]
+| Run agent memory on Cloudflare Workers or Vercel Edge — the `fetch`-only transport works everywhere.
+
+| xref:how-to/typescript/vercel-ai.adoc[Vercel AI SDK Middleware]
+| Three-tier context injection + automatic persistence as a `LanguageModelV1Middleware`.
+
+| xref:how-to/typescript/mcp.adoc[MCP Tools]
+| Wire the standard 12-tool memory surface into Claude Desktop, Cursor, or any MCP-aware client.
+
+| xref:how-to/typescript/langchain.adoc[LangChain JS]
+| `Neo4jChatMessageHistory` and `Neo4jEntityRetriever` duck-typed against LangChain JS.
+
+| xref:how-to/typescript/mastra.adoc[Mastra]
+| `Neo4jMastraMemory` provider for the Mastra agent framework.
+
+| xref:how-to/typescript/strands.adoc[AWS Strands Agents (JS)]
+| Session storage + conversation manager + reasoning hooks for the Strands JS SDK.
+
+| xref:how-to/typescript/observability.adoc[Observability]
+| Request/response logging, request-id correlation, OpenTelemetry-compatible event stream.
+
+| xref:how-to/typescript/handle-errors.adoc[Handle Errors]
+| The TS exception hierarchy, retry policy, and request-id propagation.
+
+| xref:how-to/typescript/troubleshooting.adoc[Troubleshooting]
+| Common failure modes and how to diagnose them.
 |===
 
 == Enterprise Use Cases

--- a/docs/modules/ROOT/pages/how-to/typescript/authenticate.adoc
+++ b/docs/modules/ROOT/pages/how-to/typescript/authenticate.adoc
@@ -1,0 +1,124 @@
+= How To Authenticate
+:description: API keys, OAuth refresh, scopes, and token rotation against the hosted service.
+
+The hosted Neo4j Agent Memory Service supports two authentication flows:
+
+* **Static `nams_*` API keys** — issued via the dashboard, expire in 90 days.
+* **OAuth 2.0 PKCE** — short-lived JWT access tokens with refresh.
+
+Every client SDK accepts either through the same `apiKey` / `tokenProvider`
+configuration knobs.
+
+== Static API keys
+
+Set the `Authorization: Bearer nams_*` header on every request.
+
+[source,bash]
+----
+curl -H "Authorization: Bearer $MEMORY_API_KEY" \
+  https://memory.neo4jlabs.com/v1/entities
+----
+
+In the SDKs:
+
+[tabs]
+======
+TypeScript::
++
+[source,ts]
+----
+new MemoryClient({
+  endpoint: "https://memory.neo4jlabs.com/v1",
+  apiKey: process.env.MEMORY_API_KEY,
+})
+----
+
+Python::
++
+[source,python]
+----
+MemoryClient(
+    endpoint="https://memory.neo4jlabs.com/v1",
+    api_key=os.environ["MEMORY_API_KEY"],
+)
+----
+
+Go::
++
+[source,go]
+----
+memory.New(
+    memory.WithEndpoint("https://memory.neo4jlabs.com/v1"),
+    memory.WithAPIKey(os.Getenv("MEMORY_API_KEY")),
+)
+----
+======
+
+== Managing keys via the SDK
+
+All five clients expose an `auth` (or `Auth`) sub-client mirroring
+`/v1/auth/api-keys`:
+
+[source,ts]
+----
+// List keys for a workspace.
+const keys = await client.auth.listApiKeys(workspaceId);
+
+// Create a new key. Plaintext is returned ONCE — store it now.
+const fresh = await client.auth.createApiKey({
+  label: "ci-runner",
+  scopes: ["read", "write"],
+  workspaceId,
+});
+console.log(fresh.key);  // nams_...
+
+// Revoke immediately.
+await client.auth.revokeApiKey(fresh.id);
+----
+
+== OAuth refresh-token rotation
+
+Static keys are convenient but coarse. For long-running services, prefer the
+OAuth flow:
+
+. Exchange your IdP token at `POST /v1/auth/exchange` to receive
+  `{access_token, refresh_token, expires_in}`.
+. Use the access token like a static key.
+. Before it expires, call `auth.refreshAccessToken(refresh_token)` to rotate.
+
+The clients support a `tokenProvider` callback so you can plug your refresh
+logic in once and forget it:
+
+[source,ts]
+----
+new MemoryClient({
+  endpoint: "https://memory.neo4jlabs.com/v1",
+  tokenProvider: async () => myTokenStore.getFreshAccessToken(),
+})
+----
+
+[source,python]
+----
+async def get_token() -> str:
+    return await my_token_store.get_fresh_access_token()
+
+MemoryClient(
+    endpoint="https://memory.neo4jlabs.com/v1",
+    token_provider=get_token,
+)
+----
+
+== Discovery endpoints
+
+The service implements the standard MCP / OAuth discovery endpoints:
+
+* `GET /.well-known/oauth-protected-resource` — RFC 9728
+* `GET /.well-known/oauth-authorization-server` — RFC 8414
+* `GET /.well-known/jwks.json` — JWT signing keys
+
+== Rotation policy
+
+Static keys expire after 90 days. Set a calendar reminder, or automate
+rotation with the `auth` API and a CI cron job. The plaintext is returned
+only at creation time — the SDK's `revealApiKey()` works only for keys you
+already created in the same workspace.

--- a/docs/modules/ROOT/pages/how-to/typescript/edge-runtime.adoc
+++ b/docs/modules/ROOT/pages/how-to/typescript/edge-runtime.adoc
@@ -1,0 +1,75 @@
+= How to: deploy to edge runtimes
+:toc: left
+:source-highlighter: rouge
+
+The `@neo4j-labs/agent-memory` package is first-class on Cloudflare
+Workers and Vercel Edge. The package uses `fetch` only, has zero runtime
+dependencies, and defensively guards every `process.env` lookup behind a
+`typeof process !== "undefined"` check.
+
+== The one gotcha: API key resolution
+
+Edge runtimes expose environment variables via the request handler
+scope, not `process.env`. The zero-config form
+
+[source,typescript]
+----
+const client = new MemoryClient();   // reads MEMORY_API_KEY from process.env
+----
+
+works on Node, Bun, and Deno. On edge, pass the key explicitly:
+
+[source,typescript]
+----
+// Cloudflare Workers
+export default {
+  async fetch(req: Request, env: { MEMORY_API_KEY: string }) {
+    const client = new MemoryClient({ apiKey: env.MEMORY_API_KEY });
+    // ...
+  },
+};
+----
+
+[source,typescript]
+----
+// Vercel Edge — pages/api or route handler
+export const runtime = "edge";
+
+export async function GET(req: Request) {
+  const client = new MemoryClient({ apiKey: process.env.MEMORY_API_KEY });
+  // Vercel Edge does expose process.env in the handler scope,
+  // but reading it explicitly avoids any surprise.
+  // ...
+}
+----
+
+== What works on edge
+
+* All `MemoryClient` short-term, long-term, and reasoning operations
+* The Vercel AI SDK middleware
+* The MCP tool dispatcher (`handleMemoryToolCall`)
+* The LangChain JS and Mastra adapters
+
+== What doesn't (and why)
+
+* The TCK bridge transport (`./testing` subpath) is intended for
+  Node-based conformance testing; we don't test it on edge.
+* `User-Agent` overrides via `headers: { "User-Agent": ... }` may be
+  silently stripped by Cloudflare Workers due to a runtime restriction on
+  setting that header in `fetch`. The default User-Agent is best-effort.
+
+== Streaming + memory persistence
+
+When using `streamText` from the Vercel AI SDK, the middleware persists
+the assistant response only after the stream completes (in
+`wrapGenerate`). On edge runtimes you must `await` the result or your
+function will return before persistence finishes.
+
+== Verifying
+
+A unit-level edge sanity test ships with the package; it constructs a
+client in an environment where `process` is undefined. To exercise the
+full path against a real Worker, deploy with `wrangler` and watch tail
+logs for request-id-tagged failures.
+
+See link:observability.adoc[How-to: enable request logging] for tracing.

--- a/docs/modules/ROOT/pages/how-to/typescript/handle-errors.adoc
+++ b/docs/modules/ROOT/pages/how-to/typescript/handle-errors.adoc
@@ -1,0 +1,90 @@
+= How to: handle errors
+:toc: left
+:source-highlighter: rouge
+
+Every error thrown by `@neo4j-labs/agent-memory` is a subclass of
+`MemoryError`. Errors from HTTP exchanges carry a `requestId` (when the
+service emitted one) so you can quote it in support threads.
+
+== The hierarchy
+
+[source]
+----
+MemoryError                     // base class
+├── ConnectionError            // network / DNS / timeout / 5xx on connect
+├── AuthenticationError        // 401, 403
+├── NotFoundError              // 404 (rarely raised — most operations soft-handle)
+├── ValidationError            // client-side argument validation
+├── TransportError             // 4xx/5xx from the service; carries statusCode
+└── NotSupportedError          // operation not implemented by current transport
+----
+
+== The `requestId` field
+
+Every error from a failed HTTP exchange has an optional `requestId`
+field, populated from `x-request-id` (or `request-id`, or
+`x-amzn-RequestId`) on the response. It's also embedded in the error's
+`toString()`:
+
+[source,typescript]
+----
+try {
+  await client.shortTerm.createConversation({ userId: "alice" });
+} catch (err) {
+  if (err instanceof MemoryError) {
+    console.error(err.message, "requestId:", err.requestId);
+  }
+  throw err;
+}
+----
+
+Sample stack-trace line:
+
+[source]
+----
+TransportError: create_conversation failed: internal error [requestId=req-abc123]
+----
+
+== Choosing what to catch
+
+[options="header"]
+|===
+| Catch | When
+| `AuthenticationError` | Renew tokens, prompt the user, log them out.
+| `NotSupportedError` | Switch transports, or skip the optional feature gracefully.
+| `TransportError` (4xx) | Validate inputs; not retryable.
+| `TransportError` (5xx) | Retry with backoff; quote `requestId` if it persists.
+| `ConnectionError` | Retry with backoff; usually network-transient.
+| `ValidationError` | Fix the call site; never retryable.
+|===
+
+== Retries
+
+The client does **not** retry automatically. Wrap your calls in a small
+retry helper if you need it — be careful with non-idempotent operations
+(`addMessage`, `recordStep`, `recordToolCall` are NOT idempotent and a
+retry may produce a duplicate).
+
+[source,typescript]
+----
+async function retry<T>(fn: () => Promise<T>, max = 3): Promise<T> {
+  let lastErr: unknown;
+  for (let i = 0; i < max; i++) {
+    try { return await fn(); }
+    catch (err) {
+      lastErr = err;
+      if (err instanceof TransportError && err.statusCode && err.statusCode < 500) throw err;
+      if (err instanceof AuthenticationError) throw err;
+      await new Promise((r) => setTimeout(r, 100 * 2 ** i));
+    }
+  }
+  throw lastErr;
+}
+----
+
+== Logging errors in production
+
+The `logger` constructor option emits a typed `error` event per failed
+request — useful for routing into structured logging without writing
+your own try/catch around every call. See
+link:observability.adoc[How-to: enable request logging].

--- a/docs/modules/ROOT/pages/how-to/typescript/integrations-overview.adoc
+++ b/docs/modules/ROOT/pages/how-to/typescript/integrations-overview.adoc
@@ -1,0 +1,136 @@
+= Framework Integrations
+:description: Memory-augmented LLM applications with Vercel AI SDK, LangChain JS, Mastra, LangGraph, PydanticAI, Semantic Kernel, ellmer.
+
+Each first-class agent framework ships a thin wrapper around `MemoryClient`.
+Pick yours below.
+
+== Vercel AI SDK (TypeScript)
+
+The `agentMemoryMiddleware` injects three-tier context (reflections +
+observations + recent messages) into every model call and persists the
+assistant's response.
+
+[source,ts]
+----
+import { generateText } from "ai";
+import { MemoryClient } from "@neo4j-labs/agent-memory";
+import { agentMemoryMiddleware } from "@neo4j-labs/agent-memory/middleware/vercel-ai";
+
+const client = new MemoryClient({ endpoint: "https://memory.neo4jlabs.com/v1", apiKey });
+
+const result = await generateText({
+  model: openai("gpt-4o"),
+  experimental_middleware: agentMemoryMiddleware(client, {
+    conversationId: "conv-uuid",
+    userId: "alice@example.com",
+    includeContext: true,
+    persistResponses: true,
+  }),
+  messages: [{ role: "user", content: "What did we decide?" }],
+});
+----
+
+== LangChain JS (TypeScript)
+
+`Neo4jChatMessageHistory` is a drop-in `ChatMessageHistory` backed by memory;
+`Neo4jEntityRetriever` returns memory entities as LangChain `Document`s.
+
+[source,ts]
+----
+import {
+  Neo4jChatMessageHistory,
+  Neo4jEntityRetriever,
+} from "@neo4j-labs/agent-memory/integrations/langchain";
+
+const history = new Neo4jChatMessageHistory(client, "conv-uuid");
+await history.addUserMessage("hello");
+
+const retriever = new Neo4jEntityRetriever(client, { topK: 4 });
+const docs = await retriever.invoke("Find entities about Acme Corp");
+----
+
+== Mastra (TypeScript)
+
+`Neo4jMastraMemory` wraps `MemoryClient` as a Mastra `Memory` provider.
+
+[source,ts]
+----
+import { Neo4jMastraMemory } from "@neo4j-labs/agent-memory/integrations/mastra";
+import { Agent } from "@mastra/core/agent";
+
+const memory = new Neo4jMastraMemory(client);
+const agent = new Agent({ name: "scout", memory });
+----
+
+== LangGraph (Python)
+
+`MemoryCheckpointSaver` persists LangGraph state under a memory conversation.
+
+[source,python]
+----
+from neo4j_agent_memory_client import MemoryClient
+from neo4j_agent_memory_client.integrations.langgraph import MemoryCheckpointSaver
+
+client = MemoryClient(endpoint="https://memory.neo4jlabs.com/v1", api_key=...)
+saver = MemoryCheckpointSaver(client)
+
+graph = StateGraph(MyState)
+graph.compile(checkpointer=saver)
+----
+
+== PydanticAI (Python)
+
+`inject_memory_context` returns a system-prompt prefix; `MemoryToolset`
+exposes the 12 memory tools as PydanticAI tools.
+
+[source,python]
+----
+from pydantic_ai import Agent
+from neo4j_agent_memory_client import MemoryClient
+from neo4j_agent_memory_client.integrations.pydantic_ai import (
+    MemoryToolset, inject_memory_context,
+)
+
+client = MemoryClient(endpoint=..., api_key=...)
+toolset = MemoryToolset(client)
+
+@agent.system_prompt
+async def memory_context() -> str:
+    return await inject_memory_context(client, conversation_id="...")
+
+agent = Agent(model="openai:gpt-4o", tools=[*toolset.tools()])
+----
+
+== Semantic Kernel (C#)
+
+`MemoryConnector` provides save/search and a `GetContextPrefixAsync` helper
+suitable for SK kernel functions.
+
+[source,csharp]
+----
+using Neo4j.AgentMemory.Integrations.SemanticKernel;
+
+var client = new MemoryClient(...);
+var connector = new MemoryConnector(client);
+
+await connector.SaveAsync(collection: "concept", id: "ddd", text: "Domain-Driven Design");
+var hits = await connector.SearchAsync("microservice patterns", limit: 5);
+var contextPrefix = await connector.GetContextPrefixAsync(conversationId);
+----
+
+== ellmer (R)
+
+`register_memory_tools(client)` returns a list of ellmer `tool()`
+definitions wrapping all 12 memory tools.
+
+[source,r]
+----
+library(neo4j.memory)
+library(ellmer)
+
+client <- MemoryClient$new(endpoint = "...", api_key = ...)
+tools <- register_memory_tools(client)
+
+chat <- chat_openai(model = "gpt-4o")
+for (t in tools) chat$register_tool(t$name, t$description, t$handler)
+----

--- a/docs/modules/ROOT/pages/how-to/typescript/langchain.adoc
+++ b/docs/modules/ROOT/pages/how-to/typescript/langchain.adoc
@@ -1,0 +1,75 @@
+= How to: integrate with LangChain JS
+:toc: left
+:source-highlighter: rouge
+
+The `@neo4j-labs/agent-memory/integrations/langchain` subpath exposes
+two duck-typed adapters that fit common LangChain JS shapes:
+
+* `Neo4jChatMessageHistory` — slots into `RunnableWithMessageHistory`
+  wherever a `BaseChatMessageHistory` is expected.
+* `Neo4jEntityRetriever` — slots into retriever chains wherever a
+  `BaseRetriever`-shaped object is expected.
+
+A runnable example lives at
+link:https://github.com/neo4j-labs/agent-memory/tree/main/typescript/examples/langchain[`clients/typescript/examples/langchain`].
+
+== Why duck-typed
+
+LangChain JS evolves quickly and the published interfaces shift between
+minor versions. Importing concrete base classes from `@langchain/core`
+would bind us to a specific version; duck-typing lets these adapters
+slot in regardless.
+
+The cost: type information about the LangChain interfaces is not
+imported. If you want stronger types in your own app, cast at the call
+site:
+
+[source,typescript]
+----
+import type { BaseChatMessageHistory } from "@langchain/core/chat_history";
+import { Neo4jChatMessageHistory } from "@neo4j-labs/agent-memory/integrations/langchain";
+
+const history: BaseChatMessageHistory =
+  new Neo4jChatMessageHistory(memory, conv.id) as unknown as BaseChatMessageHistory;
+----
+
+== Chat message history
+
+[source,typescript]
+----
+import { RunnableWithMessageHistory } from "@langchain/core/runnables";
+import { Neo4jChatMessageHistory } from "@neo4j-labs/agent-memory/integrations/langchain";
+
+const chain = baseChain.pipe(...);
+
+const memoryChain = new RunnableWithMessageHistory({
+  runnable: chain,
+  getMessageHistory: (sessionId) => new Neo4jChatMessageHistory(memory, sessionId),
+  inputMessagesKey: "input",
+  historyMessagesKey: "history",
+});
+
+await memoryChain.invoke(
+  { input: "Hello!" },
+  { configurable: { sessionId: conv.id } },
+);
+----
+
+== Entity retriever
+
+[source,typescript]
+----
+import { Neo4jEntityRetriever } from "@neo4j-labs/agent-memory/integrations/langchain";
+
+const retriever = new Neo4jEntityRetriever(memory, { limit: 5 });
+const docs = await retriever.invoke("Neo4j graph database");
+// docs[i].pageContent === entity.description
+// docs[i].metadata.name === entity.name
+----
+
+== Version compatibility
+
+These adapters are tested against LangChain JS 0.2+ shapes. We will not
+break the adapter signatures across minor releases without a CHANGELOG
+callout, but upstream interface drift can still surface — if you hit it,
+please file an issue with the LangChain JS version you're on.

--- a/docs/modules/ROOT/pages/how-to/typescript/mastra.adoc
+++ b/docs/modules/ROOT/pages/how-to/typescript/mastra.adoc
@@ -1,0 +1,49 @@
+= How to: integrate with Mastra
+:toc: left
+:source-highlighter: rouge
+
+The `@neo4j-labs/agent-memory/integrations/mastra` subpath exports
+`Neo4jMastraMemory` — a duck-typed Mastra memory provider backed by a
+`MemoryClient`. Hand it to `new Agent({ memory })` and your agent gets
+graph-backed conversation history and entity memory.
+
+A runnable example lives at
+link:https://github.com/neo4j-labs/agent-memory/tree/main/typescript/examples/mastra[`clients/typescript/examples/mastra`].
+
+== Wiring
+
+[source,typescript]
+----
+import { Agent } from "@mastra/core/agent";
+import { MemoryClient } from "@neo4j-labs/agent-memory";
+import { Neo4jMastraMemory } from "@neo4j-labs/agent-memory/integrations/mastra";
+
+const memory = new Neo4jMastraMemory(new MemoryClient());
+
+const agent = new Agent({
+  name: "scout",
+  instructions: "You help users plan trips.",
+  memory,
+});
+----
+
+== What the adapter implements
+
+* `createThread({ resourceId, title?, metadata? })` — wraps
+  `createConversation`. `resourceId` becomes the `userId`.
+* `getMessages(threadId, { limit? })` — wraps `getConversation`.
+* `saveMessage({ threadId, role, content, metadata? })` — wraps
+  `addMessage`.
+* `deleteThread(threadId)` — wraps `deleteConversation`.
+
+Bridge transports (TCK conformance servers, local reference) don't
+implement `createConversation`; in that case `createThread` synthesizes
+a thread id from the supplied `resourceId`.
+
+== Versioning
+
+Mastra's interfaces are still evolving. We duck-type rather than
+importing `@mastra/core` so this adapter doesn't pin you to a specific
+version. If your Mastra version expects shapes the adapter doesn't
+produce, file an issue with the Mastra version pinned in your
+`package.json`.

--- a/docs/modules/ROOT/pages/how-to/typescript/mcp.adoc
+++ b/docs/modules/ROOT/pages/how-to/typescript/mcp.adoc
@@ -1,0 +1,88 @@
+= How to: use the MCP tools
+:toc: left
+:source-highlighter: rouge
+
+The `@neo4j-labs/agent-memory/mcp` subpath ships the 12 standard
+neo4j-agent-memory tool definitions plus a dispatcher. Use it to register
+the same tool surface on your own MCP server, or to programmatically
+invoke tools against a `MemoryClient`.
+
+A runnable example lives at
+link:https://github.com/neo4j-labs/agent-memory/tree/main/typescript/examples/mcp[`clients/typescript/examples/mcp`].
+
+== When to self-host MCP
+
+Most users don't need to. The hosted service already exposes the same 12
+tools at `https://memory.neo4jlabs.com/mcp`. Reach for self-hosting when
+you want to add a logging layer, filter or rewrite tool calls, or run an
+MCP server inside a corporate boundary.
+
+== The 12 tools
+
+[options="header"]
+|===
+| Tool | Wraps
+| `memory_create_conversation` | `shortTerm.createConversation`
+| `memory_add_messages` | `shortTerm.addMessage` (bulk-aware)
+| `memory_get_context` | `shortTerm.getContext`
+| `memory_search_messages` | `shortTerm.searchMessages`
+| `memory_search_entities` | `longTerm.searchEntities`
+| `memory_get_entity` | `longTerm.getEntity`
+| `memory_add_entity` | `longTerm.addEntity`
+| `memory_get_entity_history` | `longTerm.getEntityHistory`
+| `memory_record_step` | `reasoning.recordStep`
+| `memory_record_tool_call` | `reasoning.recordToolCall`
+| `memory_get_trace` | `reasoning.getTraceByConversation`
+| `memory_explain_decision` | `reasoning.explainStep`
+|===
+
+== Registering with an MCP server
+
+[source,typescript]
+----
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { CallToolRequestSchema, ListToolsRequestSchema }
+  from "@modelcontextprotocol/sdk/types.js";
+import { MemoryClient } from "@neo4j-labs/agent-memory";
+import { createMemoryTools, handleMemoryToolCall }
+  from "@neo4j-labs/agent-memory/mcp";
+
+const memory = new MemoryClient();
+const tools = createMemoryTools();
+const server = new Server({ name: "...", version: "..." }, { capabilities: { tools: {} } });
+
+server.setRequestHandler(ListToolsRequestSchema, async () => ({
+  tools: tools.map((t) => ({
+    name: t.name, description: t.description, inputSchema: t.inputSchema,
+  })),
+}));
+
+server.setRequestHandler(CallToolRequestSchema, async (req) => {
+  const result = await handleMemoryToolCall(
+    memory, req.params.name, (req.params.arguments ?? {}) as Record<string, unknown>,
+  );
+  return { content: [{ type: "text", text: JSON.stringify(result) }] };
+});
+----
+
+== Programmatic dispatch
+
+You can also call `handleMemoryToolCall` directly — useful for tests, or
+when bridging an LLM that uses a different tool-calling convention than
+MCP:
+
+[source,typescript]
+----
+const conv = await handleMemoryToolCall(memory, "memory_create_conversation", {
+  user_id: "alice",
+});
+----
+
+Argument keys use snake_case (matching the JSON schema published by
+`createMemoryTools()`).
+
+== Deprecated tool names
+
+A few `memory.<verb>` aliases from earlier drafts are still accepted and
+forward to the new names with a warning. Migrate to the
+`memory_<noun>_<verb>` form when you can.

--- a/docs/modules/ROOT/pages/how-to/typescript/observability.adoc
+++ b/docs/modules/ROOT/pages/how-to/typescript/observability.adoc
@@ -1,0 +1,97 @@
+= How to: enable request logging
+:toc: left
+:source-highlighter: rouge
+
+The TypeScript client emits a typed event stream around every HTTP
+exchange via the `logger` constructor option. Hook this into your
+favourite logger (Pino, Winston, console) for tracing, request-id
+correlation, and ops dashboards.
+
+== Basic usage
+
+[source,typescript]
+----
+import { MemoryClient, type LogEvent } from "@neo4j-labs/agent-memory";
+
+const client = new MemoryClient({
+  logger: (event: LogEvent) => {
+    console.log(JSON.stringify(event));
+  },
+});
+----
+
+You'll see two events per successful call:
+
+[source,json]
+----
+{ "kind": "request", "method": "create_conversation", "url": "...", "httpMethod": "POST" }
+{ "kind": "response", "method": "create_conversation", "url": "...", "status": 200,
+  "requestId": "req-abc", "durationMs": 142 }
+----
+
+Failures emit `request` then `error`:
+
+[source,json]
+----
+{ "kind": "request", "method": "create_conversation", "url": "...", "httpMethod": "POST" }
+{ "kind": "error", "method": "create_conversation", "url": "...", "status": 500,
+  "requestId": "req-abc", "durationMs": 87, "message": "..." }
+----
+
+== Event shape
+
+[source,typescript]
+----
+type LogEvent =
+  | { kind: "request"; method: string; url: string; httpMethod?: string }
+  | { kind: "response"; method: string; url: string; status: number;
+      requestId?: string; durationMs: number }
+  | { kind: "error"; method: string; url: string; status?: number;
+      requestId?: string; durationMs: number; message: string };
+----
+
+`method` is the snake_case bridge method name
+(`create_conversation`, `search_entities`, `record_step`, …). `httpMethod`
+is the HTTP verb (`POST`, `GET`, …).
+
+== Bodies are never logged by default
+
+To avoid leaking PII, the logger never receives request or response
+bodies. If you need bodies during development, log them yourself by
+wrapping the call:
+
+[source,typescript]
+----
+const msg = await client.shortTerm.addMessage(conv.id, "user", "hi");
+console.debug("addMessage result:", msg);
+----
+
+== Logger exceptions are swallowed
+
+If your logger throws, the SDK catches the error and continues. This
+means a misbehaving logger can't take down your application — but it
+also means logging is best-effort. Wrap calls into your structured
+logger in your own try/catch if you care.
+
+== User-Agent customization
+
+The client sends a default `User-Agent` like
+`@neo4j-labs/agent-memory/0.3.0 (node/22.5.0; darwin)`. To override,
+pass your own:
+
+[source,typescript]
+----
+new MemoryClient({
+  headers: { "User-Agent": "my-app/2.1 (CI runner)" },
+});
+----
+
+Wrapping SDKs should append their own identifier (e.g.,
+`@neo4j-labs/agent-memory/0.3.0 my-wrapper/1.0`) so server-side metrics
+can break the population down.
+
+== Request-id correlation
+
+Every error carries `error.requestId`. Use it to find the failing
+request in service-side logs. See
+link:handle-errors.adoc[How-to: handle errors].

--- a/docs/modules/ROOT/pages/how-to/typescript/strands.adoc
+++ b/docs/modules/ROOT/pages/how-to/typescript/strands.adoc
@@ -1,0 +1,173 @@
+= How to: integrate with AWS Strands Agents
+:toc: left
+:source-highlighter: rouge
+
+The `@neo4j-labs/agent-memory/integrations/strands` subpath plugs into
+all three of Strands' orthogonal extension surfaces:
+
+* **`SnapshotStorage`** — session state persists to a NAMS conversation
+  automatically. Real conversation messages land as `Message` graph
+  nodes; non-message snapshot state (Strands' `data` minus messages,
+  plus `appData`, plus manifests) rides on synthetic `role: "user"`
+  marker messages whose content is `__strands_state__:{base64-JSON}`.
+* **`ConversationManager`** — three-tier context (reflections + observations
+  from `getContext()`) is prepended to every model invocation, *on top of*
+  a configurable inner manager (defaults to `SlidingWindowConversationManager`).
+* **`HookRegistry` events** — `BeforeInvocation`, `AfterInvocation`,
+  `BeforeToolCall`, and `AfterToolCall` are wired to the reasoning subclient
+  so every agent turn becomes a queryable `ReasoningStep` with tool calls
+  attached.
+
+A runnable example lives at
+link:https://github.com/neo4j-labs/agent-memory/tree/main/typescript/examples/strands[`clients/typescript/examples/strands`].
+
+== When to use this
+
+You want any of:
+
+* Agent state that survives process restarts AND is queryable as a graph
+* Reflections/observations injected into the model context automatically
+* A full reasoning trace of every agent turn, browseable later via
+  `client.reasoning.getTraceByConversation(id)`
+* Cross-agent memory sharing through the same conversation
+
+== One-line wiring with `connectMemoryToAgent`
+
+[source,typescript]
+----
+import { Agent } from "@strands-agents/sdk";
+import { OpenAIModel } from "@strands-agents/sdk/models/openai";
+import { MemoryClient } from "@neo4j-labs/agent-memory";
+import { connectMemoryToAgent } from "@neo4j-labs/agent-memory/integrations/strands";
+
+const memory = new MemoryClient();
+const conv = await memory.shortTerm.createConversation({ userId: "alice" });
+
+const agent = new Agent({
+  ...await connectMemoryToAgent(memory, { conversationId: conv.id }),
+  model: new OpenAIModel({ modelId: "gpt-4o-mini" }),
+  tools: [/* ... */],
+});
+
+await agent.invoke("Tell me about graph databases.");
+----
+
+The factory returns `{ sessionManager, conversationManager }` — spread it
+into `new Agent({...})`. Reasoning hooks attach automatically when the
+conversation manager's `initAgent` runs.
+
+== Individual pieces (advanced)
+
+For finer control:
+
+[source,typescript]
+----
+import {
+  SessionManager,
+  SlidingWindowConversationManager,
+} from "@strands-agents/sdk";
+import {
+  Neo4jSessionStorage,
+  Neo4jConversationManager,
+  registerReasoningHooks,
+} from "@neo4j-labs/agent-memory/integrations/strands";
+
+const sessionManager = new SessionManager({
+  sessionId: conv.id,
+  storage: { snapshot: new Neo4jSessionStorage(memory) },
+});
+
+const conversationManager = new Neo4jConversationManager(memory, {
+  conversationId: conv.id,
+  inner: new SlidingWindowConversationManager(),  // or any custom CM
+  includeReflections: true,
+  includeObservations: true,
+});
+
+const agent = new Agent({ sessionManager, conversationManager, model, tools });
+
+// If you skipped connectMemoryToAgent, attach reasoning hooks explicitly:
+await registerReasoningHooks(memory, agent, { conversationId: conv.id });
+----
+
+== What gets stored where
+
+[options="header"]
+|===
+| Strands construct | Where it lands in NAMS
+| Conversation messages | `Message` nodes attached to the Conversation
+| Agent state (`Snapshot.data`, non-message fields) | synthetic `role: "user"` message with content `__strands_state__:{base64-JSON-blob}`
+| Application state (`Snapshot.appData`) | inside the same synthetic message's content blob
+| Tool calls | `ToolCall` nodes attached to a `ReasoningStep`
+| Per-turn reasoning | `ReasoningStep` nodes attached to the Conversation
+| Manifests (snapshot metadata) | synthetic `role: "user"` message with content `__strands_manifest__:{base64-JSON-blob}`
+|===
+
+NAMS exposes no endpoint to update a Conversation's `metadata` after
+creation, and we observed that per-message metadata doesn't reliably
+round-trip via `GET /conversations/{id}/messages` either. So the
+integration stuffs the serialized blob directly into the message's
+`content` field, base64-encoded after a recognizable prefix. Each
+`saveSnapshot` writes one synthetic message; `listSnapshotIds` walks
+the message list, filters by the `__strands_state__:` content prefix,
+and dedupes by `snapshotId` (last-write-wins for the `isLatest` flag).
+
+Synthetic markers are filtered out before the Snapshot is handed back
+to Strands on `loadSnapshot`, so the agent never sees them in its
+prompt. Consumers walking the raw message list themselves (chat UIs,
+Cypher queries, custom analytics) should filter on the prefixes too —
+the integration exports `isSyntheticStrandsMessage` and
+`SYNTHETIC_MESSAGE_PREFIXES` for convenience:
+
+[source,typescript]
+----
+import { isSyntheticStrandsMessage } from "@neo4j-labs/agent-memory/integrations/strands";
+
+const conv = await memory.shortTerm.getConversation(conversationId);
+const realMessages = conv.messages.filter((m) => !isSyntheticStrandsMessage(m));
+----
+
+The chat UI in `demo/agents/spool/` doesn't fetch raw conversation
+messages (it streams from `agent.invoke` directly) so it doesn't need
+to filter; consumers that DO fetch raw messages must.
+
+== Behaviour details
+
+=== ConversationManager layering
+
+`Neo4jConversationManager` does NOT replace your inner manager's trimming
+or summarization logic — it layers context injection *on top* of it. So:
+
+* Sliding-window trimming still happens (if you use `SlidingWindowConversationManager`)
+* Summarization still happens (if you use `SummarizingConversationManager`)
+* If `getContext()` fails (cold conversation, transient error), the inner
+  manager's output is used unchanged
+
+=== Reasoning capture is best-effort
+
+Every reasoning write (`recordStep`, `recordToolCall`) is wrapped in
+try/catch. A failed reasoning write logs through the constructor `logger`
+but never breaks the agent run. If you depend on the trace being complete,
+check `getTraceByConversation(id)` after the run and replay missing steps
+yourself.
+
+=== Auth errors propagate
+
+`SnapshotStorage` failures are *not* best-effort. If the integration
+can't read or write the snapshot blob, Strands' own retry semantics kick
+in. An auth failure surfaces as `AuthenticationError` from
+`saveSnapshot` / `loadSnapshot`.
+
+== Version compatibility
+
+We test against `@strands-agents/sdk@^1.2.0`. Strands' v1 API is stable
+under semver — the integration should track v1 minor releases without
+adjustment. We will not break the integration API across minor releases
+of `@neo4j-labs/agent-memory` without a CHANGELOG callout.
+
+== See also
+
+- link:https://github.com/neo4j-labs/agent-memory/tree/main/typescript/examples/strands[Runnable Strands example]
+- link:observability.adoc[Enable request logging]
+- link:handle-errors.adoc[Error handling]
+- https://strandsagents.com[Strands Agents docs]

--- a/docs/modules/ROOT/pages/how-to/typescript/troubleshooting.adoc
+++ b/docs/modules/ROOT/pages/how-to/typescript/troubleshooting.adoc
@@ -1,0 +1,78 @@
+= Troubleshooting
+:toc: left
+:source-highlighter: rouge
+
+== `AuthenticationError: Authentication failed: 401`
+
+Your `MEMORY_API_KEY` is missing, mistyped, or revoked.
+
+* Check the env var is set: `echo $MEMORY_API_KEY` (Node/Bun/Deno).
+* On Cloudflare Workers or Vercel Edge, `process.env` is not in scope at
+  module init — pass the key explicitly:
+  `new MemoryClient({ apiKey: env.MEMORY_API_KEY })`.
+* Sign up for a key at https://memory.neo4jlabs.com if you don't have
+  one.
+* The error's `requestId` field can be quoted in a Community Forum
+  thread for service-side correlation.
+
+== `NotSupportedError: Method 'X' has no equivalent in the hosted REST API`
+
+You're calling a bridge-only operation against the hosted service (or
+vice versa). The hosted service exposes a richer surface (three-tier
+context, observations, reflections, entity feedback, graph view); the
+bridge supports the legacy long-term/reasoning operations from the TCK.
+
+Either:
+
+* Switch operations to the hosted-native equivalent (most of `shortTerm`,
+  `longTerm`, `reasoning` is supported on both transports).
+* Use the bridge transport explicitly for conformance testing — import
+  `BridgeTransport` from `@neo4j-labs/agent-memory/testing` and supply
+  it to the `MemoryClient` constructor.
+
+== Entity search returns empty
+
+Long-term entity extraction is asynchronous on the hosted service.
+After you add a message, the service runs entity extraction in the
+background and indexes the result for search. Typical lag is a few
+seconds.
+
+If you need the entity immediately, call `longTerm.addEntity()` to add
+it explicitly rather than relying on extraction from a message.
+
+== Edge runtime: `process is not defined`
+
+Some edge bundlers throw at *build* time if `process.env` appears in
+imported code. The client guards every `process.env` read with
+`typeof process !== "undefined"` — if you still see this error, it's
+likely coming from a different dependency. Run with
+`wrangler dev --verbose` (Workers) to see which module is referencing
+`process` directly.
+
+== TypeScript: `Cannot find module '@neo4j-labs/agent-memory/middleware/vercel-ai'`
+
+Make sure `tsconfig.json` has `"moduleResolution": "bundler"`, or use
+`"Node16"` / `"NodeNext"` together with ESM output. The package uses
+ESM-only subpath exports, which require modern module resolution.
+
+== Hook timeout in Vitest e2e tests
+
+If you wrote your own e2e tests against the live hosted service and see
+"Hook timed out in 10000ms" on `beforeAll(client.connect)`: vitest's
+default `hookTimeout` is 10s, but the first connect on a cold path can
+take longer. Bump it in `vitest.config.ts`:
+
+[source,typescript]
+----
+test: { testTimeout: 30_000, hookTimeout: 30_000 }
+----
+
+== Still stuck?
+
+* Ask on the
+  https://community.neo4j.com[Neo4j Community Forum] (primary
+  support channel).
+* File a https://github.com/neo4j-labs/agent-memory/issues[GitHub
+  issue]. Include the `requestId` from any failing request.
+* For suspected security issues, see
+  https://github.com/neo4j-labs/agent-memory/blob/main/SECURITY.md[SECURITY.md].

--- a/docs/modules/ROOT/pages/how-to/typescript/vercel-ai.adoc
+++ b/docs/modules/ROOT/pages/how-to/typescript/vercel-ai.adoc
@@ -1,0 +1,84 @@
+= How to: integrate with the Vercel AI SDK
+:toc: left
+:source-highlighter: rouge
+
+The TypeScript client ships a `LanguageModelV1`-shaped middleware that
+auto-injects context and persists messages around any Vercel AI SDK call.
+This page covers the wiring; a runnable example lives at
+link:https://github.com/neo4j-labs/agent-memory/tree/main/typescript/examples/vercel-ai[`clients/typescript/examples/vercel-ai`].
+
+== What the middleware does
+
+For every model invocation:
+
+1. Fetches three-tier context for the conversation (reflections,
+   observations, recent messages) and prepends it to the prompt.
+2. Persists the user's input message before generation.
+3. Persists the assistant's response after generation.
+
+If three-tier context is unavailable (bridge transport, or a service
+error), the middleware falls back to flat conversation history.
+
+== Basic wiring
+
+[source,typescript]
+----
+import { generateText, experimental_wrapLanguageModel as wrapModel } from "ai";
+import { openai } from "@ai-sdk/openai";
+import { MemoryClient } from "@neo4j-labs/agent-memory";
+import { agentMemoryMiddleware } from "@neo4j-labs/agent-memory/middleware/vercel-ai";
+
+const memory = new MemoryClient();
+const conv = await memory.shortTerm.createConversation({ userId: "alice" });
+
+const model = wrapModel({
+  model: openai("gpt-4o-mini"),
+  middleware: agentMemoryMiddleware(memory, { conversationId: conv.id }),
+});
+
+const { text } = await generateText({
+  model,
+  messages: [{ role: "user", content: "Hello!" }],
+});
+----
+
+== Options
+
+[source,typescript]
+----
+agentMemoryMiddleware(client, {
+  conversationId: "conv-uuid",     // or a function returning one
+  userId: "alice",                  // used if conversation is lazily created
+  includeContext: true,             // default true on REST
+  historyLimit: 20,                 // flat-history fallback cap
+  persistInput: true,               // default true
+  persistResponses: true,           // default true
+});
+----
+
+`conversationId` can be a string or a function. The function form is useful
+when the id is derived from request state (e.g., from `req.user.id` in a
+Next.js route handler).
+
+== Streaming
+
+The same middleware works with `streamText` because Vercel AI handles
+streaming via the wrapped model — the middleware's `wrapGenerate` is
+called once the stream completes.
+
+== Edge runtimes
+
+Pass `apiKey` explicitly because `process.env` is not available at
+module-init scope on Cloudflare Workers and Vercel Edge:
+
+[source,typescript]
+----
+export default {
+  async fetch(req, env) {
+    const memory = new MemoryClient({ apiKey: env.MEMORY_API_KEY });
+    // ... wire middleware as above
+  },
+};
+----
+
+See link:edge-runtime.adoc[How-to: deploy to edge runtimes] for details.

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -18,19 +18,48 @@ icon:flask[] *Neo4j Labs* · icon:database[] Graph-native memory for AI agents
 [.lead]
 Your agents forget everything. *Fix that.*
 
-Store conversations, build knowledge graphs, and let your agents learn from their own reasoning — all backed by Neo4j.
+Production-grade memory for single- and multi-agent systems. Three memory layers — conversations, entities, reasoning — in one graph. Available as a *hosted service* (zero infra, just an API key) or run against your own Neo4j. Python + TypeScript SDKs that interoperate.
 
 [NOTE]
 ====
 *Experimental · Community Supported*
 ====
 
+== Pick your install
+
+[cols="1,3", options="header"]
+|===
+|Path |Get started in ~30 seconds
+
+|*Hosted service (recommended for new projects)* +
+Sign up at link:https://memory.neo4jlabs.com[memory.neo4jlabs.com], get an API key, install one of the SDKs. No Neo4j to run.
+a|
+[source,bash]
+----
+# Python
+pip install neo4j-agent-memory
+export MEMORY_API_KEY=nams_...
+
+# TypeScript
+npm install @neo4j-labs/agent-memory
+export MEMORY_API_KEY=nams_...
+----
+
+See xref:tutorials/nams-quickstart.adoc[NAMS Quickstart (Python)] or xref:tutorials/hosted-quickstart-typescript.adoc[Hosted Quickstart (TypeScript)].
+
+|*Self-hosted Neo4j* +
+Bring your own Neo4j (Aura, Docker, Desktop). Full schema control, write-Cypher access, geospatial features.
+a|
 [source,bash]
 ----
 pip install neo4j-agent-memory
+# Point at bolt://your-neo4j:7687
 ----
 
-xref:tutorials/first-agent-memory.adoc[Get Started] | https://github.com/neo4j-labs/agent-memory[GitHub] | https://pypi.org/project/neo4j-agent-memory/[PyPI]
+See xref:tutorials/first-agent-memory.adoc[Build Your First Memory-Enabled Agent].
+|===
+
+xref:tutorials/first-agent-memory.adoc[Get Started] · xref:sdks/python.adoc[Python SDK] · xref:sdks/typescript.adoc[TypeScript SDK] · link:https://github.com/neo4j-labs/agent-memory[GitHub] · link:https://pypi.org/project/neo4j-agent-memory/[PyPI] · link:https://www.npmjs.com/package/@neo4j-labs/agent-memory[npm]
 
 == Three Memory Types, One Graph
 
@@ -74,6 +103,29 @@ async with MemoryClient(settings) as memory:
     context = await memory.get_context("restaurant recommendation", session_id=session_id)
 ----
 
+== Multi-Agent Ready
+
+Multiple agents — even in different languages — can read and write the same memory graph. Conversations stay private per session; entities, preferences, and facts are shared.
+
+[cols="1,2", options="header"]
+|===
+|Capability |How it works
+
+|icon:users[] *Shared knowledge graph*
+|Every agent in the system reads the same `Entity`, `Preference`, and `Fact` nodes. When Agent A learns something new, Agent B sees it on the next query — no manual sync.
+
+|icon:lock[] *Per-session isolation*
+|`session_id` (or `user_identifier=` for multi-tenant) keeps each agent's conversations and reasoning traces separate. One agent never reads another's chat history by accident.
+
+|icon:exchange[] *Cross-language by design*
+|A Python agent (PydanticAI, LangChain, CrewAI, Google ADK, AWS Strands) and a TypeScript agent (Vercel AI SDK, LangChain JS, Mastra, MCP) on the same NAMS endpoint share memory transparently. Both SDKs implement the same xref:reference/rest-api.adoc[NAMS REST contract].
+
+|icon:shield[] *Multi-tenant scoping*
+|Pass `user_identifier=` on any operation to scope writes and reads per end-user. One backend, many tenants — see xref:how-to/multi-tenancy.adoc[Multi-tenant memory].
+|===
+
+See xref:explanation/multi-agent-sharing.adoc[Cross-Agent Memory Sharing] for the conceptual model and xref:tutorials/nams-quickstart.adoc[NAMS Quickstart] for the deployment shape.
+
 == What Makes This Different
 
 [cols="1,3", options="header"]
@@ -96,7 +148,10 @@ async with MemoryClient(settings) as memory:
 |Entities are automatically enriched with *Wikipedia descriptions, images, and Wikidata IDs*. Location entities get coordinates for geospatial queries. All in the background.
 
 |icon:plug[] *Framework Agnostic*
-|Works with *LangChain, PydanticAI, LlamaIndex, and CrewAI*. Or use the client directly. Your agent framework, your choice — the memory layer stays the same.
+|Python: *LangChain, PydanticAI, LlamaIndex, CrewAI, OpenAI Agents, AWS Strands, Google ADK, Microsoft Agent Framework, AgentCore*. TypeScript: *Vercel AI SDK, LangChain JS, Mastra, AWS Strands, MCP tools*. Or use the client directly.
+
+|icon:cloud[] *Hosted or Self-Hosted*
+|Use the link:https://memory.neo4jlabs.com[NAMS hosted service] for zero-infra deployments, or run the same SDK against your own Neo4j (Aura, Desktop, Docker) when you need write-Cypher, geospatial, or air-gapped operation. See xref:explanation/backends.adoc[Bolt vs NAMS].
 |===
 
 == Demos
@@ -199,6 +254,8 @@ Combine extractors in a configurable pipeline. 5 merge strategies. 8 domain sche
 
 == Framework Integrations
 
+=== Python (`neo4j-agent-memory`)
+
 [cols="1,2,1"]
 |===
 |Framework |Integration |Guide
@@ -219,13 +276,52 @@ Combine extractors in a configurable pipeline. 5 merge strategies. 8 domain sche
 |Crew memory
 |xref:how-to/integrations/crewai.adoc[CrewAI guide]
 
+|*OpenAI Agents*
+|Session memory
+|xref:how-to/integrations/openai-agents.adoc[OpenAI Agents guide]
+
 |*AWS Strands*
 |Agent tools
 |xref:how-to/integrations/aws-strands.adoc[Strands guide]
 
 |*Google ADK*
 |MemoryService
-|xref:tutorials/first-agent-memory.adoc[ADK tutorial]
+|xref:how-to/integrations/google-cloud.adoc[Google Cloud guide]
+
+|*Microsoft Agent Framework*
+|ContextProvider + GDS
+|xref:how-to/integrations/microsoft-agent.adoc[Microsoft Agent guide]
+
+|*AWS AgentCore*
+|HybridMemoryProvider
+|xref:how-to/integrations/aws-hybrid-memory.adoc[AgentCore guide]
+|===
+
+=== TypeScript (`@neo4j-labs/agent-memory`)
+
+[cols="1,2,1"]
+|===
+|Framework |Integration |Guide
+
+|*Vercel AI SDK*
+|Middleware (3-tier context injection + auto-persist)
+|xref:how-to/typescript/vercel-ai.adoc[Vercel AI guide]
+
+|*LangChain JS*
+|`Neo4jChatMessageHistory`, `Neo4jEntityRetriever`
+|xref:how-to/typescript/langchain.adoc[LangChain JS guide]
+
+|*Mastra*
+|`Neo4jMastraMemory` provider
+|xref:how-to/typescript/mastra.adoc[Mastra guide]
+
+|*AWS Strands (JS)*
+|Session storage + conversation manager
+|xref:how-to/typescript/strands.adoc[Strands guide]
+
+|*MCP tools*
+|12 standard tools + dispatcher (Node, Bun, Deno, Workers, Edge)
+|xref:how-to/typescript/mcp.adoc[MCP guide]
 |===
 
 == Architecture
@@ -279,6 +375,13 @@ image::diagrams/architecture-overview.png[Architecture overview: MemoryClient wi
 
 == Requirements
 
-* Python 3.10+
-* Neo4j 5.20+ (with APOC plugin recommended)
-* OpenAI API key (for embeddings and LLM extraction)
+[cols="1,2", options="header"]
+|===
+|If you use… |You need…
+
+|*NAMS (hosted)*
+|Python 3.10+ *or* Node.js 20+. An API key from link:https://memory.neo4jlabs.com[memory.neo4jlabs.com]. _No Neo4j to run._
+
+|*Self-hosted (Bolt)*
+|Python 3.10+. Neo4j 5.20+ (Aura, Desktop, or Docker — APOC plugin recommended). Optional OpenAI/Anthropic/Bedrock/Vertex key for client-side embeddings and LLM extraction.
+|===

--- a/docs/modules/ROOT/pages/reference/mcp-tools.adoc
+++ b/docs/modules/ROOT/pages/reference/mcp-tools.adoc
@@ -479,3 +479,9 @@ neo4j-agent-memory mcp serve [OPTIONS]
 | `false`
 | Disable automatic preference detection.
 |===
+
+== See Also
+
+* xref:how-to/typescript/mcp.adoc[Wire the same tools into the TypeScript SDK]
+* xref:reference/rest-api.adoc[NAMS REST API] - HTTP surface backing the MCP tools
+* link:https://github.com/neo4j-labs/agent-memory-tck/blob/main/docs/reference/mcp-tools.adoc[MCP tools spec in the TCK] - Cross-language behavioral contract

--- a/docs/modules/ROOT/pages/reference/rest-api.adoc
+++ b/docs/modules/ROOT/pages/reference/rest-api.adoc
@@ -1,0 +1,85 @@
+= REST API Reference
+:description: Hosted-service REST endpoints mapped to client SDK methods in each language.
+
+The hosted service at `https://memory.neo4jlabs.com/v1` exposes a REST API.
+This page maps every endpoint to its bridge-protocol equivalent and the
+corresponding method on each language client.
+
+Bridge-method names are what the link:https://github.com/neo4j-labs/agent-memory-tck[agent-memory-tck]
+cross-language conformance suite uses. SDK methods take language-idiomatic
+casing.
+
+== Conversations
+
+[cols="2,3,1,1,1,1,1"]
+|===
+| HTTP | Path | Bridge | TS | Go | Py | C#
+
+| `GET` | `/conversations` | `list_conversations` | `listConversations` | `ListConversations` | `list_conversations` | `ListConversationsAsync`
+| `POST` | `/conversations` | `create_conversation` | `createConversation` | `CreateConversation` | `create_conversation` | `CreateConversationAsync`
+| `GET` | `/conversations/{id}` | `get_conversation_metadata` | `getConversationMetadata` | `GetConversationMetadata` | `get_conversation_metadata` | `GetConversationMetadataAsync`
+| `DELETE` | `/conversations/{id}` | `delete_conversation` | `deleteConversation` | `DeleteConversation` | `delete_conversation` | `DeleteConversationAsync`
+| `GET` | `/conversations/{id}/messages` | `get_conversation` | `getConversation` | `GetConversation` | `get_conversation` | `GetConversationAsync`
+| `POST` | `/conversations/{id}/messages` | `add_message` | `addMessage` | `AddMessage` | `add_message` | `AddMessageAsync`
+| `POST` | `/conversations/{id}/messages/bulk` | `bulk_add_messages` | `bulkAddMessages` | `BulkAddMessages` | `bulk_add_messages` | `BulkAddMessagesAsync`
+| `POST` | `/conversations/{id}/search` | `search_messages` | `searchMessages` | `SearchMessages` | `search_messages` | `SearchMessagesAsync`
+| `GET` | `/conversations/{id}/context` | `get_context` | `getContext` | `GetContext` | `get_context` | `GetContextAsync`
+| `GET` | `/conversations/{id}/observations` | `get_observations` | `getObservations` | `GetObservations` | `get_observations` | `GetObservationsAsync`
+| `GET` | `/conversations/{id}/reflections` | `get_reflections` | `getReflections` | `GetReflections` | `get_reflections` | `GetReflectionsAsync`
+|===
+
+== Entities
+
+[cols="2,3,1,1,1,1,1"]
+|===
+| HTTP | Path | Bridge | TS | Go | Py | C#
+
+| `GET` | `/entities` | `list_entities` | `listEntities` | `ListEntities` | `list_entities` | `ListEntitiesAsync`
+| `POST` | `/entities` | `add_entity` | `addEntity` | `AddEntity` | `add_entity` | `AddEntityAsync`
+| `GET` | `/entities/{id}` | `get_entity` | `getEntity` | `GetEntity` | `get_entity` | `GetEntityAsync`
+| `PUT` | `/entities/{id}` | `update_entity` | `updateEntity` | `UpdateEntity` | `update_entity` | `UpdateEntityAsync`
+| `DELETE` | `/entities/{id}` | `delete_entity` | `deleteEntity` | `DeleteEntity` | `delete_entity` | `DeleteEntityAsync`
+| `PUT` | `/entities/{id}/feedback` | `set_entity_feedback` | `setEntityFeedback` | `SetEntityFeedback` | `set_entity_feedback` | `SetEntityFeedbackAsync`
+| `GET` | `/entities/{id}/history` | `get_entity_history` | `getEntityHistory` | `GetEntityHistory` | `get_entity_history` | `GetEntityHistoryAsync`
+| `POST` | `/entities/{id}/merge` | `merge_entities` | `mergeEntities` | `MergeEntities` | `merge_entities` | `MergeEntitiesAsync`
+| `GET` | `/entities/graph` | `get_entity_graph` | `getEntityGraph` | `GetEntityGraph` | `get_entity_graph` | `GetEntityGraphAsync`
+| `POST` | `/entities/search` | `search_entities` | `searchEntities` | `SearchEntities` | `search_entities` | `SearchEntitiesAsync`
+|===
+
+== Reasoning
+
+[cols="2,3,1,1,1,1,1"]
+|===
+| HTTP | Path | Bridge | TS | Go | Py | C#
+
+| `POST` | `/reasoning/steps` | `record_step` | `recordStep` | `RecordStep` | `record_step` | `RecordStepAsync`
+| `GET` | `/reasoning/steps` | `list_steps` | `listSteps` | `ListSteps` | `list_steps` | `ListStepsAsync`
+| `GET` | `/reasoning/explain/{step}` | `explain_step` | `explainStep` | `ExplainStep` | `explain_step` | `ExplainStepAsync`
+| `POST` | `/reasoning/tool-calls` | `record_tool_call` | `recordToolCall` | `RecordToolCall` | `record_tool_call` | `RecordToolCallAsync`
+| `GET` | `/reasoning/trace/{conv}` | `get_trace_by_conversation` | `getTraceByConversation` | `GetTraceByConversation` | `get_trace_by_conversation` | `GetTraceByConversationAsync`
+| `GET` | `/reasoning/provenance/{entity}` | `get_entity_provenance` | `getEntityProvenance` | `GetEntityProvenance` | `get_entity_provenance` | `GetEntityProvenanceAsync`
+|===
+
+== Cypher and Auth
+
+[cols="2,3,1,1,1,1,1"]
+|===
+| HTTP | Path | Bridge | TS | Go | Py | C#
+
+| `POST` | `/query` | `cypher_query` | `query.cypher` | `Query.Cypher` | `query.cypher` | `Query.CypherAsync`
+| `GET` | `/auth/api-keys` | `list_api_keys` | `auth.listApiKeys` | `Auth.ListAPIKeys` | `auth.list_api_keys` | `Auth.ListApiKeysAsync`
+| `POST` | `/auth/api-keys` | `create_api_key` | `auth.createApiKey` | `Auth.CreateAPIKey` | `auth.create_api_key` | `Auth.CreateApiKeyAsync`
+| `DELETE` | `/auth/api-keys/{id}` | `revoke_api_key` | `auth.revokeApiKey` | `Auth.RevokeAPIKey` | `auth.revoke_api_key` | `Auth.RevokeApiKeyAsync`
+| `GET` | `/auth/api-keys/{id}/reveal` | `reveal_api_key` | `auth.revealApiKey` | `Auth.RevealAPIKey` | `auth.reveal_api_key` | `Auth.RevealApiKeyAsync`
+| `POST` | `/auth/refresh` | `refresh_access_token` | `auth.refreshAccessToken` | `Auth.RefreshAccessToken` | `auth.refresh_access_token` | `Auth.RefreshAccessTokenAsync`
+|===
+
+== Wire format differences
+
+* Hosted REST: camelCase fields (`userId`, `conversationId`, `createdAt`).
+* Bridge protocol: snake_case fields (`user_id`, `conversation_id`,
+  `created_at`).
+
+The clients translate transparently. If you're writing a custom transport,
+see the link:https://github.com/neo4j-labs/agent-memory-tck/blob/main/docs/reference/bridge-protocol.adoc[bridge-protocol reference]
+and the language-specific `casing` modules in the TCK repo.

--- a/docs/modules/ROOT/pages/sdks/python.adoc
+++ b/docs/modules/ROOT/pages/sdks/python.adoc
@@ -1,0 +1,63 @@
+= Python SDK — neo4j-agent-memory
+:description: Install, configure, and use the Python SDK for Neo4j Agent Memory.
+
+The Python SDK is the original implementation of the agent-memory contract.
+It can talk to Neo4j directly over Bolt or to the hosted
+xref:reference/rest-api.adoc[NAMS] service over HTTP.
+
+== Install
+
+[source,bash]
+----
+pip install neo4j-agent-memory
+# or, with uv:
+uv add neo4j-agent-memory
+----
+
+Optional extras (extractors, framework integrations, embeddings):
+
+[source,bash]
+----
+pip install "neo4j-agent-memory[all]"
+----
+
+== Quick start
+
+[source,python]
+----
+from neo4j_agent_memory import MemoryClient, MemorySettings
+
+settings = MemorySettings(
+    neo4j={"uri": "bolt://localhost:7687", "password": "password"}
+)
+
+async with MemoryClient(settings) as client:
+    msg = await client.short_term.add_message("session-1", "user", "Hello")
+    await client.long_term.add_entity("Alice", "PERSON")
+    context = await client.get_context("hello")
+----
+
+For the hosted service, swap the `neo4j={...}` config for
+`nams={"api_key": "nams_..."}` — see xref:tutorials/nams-quickstart.adoc[NAMS Quickstart].
+
+== Where to go next
+
+* xref:tutorials/first-agent-memory.adoc[Tutorial: First agent memory]
+* xref:tutorials/conversation-memory.adoc[Tutorial: Add memory to a chatbot]
+* xref:how-to/index.adoc[How-To Guides] — entity extraction, batch processing,
+  framework integrations, deduplication, and more.
+* xref:reference/configuration.adoc[Configuration reference]
+* xref:reference/cli.adoc[CLI reference]
+
+== Source and releases
+
+* Package: link:https://pypi.org/project/neo4j-agent-memory/[neo4j-agent-memory on PyPI]
+* Source: link:https://github.com/neo4j-labs/agent-memory[github.com/neo4j-labs/agent-memory]
+* Release tags: `python-v*` (e.g. `python-v0.4.1`)
+* Changelog: link:https://github.com/neo4j-labs/agent-memory/blob/main/CHANGELOG.md[CHANGELOG.md]
+
+== Looking for the TypeScript SDK?
+
+See xref:sdks/typescript.adoc[TypeScript SDK]. The two SDKs share the same
+memory model and back onto the same NAMS service, so a Python and a TypeScript
+agent can read and write the same memory.

--- a/docs/modules/ROOT/pages/sdks/typescript.adoc
+++ b/docs/modules/ROOT/pages/sdks/typescript.adoc
@@ -1,0 +1,82 @@
+= TypeScript SDK — @neo4j-labs/agent-memory
+:description: Install, configure, and use the TypeScript SDK for Neo4j Agent Memory.
+
+The TypeScript SDK is a thin HTTP client over the
+xref:reference/rest-api.adoc[NAMS] hosted service. It runs on Node 20+,
+Bun, Deno, Cloudflare Workers, and Vercel Edge.
+
+== Install
+
+[source,bash]
+----
+npm install @neo4j-labs/agent-memory
+# or
+pnpm add @neo4j-labs/agent-memory
+bun add @neo4j-labs/agent-memory
+----
+
+Requires Node.js 20+.
+
+== Quick start
+
+Get an API key from link:https://memory.neo4jlabs.com[memory.neo4jlabs.com],
+set `MEMORY_API_KEY`, then:
+
+[source,typescript]
+----
+import { MemoryClient } from "@neo4j-labs/agent-memory";
+
+const client = new MemoryClient();
+
+const conv = await client.shortTerm.createConversation({ userId: "alice" });
+await client.shortTerm.addMessage(conv.id, "user", "Hello!");
+
+const entity = await client.longTerm.addEntity("Alice Johnson", "person", {
+  description: "Software engineer working on graph memory.",
+});
+
+const ctx = await client.shortTerm.getContext(conv.id);
+console.log(ctx.recentMessages, ctx.observations, ctx.reflections);
+----
+
+For edge runtimes (Cloudflare Workers, Vercel Edge), pass the API key
+explicitly — see xref:how-to/typescript/edge-runtime.adoc[Edge Runtime].
+
+== Framework integrations
+
+All five ship as subpath exports.
+
+[cols="1,2,1", options="header"]
+|===
+| Integration | Import | Guide
+
+| Vercel AI SDK | `@neo4j-labs/agent-memory/middleware/vercel-ai` | xref:how-to/typescript/vercel-ai.adoc[Vercel AI SDK]
+| MCP tools | `@neo4j-labs/agent-memory/mcp` | xref:how-to/typescript/mcp.adoc[MCP Tools]
+| LangChain JS | `@neo4j-labs/agent-memory/integrations/langchain` | xref:how-to/typescript/langchain.adoc[LangChain JS]
+| Mastra | `@neo4j-labs/agent-memory/integrations/mastra` | xref:how-to/typescript/mastra.adoc[Mastra]
+| AWS Strands | `@neo4j-labs/agent-memory/integrations/strands` | xref:how-to/typescript/strands.adoc[Strands]
+|===
+
+== Where to go next
+
+* xref:tutorials/first-agent-memory-typescript.adoc[Tutorial: First agent memory (TypeScript)]
+* xref:tutorials/hosted-quickstart-typescript.adoc[Tutorial: Hosted quickstart]
+* xref:how-to/typescript/authenticate.adoc[How-to: authenticate]
+* xref:how-to/typescript/edge-runtime.adoc[How-to: deploy to edge runtimes]
+* xref:how-to/typescript/observability.adoc[How-to: enable observability]
+* xref:how-to/typescript/handle-errors.adoc[How-to: handle errors]
+* xref:how-to/typescript/troubleshooting.adoc[Troubleshooting]
+* link:https://neo4j-labs.github.io/agent-memory/typescript/[Full API reference (TypeDoc)]
+
+== Source and releases
+
+* Package: link:https://www.npmjs.com/package/@neo4j-labs/agent-memory[`@neo4j-labs/agent-memory` on npm]
+* Source: link:https://github.com/neo4j-labs/agent-memory/tree/main/typescript[`typescript/` in the agent-memory repo]
+* Release tags: `typescript-v*` (e.g. `typescript-v0.3.0`)
+* Changelog: link:https://github.com/neo4j-labs/agent-memory/blob/main/typescript/CHANGELOG.md[typescript/CHANGELOG.md]
+
+== Looking for the Python SDK?
+
+See xref:sdks/python.adoc[Python SDK]. The two SDKs share the same memory
+model and back onto the same NAMS service. Mixed Python + TypeScript agents
+can read and write the same memory.

--- a/docs/modules/ROOT/pages/tutorials/first-agent-memory-typescript.adoc
+++ b/docs/modules/ROOT/pages/tutorials/first-agent-memory-typescript.adoc
@@ -1,0 +1,178 @@
+= Building Your First TypeScript Agent with Memory
+:toc:
+:toclevels: 2
+:source-highlighter: rouge
+
+This tutorial shows you how to add persistent memory to a TypeScript AI application using `@neo4j-labs/agent-memory` and the Vercel AI SDK.
+
+== What You'll Build
+
+A simple chat application where the AI assistant remembers conversation history across sessions, stores entities it learns about, and records its reasoning process.
+
+== Prerequisites
+
+* Node.js 20+ or Bun
+* An OpenAI API key
+* Either a `nams_*` API key for `https://memory.neo4jlabs.com/v1` (recommended) or a local Neo4j + bridge server
+
+== Step 1: Create the Project
+
+[source,bash]
+----
+mkdir my-memory-agent && cd my-memory-agent
+npm init -y
+npm install @neo4j-labs/agent-memory ai @ai-sdk/openai
+----
+
+== Step 2: Connect the Memory Client
+
+Set `MEMORY_API_KEY` in your environment, then:
+
+[source,typescript]
+----
+// index.ts
+import { MemoryClient } from "@neo4j-labs/agent-memory";
+
+// Zero-config: defaults to https://memory.neo4jlabs.com/v1 and reads
+// MEMORY_API_KEY from the environment.
+const client = new MemoryClient();
+----
+
+The first request acts as the implicit auth check. To fail fast at
+startup, call `await client.connect()` explicitly.
+
+On Cloudflare Workers or Vercel Edge, pass the key explicitly because
+`process.env` is not available at module init:
+
+[source,typescript]
+----
+const client = new MemoryClient({ apiKey: env.MEMORY_API_KEY });
+----
+
+== Step 3: Store and Retrieve Messages
+
+[source,typescript]
+----
+// Store a message
+const msg = await client.shortTerm.addMessage(
+  "session-1",
+  "user",
+  "My name is Alice and I work at Acme Corp"
+);
+console.log(`Stored message: ${msg.id}`);
+
+// Retrieve the conversation
+const conv = await client.shortTerm.getConversation("session-1");
+console.log(`Messages: ${conv.messages.length}`);
+
+// Search across all messages
+const results = await client.shortTerm.searchMessages("Alice", {
+  limit: 5,
+  threshold: 0.0,
+});
+console.log(`Found ${results.length} matching messages`);
+----
+
+== Step 4: Build a Knowledge Graph
+
+[source,typescript]
+----
+// Store entities
+const alice = await client.longTerm.addEntity("Alice Johnson", "PERSON", {
+  description: "Software engineer at Acme Corp",
+});
+
+const acme = await client.longTerm.addEntity("Acme Corp", "ORGANIZATION", {
+  description: "Technology company",
+});
+
+// Create a relationship
+await client.longTerm.addRelationship(alice.id, acme.id, "WORKS_AT");
+
+// Store facts
+await client.longTerm.addFact("Alice Johnson", "ROLE", "Software Engineer");
+
+// Search the graph
+const entities = await client.longTerm.searchEntities("Alice");
+console.log(`Found: ${entities.map(e => e.name).join(", ")}`);
+----
+
+== Step 5: Record Reasoning Traces
+
+[source,typescript]
+----
+// Start a reasoning trace
+const trace = await client.reasoning.startTrace(
+  "session-1",
+  "Find Alice's employer"
+);
+
+// Record each step
+const step = await client.reasoning.addStep(trace.id, {
+  thought: "I need to look up Alice in the entity graph",
+  action: "search_entities",
+});
+
+// Record tool calls
+await client.reasoning.recordToolCall(step.id, "search_entities", {
+  query: "Alice Johnson",
+}, {
+  result: { found: true },
+  durationMs: 42,
+});
+
+// Complete the trace
+await client.reasoning.completeTrace(trace.id, {
+  outcome: "Alice works at Acme Corp",
+  success: true,
+});
+----
+
+== Step 6: Add Vercel AI SDK Middleware
+
+The middleware injects three-tier conversational context (reflections + observations + recent messages, when available from the hosted service) and persists assistant responses:
+
+[source,typescript]
+----
+import { generateText } from "ai";
+import { openai } from "@ai-sdk/openai";
+import { agentMemoryMiddleware } from "@neo4j-labs/agent-memory/middleware/vercel-ai";
+
+// On REST transports, pass conversationId (UUID from createConversation).
+// On bridge transports, pass sessionId (any free-form string).
+const conv = await client.shortTerm.createConversation({ userId: "alice@example.com" });
+
+const middleware = agentMemoryMiddleware(client, {
+  conversationId: conv.id,
+  userId: "alice@example.com",
+  includeContext: true,     // 3-tier context on REST; flat history on bridge
+  persistResponses: true,
+});
+
+const result = await generateText({
+  model: openai("gpt-4o-mini"),
+  experimental_middleware: middleware,
+  prompt: "What do you know about my role?",
+});
+
+console.log(result.text);
+// The assistant sees the full conversation history (plus any reflections
+// and observations the service has generated) and can reference that
+// Alice works at Acme Corp as a software engineer.
+----
+
+== Step 7: Clean Up
+
+[source,typescript]
+----
+await client.close();
+----
+
+== Next Steps
+
+* link:../how-to/typescript/integrations-overview.html[Framework Integrations] — LangChain JS, Mastra, MCP, and more
+* link:../how-to/typescript/authenticate.html[Authenticate] — API key rotation, OAuth refresh, scope management
+* link:../reference/rest-api.html[REST API Reference] — every hosted endpoint mapped to a client method
+* link:../reference/mcp-tools.html[MCP Tool Reference] — wire the same surface into Claude Desktop, Cursor, or Windsurf
+* link:../explanation/memory-types.html[The Agent Memory Model] — short-term, long-term, reasoning, plus observations and reflections
+* link:../explanation/multi-agent-sharing.html[Cross-Agent Memory Sharing] — how multiple agents share one graph

--- a/docs/modules/ROOT/pages/tutorials/first-agent-memory.adoc
+++ b/docs/modules/ROOT/pages/tutorials/first-agent-memory.adoc
@@ -12,10 +12,15 @@
 :page-ad-underline-role: button
 :page-ad-underline: Enroll now
 
-A step-by-step tutorial to build your first AI agent with persistent memory and a context graph.
+A step-by-step tutorial to build your first AI agent with persistent memory and a context graph, running against your own Neo4j.
 
 [.lead]
 In this tutorial, we'll build a simple agent that remembers conversations, learns user preferences, and uses a context graph to provide personalized responses. By the end, you'll have a working memory system that persists across sessions.
+
+[TIP]
+====
+*Don't want to run Neo4j?* If you'd rather skip the database setup, the hosted xref:tutorials/nams-quickstart.adoc[NAMS Quickstart] gets you to the same place in ~10 minutes with just an API key — same SDK, same code, no infrastructure. Come back here when you need write-Cypher, geospatial queries, or to layer agent memory onto an existing Neo4j graph. See xref:explanation/backends.adoc[Bolt vs NAMS] for the trade-offs.
+====
 
 == What You'll Learn
 

--- a/docs/modules/ROOT/pages/tutorials/hosted-quickstart-typescript.adoc
+++ b/docs/modules/ROOT/pages/tutorials/hosted-quickstart-typescript.adoc
@@ -1,0 +1,192 @@
+= Hosted-Service Quickstart
+:description: Five-minute quickstart for the hosted Neo4j Agent Memory Service.
+
+This tutorial walks you from zero to a working agent against the hosted
+service at `https://memory.neo4jlabs.com/v1`, using whichever language client
+fits your stack.
+
+== Prerequisites
+
+* An API key (`nams_*`) from the link:https://memory.neo4jlabs.com/dashboard[NAMS dashboard].
+  Static keys expire after 90 days.
+* A bash shell with `curl` for the warm-up checks.
+
+== Step 1 — Sanity-check the service
+
+[source,bash]
+----
+curl -H "Authorization: Bearer $MEMORY_API_KEY" \
+  https://memory.neo4jlabs.com/v1/conversations
+----
+
+If you see a JSON `{"conversations": [...]}` response, your token is valid.
+
+== Step 2 — Install a client
+
+[tabs]
+======
+TypeScript::
++
+[source,bash]
+----
+npm install @neo4j-labs/agent-memory
+----
+
+Python::
++
+[source,bash]
+----
+uv add neo4j-agent-memory-client
+# or: pip install neo4j-agent-memory-client
+----
+
+Go::
++
+[source,bash]
+----
+go get github.com/neo4j-labs/agent-memory-tck/clients/go
+----
+
+C#::
++
+[source,bash]
+----
+dotnet add package Neo4j.AgentMemory
+----
+
+R::
++
+[source,r]
+----
+install.packages("neo4j.memory")
+# or: devtools::install_github("neo4j-labs/agent-memory-tck", subdir = "clients/rlang/neo4j.memory")
+----
+======
+
+== Step 3 — Create a conversation and add messages
+
+[tabs]
+======
+TypeScript::
++
+[source,ts]
+----
+import { MemoryClient } from "@neo4j-labs/agent-memory";
+
+const client = new MemoryClient({
+  endpoint: "https://memory.neo4jlabs.com/v1",
+  apiKey: process.env.MEMORY_API_KEY!,
+});
+await client.connect();
+
+const conv = await client.shortTerm.createConversation({ userId: "alice" });
+await client.shortTerm.addMessage(conv.id, "user", "John works at Acme.");
+const ctx = await client.shortTerm.getContext(conv.id);
+console.log(ctx);
+----
+
+Python::
++
+[source,python]
+----
+import asyncio
+from neo4j_agent_memory_client import MemoryClient
+
+async def main():
+    async with MemoryClient(
+        endpoint="https://memory.neo4jlabs.com/v1",
+        api_key=os.environ["MEMORY_API_KEY"],
+    ) as client:
+        conv = await client.short_term.create_conversation(user_id="alice")
+        await client.short_term.add_message(conv.id, "user", "John works at Acme.")
+        ctx = await client.short_term.get_context(conv.id)
+        print(ctx)
+
+asyncio.run(main())
+----
+
+Go::
++
+[source,go]
+----
+client, _ := memory.New(
+    memory.WithEndpoint("https://memory.neo4jlabs.com/v1"),
+    memory.WithAPIKey(os.Getenv("MEMORY_API_KEY")),
+)
+ctx := context.Background()
+
+conv, _ := client.ShortTerm.CreateConversation(ctx, memory.CreateConversationParams{
+    UserID: "alice",
+})
+_, _ = client.ShortTerm.AddMessage(ctx, conv.ID, memory.RoleUser, "John works at Acme.")
+context, _ := client.ShortTerm.GetContext(ctx, conv.ID)
+fmt.Println(context)
+----
+
+C#::
++
+[source,csharp]
+----
+using var client = new MemoryClient(new MemoryClientOptions {
+    Endpoint = "https://memory.neo4jlabs.com/v1",
+    ApiKey = Environment.GetEnvironmentVariable("MEMORY_API_KEY"),
+});
+await client.ConnectAsync();
+
+var conv = await client.ShortTerm.CreateConversationAsync("alice");
+await client.ShortTerm.AddMessageAsync(conv.Id, MessageRole.User, "John works at Acme.");
+var ctx = await client.ShortTerm.GetContextAsync(conv.Id);
+----
+
+R::
++
+[source,r]
+----
+library(neo4j.memory)
+
+client <- MemoryClient$new(
+  endpoint = "https://memory.neo4jlabs.com/v1",
+  api_key = Sys.getenv("MEMORY_API_KEY")
+)
+client$connect()
+
+conv <- client$short_term$create_conversation(user_id = "alice")
+client$short_term$add_message(conv$id, "user", "John works at Acme.")
+ctx <- client$short_term$get_context(conv$id)
+----
+======
+
+== Step 4 — Inspect the entity graph
+
+The service automatically extracts entities (`John`, `Acme`) from the message
+content. Pull the full graph view with one call:
+
+[source,ts]
+----
+const graph = await client.longTerm.getEntityGraph();
+console.log(graph.nodes, graph.edges);
+----
+
+== Step 5 — Reasoning provenance
+
+Record reasoning steps under a conversation, then ask why an entity exists:
+
+[source,ts]
+----
+await client.reasoning.recordStep({
+  conversationId: conv.id,
+  reasoning: "User mentioned John works at Acme.",
+  actionTaken: "extract_entities",
+  result: "John (person), Acme (organization)",
+});
+
+const provenance = await client.reasoning.getEntityProvenance(entityId);
+console.log(provenance.steps);
+----
+
+== Next steps
+
+* link:authenticate.html[How-To: Authenticate] — API key rotation, OAuth, scopes.
+* link:../reference/rest-api.html[Reference: REST API endpoints].
+* link:../reference/mcp-tools.html[Reference: MCP Tools] — wire the same
+  surface into Claude Desktop / Cursor / Windsurf.

--- a/docs/modules/ROOT/pages/tutorials/index.adoc
+++ b/docs/modules/ROOT/pages/tutorials/index.adoc
@@ -16,15 +16,27 @@ Tutorials are *learning-oriented*. They take you by the hand through a series of
 
 == Getting Started
 
-Start here if you're new to neo4j-agent-memory:
+Pick the path that matches your stack:
 
 [cols="1,2,1", options="header"]
 |===
 | Tutorial | What You'll Build | Time
 
-| xref:tutorials/first-agent-memory.adoc[Build Your First Memory-Enabled Agent]
-| A working memory system that stores conversations, extracts entities automatically, and enables semantic search. You'll see your context graph in Neo4j Browser.
+| xref:tutorials/nams-quickstart.adoc[NAMS Quickstart (Python)]
+| The hosted-service path. Get an API key, install the SDK, run your first memory operations — no Neo4j to operate. Ideal for prototypes and SaaS deployments.
+| ~10 min
+
+| xref:tutorials/hosted-quickstart-typescript.adoc[Hosted Quickstart (TypeScript)]
+| Same hosted-service path, TypeScript flavor. Works on Node, Bun, Deno, Cloudflare Workers, and Vercel Edge.
+| ~10 min
+
+| xref:tutorials/first-agent-memory.adoc[Build Your First Memory-Enabled Agent (Self-Hosted)]
+| A working memory system against your own Neo4j. Stores conversations, extracts entities automatically, enables semantic search. You'll see your context graph in Neo4j Browser.
 | ~30 min
+
+| xref:tutorials/first-agent-memory-typescript.adoc[First Agent Memory (TypeScript, hosted)]
+| TypeScript end-to-end: NAMS + Vercel AI SDK middleware, multi-turn chat with three-tier context recall.
+| ~20 min
 |===
 
 == Building Real Applications
@@ -72,11 +84,17 @@ Each tutorial includes examples for common enterprise use cases:
 
 == Before You Start
 
-Each tutorial assumes you have:
+The Python tutorials assume:
 
 * Python 3.10 or later installed
 * Basic familiarity with Python and async programming
-* Access to a Neo4j database (tutorials include setup instructions)
+* Either an API key from link:https://memory.neo4jlabs.com[NAMS] (hosted path) **or** access to a Neo4j database (self-hosted path; setup instructions included)
+
+The TypeScript tutorials assume:
+
+* Node.js 20 or later
+* An API key from link:https://memory.neo4jlabs.com[NAMS]
+* Basic familiarity with TypeScript and async/await
 
 == Tutorial Philosophy
 

--- a/tests/docs/test_code_snippets.py
+++ b/tests/docs/test_code_snippets.py
@@ -306,7 +306,9 @@ class TestSnippetCoverage:
             if tutorial.name == "index.adoc":
                 continue
             content = tutorial.read_text(encoding="utf-8")
-            assert "[source,python]" in content, f"{tutorial.name} has no Python code snippets"
+            assert "[source,python]" in content or "[source,typescript]" in content, (
+                f"{tutorial.name} has no Python or TypeScript code snippets"
+            )
 
     def test_howto_guides_have_code_snippets(self, docs_dir: Path):
         """Each how-to guide should have code snippets."""

--- a/typescript/.gitignore
+++ b/typescript/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+*.tsbuildinfo

--- a/typescript/CHANGELOG.md
+++ b/typescript/CHANGELOG.md
@@ -1,0 +1,70 @@
+# Changelog
+
+All notable changes to `@neo4j-labs/agent-memory` will be documented in
+this file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
+and this project follows [Semantic Versioning](https://semver.org).
+
+This is a Neo4j Labs project under Beta status — breaking changes may
+appear in minor versions with a callout in this file.
+
+## [Unreleased]
+
+### Changed
+
+- Repository moved from
+  [`neo4j-labs/agent-memory-tck`](https://github.com/neo4j-labs/agent-memory-tck)
+  (source SHA `4603b91f`) to
+  [`neo4j-labs/agent-memory`](https://github.com/neo4j-labs/agent-memory),
+  alongside the Python SDK. No code changes — `package.json` repository
+  and homepage fields point at the new location.
+- Documentation is now served from
+  [neo4j.com/labs/agent-memory/](https://neo4j.com/labs/agent-memory/)
+  under the unified Antora site. TypeDoc API reference is published at
+  [neo4j-labs.github.io/agent-memory/typescript/](https://neo4j-labs.github.io/agent-memory/typescript/).
+- Release tags are now namespaced as `typescript-v*` (e.g.
+  `typescript-v0.3.0`); the Python SDK uses `python-v*`.
+
+## 0.3.0 — Beta launch
+
+Beta launch release for the hosted-service-first TypeScript client.
+
+### Added
+
+- `MemoryClient` with `shortTerm`, `longTerm`, `reasoning`, `query`, and
+  `auth` subclients
+- Featured framework integrations:
+  - `@neo4j-labs/agent-memory/middleware/vercel-ai` — Vercel AI SDK
+    middleware with three-tier context injection and automatic
+    persistence
+  - `@neo4j-labs/agent-memory/mcp` — the 12 standard MCP tool
+    definitions plus a dispatcher
+  - `@neo4j-labs/agent-memory/integrations/langchain` —
+    `Neo4jChatMessageHistory` and `Neo4jEntityRetriever` (duck-typed)
+  - `@neo4j-labs/agent-memory/integrations/mastra` — `Neo4jMastraMemory`
+    provider (duck-typed)
+  - `@neo4j-labs/agent-memory/integrations/strands` — AWS Strands Agents
+    integration: `Neo4jSessionStorage` (SnapshotStorage backend),
+    `Neo4jConversationManager` (three-tier context injection layered on
+    top of an inner manager), `registerReasoningHooks` + `connectMemoryToAgent`
+    factory. Compatible with `@strands-agents/sdk@^1.2.0`.
+- `@neo4j-labs/agent-memory/testing` — `BridgeTransport` for TCK
+  conformance testing
+- Zero-config construction: defaults endpoint to
+  `https://memory.neo4jlabs.com/v1`; reads `MEMORY_API_KEY` from
+  environment
+- Lazy `connect()`: the first request acts as the implicit auth check;
+  explicit `connect()` is supported for fail-fast startups
+- Auto User-Agent header with caller override
+- `requestId` propagated onto every `MemoryError` from the
+  `x-request-id` (or equivalent) response header
+- `logger` constructor option emitting typed `request` / `response` /
+  `error` events
+- Edge runtime support: Cloudflare Workers, Vercel Edge (with explicit
+  `apiKey` pattern)
+- TCK Bronze conformance via the polyglot test suite
+
+### Breaking
+
+- `BridgeTransport` is no longer exported from the package root. Import it
+  from `@neo4j-labs/agent-memory/testing` instead.
+- Deprecated `HttpTransport` / `HttpTransportOptions` aliases were removed.

--- a/typescript/CHANGELOG.md
+++ b/typescript/CHANGELOG.md
@@ -24,6 +24,15 @@ appear in minor versions with a callout in this file.
 - Release tags are now namespaced as `typescript-v*` (e.g.
   `typescript-v0.3.0`); the Python SDK uses `python-v*`.
 
+### Fixed
+
+- `npm run lint` now invokes only `tsc --noEmit`. The previous script
+  chained `eslint src/` but `eslint` was never in `devDependencies` and
+  no `.eslintrc*` / `eslint.config.*` ever existed — the second half
+  silently failed on TCK CI and now blocks the new TypeScript CI. Adding
+  eslint properly (config + rule choices + likely codebase touch-ups) is
+  deferred to a follow-up PR.
+
 ## 0.3.0 — Beta launch
 
 Beta launch release for the hosted-service-first TypeScript client.

--- a/typescript/LICENSE
+++ b/typescript/LICENSE
@@ -1,0 +1,190 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to the Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by the Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding any notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright 2026 Neo4j Labs
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -1,0 +1,154 @@
+# @neo4j-labs/agent-memory
+
+![Neo4j Labs](https://img.shields.io/badge/Neo4j-Labs-6366F1?logo=neo4j)
+![Status: Beta](https://img.shields.io/badge/Status-Beta-6366F1)
+![Community Supported](https://img.shields.io/badge/Support-Community-6B7280)
+
+> **New home:** this package moved from
+> [`neo4j-labs/agent-memory-tck`](https://github.com/neo4j-labs/agent-memory-tck)
+> to [`neo4j-labs/agent-memory`](https://github.com/neo4j-labs/agent-memory),
+> alongside the Python SDK. Install path, package name, and exports are
+> unchanged — `npm install @neo4j-labs/agent-memory`.
+
+> TypeScript client for the Neo4j Agent Memory Service — short-term,
+> long-term, and reasoning memory for AI agents, backed by Neo4j.
+
+> ⚠️ **Neo4j Labs Project**
+>
+> This project is part of Neo4j Labs and is actively maintained, but not
+> officially supported. There are no SLAs or guarantees around backwards
+> compatibility and deprecation. For questions and support, please use
+> the [Neo4j Community Forum](https://community.neo4j.com).
+
+## ✨ Features
+
+- Three memory subclients in one client: **short-term** (conversations,
+  messages, three-tier context), **long-term** (entities, search,
+  relationships, graph view), and **reasoning** (steps, traces,
+  provenance, tool calls).
+- Zero-config construction — reads `MEMORY_API_KEY` from the
+  environment and defaults to the hosted service.
+- Works in Node 20+, Bun, Deno, Cloudflare Workers, and Vercel Edge.
+- Five framework integrations: Vercel AI SDK middleware, MCP tools,
+  LangChain JS, Mastra, and AWS Strands Agents.
+- Built-in request logging, request-id correlation, and edge-friendly
+  `fetch`-only transports.
+- TCK Bronze conformance verified by the
+  [agent-memory-tck](https://github.com/neo4j-labs/agent-memory-tck)
+  cross-language test suite.
+
+## 📦 Installation
+
+```bash
+npm install @neo4j-labs/agent-memory
+```
+
+Requires Node.js 20+.
+
+## 🚀 Quick start
+
+Get an API key from [memory.neo4jlabs.com](https://memory.neo4jlabs.com),
+export it as `MEMORY_API_KEY`, then:
+
+```ts
+import { MemoryClient } from "@neo4j-labs/agent-memory";
+
+const client = new MemoryClient();
+
+const conv = await client.shortTerm.createConversation({ userId: "alice" });
+await client.shortTerm.addMessage(conv.id, "user", "Hello!");
+
+const entity = await client.longTerm.addEntity("Alice Johnson", "person", {
+  description: "Software engineer working on graph memory.",
+});
+
+const ctx = await client.shortTerm.getContext(conv.id);
+console.log(ctx.recentMessages, ctx.observations, ctx.reflections);
+```
+
+### On the edge
+
+Edge runtimes (Cloudflare Workers, Vercel Edge) expose environment
+variables via the request handler scope, not `process.env`. Pass the key
+explicitly:
+
+```ts
+export default {
+  async fetch(req: Request, env: { MEMORY_API_KEY: string }) {
+    const client = new MemoryClient({ apiKey: env.MEMORY_API_KEY });
+    // ...
+  },
+};
+```
+
+## 🧩 Integrations
+
+All four ship as subpath exports. See each integration's
+[example](./examples) and how-to guide for a runnable walkthrough.
+
+| Integration | Import | Example |
+|---|---|---|
+| **Vercel AI SDK** | `@neo4j-labs/agent-memory/middleware/vercel-ai` | [`examples/vercel-ai`](./examples/vercel-ai) |
+| **MCP tools** | `@neo4j-labs/agent-memory/mcp` | [`examples/mcp`](./examples/mcp) |
+| **LangChain JS** | `@neo4j-labs/agent-memory/integrations/langchain` | [`examples/langchain`](./examples/langchain) |
+| **Mastra** | `@neo4j-labs/agent-memory/integrations/mastra` | [`examples/mastra`](./examples/mastra) |
+| **AWS Strands** | `@neo4j-labs/agent-memory/integrations/strands` | [`examples/strands`](./examples/strands) |
+
+## 📖 Documentation
+
+- [TypeScript SDK landing page](https://neo4j.com/labs/agent-memory/sdks/typescript)
+- [Tutorial: First Agent Memory (TypeScript)](https://neo4j.com/labs/agent-memory/tutorials/first-agent-memory-typescript)
+- [How-to guides](https://neo4j.com/labs/agent-memory/how-to/typescript) — authentication,
+  edge deployment, error handling, observability, framework integrations
+- [Concept: short-term vs long-term vs reasoning memory](https://neo4j.com/labs/agent-memory/explanation/memory-types)
+- [Architecture overview](https://neo4j.com/labs/agent-memory/explanation/graph-architecture)
+- [Troubleshooting](https://neo4j.com/labs/agent-memory/how-to/typescript/troubleshooting)
+
+Full API reference (TypeDoc) is published at
+[neo4j-labs.github.io/agent-memory/typescript/](https://neo4j-labs.github.io/agent-memory/typescript/).
+
+## 🔧 Configuration
+
+The client accepts a small options bag:
+
+```ts
+new MemoryClient({
+  endpoint: "https://memory.neo4jlabs.com/v1",  // default
+  apiKey: "nams_...",                            // falls back to MEMORY_API_KEY env
+  timeout: 30_000,                               // ms; default 30s
+  headers: { "X-My-Trace": "..." },              // additional request headers
+  logger: (event) => console.log(event),         // request/response/error events
+});
+```
+
+`connect()` is optional — the first request acts as the implicit auth
+check. Call it explicitly if you prefer fail-fast at startup.
+
+## 🤝 Contributing
+
+We welcome contributions. See the repo-root
+[CONTRIBUTING.md](https://github.com/neo4j-labs/agent-memory/blob/main/CONTRIBUTING.md)
+for the development setup, test commands, and PR conventions — there is a
+dedicated "TypeScript contributions" section covering Node setup, vitest,
+linting, and the TCK bridge.
+
+This package lives alongside the Python SDK
+([`neo4j-agent-memory`](https://pypi.org/project/neo4j-agent-memory/)) in
+[`neo4j-labs/agent-memory`](https://github.com/neo4j-labs/agent-memory).
+The two SDKs implement the same memory model and share the same backend
+(NAMS). The cross-language behavioral contract is defined and certified
+by the [`agent-memory-tck`](https://github.com/neo4j-labs/agent-memory-tck)
+spec repo, which consumes this package from npm.
+
+## 💬 Support
+
+- [Neo4j Community Forum](https://community.neo4j.com) — questions and
+  discussion (primary)
+- [GitHub Issues](https://github.com/neo4j-labs/agent-memory/issues) —
+  bug reports and feature requests
+- Security vulnerabilities: see
+  [SECURITY.md](https://github.com/neo4j-labs/agent-memory/blob/main/SECURITY.md)
+
+## 📝 License
+
+Apache-2.0 — see [LICENSE](./LICENSE).

--- a/typescript/conformance/server.ts
+++ b/typescript/conformance/server.ts
@@ -1,0 +1,305 @@
+/**
+ * HTTP Bridge Conformance Server for the TypeScript client.
+ *
+ * Implements the TCK HTTP bridge protocol so the Python TCK suite can validate
+ * the TypeScript client end-to-end.
+ *
+ * Routes are POST /{snake_case_method}; bodies are snake_case JSON. The server
+ * forwards each call to the upstream `MemoryClient` (configured via
+ * `MEMORY_ENDPOINT` — set this to your bridge endpoint or to
+ * `https://memory.neo4jlabs.com/v1` for hosted-mode conformance runs).
+ *
+ * Usage:
+ *   MEMORY_ENDPOINT=http://localhost:7687 tsx conformance/server.ts
+ *   MEMORY_ENDPOINT=https://memory.neo4jlabs.com/v1 \
+ *     MEMORY_API_KEY=nams_... tsx conformance/server.ts
+ *   # Then from the TCK repo:
+ *   pytest -m bronze --bridge-url http://localhost:3001
+ */
+
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import { MemoryClient } from "../src/client.js";
+
+const PORT = parseInt(process.env["TCK_BRIDGE_PORT"] ?? "3001", 10);
+const UPSTREAM = process.env["MEMORY_ENDPOINT"] ?? process.env["NEO4J_URI"] ?? "";
+const API_KEY = process.env["MEMORY_API_KEY"];
+
+if (!UPSTREAM) {
+  console.error(
+    "Set MEMORY_ENDPOINT (hosted service URL or bridge endpoint) or NEO4J_URI env var.",
+  );
+  process.exit(1);
+}
+
+const client = new MemoryClient({ endpoint: UPSTREAM, apiKey: API_KEY });
+
+async function readBody(req: IncomingMessage): Promise<Record<string, unknown>> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of req) chunks.push(chunk as Buffer);
+  const text = Buffer.concat(chunks).toString("utf-8");
+  if (!text) return {};
+  return JSON.parse(text) as Record<string, unknown>;
+}
+
+function jsonResponse(res: ServerResponse, data: unknown, status = 200): void {
+  res.writeHead(status, { "Content-Type": "application/json" });
+  res.end(JSON.stringify(data));
+}
+
+function noContent(res: ServerResponse): void {
+  res.writeHead(204);
+  res.end();
+}
+
+type Handler = (body: Record<string, unknown>) => Promise<unknown>;
+
+const handlers: Record<string, Handler> = {
+  // ---- Lifecycle --------------------------------------------------------
+  setup: async () => ({ ok: true, protocol_version: "0.2.0" }),
+  teardown: async () => undefined,
+  clear_all_data: async () => undefined,
+
+  // ---- Short-Term Memory (Bronze) --------------------------------------
+  add_message: async (body) =>
+    client.shortTerm.addMessage(
+      body["session_id"] as string,
+      body["role"] as "user" | "assistant" | "system",
+      body["content"] as string,
+      { metadata: body["metadata"] as Record<string, unknown> | undefined },
+    ),
+
+  get_conversation: async (body) =>
+    client.shortTerm.getConversation(body["session_id"] as string, {
+      limit: body["limit"] as number | undefined,
+    }),
+
+  search_messages: async (body) =>
+    client.shortTerm.searchMessages(body["query"] as string, {
+      sessionId: body["session_id"] as string | undefined,
+      limit: (body["limit"] as number) ?? 10,
+      threshold: (body["threshold"] as number) ?? 0.7,
+    }),
+
+  list_sessions: async (body) =>
+    client.shortTerm.listSessions({ limit: (body["limit"] as number) ?? 100 }),
+
+  delete_message: async (body) => ({
+    deleted: await client.shortTerm.deleteMessage(body["message_id"] as string),
+  }),
+
+  clear_session: async (body) => {
+    await client.shortTerm.clearSession(body["session_id"] as string);
+    return undefined;
+  },
+
+  // ---- Long-Term Memory (Silver) --------------------------------------
+  add_entity: async (body) =>
+    client.longTerm.addEntity(body["name"] as string, body["entity_type"] as string, {
+      description: body["description"] as string | undefined,
+    }),
+
+  add_preference: async (body) =>
+    client.longTerm.addPreference(body["category"] as string, body["preference"] as string, {
+      context: body["context"] as string | undefined,
+    }),
+
+  add_fact: async (body) =>
+    client.longTerm.addFact(
+      body["subject"] as string,
+      body["predicate"] as string,
+      body["obj"] as string,
+    ),
+
+  search_entities: async (body) =>
+    client.longTerm.searchEntities(body["query"] as string, {
+      limit: (body["limit"] as number) ?? 10,
+    }),
+
+  search_preferences: async (body) =>
+    client.longTerm.searchPreferences(body["query"] as string, {
+      category: body["category"] as string | undefined,
+      limit: (body["limit"] as number) ?? 10,
+    }),
+
+  get_entity_by_name: async (body) =>
+    client.longTerm.getEntityByName(body["name"] as string),
+
+  get_related_entities: async (body) =>
+    client.longTerm.getRelatedEntities(body["entity_id"] as string, {
+      relationshipType: body["relationship_type"] as string | undefined,
+      depth: (body["depth"] as number) ?? 1,
+    }),
+
+  // ---- Reasoning Memory (Silver) --------------------------------------
+  start_trace: async (body) =>
+    client.reasoning.startTrace(body["session_id"] as string, body["task"] as string),
+
+  add_step: async (body) =>
+    client.reasoning.addStep(body["trace_id"] as string, {
+      thought: body["thought"] as string | undefined,
+      action: body["action"] as string | undefined,
+      observation: body["observation"] as string | undefined,
+    }),
+
+  record_tool_call: async (body) =>
+    client.reasoning.recordToolCall(
+      body["step_id"] as string,
+      body["tool_name"] as string,
+      (body["arguments"] as Record<string, unknown>) ?? {},
+      {
+        result: body["result"],
+        status: body["status"] as "success" | "failure" | undefined,
+        durationMs: body["duration_ms"] as number | undefined,
+        error: body["error"] as string | undefined,
+      },
+    ),
+
+  complete_trace: async (body) =>
+    client.reasoning.completeTrace(body["trace_id"] as string, {
+      outcome: body["outcome"] as string | undefined,
+      success: body["success"] as boolean | undefined,
+    }),
+
+  get_trace_with_steps: async (body) =>
+    client.reasoning.getTraceWithSteps(body["trace_id"] as string),
+
+  list_traces: async (body) =>
+    client.reasoning.listTraces({
+      sessionId: body["session_id"] as string | undefined,
+      limit: (body["limit"] as number) ?? 100,
+    }),
+
+  get_tool_stats: async (body) =>
+    client.reasoning.getToolStats(body["tool_name"] as string | undefined),
+
+  // ---- Gold Tier ---------------------------------------------------------
+  add_relationship: async (body) =>
+    client.longTerm.addRelationship(
+      body["source_id"] as string,
+      body["target_id"] as string,
+      body["relationship_type"] as string,
+      { properties: body["properties"] as Record<string, unknown> | undefined },
+    ),
+
+  merge_duplicate_entities: async (body) =>
+    client.longTerm.mergeDuplicateEntities(
+      body["source_id"] as string,
+      body["target_id"] as string,
+      { canonicalName: body["canonical_name"] as string | undefined },
+    ),
+
+  get_similar_traces: async (body) =>
+    client.reasoning.getSimilarTraces(body["task"] as string, {
+      limit: (body["limit"] as number) ?? 5,
+      successOnly: (body["success_only"] as boolean) ?? true,
+    }),
+
+  // ---- Volume 5 / Platinum Tier (hosted-native) -------------------------
+  create_conversation: async (body) =>
+    client.shortTerm.createConversation({
+      userId: body["user_id"] as string,
+      metadata: body["metadata"] as Record<string, unknown> | undefined,
+    }),
+  list_conversations: async (body) =>
+    client.shortTerm.listConversations({ limit: body["limit"] as number | undefined }),
+  get_conversation_metadata: async (body) =>
+    client.shortTerm.getConversationMetadata(body["conversation_id"] as string),
+  delete_conversation: async (body) => {
+    await client.shortTerm.deleteConversation(body["conversation_id"] as string);
+    return undefined;
+  },
+  get_context: async (body) => client.shortTerm.getContext(body["conversation_id"] as string),
+  bulk_add_messages: async (body) =>
+    client.shortTerm.bulkAddMessages(
+      body["conversation_id"] as string,
+      (body["messages"] as Array<{ role: "user" | "assistant" | "system"; content: string }>) ?? [],
+    ),
+  get_observations: async (body) =>
+    client.shortTerm.getObservations(body["conversation_id"] as string, {
+      limit: body["limit"] as number | undefined,
+    }),
+  get_reflections: async (body) =>
+    client.shortTerm.getReflections(body["conversation_id"] as string),
+
+  list_entities: async (body) =>
+    client.longTerm.listEntities({
+      type: body["type"] as string | undefined,
+      limit: body["limit"] as number | undefined,
+    }),
+  get_entity: async (body) => client.longTerm.getEntity(body["entity_id"] as string),
+  update_entity: async (body) =>
+    client.longTerm.updateEntity(body["entity_id"] as string, {
+      name: body["name"] as string | undefined,
+      description: body["description"] as string | undefined,
+    }),
+  delete_entity: async (body) => {
+    await client.longTerm.deleteEntity(body["entity_id"] as string);
+    return undefined;
+  },
+  set_entity_feedback: async (body) =>
+    client.longTerm.setEntityFeedback(body["entity_id"] as string, {
+      userScore: body["user_score"] as number,
+      confirmed: (body["confirmed"] as boolean) ?? false,
+    }),
+  get_entity_history: async (body) =>
+    client.longTerm.getEntityHistory(body["entity_id"] as string),
+  merge_entities: async (body) =>
+    client.longTerm.mergeEntities(body["source_id"] as string, body["target_id"] as string),
+  get_entity_graph: async () => client.longTerm.getEntityGraph(),
+
+  record_step: async (body) =>
+    client.reasoning.recordStep({
+      conversationId: body["conversation_id"] as string,
+      reasoning: body["reasoning"] as string,
+      actionTaken: body["action_taken"] as string,
+      result: body["result"] as string | undefined,
+    }),
+  list_steps: async (body) =>
+    client.reasoning.listSteps(body["conversation_id"] as string),
+  explain_step: async (body) => client.reasoning.explainStep(body["step_id"] as string),
+  get_trace_by_conversation: async (body) =>
+    client.reasoning.getTraceByConversation(body["conversation_id"] as string),
+  get_entity_provenance: async (body) =>
+    client.reasoning.getEntityProvenance(body["entity_id"] as string),
+  cypher_query: async (body) =>
+    client.query.cypher({
+      cypher: body["cypher"] as string,
+      params: body["params"] as Record<string, unknown> | undefined,
+    }),
+};
+
+const server = createServer(async (req, res) => {
+  if (req.method !== "POST") {
+    res.writeHead(405);
+    res.end();
+    return;
+  }
+
+  const method = req.url?.replace(/^\//, "") ?? "";
+  const handler = handlers[method];
+
+  if (!handler) {
+    jsonResponse(res, { error: `Unknown method: ${method}` }, 404);
+    return;
+  }
+
+  try {
+    const body = await readBody(req);
+    const result = await handler(body);
+    if (result === undefined) noContent(res);
+    else jsonResponse(res, result);
+  } catch (error) {
+    // The conformance server is a dev-only tool: log the full error
+    // (including any stack) to stderr where the operator can read it, but
+    // return a generic message to the caller so we don't leak internals
+    // (file paths, server config) over the wire.
+    console.error("[conformance]", method, error);
+    jsonResponse(res, { error: `${method} failed` }, 500);
+  }
+});
+
+server.listen(PORT, () => {
+  console.log(`TypeScript conformance server running on http://localhost:${PORT}`);
+  console.log(`Upstream: ${UPSTREAM}`);
+  console.log("Press Ctrl+C to stop");
+});

--- a/typescript/examples/README.md
+++ b/typescript/examples/README.md
@@ -1,0 +1,41 @@
+# Examples
+
+Runnable examples demonstrating each integration shipped with
+`@neo4j-labs/agent-memory`. Each example is a self-contained Node.js
+script you can clone, install, and run against the hosted Neo4j Agent
+Memory Service.
+
+## Prerequisites
+
+- Node.js 20+
+- A `MEMORY_API_KEY` from [memory.neo4jlabs.com](https://memory.neo4jlabs.com)
+
+## The examples
+
+| Folder | What it shows |
+|---|---|
+| [`vercel-ai/`](./vercel-ai) | Memory-augmented chat using the Vercel AI SDK middleware |
+| [`mcp/`](./mcp) | Registering the 12 memory tools with an MCP server |
+| [`langchain/`](./langchain) | Chat history + entity retriever shapes for LangChain JS |
+| [`mastra/`](./mastra) | Wrapping the client as a Mastra-compatible memory provider |
+| [`strands/`](./strands) | AWS Strands agent with session persistence, three-tier context, and reasoning capture |
+
+## Running an example
+
+```bash
+cd vercel-ai
+cp .env.example .env       # then edit .env with your MEMORY_API_KEY
+npm install
+npm start
+```
+
+Each example's own README has the full step-by-step.
+
+## Notes
+
+- These examples use `"file:.."` to depend on the local client package
+  during development. When using the examples as a template for your own
+  project, replace that with a pinned version like
+  `"@neo4j-labs/agent-memory": "^0.3.0"`.
+- Examples are **not** exercised by CI — they're documentation. If you
+  find one broken, please open an issue.

--- a/typescript/examples/langchain/.env.example
+++ b/typescript/examples/langchain/.env.example
@@ -1,0 +1,1 @@
+MEMORY_API_KEY=nams_your_key_here

--- a/typescript/examples/langchain/README.md
+++ b/typescript/examples/langchain/README.md
@@ -1,0 +1,43 @@
+# LangChain JS example
+
+Exercises `Neo4jChatMessageHistory` and `Neo4jEntityRetriever` directly,
+without depending on any specific `@langchain/*` package version. These
+classes are duck-typed against the LangChain JS interfaces, so they fit
+into `RunnableWithMessageHistory` and a retriever chain regardless of
+LangChain JS version skew.
+
+## Run it
+
+```bash
+cp .env.example .env       # set MEMORY_API_KEY
+npm install
+npm start
+```
+
+The script:
+1. Creates a fresh conversation.
+2. Persists three messages via the `BaseChatMessageHistory`-shaped API.
+3. Reads them back.
+4. Adds an entity and queries it via the retriever interface.
+
+## Using inside a real LangChain JS app
+
+```ts
+import { ChatOpenAI } from "@langchain/openai";
+import { RunnableWithMessageHistory } from "@langchain/core/runnables";
+import { Neo4jChatMessageHistory } from "@neo4j-labs/agent-memory/integrations/langchain";
+
+const chain = new ChatOpenAI({ model: "gpt-4o-mini" }).pipe(...);
+
+const memoryChain = new RunnableWithMessageHistory({
+  runnable: chain,
+  getMessageHistory: (sessionId) => new Neo4jChatMessageHistory(memory, sessionId),
+  inputMessagesKey: "input",
+  historyMessagesKey: "history",
+});
+```
+
+## See also
+
+- [How-to: LangChain JS](../../../../docs/how-to/langchain.adoc)
+- [LangChain JS docs](https://js.langchain.com)

--- a/typescript/examples/langchain/package.json
+++ b/typescript/examples/langchain/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "agent-memory-example-langchain",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "tsx src/index.ts"
+  },
+  "dependencies": {
+    "@neo4j-labs/agent-memory": "file:.."
+  },
+  "devDependencies": {
+    "tsx": "^4.0.0",
+    "@types/node": "^20.0.0"
+  }
+}

--- a/typescript/examples/langchain/package.json
+++ b/typescript/examples/langchain/package.json
@@ -7,10 +7,11 @@
     "start": "tsx src/index.ts"
   },
   "dependencies": {
-    "@neo4j-labs/agent-memory": "file:.."
+    "@neo4j-labs/agent-memory": "file:../.."
   },
   "devDependencies": {
+    "@types/node": "^20.0.0",
     "tsx": "^4.0.0",
-    "@types/node": "^20.0.0"
+    "typescript": "^5.9.3"
   }
 }

--- a/typescript/examples/langchain/src/index.ts
+++ b/typescript/examples/langchain/src/index.ts
@@ -1,0 +1,51 @@
+/**
+ * LangChain JS example — uses Neo4jChatMessageHistory and
+ * Neo4jEntityRetriever directly so you can see the duck-typed shape
+ * without depending on any specific @langchain/* version.
+ *
+ * In a real LangChain JS app you'd pass these to `RunnableWithMessageHistory`
+ * and a retriever chain respectively — the duck-typing here means they fit
+ * those slots regardless of the LangChain JS minor version.
+ */
+
+import { MemoryClient } from "@neo4j-labs/agent-memory";
+import {
+  Neo4jChatMessageHistory,
+  Neo4jEntityRetriever,
+} from "@neo4j-labs/agent-memory/integrations/langchain";
+
+async function main() {
+  const memory = new MemoryClient();
+  const conv = await memory.shortTerm.createConversation({ userId: "langchain-demo" });
+
+  const history = new Neo4jChatMessageHistory(memory, conv.id);
+
+  console.log("Persisting messages via Neo4jChatMessageHistory ...");
+  await history.addUserMessage("Tell me about graph databases.");
+  await history.addAIMessage(
+    "Graph databases store data as nodes and relationships, making path queries fast.",
+  );
+  await history.addUserMessage("How does that compare to relational?");
+
+  const messages = await history.getMessages();
+  console.log(`Retrieved ${messages.length} messages from history.`);
+  for (const m of messages) {
+    console.log(`  [${m.type}] ${m.content.slice(0, 60)}`);
+  }
+
+  console.log("\nLooking up entities via Neo4jEntityRetriever ...");
+  await memory.longTerm.addEntity("Neo4j", "concept", {
+    description: "Graph database; mentioned in this demo.",
+  });
+  const retriever = new Neo4jEntityRetriever(memory, { limit: 3 });
+  const docs = await retriever.invoke("graph database");
+  console.log(`Found ${docs.length} entity-shaped documents.`);
+  for (const d of docs) {
+    console.log(`  ${d.metadata.name}: ${d.pageContent.slice(0, 60)}`);
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/typescript/examples/langchain/src/index.ts
+++ b/typescript/examples/langchain/src/index.ts
@@ -22,7 +22,7 @@ async function main() {
 
   console.log("Persisting messages via Neo4jChatMessageHistory ...");
   await history.addUserMessage("Tell me about graph databases.");
-  await history.addAIMessage(
+  await history.addAIChatMessage(
     "Graph databases store data as nodes and relationships, making path queries fast.",
   );
   await history.addUserMessage("How does that compare to relational?");
@@ -37,7 +37,7 @@ async function main() {
   await memory.longTerm.addEntity("Neo4j", "concept", {
     description: "Graph database; mentioned in this demo.",
   });
-  const retriever = new Neo4jEntityRetriever(memory, { limit: 3 });
+  const retriever = new Neo4jEntityRetriever(memory, { topK: 3 });
   const docs = await retriever.invoke("graph database");
   console.log(`Found ${docs.length} entity-shaped documents.`);
   for (const d of docs) {

--- a/typescript/examples/langchain/tsconfig.json
+++ b/typescript/examples/langchain/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../tsconfig.base.json",
+  "include": ["src/**/*"]
+}

--- a/typescript/examples/mastra/.env.example
+++ b/typescript/examples/mastra/.env.example
@@ -1,0 +1,1 @@
+MEMORY_API_KEY=nams_your_key_here

--- a/typescript/examples/mastra/README.md
+++ b/typescript/examples/mastra/README.md
@@ -1,0 +1,37 @@
+# Mastra example
+
+Wraps a `MemoryClient` in `Neo4jMastraMemory` and exercises the duck-typed
+Mastra memory provider interface (`createThread`, `saveMessage`, `getMessages`,
+`deleteThread`) without depending on `@mastra/core` at install time.
+
+## Run it
+
+```bash
+cp .env.example .env       # set MEMORY_API_KEY
+npm install
+npm start
+```
+
+The script creates a thread, persists a three-turn conversation, then
+reads it back.
+
+## Using inside a real Mastra app
+
+```ts
+import { Agent } from "@mastra/core/agent";
+import { MemoryClient } from "@neo4j-labs/agent-memory";
+import { Neo4jMastraMemory } from "@neo4j-labs/agent-memory/integrations/mastra";
+
+const memory = new Neo4jMastraMemory(new MemoryClient());
+
+const agent = new Agent({
+  name: "scout",
+  instructions: "You help users plan trips.",
+  memory,
+});
+```
+
+## See also
+
+- [How-to: Mastra](../../../../docs/how-to/mastra.adoc)
+- [Mastra docs](https://mastra.ai)

--- a/typescript/examples/mastra/package.json
+++ b/typescript/examples/mastra/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "agent-memory-example-mastra",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "tsx src/index.ts"
+  },
+  "dependencies": {
+    "@neo4j-labs/agent-memory": "file:.."
+  },
+  "devDependencies": {
+    "tsx": "^4.0.0",
+    "@types/node": "^20.0.0"
+  }
+}

--- a/typescript/examples/mastra/package.json
+++ b/typescript/examples/mastra/package.json
@@ -7,10 +7,11 @@
     "start": "tsx src/index.ts"
   },
   "dependencies": {
-    "@neo4j-labs/agent-memory": "file:.."
+    "@neo4j-labs/agent-memory": "file:../.."
   },
   "devDependencies": {
     "tsx": "^4.0.0",
+    "typescript": "^5.5.0",
     "@types/node": "^20.0.0"
   }
 }

--- a/typescript/examples/mastra/src/index.ts
+++ b/typescript/examples/mastra/src/index.ts
@@ -1,0 +1,49 @@
+/**
+ * Mastra example — wraps a MemoryClient in Neo4jMastraMemory and exercises
+ * the duck-typed Mastra memory provider interface.
+ *
+ * In a real Mastra app you'd hand this object to `new Agent({ memory })`.
+ * Here we drive it directly so you can see the contract without depending
+ * on `@mastra/core` at install time.
+ */
+
+import { MemoryClient } from "@neo4j-labs/agent-memory";
+import { Neo4jMastraMemory } from "@neo4j-labs/agent-memory/integrations/mastra";
+
+async function main() {
+  const memory = new Neo4jMastraMemory(new MemoryClient());
+
+  const thread = await memory.createThread({
+    resourceId: "mastra-demo-user",
+    title: "Vacation planning session",
+    metadata: { source: "mastra-example" },
+  });
+  console.log(`Created thread ${thread.id} for ${thread.resourceId}`);
+
+  await memory.saveMessage({
+    threadId: thread.id,
+    role: "user",
+    content: "I'm planning a 7-day trip to Lisbon.",
+  });
+  await memory.saveMessage({
+    threadId: thread.id,
+    role: "assistant",
+    content: "Great choice — what are your interests? Food, history, day trips?",
+  });
+  await memory.saveMessage({
+    threadId: thread.id,
+    role: "user",
+    content: "Food and history.",
+  });
+
+  const messages = await memory.getMessages(thread.id);
+  console.log(`Recovered ${messages.length} messages:`);
+  for (const m of messages) {
+    console.log(`  [${m.role}] ${m.content.slice(0, 60)}`);
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/typescript/examples/mastra/tsconfig.json
+++ b/typescript/examples/mastra/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../tsconfig.base.json",
+  "include": ["src/**/*"]
+}

--- a/typescript/examples/mcp/.env.example
+++ b/typescript/examples/mcp/.env.example
@@ -1,0 +1,1 @@
+MEMORY_API_KEY=nams_your_key_here

--- a/typescript/examples/mcp/README.md
+++ b/typescript/examples/mcp/README.md
@@ -1,0 +1,42 @@
+# MCP example
+
+A self-hosted MCP server that exposes the 12 standard neo4j-agent-memory
+tools, backed by a `MemoryClient`. Communicates over stdio.
+
+## When to use this
+
+Most users **don't** need to self-host MCP — the hosted service already
+exposes the same tools at `https://memory.neo4jlabs.com/mcp`. Reach for
+this pattern when you want to:
+
+- Add a logging / auditing layer between an MCP client and the service
+- Filter or rewrite tool calls before they reach the service
+- Run an MCP server inside a corporate boundary that can't talk to the
+  public service directly
+
+## Run it
+
+```bash
+cp .env.example .env       # set MEMORY_API_KEY
+npm install
+npm start                  # waits on stdio for an MCP client
+```
+
+To point Claude Desktop at it, add this to your Claude Desktop config:
+
+```jsonc
+{
+  "mcpServers": {
+    "agent-memory": {
+      "command": "node",
+      "args": ["--import", "tsx", "/absolute/path/to/this/src/index.ts"],
+      "env": { "MEMORY_API_KEY": "nams_..." }
+    }
+  }
+}
+```
+
+## See also
+
+- [How-to: MCP tools](../../../../docs/how-to/mcp.adoc)
+- [Model Context Protocol spec](https://modelcontextprotocol.io)

--- a/typescript/examples/mcp/package.json
+++ b/typescript/examples/mcp/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "agent-memory-example-mcp",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "tsx src/index.ts"
+  },
+  "dependencies": {
+    "@neo4j-labs/agent-memory": "file:..",
+    "@modelcontextprotocol/sdk": "^1.0.0"
+  },
+  "devDependencies": {
+    "tsx": "^4.0.0",
+    "@types/node": "^20.0.0"
+  }
+}

--- a/typescript/examples/mcp/package.json
+++ b/typescript/examples/mcp/package.json
@@ -7,11 +7,12 @@
     "start": "tsx src/index.ts"
   },
   "dependencies": {
-    "@neo4j-labs/agent-memory": "file:..",
+    "@neo4j-labs/agent-memory": "file:../..",
     "@modelcontextprotocol/sdk": "^1.0.0"
   },
   "devDependencies": {
     "tsx": "^4.0.0",
+    "typescript": "^5.5.0",
     "@types/node": "^20.0.0"
   }
 }

--- a/typescript/examples/mcp/src/index.ts
+++ b/typescript/examples/mcp/src/index.ts
@@ -1,0 +1,58 @@
+/**
+ * Self-hosted MCP server that exposes the 12 standard neo4j-agent-memory
+ * tools, backed by a `MemoryClient`. Connects via stdio — point any MCP
+ * client (Claude Desktop, an MCP IDE plugin, a custom dispatcher) at the
+ * resulting process.
+ *
+ * For most use cases you don't need to self-host: the hosted service at
+ * memory.neo4jlabs.com already exposes the same tool surface at
+ * https://memory.neo4jlabs.com/mcp. This example is for cases where you
+ * want to wrap, log, or filter tool calls before they reach the service.
+ */
+
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+} from "@modelcontextprotocol/sdk/types.js";
+import { MemoryClient } from "@neo4j-labs/agent-memory";
+import { createMemoryTools, handleMemoryToolCall } from "@neo4j-labs/agent-memory/mcp";
+
+async function main() {
+  const memory = new MemoryClient();
+  const tools = createMemoryTools();
+
+  const server = new Server(
+    { name: "neo4j-agent-memory-mcp", version: "0.1.0" },
+    { capabilities: { tools: {} } },
+  );
+
+  server.setRequestHandler(ListToolsRequestSchema, async () => ({
+    tools: tools.map((t) => ({
+      name: t.name,
+      description: t.description,
+      inputSchema: t.inputSchema,
+    })),
+  }));
+
+  server.setRequestHandler(CallToolRequestSchema, async (req) => {
+    const result = await handleMemoryToolCall(
+      memory,
+      req.params.name,
+      (req.params.arguments ?? {}) as Record<string, unknown>,
+    );
+    return {
+      content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+    };
+  });
+
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+  // The server stays alive on stdio until the client disconnects.
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/typescript/examples/mcp/tsconfig.json
+++ b/typescript/examples/mcp/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../tsconfig.base.json",
+  "include": ["src/**/*"]
+}

--- a/typescript/examples/strands/.env.example
+++ b/typescript/examples/strands/.env.example
@@ -1,0 +1,7 @@
+# Neo4j Agent Memory Service API key. Get one at https://memory.neo4jlabs.com
+MEMORY_API_KEY=nams_your_key_here
+
+# Strands needs a model provider. Either:
+#  - OpenAI (set OPENAI_API_KEY)
+#  - Amazon Bedrock (set AWS_REGION + credentials; uncomment the Bedrock import in src/index.ts)
+OPENAI_API_KEY=sk-your_key_here

--- a/typescript/examples/strands/README.md
+++ b/typescript/examples/strands/README.md
@@ -1,0 +1,49 @@
+# AWS Strands example
+
+Memory-augmented Strands agent using all three integration surfaces:
+session persistence, three-tier context injection, and reasoning capture.
+
+## What it shows
+
+- `Neo4jSessionStorage` — agent state automatically persists to a NAMS
+  conversation between turns and across script runs.
+- `Neo4jConversationManager` — reflections and observations from
+  `getContext()` are prepended to every model invocation.
+- `registerReasoningHooks` — reasoning steps and tool calls are recorded
+  in the graph as the agent thinks. Browse them with
+  `client.reasoning.getTraceByConversation(conversationId)`.
+
+All three are wired via the single `connectMemoryToAgent` factory.
+
+## Run it
+
+```bash
+cp .env.example .env
+# edit .env: set MEMORY_API_KEY and OPENAI_API_KEY
+npm install
+npm start
+```
+
+You'll see a three-turn dialogue. After the run completes, the script
+prints the conversation id — re-run with that id as `DEMO_USER_ID` to
+see context recall across script runs.
+
+## Using Amazon Bedrock instead of OpenAI
+
+Strands' first-class pairing is AWS Bedrock. To switch:
+
+```ts
+import { BedrockModel } from "@strands-agents/sdk/models/anthropic";
+
+const agent = new Agent({
+  model: new BedrockModel({ modelId: "anthropic.claude-3-haiku-20240307-v1:0" }),
+  // ...
+});
+```
+
+Then set `AWS_REGION` and AWS credentials in your environment.
+
+## See also
+
+- [How-to: Strands integration](../../../../docs/how-to/strands.adoc)
+- [Strands Agents SDK docs](https://strandsagents.com)

--- a/typescript/examples/strands/package.json
+++ b/typescript/examples/strands/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "agent-memory-example-strands",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "tsx src/index.ts"
+  },
+  "dependencies": {
+    "@neo4j-labs/agent-memory": "file:../..",
+    "openai": "^6.7.0",
+    "@strands-agents/sdk": "^1.2.0",
+    "@ai-sdk/provider": "^3.0.0",
+    "@opentelemetry/api": "^1.9.0",
+    "@modelcontextprotocol/sdk": "^1.0.0"
+  },
+  "devDependencies": {
+    "tsx": "^4.0.0",
+    "@types/node": "^20.0.0"
+  }
+}

--- a/typescript/examples/strands/package.json
+++ b/typescript/examples/strands/package.json
@@ -16,6 +16,7 @@
   },
   "devDependencies": {
     "tsx": "^4.0.0",
+    "typescript": "^5.5.0",
     "@types/node": "^20.0.0"
   }
 }

--- a/typescript/examples/strands/src/index.ts
+++ b/typescript/examples/strands/src/index.ts
@@ -1,0 +1,95 @@
+/**
+ * AWS Strands + neo4j-agent-memory — a memory-augmented agent.
+ *
+ * Demonstrates the three integration surfaces:
+ *  1. Neo4jSessionStorage  — agent state persists to NAMS automatically
+ *  2. Neo4jConversationManager — three-tier context injected before each turn
+ *  3. registerReasoningHooks — reasoning steps + tool calls captured in the graph
+ *
+ * Wired via the single `connectMemoryToAgent` factory.
+ */
+
+import { Agent, FunctionTool } from "@strands-agents/sdk";
+import { OpenAIModel } from "@strands-agents/sdk/models/openai";
+import type { ContentBlock } from "@strands-agents/sdk";
+import { MemoryClient } from "@neo4j-labs/agent-memory";
+import { connectMemoryToAgent } from "@neo4j-labs/agent-memory/integrations/strands";
+
+async function main() {
+  // 1. Set up the memory client and a fresh conversation.
+  const memory = new MemoryClient();
+  const conv = await memory.shortTerm.createConversation({
+    userId: process.env.DEMO_USER_ID ?? "strands-demo-user",
+    metadata: { source: "strands-example" },
+  });
+  process.stdout.write(`Created conversation ${conv.id}\n`);
+
+  // 2. Spread the memory integration into the Agent config.
+  const { sessionManager, conversationManager } = await connectMemoryToAgent(memory, {
+    conversationId: conv.id,
+  });
+  type AgentConfig = NonNullable<ConstructorParameters<typeof Agent>[0]>;
+  // The local example and the file-linked client each resolve their own
+  // `@strands-agents/sdk` instance during validation, so TypeScript treats
+  // the nominal classes as distinct because they carry private fields.
+  const memoryAgentConfig = {
+    sessionManager: sessionManager as unknown as AgentConfig["sessionManager"],
+    conversationManager: conversationManager as unknown as AgentConfig["conversationManager"],
+  };
+
+  // 3. Build the agent. A toy tool is included so the reasoning trace has
+  //    something interesting to record.
+  const lookupTool = new FunctionTool({
+    name: "lookup_fact",
+    description: "Look up a fact about a topic.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        topic: { type: "string", description: "Topic to look up" },
+      },
+      required: ["topic"],
+    },
+    callback: async (input: unknown) => {
+      const topic = (input as { topic?: string })?.topic ?? "unknown";
+      return `Fact about ${topic}: graphs model relationships natively.`;
+    },
+  });
+
+  const agent = new Agent({
+    systemPrompt: "You are a helpful assistant who explains things concisely.",
+    model: new OpenAIModel({ modelId: "gpt-4o-mini" }),
+    tools: [lookupTool],
+    ...memoryAgentConfig,
+  });
+
+  // 4. Drive a three-turn dialogue.
+  const turns = [
+    "Tell me about graph databases.",
+    "Use the lookup_fact tool to find one more thing about Neo4j.",
+    "Summarize what we've discussed so far.",
+  ];
+  for (const userMessage of turns) {
+    process.stdout.write(`\n[user] ${userMessage}\n[assistant] `);
+    const result = await agent.invoke(userMessage);
+    const text = flattenText(result.lastMessage.content) || "(no text response)";
+    process.stdout.write(`${text}\n`);
+  }
+
+  process.stdout.write(
+    `\nConversation persisted as ${conv.id}.\n` +
+      `View reasoning trace: client.reasoning.getTraceByConversation("${conv.id}").\n` +
+      `Re-run with DEMO_USER_ID=${conv.userId} to see context recall.\n`,
+  );
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});
+
+function flattenText(blocks: ContentBlock[]): string {
+  return blocks
+    .map((block) => ("text" in block && typeof block.text === "string" ? block.text : ""))
+    .filter((chunk) => chunk.length > 0)
+    .join("");
+}

--- a/typescript/examples/strands/tsconfig.json
+++ b/typescript/examples/strands/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../tsconfig.base.json",
+  "include": ["src/**/*"]
+}

--- a/typescript/examples/tsconfig.base.json
+++ b/typescript/examples/tsconfig.base.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true
+  }
+}

--- a/typescript/examples/vercel-ai/.env.example
+++ b/typescript/examples/vercel-ai/.env.example
@@ -1,0 +1,5 @@
+# Neo4j Agent Memory Service API key. Get one at https://memory.neo4jlabs.com
+MEMORY_API_KEY=nams_your_key_here
+
+# OpenAI key used by the @ai-sdk/openai provider in this example.
+OPENAI_API_KEY=sk-your_key_here

--- a/typescript/examples/vercel-ai/README.md
+++ b/typescript/examples/vercel-ai/README.md
@@ -1,0 +1,30 @@
+# Vercel AI SDK example
+
+Memory-augmented chat using the Vercel AI SDK and the
+`agentMemoryMiddleware` from `@neo4j-labs/agent-memory/middleware/vercel-ai`.
+
+## What it shows
+
+- Wiring `agentMemoryMiddleware` around an `openai("gpt-4o-mini")` model
+  via `experimental_wrapLanguageModel`.
+- Three-tier context (reflections + observations + recent messages)
+  prepended to every model call.
+- Automatic persistence of both the user input and the assistant response.
+
+## Run it
+
+```bash
+cp .env.example .env
+# edit .env: set MEMORY_API_KEY and OPENAI_API_KEY
+npm install
+npm start
+```
+
+You'll see a three-turn chat where the assistant remembers context from
+prior turns. Re-run the script to see context recalled across sessions
+(the conversation id is printed at the end of each run).
+
+## See also
+
+- [How-to: Vercel AI middleware](../../../../docs/how-to/vercel-ai.adoc)
+- [Vercel AI SDK docs](https://sdk.vercel.ai)

--- a/typescript/examples/vercel-ai/package.json
+++ b/typescript/examples/vercel-ai/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "agent-memory-example-vercel-ai",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "tsx src/index.ts"
+  },
+  "dependencies": {
+    "@neo4j-labs/agent-memory": "file:..",
+    "ai": "^4.0.0",
+    "@ai-sdk/openai": "^1.0.0"
+  },
+  "devDependencies": {
+    "tsx": "^4.0.0",
+    "@types/node": "^20.0.0"
+  }
+}

--- a/typescript/examples/vercel-ai/package.json
+++ b/typescript/examples/vercel-ai/package.json
@@ -7,12 +7,13 @@
     "start": "tsx src/index.ts"
   },
   "dependencies": {
-    "@neo4j-labs/agent-memory": "file:..",
+    "@neo4j-labs/agent-memory": "file:../..",
     "ai": "^4.0.0",
     "@ai-sdk/openai": "^1.0.0"
   },
   "devDependencies": {
     "tsx": "^4.0.0",
+    "typescript": "^5.5.0",
     "@types/node": "^20.0.0"
   }
 }

--- a/typescript/examples/vercel-ai/src/index.ts
+++ b/typescript/examples/vercel-ai/src/index.ts
@@ -1,0 +1,54 @@
+/**
+ * Vercel AI SDK + neo4j-agent-memory — a memory-augmented multi-turn chat.
+ *
+ * The middleware injects three-tier context (reflections + observations +
+ * recent messages) into every model call and persists both sides of the
+ * conversation. Run it twice in a row with the same userId to see the
+ * second run remember the first.
+ */
+
+import { generateText, experimental_wrapLanguageModel as wrapModel } from "ai";
+import { openai } from "@ai-sdk/openai";
+import { MemoryClient } from "@neo4j-labs/agent-memory";
+import { agentMemoryMiddleware } from "@neo4j-labs/agent-memory/middleware/vercel-ai";
+
+async function main() {
+  const memory = new MemoryClient();
+
+  // One conversation per user. Reuse the same id across runs to see the
+  // assistant carry context from prior sessions.
+  const conv = await memory.shortTerm.createConversation({
+    userId: process.env.DEMO_USER_ID ?? "demo-user",
+    metadata: { source: "vercel-ai-example" },
+  });
+
+  const model = wrapModel({
+    model: openai("gpt-4o-mini"),
+    middleware: agentMemoryMiddleware(memory, { conversationId: conv.id }),
+  });
+
+  const turns = [
+    "Hi! I'm building a recommendation engine for board games. I love euro-style games.",
+    "What kind of dataset would you use?",
+    "Given what I just told you about my preferences, suggest a starter project.",
+  ];
+
+  for (const userMessage of turns) {
+    process.stdout.write(`\n[user] ${userMessage}\n[assistant] `);
+    const { text } = await generateText({
+      model,
+      messages: [{ role: "user", content: userMessage }],
+    });
+    process.stdout.write(`${text}\n`);
+  }
+
+  process.stdout.write(
+    `\nConversation persisted as ${conv.id}. ` +
+      `Re-run with DEMO_USER_ID=${conv.id} to see context recall.\n`,
+  );
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/typescript/examples/vercel-ai/src/index.ts
+++ b/typescript/examples/vercel-ai/src/index.ts
@@ -7,7 +7,11 @@
  * second run remember the first.
  */
 
-import { generateText, experimental_wrapLanguageModel as wrapModel } from "ai";
+import {
+  generateText,
+  experimental_wrapLanguageModel as wrapModel,
+  type LanguageModelV1Middleware,
+} from "ai";
 import { openai } from "@ai-sdk/openai";
 import { MemoryClient } from "@neo4j-labs/agent-memory";
 import { agentMemoryMiddleware } from "@neo4j-labs/agent-memory/middleware/vercel-ai";
@@ -22,9 +26,15 @@ async function main() {
     metadata: { source: "vercel-ai-example" },
   });
 
+  // The middleware is duck-typed against Vercel AI v4's
+  // `LanguageModelV1Middleware`; the cast is safe at runtime — see
+  // src/middleware/vercel-ai.ts. Tighten the SDK-side type in a future
+  // release to drop this.
   const model = wrapModel({
     model: openai("gpt-4o-mini"),
-    middleware: agentMemoryMiddleware(memory, { conversationId: conv.id }),
+    middleware: agentMemoryMiddleware(memory, {
+      conversationId: conv.id,
+    }) as unknown as LanguageModelV1Middleware,
   });
 
   const turns = [

--- a/typescript/examples/vercel-ai/tsconfig.json
+++ b/typescript/examples/vercel-ai/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../tsconfig.base.json",
+  "include": ["src/**/*"]
+}

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1,0 +1,5832 @@
+{
+  "name": "@neo4j-labs/agent-memory",
+  "version": "0.3.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@neo4j-labs/agent-memory",
+      "version": "0.3.0",
+      "license": "Apache-2.0",
+      "devDependencies": {
+        "@ai-sdk/provider": "^3.0.10",
+        "@modelcontextprotocol/sdk": "^1.29.0",
+        "@opentelemetry/api": "^1.9.1",
+        "@strands-agents/sdk": "^1.2.0",
+        "@types/node": "^20.0.0",
+        "dotenv": "^17.4.2",
+        "msw": "^2.14.3",
+        "tsup": "^8.0.0",
+        "tsx": "^4.0.0",
+        "typedoc": "^0.26.0",
+        "typescript": "^5.5.0",
+        "vitest": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@ai-sdk/provider": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.10.tgz",
+      "integrity": "sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@aws-crypto/crc32": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
+      "integrity": "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-js": "^5.2.0",
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-js": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/util": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-bedrock-runtime": {
+      "version": "3.1048.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.1048.0.tgz",
+      "integrity": "sha512-u+NT61JZEkRFtpL0CAw1N1dwxnaLgwVXQl/zjJxTGgLyS/jTIdg2SdoEoCTHxgDyCnqa1HEi9QOoE9/pYRNpOQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/credential-provider-node": "^3.972.42",
+        "@aws-sdk/eventstream-handler-node": "^3.972.16",
+        "@aws-sdk/middleware-eventstream": "^3.972.12",
+        "@aws-sdk/middleware-websocket": "^3.972.19",
+        "@aws-sdk/token-providers": "3.1048.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/fetch-http-handler": "^5.4.2",
+        "@smithy/node-http-handler": "^4.7.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core": {
+      "version": "3.974.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.11.tgz",
+      "integrity": "sha512-QpnINq5FZH6EOaDEkmHdT7eUunbvD27pDNQypaWjFyYz7Zl1q3UCMQErBZxpmfGfI7MvI2TlK8KTkgNpv8b1ug==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/xml-builder": "^3.972.24",
+        "@aws/lambda-invoke-store": "^0.2.2",
+        "@smithy/core": "^3.24.2",
+        "@smithy/signature-v4": "^5.4.2",
+        "@smithy/types": "^4.14.1",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.37",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.37.tgz",
+      "integrity": "sha512-/jpPvEh6f7ntmIzf7dNxoNX6Q8vt8UpesCjbW6mFfk4V1NW6bIy9qxcQ6WbA8As5yQhsZOe+xeNd4xHX8kdY2Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.972.39",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.39.tgz",
+      "integrity": "sha512-pIgTpisWyWg7X1bUbzSjuUYosYTD0Ghz2M0hkSTmb3a6i3qV3uU+NYJPI/E2XSC0HcsZh5rsLPzeXrkb2DS0Cg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/fetch-http-handler": "^5.4.2",
+        "@smithy/node-http-handler": "^4.7.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.972.41",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.41.tgz",
+      "integrity": "sha512-u2tyjaxJJzW8UtW4SM1ZcPMDwO6y+kV+llvou+Adts0FAKyzes5jG4izQN+KX3yE8ZROpS5y1LJ//xL2iSf76w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/credential-provider-env": "^3.972.37",
+        "@aws-sdk/credential-provider-http": "^3.972.39",
+        "@aws-sdk/credential-provider-login": "^3.972.41",
+        "@aws-sdk/credential-provider-process": "^3.972.37",
+        "@aws-sdk/credential-provider-sso": "^3.972.41",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.41",
+        "@aws-sdk/nested-clients": "^3.997.9",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/credential-provider-imds": "^4.3.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.41",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.41.tgz",
+      "integrity": "sha512-0LBitxXiAiaE5nlFPfpNIww/8FRY/I7WIndWsc9GmNFOM7cE1wNpVNQEGEk9Outg5l8xl+3vybxFyUy4l9q/LQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/nested-clients": "^3.997.9",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.972.42",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.42.tgz",
+      "integrity": "sha512-D4oon2zbqqsWOJUM99Gm3/ZyJ0IJvTXVN3PyloGb3kQEyI36fjCZheZj422lAgTWWd6TSHgiImLt3RIaLdv3dQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "^3.972.37",
+        "@aws-sdk/credential-provider-http": "^3.972.39",
+        "@aws-sdk/credential-provider-ini": "^3.972.41",
+        "@aws-sdk/credential-provider-process": "^3.972.37",
+        "@aws-sdk/credential-provider-sso": "^3.972.41",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.41",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/credential-provider-imds": "^4.3.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.972.37",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.37.tgz",
+      "integrity": "sha512-7nVaHBUaWIddASYfVaA9O4D5ZVjewU3sCol9WqZPGfW0nR+0WqE0xHZnD/U2L33PlOB8KNXGKZ6wOES/QijKzg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.972.41",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.41.tgz",
+      "integrity": "sha512-IOWAWEHe5LkjSKkkUUX9ciV6Y1scHTsnfEkdt5yyC4Slrc7AGbkLPrpntjqh18ksJAMOaVhoBsO8p2WyTcY2wQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/nested-clients": "^3.997.9",
+        "@aws-sdk/token-providers": "3.1048.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.972.41",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.41.tgz",
+      "integrity": "sha512-mbACk9Yypa8nm4iGZLs0PofOXEcTDOUw6wDnsPXNDNSd2WNXs1tSo+6nc/fh0jLYdfVZThhBL98PHW4aXFsG5A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/nested-clients": "^3.997.9",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/eventstream-handler-node": {
+      "version": "3.972.16",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.16.tgz",
+      "integrity": "sha512-yedpPgKftqjU5SlPFHfqWpOw6xSCRieWRG1euWOlXn4WJxt2VX92VprCa2PpSOXjVCAeK6dTjW9eJRXVig9yGA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-eventstream": {
+      "version": "3.972.12",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.12.tgz",
+      "integrity": "sha512-tHTHHCHNrq6XklQvlzHBDJG4Iuhh7NVPRdtmvP+nHFA+5sxPlIDzlAHHgfoYHGvT3NXP1yVP/L5c3opUn6T3Qg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-websocket": {
+      "version": "3.972.19",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.19.tgz",
+      "integrity": "sha512-mkEhOGYozqKQkbFaVrjwr0faiwwZza1v5/jSY6Tucm3bD+uKTazIUH/4Yo6aMnQD2ua2W9cMP6s8mvwTcjtqHw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/fetch-http-handler": "^5.4.2",
+        "@smithy/signature-v4": "^5.4.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients": {
+      "version": "3.997.9",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.9.tgz",
+      "integrity": "sha512-jPR3rnmRI4hWYyzfmTGBr7NblMp8QYYeflHXba1H6+7CGrWVqWKQzaXFQ4qbExqPRsXN3T3L3JxFhr6aouXUGQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.27",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/fetch-http-handler": "^5.4.2",
+        "@smithy/node-http-handler": "^4.7.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.27",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.27.tgz",
+      "integrity": "sha512-0Phbz4t6HI3D3skxvG2uI+VWU034/nSIw1T8d+FPzzQG9EQTrw94o9mOKO2Gv3n3Oc8P7JD7RAUxkoneLWv5Eg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/signature-v4": "^5.4.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.1048.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1048.0.tgz",
+      "integrity": "sha512-k0y/GcuesuSfWyUM0WamrGyeZmltRYaPbHO82UDA6mZ/doB+FOHKutikPAtSXMn/hDz970cF+iRuuiYO9VEbAA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/nested-clients": "^3.997.9",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.973.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.8.tgz",
+      "integrity": "sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-locate-window": {
+      "version": "3.965.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.5.tgz",
+      "integrity": "sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.24",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.24.tgz",
+      "integrity": "sha512-V8z5YcDPfsvzrBlj0xR1vhRtocblhYbqdreCJB/voGd4Sr5zjNAeWxexbnqVtskTJe0vFb5KMqbSL++ePl+zRw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@nodable/entities": "2.1.0",
+        "@smithy/types": "^4.14.1",
+        "fast-xml-parser": "5.7.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws/lambda-invoke-store": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.4.tgz",
+      "integrity": "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.4.tgz",
+      "integrity": "sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.4.tgz",
+      "integrity": "sha512-X9bUgvxiC8CHAGKYufLIHGXPJWnr0OCdR0anD2e21vdvgCI8lIfqFbnoeOz7lBjdrAGUhqLZLcQo6MLhTO2DKQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.4.tgz",
+      "integrity": "sha512-gdLscB7v75wRfu7QSm/zg6Rx29VLdy9eTr2t44sfTW7CxwAtQghZ4ZnqHk3/ogz7xao0QAgrkradbBzcqFPasw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.4.tgz",
+      "integrity": "sha512-PzPFnBNVF292sfpfhiyiXCGSn9HZg5BcAz+ivBuSsl6Rk4ga1oEXAamhOXRFyMcjwr2DVtm40G65N3GLeH1Lvw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.4.tgz",
+      "integrity": "sha512-b7xaGIwdJlht8ZFCvMkpDN6uiSmnxxK56N2GDTMYPr2/gzvfdQN8rTfBsvVKmIVY/X7EM+/hJKEIbbHs9oA4tQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.4.tgz",
+      "integrity": "sha512-sR+OiKLwd15nmCdqpXMnuJ9W2kpy0KigzqScqHI3Hqwr7IXxBp3Yva+yJwoqh7rE8V77tdoheRYataNKL4QrPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.4.tgz",
+      "integrity": "sha512-jnfpKe+p79tCnm4GVav68A7tUFeKQwQyLgESwEAUzyxk/TJr4QdGog9sqWNcUbr/bZt/O/HXouspuQDd9JxFSw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.4.tgz",
+      "integrity": "sha512-2kb4ceA/CpfUrIcTUl1wrP/9ad9Atrp5J94Lq69w7UwOMolPIGrfLSvAKJp0RTvkPPyn6CIWrNy13kyLikZRZQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.4.tgz",
+      "integrity": "sha512-aBYgcIxX/wd5n2ys0yESGeYMGF+pv6g0DhZr3G1ZG4jMfruU9Tl1i2Z+Wnj9/KjGz1lTLCcorqE2viePZqj4Eg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.4.tgz",
+      "integrity": "sha512-7nQOttdzVGth1iz57kxg9uCz57dxQLHWxopL6mYuYthohPKEK0vU0C3O21CcBK6KDlkYVcnDXY099HcCDXd9dA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.4.tgz",
+      "integrity": "sha512-oPtixtAIzgvzYcKBQM/qZ3R+9TEUd1aNJQu0HhGyqtx6oS7qTpvjheIWBbes4+qu1bNlo2V4cbkISr8q6gRBFA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.4.tgz",
+      "integrity": "sha512-8mL/vh8qeCoRcFH2nM8wm5uJP+ZcVYGGayMavi8GmRJjuI3g1v6Z7Ni0JJKAJW+m0EtUuARb6Lmp4hMjzCBWzA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.4.tgz",
+      "integrity": "sha512-1RdrWFFiiLIW7LQq9Q2NES+HiD4NyT8Itj9AUeCl0IVCA459WnPhREKgwrpaIfTOe+/2rdntisegiPWn/r/aAw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.4.tgz",
+      "integrity": "sha512-tLCwNG47l3sd9lpfyx9LAGEGItCUeRCWeAx6x2Jmbav65nAwoPXfewtAdtbtit/pJFLUWOhpv0FpS6GQAmPrHA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.4.tgz",
+      "integrity": "sha512-BnASypppbUWyqjd1KIpU4AUBiIhVr6YlHx/cnPgqEkNoVOhHg+YiSVxM1RLfiy4t9cAulbRGTNCKOcqHrEQLIw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.4.tgz",
+      "integrity": "sha512-+eUqgb/Z7vxVLezG8bVB9SfBie89gMueS+I0xYh2tJdw3vqA/0ImZJ2ROeWwVJN59ihBeZ7Tu92dF/5dy5FttA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.4.tgz",
+      "integrity": "sha512-S5qOXrKV8BQEzJPVxAwnryi2+Iq5pB40gTEIT69BQONqR7JH1EPIcQ/Uiv9mCnn05jff9umq/5nqzxlqTOg9NA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.4.tgz",
+      "integrity": "sha512-xHT8X4sb0GS8qTqiwzHqpY00C95DPAq7nAwX35Ie/s+LO9830hrMd3oX0ZMKLvy7vsonee73x0lmcdOVXFzd6Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.4.tgz",
+      "integrity": "sha512-RugOvOdXfdyi5Tyv40kgQnI0byv66BFgAqjdgtAKqHoZTbTF2QqfQrFwa7cHEORJf6X2ht+l9ABLMP0dnKYsgg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.4.tgz",
+      "integrity": "sha512-2MyL3IAaTX+1/qP0O1SwskwcwCoOI4kV2IBX1xYnDDqthmq5ArrW94qSIKCAuRraMgPOmG0RDTA74mzYNQA9ow==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.4.tgz",
+      "integrity": "sha512-u8fg/jQ5aQDfsnIV6+KwLOf1CmJnfu1ShpwqdwC0uA7ZPwFws55Ngc12vBdeUdnuWoQYx/SOQLGDcdlfXhYmXQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.4.tgz",
+      "integrity": "sha512-JkTZrl6VbyO8lDQO3yv26nNr2RM2yZzNrNHEsj9bm6dOwwu9OYN28CjzZkH57bh4w0I2F7IodpQvUAEd1mbWXg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.4.tgz",
+      "integrity": "sha512-/gOzgaewZJfeJTlsWhvUEmUG4tWEY2Spp5M20INYRg2ZKl9QPO3QEEgPeRtLjEWSW8FilRNacPOg8R1uaYkA6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.4.tgz",
+      "integrity": "sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.4.tgz",
+      "integrity": "sha512-DAyGLS0Jz5G5iixEbMHi5KdiApqHBWMGzTtMiJ72ZOLhbu/bzxgAe8Ue8CTS3n3HbIUHQz/L51yMdGMeoxXNJw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.4.tgz",
+      "integrity": "sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@inquirer/ansi": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-2.0.5.tgz",
+      "integrity": "sha512-doc2sWgJpbFQ64UflSVd17ibMGDuxO1yKgOgLMwavzESnXjFWJqUeG8saYosqKpHp4kWiM5x1nXvEjbpx90gzw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      }
+    },
+    "node_modules/@inquirer/confirm": {
+      "version": "6.0.12",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-6.0.12.tgz",
+      "integrity": "sha512-h9FgGun3QwVYNj5TWIZZ+slii73bMoBFjPfVIGtnFuL4t8gBiNDV9PcSfIzkuxvgquJKt9nr1QzszpBzTbH8Og==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.1.9",
+        "@inquirer/type": "^4.0.5"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/core": {
+      "version": "11.1.9",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-11.1.9.tgz",
+      "integrity": "sha512-BDE4fG22uYh1bGSifcj7JSx119TVYNViMhMu85usp4Fswrzh6M0DV3yld64jA98uOAa2GSQ4Bg4bZRm2d2cwSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^2.0.5",
+        "@inquirer/figures": "^2.0.5",
+        "@inquirer/type": "^4.0.5",
+        "cli-width": "^4.1.0",
+        "fast-wrap-ansi": "^0.2.0",
+        "mute-stream": "^3.0.0",
+        "signal-exit": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/figures": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-2.0.5.tgz",
+      "integrity": "sha512-NsSs4kzfm12lNetHwAn3GEuH317IzpwrMCbOuMIVytpjnJ90YYHNwdRgYGuKmVxwuIqSgqk3M5qqQt1cDk0tGQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      }
+    },
+    "node_modules/@inquirer/type": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-4.0.5.tgz",
+      "integrity": "sha512-aetVUNeKNc/VriqXlw1NRSW0zhMBB0W4bNbWRJgzRl/3d0QNDQFfk0GO5SDdtjMZVg6o8ZKEiadd7SCCzoOn5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@mswjs/interceptors": {
+      "version": "0.41.8",
+      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.41.8.tgz",
+      "integrity": "sha512-pRLMNKTSGRoLq+KnEB/7OY5vijw1XmcheAAOiv6pj7W1FG32kAGqj1C/RK/cqxRGr1Fh+zBi8sDur8kj3EQv6A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@open-draft/deferred-promise": "^2.2.0",
+        "@open-draft/logger": "^0.3.0",
+        "@open-draft/until": "^2.0.0",
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.3",
+        "strict-event-emitter": "^0.5.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@mswjs/interceptors/node_modules/@open-draft/deferred-promise": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-2.2.0.tgz",
+      "integrity": "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@nodable/entities": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@open-draft/deferred-promise": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-3.0.0.tgz",
+      "integrity": "sha512-XW375UK8/9SqUVNVa6M0yEy8+iTi4QN5VZ7aZuRFQmy76LRwI9wy5F4YIBU6T+eTe2/DNDo8tqu8RHlwLHM6RA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@open-draft/logger": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/logger/-/logger-0.3.0.tgz",
+      "integrity": "sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.0"
+      }
+    },
+    "node_modules/@open-draft/until": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
+      "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.0.tgz",
+      "integrity": "sha512-WOhNW9K8bR3kf4zLxbfg6Pxu2ybOUbB2AjMDHSQx86LIF4rH4Ft7vmMwNt0loO0eonglSNy4cpD3MKXXKQu0/A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.0.tgz",
+      "integrity": "sha512-u6JHLll5QKRvjciE78bQXDmqRqNs5M/3GVqZeMwvmjaNODJih/WIrJlFVEihvV0MiYFmd+ZyPr9wxOVbPAG2Iw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.0.tgz",
+      "integrity": "sha512-qEF7CsKKzSRc20Ciu2Zw1wRrBz4g56F7r/vRwY430UPp/nt1x21Q/fpJ9N5l47WWvJlkNCPJz3QRVw008fi7yA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.0.tgz",
+      "integrity": "sha512-WADYozJ4QCnXCH4wPB+3FuGmDPoFseVCUrANmA5LWwGmC6FL14BWC7pcq+FstOZv3baGX65tZ378uT6WG8ynTw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.0.tgz",
+      "integrity": "sha512-6b8wGHJlDrGeSE3aH5mGNHBjA0TTkxdoNHik5EkvPHCt351XnigA4pS7Wsj/Eo9Y8RBU6f35cjN9SYmCFBtzxw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.0.tgz",
+      "integrity": "sha512-h25Ga0t4jaylMB8M/JKAyrvvfxGRjnPQIR8lnCayyzEjEOx2EJIlIiMbhpWxDRKGKF8jbNH01NnN663dH638mA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.0.tgz",
+      "integrity": "sha512-RzeBwv0B3qtVBWtcuABtSuCzToo2IEAIQrcyB/b2zMvBWVbjo8bZDjACUpnaafaxhTw2W+imQbP2BD1usasK4g==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.0.tgz",
+      "integrity": "sha512-Sf7zusNI2CIU1HLzuu9Tc5YGAHEZs5Lu7N1ssJG4Tkw6e0MEsN7NdjUDDfGNHy2IU+ENyWT+L2obgWiguWibWQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.0.tgz",
+      "integrity": "sha512-DX2x7CMcrJzsE91q7/O02IJQ5/aLkVtYFryqCjduJhUfGKG6yJV8hxaw8pZa93lLEpPTP/ohdN4wFz7yp/ry9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.0.tgz",
+      "integrity": "sha512-09EL+yFVbJZlhcQfShpswwRZ0Rg+z/CsSELFCnPt3iK+iqwGsI4zht3secj5vLEs957QvFFXnzAT0FFPIxSrkQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.0.tgz",
+      "integrity": "sha512-i9IcCMPr3EXm8EQg5jnja0Zyc1iFxJjZWlb4wr7U2Wx/GrddOuEafxRdMPRYVaXjgbhvqalp6np07hN1w9kAKw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.0.tgz",
+      "integrity": "sha512-DGzdJK9kyJ+B78MCkWeGnpXJ91tK/iKA6HwHxF4TAlPIY7GXEvMe8hBFRgdrR9Ly4qebR/7gfUs9y2IoaVEyog==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.0.tgz",
+      "integrity": "sha512-RwpnLsqC8qbS8z1H1AxBA1H6qknR4YpPR9w2XX0vo2Sz10miu57PkNcnHVaZkbqyw/kUWfKMI73jhmfi9BRMUQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.0.tgz",
+      "integrity": "sha512-Z8pPf54Ly3aqtdWC3G4rFigZgNvd+qJlOE52fmko3KST9SoGfAdSRCwyoyG05q1HrrAblLbk1/PSIV+80/pxLg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.0.tgz",
+      "integrity": "sha512-3a3qQustp3COCGvnP4SvrMHnPQ9d1vzCakQVRTliaz8cIp/wULGjiGpbcqrkv0WrHTEp8bQD/B3HBjzujVWLOA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.0.tgz",
+      "integrity": "sha512-pjZDsVH/1VsghMJ2/kAaxt6dL0psT6ZexQVrijczOf+PeP2BUqTHYejk3l6TlPRydggINOeNRhvpLa0AYpCWSQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.0.tgz",
+      "integrity": "sha512-3ObQs0BhvPgiUVZrN7gqCSvmFuMWvWvsjG5ayJ3Lraqv+2KhOsp+pUbigqbeWqueGIsnn+09HBw27rJ+gYK4VQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.0.tgz",
+      "integrity": "sha512-EtylprDtQPdS5rXvAayrNDYoJhIz1/vzN2fEubo3yLE7tfAw+948dO0g4M0vkTVFhKojnF+n6C8bDNe+gDRdTg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.0.tgz",
+      "integrity": "sha512-k09oiRCi/bHU9UVFqD17r3eJR9bn03TyKraCrlz5ULFJGdJGi7VOmm9jl44vOJvRJ6P7WuBi/s2A97LxxHGIdw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.0.tgz",
+      "integrity": "sha512-1o/0/pIhozoSaDJoDcec+IVLbnRtQmHwPV730+AOD29lHEEo4F5BEUB24H0OBdhbBBDwIOSuf7vgg0Ywxdfiiw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.0.tgz",
+      "integrity": "sha512-pESDkos/PDzYwtyzB5p/UoNU/8fJo68vcXM9ZW2V0kjYayj1KaaUfi1NmTUTUpMn4UhU4gTuK8gIaFO4UGuMbA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.0.tgz",
+      "integrity": "sha512-hj1wFStD7B1YBeYmvY+lWXZ7ey73YGPcViMShYikqKT1GtstIKQAtfUI6yrzPjAy/O7pO0VLXGmUVWXQMaYgTQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.0.tgz",
+      "integrity": "sha512-SyaIPFoxmUPlNDq5EHkTbiKzmSEmq/gOYFI/3HHJ8iS/v1mbugVa7dXUzcJGQfoytp9DJFLhHH4U3/eTy2Bq4w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.0.tgz",
+      "integrity": "sha512-RdcryEfzZr+lAr5kRm2ucN9aVlCCa2QNq4hXelZxb8GG0NJSazq44Z3PCCc8wISRuCVnGs0lQJVX5Vp6fKA+IA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.0.tgz",
+      "integrity": "sha512-PrsWNQ8BuE00O3Xsx3ALh2Df8fAj9+cvvX9AIA6o4KpATR98c9mud4XtDWVvsEuyia5U4tVSTKygawyJkjm60w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@shikijs/core": {
+      "version": "1.29.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-1.29.2.tgz",
+      "integrity": "sha512-vju0lY9r27jJfOY4Z7+Rt/nIOjzJpZ3y+nYpqtUZInVoXQ/TJZcfGnNOGnKjFdVZb8qexiCuSlZRKcGfhhTTZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/engine-javascript": "1.29.2",
+        "@shikijs/engine-oniguruma": "1.29.2",
+        "@shikijs/types": "1.29.2",
+        "@shikijs/vscode-textmate": "^10.0.1",
+        "@types/hast": "^3.0.4",
+        "hast-util-to-html": "^9.0.4"
+      }
+    },
+    "node_modules/@shikijs/engine-javascript": {
+      "version": "1.29.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-1.29.2.tgz",
+      "integrity": "sha512-iNEZv4IrLYPv64Q6k7EPpOCE/nuvGiKl7zxdq0WFuRPF5PAE9PRo2JGq/d8crLusM59BRemJ4eOqrFrC4wiQ+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "1.29.2",
+        "@shikijs/vscode-textmate": "^10.0.1",
+        "oniguruma-to-es": "^2.2.0"
+      }
+    },
+    "node_modules/@shikijs/engine-oniguruma": {
+      "version": "1.29.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-1.29.2.tgz",
+      "integrity": "sha512-7iiOx3SG8+g1MnlzZVDYiaeHe7Ez2Kf2HrJzdmGwkRisT7r4rak0e655AcM/tF9JG/kg5fMNYlLLKglbN7gBqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "1.29.2",
+        "@shikijs/vscode-textmate": "^10.0.1"
+      }
+    },
+    "node_modules/@shikijs/langs": {
+      "version": "1.29.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-1.29.2.tgz",
+      "integrity": "sha512-FIBA7N3LZ+223U7cJDUYd5shmciFQlYkFXlkKVaHsCPgfVLiO+e12FmQE6Tf9vuyEsFe3dIl8qGWKXgEHL9wmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "1.29.2"
+      }
+    },
+    "node_modules/@shikijs/themes": {
+      "version": "1.29.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-1.29.2.tgz",
+      "integrity": "sha512-i9TNZlsq4uoyqSbluIcZkmPL9Bfi3djVxRnofUHwvx/h6SRW3cwgBC5SML7vsDcWyukY0eCzVN980rqP6qNl9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "1.29.2"
+      }
+    },
+    "node_modules/@shikijs/types": {
+      "version": "1.29.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-1.29.2.tgz",
+      "integrity": "sha512-VJjK0eIijTZf0QSTODEXCqinjBn0joAHQ+aPSBzrv4O2d/QSbsMw+ZeSRx03kV34Hy7NzUvV/7NqfYGRLrASmw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/vscode-textmate": "^10.0.1",
+        "@types/hast": "^3.0.4"
+      }
+    },
+    "node_modules/@shikijs/vscode-textmate": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
+      "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@smithy/core": {
+      "version": "3.24.3",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.24.3.tgz",
+      "integrity": "sha512-Ep/7tPamGY8mgESE3LyLKtxJyy6U52WWAqr/3wial47Sj4u3PiIF73AOGI27UyLy9duTkhZbgzodOfLV4TduZg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/crc32": "5.2.0",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.3.3.tgz",
+      "integrity": "sha512-I2Bti0DKFo2IJyN28ijCsx51BAumEYR4/1yZ1FXyBygy9MqbnMqCev4JPth/MbpRfBSRAX35hITSnAdJRo1u5w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.3",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler": {
+      "version": "5.4.3",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.4.3.tgz",
+      "integrity": "sha512-F+DRf8IJazRJgYog2A/yJK7eYVc0rqTlRzO+5ZxjJd4WkZoKz0IJRncf7G6t1pdVT3kryJcwuTFhN1c5m6N47A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.3",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.7.3.tgz",
+      "integrity": "sha512-/jPhevcTFPMVl6KNjbaI47iOg1zxC7IsnX4PQDGVZKMFceOXtB8IEYaB7a9VvkP/3oC60WzTeKocvSI7vLT0vA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.3",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4": {
+      "version": "5.4.3",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.4.3.tgz",
+      "integrity": "sha512-53+75QuPl6DL+ct6vVEB51FDO5oulXr20TPV46VvJZg76lIlXNWfxi8j+G2V/t0I2qxCBOa3vX/8bmjrpFVo9g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.3",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "4.14.2",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.2.tgz",
+      "integrity": "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@strands-agents/sdk": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@strands-agents/sdk/-/sdk-1.2.0.tgz",
+      "integrity": "sha512-dPetRpgOFs37hwsHnSGZO7fxRHUFwlmtO4vhl/nXRa5A1gwnbvnQNUqdQxu9G+0J5MiRYlOllHZM/WlC3rnNTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/client-bedrock-runtime": "^3.1037.0",
+        "@types/json-schema": "^7.0.15",
+        "uuid": "^14.0.0",
+        "yaml": "^2.8.3"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@a2a-js/sdk": "^0.3.10",
+        "@ai-sdk/provider": "^3.0.0",
+        "@anthropic-ai/sdk": "^0.92.0",
+        "@aws-sdk/client-s3": "^3.943.0",
+        "@google/genai": "^1.40.0",
+        "@modelcontextprotocol/sdk": "^1.25.2",
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/exporter-metrics-otlp-http": "^0.214.0",
+        "@opentelemetry/exporter-trace-otlp-http": "^0.214.0",
+        "@opentelemetry/resources": "^2.6.1",
+        "@opentelemetry/sdk-metrics": "^2.6.1",
+        "@opentelemetry/sdk-trace-base": "^2.6.1",
+        "@opentelemetry/sdk-trace-node": "^2.6.1",
+        "express": "^5.1.0",
+        "openai": "^6.7.0",
+        "zod": "^4.1.12"
+      },
+      "peerDependenciesMeta": {
+        "@a2a-js/sdk": {
+          "optional": true
+        },
+        "@ai-sdk/provider": {
+          "optional": true
+        },
+        "@anthropic-ai/sdk": {
+          "optional": true
+        },
+        "@aws-sdk/client-s3": {
+          "optional": true
+        },
+        "@google/genai": {
+          "optional": true
+        },
+        "@opentelemetry/exporter-metrics-otlp-http": {
+          "optional": true
+        },
+        "@opentelemetry/exporter-trace-otlp-http": {
+          "optional": true
+        },
+        "@opentelemetry/resources": {
+          "optional": true
+        },
+        "@opentelemetry/sdk-metrics": {
+          "optional": true
+        },
+        "@opentelemetry/sdk-trace-base": {
+          "optional": true
+        },
+        "@opentelemetry/sdk-trace-node": {
+          "optional": true
+        },
+        "express": {
+          "optional": true
+        },
+        "openai": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/hast": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.37",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.37.tgz",
+      "integrity": "sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/set-cookie-parser": {
+      "version": "2.4.10",
+      "resolved": "https://registry.npmjs.org/@types/set-cookie-parser/-/set-cookie-parser-2.4.10.tgz",
+      "integrity": "sha512-GGmQVGpQWUe5qglJozEjZV/5dyxbOOZ0LHe/lqyWssB88Y4svNfst0uqBVscdDeIKl5Jy5+aPSvy7mI9tYRguw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/statuses": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/statuses/-/statuses-2.0.6.tgz",
+      "integrity": "sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.1.tgz",
+      "integrity": "sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner/node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot/node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bowser": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/bundle-require": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/bundle-require/-/bundle-require-5.1.0.tgz",
+      "integrity": "sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "load-tsconfig": "^0.2.3"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "esbuild": ">=0.18"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/character-entities-html4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/cli-width": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
+      "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/commander": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/confbox": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
+      "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/consola": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/consola/-/consola-3.4.2.tgz",
+      "integrity": "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.18.0 || >=16.10.0"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex-xs": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex-xs/-/emoji-regex-xs-1.0.0.tgz",
+      "integrity": "sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.4.tgz",
+      "integrity": "sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.4",
+        "@esbuild/android-arm": "0.27.4",
+        "@esbuild/android-arm64": "0.27.4",
+        "@esbuild/android-x64": "0.27.4",
+        "@esbuild/darwin-arm64": "0.27.4",
+        "@esbuild/darwin-x64": "0.27.4",
+        "@esbuild/freebsd-arm64": "0.27.4",
+        "@esbuild/freebsd-x64": "0.27.4",
+        "@esbuild/linux-arm": "0.27.4",
+        "@esbuild/linux-arm64": "0.27.4",
+        "@esbuild/linux-ia32": "0.27.4",
+        "@esbuild/linux-loong64": "0.27.4",
+        "@esbuild/linux-mips64el": "0.27.4",
+        "@esbuild/linux-ppc64": "0.27.4",
+        "@esbuild/linux-riscv64": "0.27.4",
+        "@esbuild/linux-s390x": "0.27.4",
+        "@esbuild/linux-x64": "0.27.4",
+        "@esbuild/netbsd-arm64": "0.27.4",
+        "@esbuild/netbsd-x64": "0.27.4",
+        "@esbuild/openbsd-arm64": "0.27.4",
+        "@esbuild/openbsd-x64": "0.27.4",
+        "@esbuild/openharmony-arm64": "0.27.4",
+        "@esbuild/sunos-x64": "0.27.4",
+        "@esbuild/win32-arm64": "0.27.4",
+        "@esbuild/win32-ia32": "0.27.4",
+        "@esbuild/win32-x64": "0.27.4"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.8.tgz",
+      "integrity": "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/express/node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-string-truncated-width": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-3.0.3.tgz",
+      "integrity": "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-string-width": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/fast-string-width/-/fast-string-width-3.0.2.tgz",
+      "integrity": "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-truncated-width": "^3.0.2"
+      }
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/fast-wrap-ansi": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/fast-wrap-ansi/-/fast-wrap-ansi-0.2.0.tgz",
+      "integrity": "sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-width": "^3.0.2"
+      }
+    },
+    "node_modules/fast-xml-builder": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.3.tgz",
+      "integrity": "sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.1.7",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.2.3"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/fix-dts-default-cjs-exports": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fix-dts-default-cjs-exports/-/fix-dts-default-cjs-exports-1.0.1.tgz",
+      "integrity": "sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "magic-string": "^0.30.17",
+        "mlly": "^1.7.4",
+        "rollup": "^4.34.8"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.13.7",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.7.tgz",
+      "integrity": "sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/graphql": {
+      "version": "16.14.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.14.0.tgz",
+      "integrity": "sha512-BBvQ/406p+4CZbTpCbVPSxfzrZrbnuWSP1ELYgyS6B+hNeKzgrdB4JczCa5VZUBQrDa9hUngm0KnexY6pJRN5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hast-util-to-html": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
+      "integrity": "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "html-void-elements": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "stringify-entities": "^4.0.0",
+        "zwitch": "^2.0.4"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-whitespace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/headers-polyfill": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-5.0.1.tgz",
+      "integrity": "sha512-1TJ6Fih/b8h5TIcv+1+Hw0PDQWJTKDKzFZzcKOiW1wJza3XoAQlkCuXLbymPYB8+ZQyw8mHvdw560e8zVFIWyA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/set-cookie-parser": "^2.4.10",
+        "set-cookie-parser": "^3.0.1"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.19",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.19.tgz",
+      "integrity": "sha512-xa3eYXYXx68XTT4hZ7dRzsXBhaq85ToSrlUJNoR0gwz/1Ap/CNwX47wfvV7pc/xWhjKVVkLT7zBJy8chhNguqQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/html-void-elements": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
+      "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-node-process": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.2.0.tgz",
+      "integrity": "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/joycon": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
+      "integrity": "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/json-schema": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
+      "dev": true,
+      "license": "(AFL-2.1 OR BSD-3-Clause)"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/lilconfig": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antonk52"
+      }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "uc.micro": "^2.0.0"
+      }
+    },
+    "node_modules/load-tsconfig": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/load-tsconfig/-/load-tsconfig-0.2.5.tgz",
+      "integrity": "sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lunr": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
+      "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/markdown-it": {
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
+      "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "^4.4.0",
+        "linkify-it": "^5.0.0",
+        "mdurl": "^2.0.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^2.1.0"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.mjs"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mdast-util-to-hast": {
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+      "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "trim-lines": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/mlly": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.2.tgz",
+      "integrity": "sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "pathe": "^2.0.3",
+        "pkg-types": "^1.3.1",
+        "ufo": "^1.6.3"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/msw": {
+      "version": "2.14.3",
+      "resolved": "https://registry.npmjs.org/msw/-/msw-2.14.3.tgz",
+      "integrity": "sha512-kk8G5cocVlJ4wsKMGZegn2H6XLOEKjbA+nSJE2354e/SRp4mDicCHUYnMXpymzVcVDCs+GUAsmNqSn+yHv4T2A==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@inquirer/confirm": "^6.0.11",
+        "@mswjs/interceptors": "^0.41.3",
+        "@open-draft/deferred-promise": "^3.0.0",
+        "@types/statuses": "^2.0.6",
+        "cookie": "^1.1.1",
+        "graphql": "^16.13.2",
+        "headers-polyfill": "^5.0.1",
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.3",
+        "path-to-regexp": "^6.3.0",
+        "picocolors": "^1.1.1",
+        "rettime": "^0.11.11",
+        "statuses": "^2.0.2",
+        "strict-event-emitter": "^0.5.1",
+        "tough-cookie": "^6.0.1",
+        "type-fest": "^5.5.0",
+        "until-async": "^3.0.2",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "msw": "cli/index.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mswjs"
+      },
+      "peerDependencies": {
+        "typescript": ">= 4.8.x"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/mute-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-3.0.0.tgz",
+      "integrity": "sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/mz": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "thenify-all": "^1.0.0"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/oniguruma-to-es": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-2.3.0.tgz",
+      "integrity": "sha512-bwALDxriqfKGfUufKGGepCzu9x7nJQuoRoAFp4AnwehhC2crqrDIAP/uN2qdlsAvSMpeRC3+Yzhqc7hLmle5+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex-xs": "^1.0.0",
+        "regex": "^5.1.1",
+        "regex-recursion": "^5.1.1"
+      }
+    },
+    "node_modules/outvariant": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/outvariant/-/outvariant-1.4.3.tgz",
+      "integrity": "sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-expression-matcher": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pirates": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+      "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/pkg-types": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
+      "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "confbox": "^0.1.8",
+        "mlly": "^1.7.4",
+        "pathe": "^2.0.1"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.8",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
+      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postcss-load-config": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-6.0.1.tgz",
+      "integrity": "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "lilconfig": "^3.1.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "jiti": ">=1.21.0",
+        "postcss": ">=8.0.9",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/property-information": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz",
+      "integrity": "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/regex": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/regex/-/regex-5.1.1.tgz",
+      "integrity": "sha512-dN5I359AVGPnwzJm2jN1k0W9LPZ+ePvoOeVMMfqIMFz53sSwXkxaJoxr50ptnsC771lK95BnTrVSZxq0b9yCGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/regex-recursion": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/regex-recursion/-/regex-recursion-5.1.1.tgz",
+      "integrity": "sha512-ae7SBCbzVNrIjgSbh7wMznPcQel1DNlDtzensnFxpiNpXt1U2ju/bHugH422r+4LAVS1FpW1YCwilmnNsjum9w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "regex": "^5.1.1",
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/regex-utilities": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/regex-utilities/-/regex-utilities-2.3.0.tgz",
+      "integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/rettime": {
+      "version": "0.11.11",
+      "resolved": "https://registry.npmjs.org/rettime/-/rettime-0.11.11.tgz",
+      "integrity": "sha512-ILJRqVWBCTlg9r42fFgwVZx1gnFAcQF8mRoMkbgQfIrjEDf9nbBFDFx00oloOa+Q869FUtaYDXZvEfnecQSCoQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/rollup": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.0.tgz",
+      "integrity": "sha512-yqjxruMGBQJ2gG4HtjZtAfXArHomazDHoFwFFmZZl0r7Pdo7qCIXKqKHZc8yeoMgzJJ+pO6pEEHa+V7uzWlrAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.0",
+        "@rollup/rollup-android-arm64": "4.60.0",
+        "@rollup/rollup-darwin-arm64": "4.60.0",
+        "@rollup/rollup-darwin-x64": "4.60.0",
+        "@rollup/rollup-freebsd-arm64": "4.60.0",
+        "@rollup/rollup-freebsd-x64": "4.60.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.0",
+        "@rollup/rollup-linux-arm64-musl": "4.60.0",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.0",
+        "@rollup/rollup-linux-loong64-musl": "4.60.0",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.0",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.0",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.0",
+        "@rollup/rollup-linux-x64-gnu": "4.60.0",
+        "@rollup/rollup-linux-x64-musl": "4.60.0",
+        "@rollup/rollup-openbsd-x64": "4.60.0",
+        "@rollup/rollup-openharmony-arm64": "4.60.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.0",
+        "@rollup/rollup-win32-x64-gnu": "4.60.0",
+        "@rollup/rollup-win32-x64-msvc": "4.60.0",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/router/node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-3.1.0.tgz",
+      "integrity": "sha512-kjnC1DXBHcxaOaOXBHBeRtltsDG2nUiUni+jP92M9gYdW12rsmx92UsfpH7o5tDRs7I1ZZPSQJQGv3UaRfCiuw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shiki": {
+      "version": "1.29.2",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-1.29.2.tgz",
+      "integrity": "sha512-njXuliz/cP+67jU2hukkxCNuH1yUi4QfdZZY+sMr5PPrIyXSu5iTb/qYC4BiWWB0vZ+7TbdvYUCeL23zpwCfbg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/core": "1.29.2",
+        "@shikijs/engine-javascript": "1.29.2",
+        "@shikijs/engine-oniguruma": "1.29.2",
+        "@shikijs/langs": "1.29.2",
+        "@shikijs/themes": "1.29.2",
+        "@shikijs/types": "1.29.2",
+        "@shikijs/vscode-textmate": "^10.0.1",
+        "@types/hast": "^3.0.4"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
+      "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strict-event-emitter": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz",
+      "integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/stringify-entities": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strnum": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
+      "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/sucrase": {
+      "version": "3.35.1",
+      "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
+      "integrity": "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.2",
+        "commander": "^4.0.0",
+        "lines-and-columns": "^1.1.6",
+        "mz": "^2.7.0",
+        "pirates": "^4.0.1",
+        "tinyglobby": "^0.2.11",
+        "ts-interface-checker": "^0.1.9"
+      },
+      "bin": {
+        "sucrase": "bin/sucrase",
+        "sucrase-node": "bin/sucrase-node"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/tagged-tag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
+      "integrity": "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/thenify": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0"
+      }
+    },
+    "node_modules/thenify-all": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+      "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "thenify": ">= 3.1.0 < 4"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.0.30",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.30.tgz",
+      "integrity": "sha512-ELrFxuqsDdHUwoh0XxDbxuLD3Wnz49Z57IFvTtvWy1hJdcMZjXLIuonjilCiWHlT2GbE4Wlv1wKVTzDFnXH1aw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.30"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.30",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.30.tgz",
+      "integrity": "sha512-uiHN8PIB1VmWyS98eZYja4xzlYqeFZVjb4OuYlJQnZAuJhMw4PbKQOKgHKhBdJR3FE/t5mUQ1Kd80++B+qhD1Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tree-kill": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "tree-kill": "cli.js"
+      }
+    },
+    "node_modules/trim-lines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/ts-interface-checker": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
+      "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/tsup": {
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/tsup/-/tsup-8.5.1.tgz",
+      "integrity": "sha512-xtgkqwdhpKWr3tKPmCkvYmS9xnQK3m3XgxZHwSUjvfTjp7YfXe5tT3GgWi0F2N+ZSMsOeWeZFh7ZZFg5iPhing==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bundle-require": "^5.1.0",
+        "cac": "^6.7.14",
+        "chokidar": "^4.0.3",
+        "consola": "^3.4.0",
+        "debug": "^4.4.0",
+        "esbuild": "^0.27.0",
+        "fix-dts-default-cjs-exports": "^1.0.0",
+        "joycon": "^3.1.1",
+        "picocolors": "^1.1.1",
+        "postcss-load-config": "^6.0.1",
+        "resolve-from": "^5.0.0",
+        "rollup": "^4.34.8",
+        "source-map": "^0.7.6",
+        "sucrase": "^3.35.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.11",
+        "tree-kill": "^1.2.2"
+      },
+      "bin": {
+        "tsup": "dist/cli-default.js",
+        "tsup-node": "dist/cli-node.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@microsoft/api-extractor": "^7.36.0",
+        "@swc/core": "^1",
+        "postcss": "^8.4.12",
+        "typescript": ">=4.5.0"
+      },
+      "peerDependenciesMeta": {
+        "@microsoft/api-extractor": {
+          "optional": true
+        },
+        "@swc/core": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.6.0.tgz",
+      "integrity": "sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "dependencies": {
+        "tagged-tag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/typedoc": {
+      "version": "0.26.11",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.26.11.tgz",
+      "integrity": "sha512-sFEgRRtrcDl2FxVP58Ze++ZK2UQAEvtvvH8rRlig1Ja3o7dDaMHmaBfvJmdGnNEFaLTpQsN8dpvZaTqJSu/Ugw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lunr": "^2.3.9",
+        "markdown-it": "^14.1.0",
+        "minimatch": "^9.0.5",
+        "shiki": "^1.16.2",
+        "yaml": "^2.5.1"
+      },
+      "bin": {
+        "typedoc": "bin/typedoc"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "typescript": "4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
+      "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/uc.micro": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ufo": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.3.tgz",
+      "integrity": "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unist-util-is": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/until-async": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/until-async/-/until-async-3.0.2.tgz",
+      "integrity": "sha512-IiSk4HlzAMqTUseHHe3VhIGyuFmN90zMTpD3Z3y8jeQbzLIq500MVM7Jq2vUAnTKAFPJrqwkzr6PoTcPhGcOiw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/kettanaito"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite-node/node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "dev": true,
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    }
+  }
+}

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,0 +1,86 @@
+{
+  "name": "@neo4j-labs/agent-memory",
+  "version": "0.3.0",
+  "description": "Neo4j Labs: TypeScript client for the Neo4j Agent Memory Service (NAMS)",
+  "type": "module",
+  "license": "Apache-2.0",
+  "author": "Neo4j Labs",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/neo4j-labs/agent-memory",
+    "directory": "typescript"
+  },
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    },
+    "./middleware/vercel-ai": {
+      "import": "./dist/middleware/vercel-ai.js",
+      "types": "./dist/middleware/vercel-ai.d.ts"
+    },
+    "./mcp": {
+      "import": "./dist/mcp/index.js",
+      "types": "./dist/mcp/index.d.ts"
+    },
+    "./integrations/langchain": {
+      "import": "./dist/integrations/langchain.js",
+      "types": "./dist/integrations/langchain.d.ts"
+    },
+    "./integrations/mastra": {
+      "import": "./dist/integrations/mastra.js",
+      "types": "./dist/integrations/mastra.d.ts"
+    },
+    "./integrations/strands": {
+      "import": "./dist/integrations/strands.js",
+      "types": "./dist/integrations/strands.d.ts"
+    },
+    "./testing": {
+      "import": "./dist/testing.js",
+      "types": "./dist/testing.d.ts"
+    }
+  },
+  "homepage": "https://neo4j.com/labs/agent-memory/sdks/typescript",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE",
+    "CHANGELOG.md"
+  ],
+  "scripts": {
+    "build": "npm run check:version && tsup",
+    "check:version": "node ./scripts/check-version-sync.mjs",
+    "dev": "tsup --watch",
+    "test": "vitest run test/unit test/integration",
+    "test:unit": "vitest run test/unit",
+    "test:integration": "vitest run test/integration",
+    "test:e2e": "vitest run test/e2e",
+    "test:all": "vitest run",
+    "test:watch": "vitest",
+    "test:tck": "RUN_TCK_BRIDGE=1 vitest run test/tck",
+    "tck:bronze": "RUN_TCK_BRIDGE=1 vitest run test/tck --grep Bronze",
+    "lint": "tsc --noEmit && eslint src/",
+    "docs:api": "typedoc",
+    "conformance:server": "tsx conformance/server.ts",
+    "prepublishOnly": "npm run build"
+  },
+  "devDependencies": {
+    "@ai-sdk/provider": "^3.0.10",
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "@opentelemetry/api": "^1.9.1",
+    "@strands-agents/sdk": "^1.2.0",
+    "@types/node": "^20.0.0",
+    "dotenv": "^17.4.2",
+    "msw": "^2.14.3",
+    "tsup": "^8.0.0",
+    "tsx": "^4.0.0",
+    "typedoc": "^0.26.0",
+    "typescript": "^5.5.0",
+    "vitest": "^2.0.0"
+  },
+  "engines": {
+    "node": ">=20.0.0"
+  }
+}

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -61,7 +61,7 @@
     "test:watch": "vitest",
     "test:tck": "RUN_TCK_BRIDGE=1 vitest run test/tck",
     "tck:bronze": "RUN_TCK_BRIDGE=1 vitest run test/tck --grep Bronze",
-    "lint": "tsc --noEmit && eslint src/",
+    "lint": "tsc --noEmit",
     "docs:api": "typedoc",
     "conformance:server": "tsx conformance/server.ts",
     "prepublishOnly": "npm run build"

--- a/typescript/scripts/check-version-sync.mjs
+++ b/typescript/scripts/check-version-sync.mjs
@@ -1,0 +1,17 @@
+import { readFileSync } from "node:fs";
+
+const pkg = JSON.parse(readFileSync(new URL("../package.json", import.meta.url), "utf8"));
+const versionSource = readFileSync(new URL("../src/version.ts", import.meta.url), "utf8");
+const match = versionSource.match(/export const VERSION = "([^"]+)";/);
+
+if (!match) {
+  console.error("Unable to find VERSION in src/version.ts");
+  process.exit(1);
+}
+
+if (match[1] !== pkg.version) {
+  console.error(
+    `src/version.ts (${match[1]}) does not match package.json (${pkg.version}).`,
+  );
+  process.exit(1);
+}

--- a/typescript/src/auth/index.ts
+++ b/typescript/src/auth/index.ts
@@ -1,0 +1,85 @@
+/**
+ * Auth & API-key management — hosted service only.
+ *
+ * Static `nams_*` keys can be created, listed, revealed, and revoked. OAuth
+ * refresh-token rotation is also exposed for clients running PKCE flows.
+ */
+
+import type { Transport } from "../transport/index.js";
+import type { AccessTokenPair, ApiKey, CreateApiKeyInput } from "../types.js";
+
+interface WireApiKey {
+  id: string;
+  label: string;
+  scopes?: string[];
+  workspace_id: string;
+  created_at: string;
+  expires_at?: string;
+  key?: string;
+}
+
+interface WireTokenPair {
+  access_token: string;
+  refresh_token: string;
+  expires_in: number;
+}
+
+function toApiKey(w: WireApiKey): ApiKey {
+  return {
+    id: w.id,
+    label: w.label,
+    scopes: w.scopes ?? [],
+    workspaceId: w.workspace_id,
+    createdAt: w.created_at,
+    expiresAt: w.expires_at,
+    key: w.key,
+  };
+}
+
+export class AuthClient {
+  constructor(private readonly transport: Transport) {}
+
+  /** List API keys for a workspace (no plaintext). */
+  async listApiKeys(workspaceId: string): Promise<ApiKey[]> {
+    const wire = await this.transport.request<WireApiKey[]>("list_api_keys", {
+      workspace_id: workspaceId,
+    });
+    return (wire ?? []).map(toApiKey);
+  }
+
+  /** Create a new API key. The plaintext value is returned only once. */
+  async createApiKey(input: CreateApiKeyInput): Promise<ApiKey> {
+    const wire = await this.transport.request<WireApiKey>("create_api_key", {
+      label: input.label,
+      scopes: input.scopes,
+      workspace_id: input.workspaceId,
+    });
+    return toApiKey(wire);
+  }
+
+  /** Revoke (delete) an API key by id. */
+  async revokeApiKey(keyId: string): Promise<void> {
+    await this.transport.request("revoke_api_key", { key_id: keyId });
+  }
+
+  /** Reveal the plaintext value of a stored API key. */
+  async revealApiKey(keyId: string, workspaceId: string): Promise<ApiKey> {
+    const wire = await this.transport.request<WireApiKey>("reveal_api_key", {
+      key_id: keyId,
+      workspace_id: workspaceId,
+    });
+    return toApiKey(wire);
+  }
+
+  /** Exchange a refresh token for a fresh access/refresh pair. */
+  async refreshAccessToken(refreshToken: string): Promise<AccessTokenPair> {
+    const wire = await this.transport.request<WireTokenPair>("refresh_access_token", {
+      refresh_token: refreshToken,
+    });
+    return {
+      accessToken: wire.access_token,
+      refreshToken: wire.refresh_token,
+      expiresIn: wire.expires_in,
+    };
+  }
+}

--- a/typescript/src/client.ts
+++ b/typescript/src/client.ts
@@ -1,0 +1,159 @@
+/**
+ * MemoryClient — root entry point for all memory operations.
+ *
+ * Zero-config form (Node, Bun, Deno):
+ *
+ *     const client = new MemoryClient();
+ *
+ * defaults the endpoint to https://memory.neo4jlabs.com/v1 and reads
+ * MEMORY_API_KEY from the environment.
+ *
+ * Edge runtimes (Cloudflare Workers, Vercel Edge) read env from the request
+ * handler scope, not module init, so pass apiKey explicitly:
+ *
+ *     const client = new MemoryClient({ apiKey: env.MEMORY_API_KEY });
+ *
+ * The first request triggers the auth probe automatically; calling
+ * `connect()` upfront is supported but optional.
+ */
+
+import { AuthClient } from "./auth/index.js";
+import { ValidationError } from "./errors.js";
+import { LongTermMemory } from "./long-term/index.js";
+import { QueryConsole } from "./query/index.js";
+import { ReasoningMemory } from "./reasoning/index.js";
+import { ShortTermMemory } from "./short-term/index.js";
+import { BridgeTransport } from "./transport/bridge.js";
+import type { Transport } from "./transport/index.js";
+import { RestTransport } from "./transport/rest.js";
+import type { MemoryClientOptions } from "./types.js";
+
+const DEFAULT_ENDPOINT = "https://memory.neo4jlabs.com/v1";
+
+export class MemoryClient {
+  /** Short-term (conversational) memory operations. */
+  readonly shortTerm: ShortTermMemory;
+
+  /** Long-term (entity / preference / fact / graph) memory operations. */
+  readonly longTerm: LongTermMemory;
+
+  /** Reasoning (trace / step / tool call / provenance) memory operations. */
+  readonly reasoning: ReasoningMemory;
+
+  /** Read-only Cypher query console (hosted service only). */
+  readonly query: QueryConsole;
+
+  /** API-key & OAuth management (hosted service only). */
+  readonly auth: AuthClient;
+
+  private readonly transport: Transport;
+
+  constructor(options?: MemoryClientOptions);
+  constructor(transport: Transport);
+  constructor(optionsOrTransport: MemoryClientOptions | Transport = {}) {
+    if (isTransport(optionsOrTransport)) {
+      this.transport = optionsOrTransport;
+    } else {
+      this.transport = new LazyConnectTransport(createTransport(optionsOrTransport));
+    }
+
+    this.shortTerm = new ShortTermMemory(this.transport);
+    this.longTerm = new LongTermMemory(this.transport);
+    this.reasoning = new ReasoningMemory(this.transport);
+    this.query = new QueryConsole(this.transport);
+    this.auth = new AuthClient(this.transport);
+  }
+
+  async connect(): Promise<void> {
+    await this.transport.connect();
+  }
+
+  async close(): Promise<void> {
+    await this.transport.close();
+  }
+}
+
+function isTransport(obj: unknown): obj is Transport {
+  return (
+    typeof obj === "object" &&
+    obj !== null &&
+    "request" in obj &&
+    typeof (obj as Transport).request === "function"
+  );
+}
+
+function pickTransport(endpoint: string, mode: MemoryClientOptions["transport"]): "bridge" | "rest" {
+  if (mode === "bridge" || mode === "rest") return mode;
+  // Auto: REST if the endpoint path contains /vN (the canonical hosted root).
+  return /\/v\d+\b/.test(endpoint) ? "rest" : "bridge";
+}
+
+/**
+ * Resolve the API key from explicit option or MEMORY_API_KEY env var.
+ *
+ * Explicit `undefined` falls through to env. Explicit empty string does NOT
+ * — passing `apiKey: ""` is treated as "I am intentionally unauthenticated."
+ */
+function resolveApiKey(option: string | undefined): string | undefined {
+  if (option !== undefined) return option;
+  if (typeof process === "undefined" || !process.env) return undefined;
+  return process.env.MEMORY_API_KEY;
+}
+
+function createTransport(options: MemoryClientOptions): Transport {
+  const endpoint = options.endpoint;
+  const apiKey = resolveApiKey(options.apiKey);
+
+  const choice = pickTransport(endpoint ?? DEFAULT_ENDPOINT, options.transport);
+  if (choice === "rest") {
+    return new RestTransport({
+      endpoint: endpoint ?? DEFAULT_ENDPOINT,
+      apiKey,
+      tokenProvider: options.tokenProvider,
+      timeout: options.timeout,
+      headers: options.headers,
+      logger: options.logger,
+    });
+  }
+  if (!endpoint) {
+    throw new ValidationError("endpoint must be provided for bridge transport.");
+  }
+  return new BridgeTransport({
+    endpoint,
+    apiKey,
+    timeout: options.timeout,
+    headers: options.headers,
+    logger: options.logger,
+  });
+}
+
+/**
+ * Wraps a Transport so requests are issued without an upfront connectivity
+ * probe — the first real request becomes the de facto health check. An
+ * explicit `connect()` still triggers the inner connect (and is idempotent
+ * across concurrent callers), letting apps that prefer fail-fast at startup
+ * opt in.
+ */
+class LazyConnectTransport implements Transport {
+  private connectPromise: Promise<void> | null = null;
+
+  constructor(public readonly inner: Transport) {}
+
+  async request<T>(method: string, params: Record<string, unknown>): Promise<T> {
+    return this.inner.request<T>(method, params);
+  }
+
+  async connect(): Promise<void> {
+    if (!this.connectPromise) {
+      this.connectPromise = this.inner.connect().catch((err) => {
+        this.connectPromise = null;
+        throw err;
+      });
+    }
+    return this.connectPromise;
+  }
+
+  async close(): Promise<void> {
+    return this.inner.close();
+  }
+}

--- a/typescript/src/errors.ts
+++ b/typescript/src/errors.ts
@@ -1,0 +1,81 @@
+/**
+ * Error hierarchy for the neo4j-agent-memory TypeScript client.
+ *
+ * Every error from a failed HTTP exchange carries a `requestId` when the
+ * service emitted one. Quote it in support threads for fast log lookup.
+ */
+
+/** Options accepted by every MemoryError subclass. */
+export interface MemoryErrorOptions extends ErrorOptions {
+  /** Server-generated correlation id (x-request-id or equivalent). */
+  requestId?: string;
+}
+
+export class MemoryError extends Error {
+  /** Server-generated correlation id, when available. */
+  public readonly requestId?: string;
+
+  constructor(message: string, options?: MemoryErrorOptions) {
+    super(message, options);
+    this.name = "MemoryError";
+    this.requestId = options?.requestId;
+  }
+
+  override toString(): string {
+    const base = super.toString();
+    return this.requestId ? `${base} [requestId=${this.requestId}]` : base;
+  }
+}
+
+export class ConnectionError extends MemoryError {
+  constructor(message: string, options?: MemoryErrorOptions) {
+    super(message, options);
+    this.name = "ConnectionError";
+  }
+}
+
+export class AuthenticationError extends MemoryError {
+  constructor(message: string, options?: MemoryErrorOptions) {
+    super(message, options);
+    this.name = "AuthenticationError";
+  }
+}
+
+export class NotFoundError extends MemoryError {
+  constructor(message: string, options?: MemoryErrorOptions) {
+    super(message, options);
+    this.name = "NotFoundError";
+  }
+}
+
+export class ValidationError extends MemoryError {
+  constructor(message: string, options?: MemoryErrorOptions) {
+    super(message, options);
+    this.name = "ValidationError";
+  }
+}
+
+export class TransportError extends MemoryError {
+  public readonly statusCode?: number;
+  public readonly responseBody?: unknown;
+
+  constructor(
+    message: string,
+    statusCode?: number,
+    responseBody?: unknown,
+    options?: MemoryErrorOptions,
+  ) {
+    super(message, options);
+    this.name = "TransportError";
+    this.statusCode = statusCode;
+    this.responseBody = responseBody;
+  }
+}
+
+/** Raised when a transport cannot fulfil a method (e.g. REST has no equivalent). */
+export class NotSupportedError extends MemoryError {
+  constructor(message: string, options?: MemoryErrorOptions) {
+    super(message, options);
+    this.name = "NotSupportedError";
+  }
+}

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -1,0 +1,119 @@
+/**
+ * @neo4j-labs/agent-memory — TypeScript client for the Neo4j Agent Memory Service.
+ *
+ * Usage against the hosted service:
+ *
+ *     import { MemoryClient } from "@neo4j-labs/agent-memory";
+ *
+ *     // Reads MEMORY_API_KEY from env; defaults to the hosted endpoint.
+ *     const client = new MemoryClient();
+ *
+ *     const conv = await client.shortTerm.createConversation({ userId: "alice" });
+ *     await client.shortTerm.addMessage(conv.id, "user", "Hello!");
+ *     const ctx = await client.shortTerm.getContext(conv.id);
+ *
+ * Bridge transport for TCK conformance testing is available via the
+ * `@neo4j-labs/agent-memory/testing` subpath.
+ */
+
+export { MemoryClient } from "./client.js";
+
+// Types — short-term
+export type {
+  Message,
+  Conversation,
+  SessionInfo,
+  ConversationContext,
+  Observation,
+  Reflection,
+  MessageRole,
+} from "./types.js";
+
+// Types — long-term
+export type {
+  Entity,
+  EntityType,
+  HostedEntityType,
+  EntityRelationshipRef,
+  EntityHistory,
+  EntityMention,
+  EntityGraph,
+  EntityGraphNode,
+  EntityGraphEdge,
+  EntityFeedbackResult,
+  EntityMergeResult,
+  Preference,
+  Fact,
+  Relationship,
+} from "./types.js";
+
+// Types — reasoning
+export type {
+  ReasoningTrace,
+  ReasoningStep,
+  ToolCall,
+  ToolCallStatus,
+  ToolStats,
+  AgentStep,
+  AgentStepExplanation,
+  ConversationTrace,
+  EntityProvenance,
+} from "./types.js";
+
+// Types — query / auth
+export type { CypherResult, ApiKey, AccessTokenPair } from "./types.js";
+
+// Options
+export type {
+  MemoryClientOptions,
+  TransportMode,
+  AddMessageOptions,
+  GetConversationOptions,
+  SearchMessagesOptions,
+  ListSessionsOptions,
+  SearchEntitiesOptions,
+  SearchPreferencesOptions,
+  GetRelatedEntitiesOptions,
+  ListTracesOptions,
+  RecordToolCallOptions,
+  CompleteTraceOptions,
+  AddRelationshipOptions,
+  GetSimilarTracesOptions,
+  CreateConversationOptions,
+  ListConversationsOptions,
+  BulkMessageInput,
+  ListEntitiesOptions,
+  UpdateEntityOptions,
+  SetEntityFeedbackOptions,
+  RecordStepInput,
+  CreateApiKeyInput,
+} from "./types.js";
+
+// Transports
+export type { Transport } from "./transport/index.js";
+export { RestTransport } from "./transport/index.js";
+export type { RestTransportOptions, TokenProvider } from "./transport/index.js";
+
+// Sub-clients (advanced)
+export { ShortTermMemory } from "./short-term/index.js";
+export { LongTermMemory } from "./long-term/index.js";
+export { ReasoningMemory } from "./reasoning/index.js";
+export { QueryConsole } from "./query/index.js";
+export { AuthClient } from "./auth/index.js";
+
+// Errors
+export {
+  MemoryError,
+  ConnectionError,
+  AuthenticationError,
+  NotFoundError,
+  NotSupportedError,
+  ValidationError,
+  TransportError,
+} from "./errors.js";
+
+// Observability
+export type { Logger, LogEvent } from "./observability.js";
+
+// Version
+export { VERSION } from "./version.js";

--- a/typescript/src/integrations/langchain.ts
+++ b/typescript/src/integrations/langchain.ts
@@ -1,0 +1,109 @@
+/**
+ * LangChain JS integration — exposes `MemoryClient` as a chat-message history
+ * store and as a retriever-shaped object for entity look-up.
+ *
+ * Implementations are duck-typed against the LangChain JS interfaces so this
+ * module has no LangChain dependency at compile time.
+ *
+ * @example
+ * ```ts
+ * import { MemoryClient } from "@neo4j-labs/agent-memory";
+ * import { Neo4jChatMessageHistory, Neo4jEntityRetriever }
+ *   from "@neo4j-labs/agent-memory/integrations/langchain";
+ *
+ * const client = new MemoryClient({ endpoint: "...", apiKey: "..." });
+ * const history = new Neo4jChatMessageHistory(client, "conversation-id");
+ * await history.addUserMessage("hello");
+ * ```
+ */
+
+import type { MemoryClient } from "../client.js";
+
+interface LangchainBaseMessage {
+  type: "human" | "ai" | "system";
+  content: string;
+}
+
+const TYPE_TO_ROLE: Record<LangchainBaseMessage["type"], "user" | "assistant" | "system"> = {
+  human: "user",
+  ai: "assistant",
+  system: "system",
+};
+
+const ROLE_TO_TYPE: Record<"user" | "assistant" | "system", LangchainBaseMessage["type"]> = {
+  user: "human",
+  assistant: "ai",
+  system: "system",
+};
+
+export class Neo4jChatMessageHistory {
+  constructor(
+    private readonly client: MemoryClient,
+    private readonly conversationId: string,
+  ) {}
+
+  async getMessages(): Promise<LangchainBaseMessage[]> {
+    const conv = await this.client.shortTerm.getConversation(this.conversationId);
+    return conv.messages.map((m) => ({
+      type: ROLE_TO_TYPE[m.role] ?? "human",
+      content: m.content,
+    }));
+  }
+
+  async addMessage(message: LangchainBaseMessage): Promise<void> {
+    await this.client.shortTerm.addMessage(
+      this.conversationId,
+      TYPE_TO_ROLE[message.type] ?? "user",
+      message.content,
+    );
+  }
+
+  async addUserMessage(content: string): Promise<void> {
+    await this.addMessage({ type: "human", content });
+  }
+
+  async addAIChatMessage(content: string): Promise<void> {
+    await this.addMessage({ type: "ai", content });
+  }
+
+  async clear(): Promise<void> {
+    await this.client.shortTerm.clearSession(this.conversationId);
+  }
+}
+
+interface LangchainDocument {
+  pageContent: string;
+  metadata: Record<string, unknown>;
+}
+
+/**
+ * Retriever-shaped wrapper over `client.longTerm.searchEntities` that returns
+ * LangChain-compatible `Document` objects.
+ */
+export class Neo4jEntityRetriever {
+  constructor(
+    private readonly client: MemoryClient,
+    private readonly options?: { type?: string; topK?: number },
+  ) {}
+
+  async invoke(query: string): Promise<LangchainDocument[]> {
+    return this.getRelevantDocuments(query);
+  }
+
+  async getRelevantDocuments(query: string): Promise<LangchainDocument[]> {
+    const entities = await this.client.longTerm.searchEntities(query, {
+      type: this.options?.type,
+      limit: this.options?.topK ?? 4,
+    });
+    return entities.map((e) => ({
+      pageContent: `${e.name}${e.description ? ` — ${e.description}` : ""}`,
+      metadata: {
+        id: e.id,
+        type: e.type,
+        confidence: e.confidence,
+        sourceStage: e.sourceStage,
+        canonicalName: e.canonicalName,
+      },
+    }));
+  }
+}

--- a/typescript/src/integrations/mastra.ts
+++ b/typescript/src/integrations/mastra.ts
@@ -1,0 +1,106 @@
+/**
+ * Mastra integration — wraps `MemoryClient` as a Mastra-compatible memory
+ * provider. Mastra's `Memory` interface is duck-typed here to avoid a hard
+ * dependency on `@mastra/core`.
+ *
+ * @example
+ * ```ts
+ * import { MemoryClient } from "@neo4j-labs/agent-memory";
+ * import { Neo4jMastraMemory } from "@neo4j-labs/agent-memory/integrations/mastra";
+ * import { Agent } from "@mastra/core/agent";
+ *
+ * const client = new MemoryClient({ endpoint: "...", apiKey: "..." });
+ * const memory = new Neo4jMastraMemory(client);
+ *
+ * const agent = new Agent({ name: "scout", memory });
+ * ```
+ */
+
+import type { MemoryClient } from "../client.js";
+import { NotSupportedError } from "../errors.js";
+
+export interface MastraThread {
+  id: string;
+  resourceId: string;
+  title?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface MastraMemoryMessage {
+  id: string;
+  threadId: string;
+  role: "user" | "assistant" | "system";
+  content: string;
+  createdAt: string;
+}
+
+export class Neo4jMastraMemory {
+  constructor(private readonly client: MemoryClient) {}
+
+  /** Create a new thread (Mastra term) — backed by createConversation on REST. */
+  async createThread(input: {
+    resourceId: string;
+    title?: string;
+    metadata?: Record<string, unknown>;
+  }): Promise<MastraThread> {
+    try {
+      const conv = await this.client.shortTerm.createConversation({
+        userId: input.resourceId,
+        metadata: { ...input.metadata, mastraTitle: input.title },
+      });
+      return {
+        id: conv.id,
+        resourceId: input.resourceId,
+        title: input.title,
+        metadata: conv.metadata,
+      };
+    } catch (err) {
+      if (err instanceof NotSupportedError) {
+        // Bridge transport: thread id == sessionId from the caller.
+        return { id: input.resourceId, resourceId: input.resourceId, title: input.title };
+      }
+      throw err;
+    }
+  }
+
+  async getMessages(threadId: string, opts?: { limit?: number }): Promise<MastraMemoryMessage[]> {
+    const conv = await this.client.shortTerm.getConversation(threadId, { limit: opts?.limit });
+    return conv.messages.map((m) => ({
+      id: m.id,
+      threadId,
+      role: m.role,
+      content: m.content,
+      createdAt: m.timestamp,
+    }));
+  }
+
+  async saveMessage(input: {
+    threadId: string;
+    role: "user" | "assistant" | "system";
+    content: string;
+    metadata?: Record<string, unknown>;
+  }): Promise<MastraMemoryMessage> {
+    const m = await this.client.shortTerm.addMessage(input.threadId, input.role, input.content, {
+      metadata: input.metadata,
+    });
+    return {
+      id: m.id,
+      threadId: input.threadId,
+      role: m.role,
+      content: m.content,
+      createdAt: m.timestamp,
+    };
+  }
+
+  async deleteThread(threadId: string): Promise<void> {
+    try {
+      await this.client.shortTerm.deleteConversation(threadId);
+    } catch (err) {
+      if (err instanceof NotSupportedError) {
+        await this.client.shortTerm.clearSession(threadId);
+        return;
+      }
+      throw err;
+    }
+  }
+}

--- a/typescript/src/integrations/strands.ts
+++ b/typescript/src/integrations/strands.ts
@@ -1,0 +1,846 @@
+/**
+ * Strands Agents SDK integration — three orthogonal surfaces, exposed
+ * through a single subpath.
+ *
+ *   1. {@link Neo4jSessionStorage} — implements `SnapshotStorage` so
+ *      Strands' `SessionManager` persists session state into a NAMS
+ *      conversation. Hybrid mapping: messages from each snapshot land as
+ *      real `Message` graph nodes via `addMessage`; the rest of the
+ *      framework's per-snapshot state is stashed losslessly in synthetic
+ *      Strands marker messages on that same conversation.
+ *
+ *   2. {@link Neo4jConversationManager} — a `ConversationManager`
+ *      subclass that delegates `reduce()` to an inner manager
+ *      (defaults to `SlidingWindowConversationManager`) AND registers
+ *      a `BeforeInvocationEvent` hook that prepends three-tier context
+ *      (reflections + observations from `getContext()`) to every model
+ *      call. Layered, not replacing — recent-history trimming still
+ *      behaves the way the inner manager defines.
+ *
+ *   3. {@link registerReasoningHooks} — wires Strands hook events to
+ *      our reasoning subclient. Each invocation opens a `ReasoningStep`;
+ *      each tool call records against that step.
+ *
+ *   {@link connectMemoryToAgent} bundles all three for the common case.
+ *
+ * Strands lives in `devDependencies` only — every import below is a
+ * type-only import, erased at compile time. The published
+ * `dist/integrations/strands.js` has no runtime reference to
+ * `@strands-agents/sdk`, so users without Strands installed pay zero
+ * bundle cost.
+ *
+ * @example
+ * ```ts
+ * import { Agent } from "@strands-agents/sdk";
+ * import { MemoryClient } from "@neo4j-labs/agent-memory";
+ * import { connectMemoryToAgent } from "@neo4j-labs/agent-memory/integrations/strands";
+ *
+ * const memory = new MemoryClient();
+ * const conv = await memory.shortTerm.createConversation({ userId: "alice" });
+ *
+ * const agent = new Agent({
+ *   ...await connectMemoryToAgent(memory, { conversationId: conv.id }),
+ *   model,
+ *   tools: [...],
+ * });
+ *
+ * await agent.invoke("Tell me about graph databases.");
+ * ```
+ */
+
+import type {
+  BeforeInvocationEvent as BeforeInvocationEventType,
+  AfterInvocationEvent as AfterInvocationEventType,
+  BeforeToolCallEvent as BeforeToolCallEventType,
+  AfterToolCallEvent as AfterToolCallEventType,
+  LocalAgent,
+  Message as StrandsMessage,
+  Snapshot,
+  SnapshotManifest,
+  SnapshotStorage,
+  SnapshotLocation,
+  ConversationManager as StrandsConversationManager,
+  ConversationManagerReduceOptions,
+  SlidingWindowConversationManager as SlidingWindowConversationManagerType,
+  SessionManager as SessionManagerType,
+  SessionManagerConfig,
+} from "@strands-agents/sdk";
+
+import type { MemoryClient } from "../client.js";
+import type { MessageRole } from "../types.js";
+
+// ---------------------------------------------------------------------------
+// Strands runtime imports are deferred to a small loader so callers who use
+// only types still pay zero runtime cost. Callers who instantiate the
+// classes below MUST have @strands-agents/sdk installed in their own
+// dependencies — same contract as every other duck-typed integration.
+// ---------------------------------------------------------------------------
+
+type StrandsModule = typeof import("@strands-agents/sdk");
+
+let _strandsModule: StrandsModule | null = null;
+
+async function loadStrands(): Promise<StrandsModule> {
+  if (!_strandsModule) {
+    // Dynamic import keeps the static export graph free of @strands-agents/sdk.
+    _strandsModule = (await import("@strands-agents/sdk")) as StrandsModule;
+  }
+  return _strandsModule;
+}
+
+// ---------------------------------------------------------------------------
+// Public options
+// ---------------------------------------------------------------------------
+
+/** Options shared by every public entrypoint in this module. */
+export interface StrandsIntegrationOptions {
+  /**
+   * NAMS Conversation id to wire to. Required by the convenience factory and
+   * by individual exports that need correlation across invocations.
+   */
+  conversationId: string;
+
+  /** Include reflections from `getContext()` in prompt injection. Default: true. */
+  includeReflections?: boolean;
+
+  /** Include observations from `getContext()` in prompt injection. Default: true. */
+  includeObservations?: boolean;
+}
+
+/** Options for {@link Neo4jConversationManager}. */
+export interface Neo4jConversationManagerOptions
+  extends Pick<StrandsIntegrationOptions, "conversationId" | "includeReflections" | "includeObservations"> {
+  /**
+   * Inner `ConversationManager` to delegate `reduce()` to. When omitted,
+   * defaults to `SlidingWindowConversationManager` (constructed lazily so
+   * Strands' module is only loaded if the manager is actually used).
+   */
+  inner?: StrandsConversationManager;
+}
+
+/** Options for {@link registerReasoningHooks}. */
+export interface ReasoningHooksOptions {
+  /** NAMS Conversation id to attribute reasoning steps and tool calls to. */
+  conversationId: string;
+}
+
+// ---------------------------------------------------------------------------
+// SnapshotStorage
+// ---------------------------------------------------------------------------
+
+/**
+ * Strands snapshot state is persisted as synthetic `role: "user"`
+ * messages on the NAMS conversation. NAMS exposes no conversation-
+ * metadata-update endpoint, so we use the only write surface that
+ * works robustly: a message whose `content` carries both the marker
+ * prefix AND the JSON-serialized blob, base64-encoded for safety.
+ *
+ * The historical choice of `role: "system"` + per-message metadata was
+ * abandoned after live-service testing showed that NAMS' GET
+ * /conversations/{id}/messages either filters out `system`-role
+ * messages or doesn't surface per-message metadata on read (or both).
+ * `role: "user"` is universally preserved, and stuffing the blob inline
+ * in `content` removes the dependency on metadata round-tripping.
+ *
+ * Each distinct snapshot state writes ONE synthetic message:
+ *
+ *   { role: "user", content: "__strands_state__:{base64(JSON.stringify(blob))}" }
+ *
+ * Manifests use a parallel prefix `__strands_manifest__:`. Consumers
+ * walking the message list MUST filter these out — see
+ * {@link isSyntheticStrandsMessage}. Strands' agent loop never sees
+ * them because {@link Neo4jSessionStorage.loadSnapshot} strips them
+ * before returning the reconstructed Snapshot.
+ *
+ * Per-snapshot synthetic messages mean `listSnapshotIds` is O(n) over
+ * the message list, but repeated idempotent saves short-circuit when the
+ * latest stored blob already matches. In practice snapshots are small
+ * JSON deltas and the conversation's message count is bounded — fine for v0.x.
+ */
+const STATE_PREFIX = "__strands_state__:";
+const MANIFEST_PREFIX = "__strands_manifest__:";
+
+/** Role used for synthetic state messages. */
+const SYNTHETIC_ROLE: MessageRole = "user";
+
+function encodeBlob(blob: unknown): string {
+  return base64Encode(JSON.stringify(blob));
+}
+
+function decodeBlob<T>(content: string, prefix: string): T | null {
+  if (!content.startsWith(prefix)) return null;
+  const payload = content.slice(prefix.length);
+  try {
+    return JSON.parse(base64Decode(payload)) as T;
+  } catch {
+    return null;
+  }
+}
+
+function base64Encode(s: string): string {
+  // Use Buffer when available (Node, Bun, edge runtimes with shims),
+  // else fall back to a btoa-on-UTF8 path for purer browser-like runtimes.
+  if (typeof Buffer !== "undefined") {
+    return Buffer.from(s, "utf8").toString("base64");
+  }
+  // eslint-disable-next-line no-restricted-globals
+  const g = globalThis as { btoa?: (s: string) => string };
+  if (typeof g.btoa === "function") {
+    // btoa requires Latin-1; wrap UTF-8 bytes first.
+    const bytes = new TextEncoder().encode(s);
+    let bin = "";
+    for (const b of bytes) bin += String.fromCharCode(b);
+    return g.btoa(bin);
+  }
+  throw new Error("No base64 encoder available in this runtime");
+}
+
+function base64Decode(b64: string): string {
+  if (typeof Buffer !== "undefined") {
+    return Buffer.from(b64, "base64").toString("utf8");
+  }
+  // eslint-disable-next-line no-restricted-globals
+  const g = globalThis as { atob?: (s: string) => string };
+  if (typeof g.atob === "function") {
+    const bin = g.atob(b64);
+    const bytes = new Uint8Array(bin.length);
+    for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
+    return new TextDecoder().decode(bytes);
+  }
+  throw new Error("No base64 decoder available in this runtime");
+}
+
+interface StrandsStateBlob {
+  /** snapshotId associated with this synthetic message. */
+  snapshotId: string;
+  /** Whether this save asserted itself as the latest. */
+  isLatest: boolean;
+  /** Snapshot data with messages stripped. */
+  snapshot: Snapshot;
+  /** Wall-clock save time (ISO 8601). Tie-breaker for "latest" elections. */
+  savedAt: string;
+}
+
+interface StrandsManifestBlob {
+  /** SnapshotLocation.scopeId so multiple agents per session can co-exist. */
+  scopeId: string;
+  manifest: SnapshotManifest;
+  savedAt: string;
+}
+
+/**
+ * Returns true if a message is one of our synthetic state/manifest
+ * markers. Exported so consumers walking the conversation can filter
+ * them out of UI rendering. See `SYNTHETIC_MESSAGE_PREFIXES` for the
+ * canonical prefix list.
+ *
+ * Recognizes ANY role — the storage role used by the integration is
+ * `"user"`, but older saves may have used `"system"`. We match on the
+ * content prefix alone for resilience.
+ */
+export function isSyntheticStrandsMessage(
+  message: { role: string; content: string },
+): boolean {
+  return (
+    message.content.startsWith(STATE_PREFIX) ||
+    message.content.startsWith(MANIFEST_PREFIX)
+  );
+}
+
+/**
+ * Canonical content prefixes used for synthetic messages. Consumers
+ * (chat UIs, message-list renderers, Cypher queries) can filter on
+ * these to skip the Strands-internal state messages.
+ */
+export const SYNTHETIC_MESSAGE_PREFIXES = [STATE_PREFIX, MANIFEST_PREFIX] as const;
+
+/**
+ * Implements Strands' `SnapshotStorage` against a NAMS `MemoryClient`.
+ *
+ * One Strands session = one NAMS Conversation (keyed by `location.sessionId`).
+ * Snapshots are versions within that conversation:
+ *
+ * - Real conversation messages from `snapshot.data.messages` land as real
+ *   `Message` graph nodes via `addMessage` (so entity extraction, search,
+ *   and the graph view all work on them).
+ * - Non-message snapshot state (Strands' `data` minus `messages`, plus
+ *   `appData`, plus the manifest) is persisted as synthetic `role: "user"`
+ *   messages whose content carries both a marker prefix and a
+ *   base64-encoded JSON blob. NAMS exposes `POST /conversations/{id}/messages`
+ *   as the only documented conversation-scoped write, so this approach
+ *   stays within the documented API surface.
+ *
+ * Consumers walking the message list (chat UIs, Cypher queries) MUST
+ * filter synthetic messages with {@link isSyntheticStrandsMessage}.
+ * Strands itself never sees them: {@link Neo4jSessionStorage.loadSnapshot}
+ * strips them from the reconstructed Snapshot before handing back to
+ * `SessionManager`.
+ *
+ * Auth errors propagate — Strands needs to know if the backing store is
+ * unreachable. Transient errors propagate too; Strands' own retry
+ * semantics (in `SessionManager`) apply.
+ */
+export class Neo4jSessionStorage implements SnapshotStorage {
+  constructor(private readonly memory: MemoryClient) {}
+
+  async saveSnapshot(params: {
+    location: SnapshotLocation;
+    snapshotId: string;
+    isLatest: boolean;
+    snapshot: Snapshot;
+  }): Promise<void> {
+    const { location, snapshotId, isLatest, snapshot } = params;
+    const conversationId = location.sessionId;
+    const existingConversation = await this.memory.shortTerm.getConversation(conversationId);
+
+    // 1. Extract conversation messages out of snapshot.data.messages and
+    //    persist any new ones as real Message nodes. Dedupe by role+content
+    //    so re-saving the same snapshot doesn't grow the message list.
+    await this.extractAndPersistMessages(conversationId, snapshot, existingConversation.messages);
+
+    // 2. Write a synthetic user message whose content carries the full
+    //    state blob (base64-encoded JSON after the marker prefix).
+    const strippedSnapshot = stripMessagesFromSnapshot(snapshot);
+    const blob: StrandsStateBlob = {
+      snapshotId,
+      isLatest,
+      snapshot: strippedSnapshot,
+      savedAt: new Date().toISOString(),
+    };
+    const previous = findLastStateBlobForSnapshotId(
+      this.readStateBlobs(existingConversation.messages),
+      snapshotId,
+    );
+    if (previous && sameStateBlob(previous, blob)) return;
+    await this.memory.shortTerm.addMessage(
+      conversationId,
+      SYNTHETIC_ROLE,
+      `${STATE_PREFIX}${encodeBlob(blob)}`,
+    );
+  }
+
+  async loadSnapshot(params: {
+    location: SnapshotLocation;
+    snapshotId?: string;
+  }): Promise<Snapshot | null> {
+    const conversationId = params.location.sessionId;
+    const conv = await this.memory.shortTerm.getConversation(conversationId);
+
+    const stateBlobs = this.readStateBlobs(conv.messages);
+    if (stateBlobs.length === 0) return null;
+
+    // If a snapshotId was requested, find that specific save.
+    // Otherwise fall back to the most recent save where isLatest=true,
+    // or the latest save overall if none asserted "latest".
+    let blob: StrandsStateBlob | undefined;
+    if (params.snapshotId) {
+      blob = findLastStateBlobForSnapshotId(stateBlobs, params.snapshotId);
+    } else {
+      blob = [...stateBlobs].reverse().find((b) => b.isLatest) ??
+        stateBlobs[stateBlobs.length - 1];
+    }
+    if (!blob) return null;
+
+    // Re-hydrate the snapshot: combine the stored data/appData with the
+    // current conversation messages (filtered to drop our synthetic
+    // markers so Strands doesn't replay them).
+    const realMessages = conv.messages
+      .filter((m) => !isSyntheticStrandsMessage(m))
+      .map(toStrandsMessage);
+    return mergeMessagesIntoSnapshot(blob.snapshot, realMessages);
+  }
+
+  async listSnapshotIds(params: {
+    location: SnapshotLocation;
+    limit?: number;
+    startAfter?: string;
+  }): Promise<string[]> {
+    const conv = await this.memory.shortTerm.getConversation(params.location.sessionId);
+    const stateBlobs = this.readStateBlobs(conv.messages);
+    // Preserve save order. Dedupe per snapshotId in case a snapshotId is
+    // saved more than once (Strands' contract permits re-saves).
+    const seen = new Set<string>();
+    const ids: string[] = [];
+    for (const blob of stateBlobs) {
+      if (seen.has(blob.snapshotId)) continue;
+      seen.add(blob.snapshotId);
+      ids.push(blob.snapshotId);
+    }
+    let start = 0;
+    if (params.startAfter) {
+      const idx = ids.indexOf(params.startAfter);
+      start = idx >= 0 ? idx + 1 : 0;
+    }
+    return ids.slice(start, params.limit ? start + params.limit : undefined);
+  }
+
+  async deleteSession(params: { sessionId: string }): Promise<void> {
+    await this.memory.shortTerm.deleteConversation(params.sessionId);
+  }
+
+  async loadManifest(params: { location: SnapshotLocation }): Promise<SnapshotManifest> {
+    const conv = await this.memory.shortTerm.getConversation(params.location.sessionId);
+    const blobs = this.readManifestBlobs(conv.messages);
+    // Last write wins per scopeId — Strands writes manifests rarely so the
+    // O(n) scan is fine.
+    const matching = blobs.filter((b) => b.scopeId === params.location.scopeId);
+    return matching[matching.length - 1]?.manifest ?? defaultManifest();
+  }
+
+  async saveManifest(params: {
+    location: SnapshotLocation;
+    manifest: SnapshotManifest;
+  }): Promise<void> {
+    const blob: StrandsManifestBlob = {
+      scopeId: params.location.scopeId,
+      manifest: params.manifest,
+      savedAt: new Date().toISOString(),
+    };
+    await this.memory.shortTerm.addMessage(
+      params.location.sessionId,
+      SYNTHETIC_ROLE,
+      `${MANIFEST_PREFIX}${encodeBlob(blob)}`,
+    );
+  }
+
+  // --- Internals ------------------------------------------------------------
+
+  /**
+   * Scan a conversation's message list and parse any state markers into
+   * blobs, in original order. Matches on the content prefix alone for
+   * resilience against role normalization on the service side.
+   */
+  private readStateBlobs(
+    messages: Array<{ role: string; content: string }>,
+  ): StrandsStateBlob[] {
+    const blobs: StrandsStateBlob[] = [];
+    for (const msg of messages) {
+      const blob = decodeBlob<StrandsStateBlob>(msg.content, STATE_PREFIX);
+      if (blob) blobs.push(blob);
+    }
+    return blobs;
+  }
+
+  /** Same idea, for manifest markers. */
+  private readManifestBlobs(
+    messages: Array<{ role: string; content: string }>,
+  ): StrandsManifestBlob[] {
+    const blobs: StrandsManifestBlob[] = [];
+    for (const msg of messages) {
+      const blob = decodeBlob<StrandsManifestBlob>(msg.content, MANIFEST_PREFIX);
+      if (blob) blobs.push(blob);
+    }
+    return blobs;
+  }
+
+  /**
+   * Pull the message list out of `snapshot.data.messages` (the canonical
+   * Strands layout), find ones not yet present on the conversation
+   * (excluding our synthetic markers), and persist them via `addMessage`.
+   * Returns the number of new messages written.
+   */
+  private async extractAndPersistMessages(
+    conversationId: string,
+    snapshot: Snapshot,
+    existingMessages?: Array<{ role: string; content: string }>,
+  ): Promise<number> {
+    const messages = pickStrandsMessages(snapshot);
+    if (messages.length === 0) return 0;
+
+    const seen = new Set(
+      (existingMessages ??
+        (await this.memory.shortTerm.getConversation(conversationId)).messages)
+        .filter((m) => !isSyntheticStrandsMessage(m))
+        .map((m) => `${m.role}::${m.content}`),
+    );
+
+    let writes = 0;
+    for (const msg of messages) {
+      const text = strandsMessageToText(msg);
+      const key = `${msg.role}::${text}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      await this.memory.shortTerm.addMessage(conversationId, msg.role as MessageRole, text);
+      writes++;
+    }
+    return writes;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// ConversationManager
+// ---------------------------------------------------------------------------
+
+/**
+ * Layered ConversationManager: context-injection hook + inner manager.
+ *
+ * The inner manager (defaults to `SlidingWindowConversationManager`) owns
+ * trimming and summarization. This manager registers a
+ * `BeforeInvocationEvent` hook that prepends reflections + observations from
+ * `getContext()` as system messages, BEFORE the inner manager's reduce
+ * logic runs.
+ *
+ * Lazily constructs an inner manager on first `initAgent` invocation so
+ * importing this module doesn't load Strands' runtime unless the manager
+ * is actually used.
+ */
+export class Neo4jConversationManager {
+  public readonly name = "neo4j:context-injection";
+  /**
+   * Mirrored from Strands' `ConversationManager` to satisfy duck-typing
+   * at compile time. We never set it — context injection has no notion
+   * of a compression threshold.
+   */
+  protected readonly _compressionThreshold: number | undefined = undefined;
+
+  // We can't extend Strands' abstract class via a static `extends` clause
+  // because Strands is a dynamic import — the base class identity isn't
+  // known at module-load time. Instead we *delegate* to a lazily-built
+  // inner manager and implement the abstract surface explicitly. Strands
+  // duck-types on shape, not on instanceof, so this works.
+
+  private inner: StrandsConversationManager | null = null;
+
+  constructor(
+    private readonly memory: MemoryClient,
+    private readonly options: Neo4jConversationManagerOptions,
+  ) {}
+
+  async reduce(opts: ConversationManagerReduceOptions): Promise<boolean> {
+    const inner = await this.ensureInner();
+    return inner.reduce(opts);
+  }
+
+  async initAgent(agent: LocalAgent): Promise<void> {
+    const inner = await this.ensureInner();
+    inner.initAgent(agent);
+
+    const strands = await loadStrands();
+    // Register a hook to inject three-tier context BEFORE every model call.
+    agent.addHook(
+      strands.BeforeInvocationEvent,
+      async (event: BeforeInvocationEventType) => {
+        await this.injectContext(event);
+      },
+    );
+  }
+
+  private async ensureInner(): Promise<StrandsConversationManager> {
+    if (this.inner) return this.inner;
+    if (this.options.inner) {
+      this.inner = this.options.inner;
+      return this.inner;
+    }
+    const strands = await loadStrands();
+    const Ctor =
+      strands.SlidingWindowConversationManager as new () => SlidingWindowConversationManagerType;
+    this.inner = new Ctor();
+    return this.inner;
+  }
+
+  private async injectContext(event: BeforeInvocationEventType): Promise<void> {
+    try {
+      const ctx = await this.memory.shortTerm.getContext(this.options.conversationId);
+      const prepend: StrandsMessage[] = [];
+      const includeReflections = this.options.includeReflections ?? true;
+      const includeObservations = this.options.includeObservations ?? true;
+
+      if (includeReflections && ctx.reflections.length > 0) {
+        for (const r of ctx.reflections) {
+          prepend.push(contextInjectionMessage(`[reflection] ${r.content}`));
+        }
+      }
+      if (includeObservations && ctx.observations.length > 0) {
+        for (const o of ctx.observations) {
+          prepend.push(contextInjectionMessage(`[observation] ${o.content}`));
+        }
+      }
+
+      if (prepend.length === 0) return;
+
+      // Prepend by mutating agent.messages in place. The order MUST be
+      // [context...] + [existing messages...]. Strands' inner manager
+      // may later trim from the head — that's intentional (these
+      // injections aren't sacred; staleness > overflow).
+      const agentLike = event.agent as unknown as { messages: StrandsMessage[] };
+      agentLike.messages = [...prepend, ...agentLike.messages];
+    } catch {
+      // Context injection is best-effort. A failed getContext() (transient,
+      // not-supported, etc.) must not break the agent run — we just fall
+      // back to whatever the inner manager produces.
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Reasoning hooks
+// ---------------------------------------------------------------------------
+
+/** Key in `invocationState` where the current reasoning step id is stashed. */
+const INVOCATION_STEP_ID_KEY = "__neo4jReasoningStepId";
+/** Key in `invocationState` where the per-invocation tool-call → toolCallId map lives. */
+const TOOL_CALL_MAP_KEY = "__neo4jReasoningToolCalls";
+
+/**
+ * Wire reasoning capture onto a Strands `HookRegistry`.
+ *
+ * - `BeforeInvocationEvent` → `reasoning.recordStep` (opens a step; stashes
+ *   step id on `event.invocationState`).
+ * - `AfterInvocationEvent` → re-records the step with a `result` field
+ *   (best-effort; we don't have a public `updateStep` API yet, so the
+ *   second write supplements rather than mutates).
+ * - `BeforeToolCallEvent` → `reasoning.recordToolCall` with status
+ *   `pending`. Strands tool-call id → our tool-call id map stashed on
+ *   `invocationState`.
+ * - `AfterToolCallEvent` → updates the recorded tool call's status.
+ *
+ * All capture is best-effort: every reasoning write is wrapped in try/catch
+ * and silently swallowed on failure. Reasoning capture must never break the
+ * agent run.
+ */
+export async function registerReasoningHooks(
+  memory: MemoryClient,
+  agent: LocalAgent,
+  options: ReasoningHooksOptions,
+): Promise<void> {
+  return registerReasoningHooksOnAgent(memory, agent, options);
+}
+
+async function registerReasoningHooksOnAgent(
+  memory: MemoryClient,
+  agent: LocalAgent,
+  options: ReasoningHooksOptions,
+): Promise<void> {
+  const strands = await loadStrands();
+  const conversationId = options.conversationId;
+
+  agent.addHook(strands.BeforeInvocationEvent, async (event: BeforeInvocationEventType) => {
+    try {
+      const step = await memory.reasoning.recordStep({
+        conversationId,
+        reasoning: "agent invocation started",
+        actionTaken: "invoke_agent",
+      });
+      (event.invocationState as Record<string, unknown>)[INVOCATION_STEP_ID_KEY] = step.id;
+      (event.invocationState as Record<string, unknown>)[TOOL_CALL_MAP_KEY] = new Map<
+        string,
+        string
+      >();
+    } catch {
+      /* best-effort */
+    }
+  });
+
+  agent.addHook(strands.AfterInvocationEvent, async (event: AfterInvocationEventType) => {
+    try {
+      const stepId = (event.invocationState as Record<string, unknown>)[INVOCATION_STEP_ID_KEY];
+      if (typeof stepId !== "string") return;
+      // Record a follow-up step with the result, since the current
+      // reasoning API doesn't expose updateStep. This is intentional —
+      // the after-invocation marker is a separate point in the trace.
+      await memory.reasoning.recordStep({
+        conversationId,
+        reasoning: `agent invocation completed (step ${stepId})`,
+        actionTaken: "invocation_complete",
+        result: "ok",
+      });
+    } catch {
+      /* best-effort */
+    }
+  });
+
+  agent.addHook(strands.BeforeToolCallEvent, async (event: BeforeToolCallEventType) => {
+    try {
+      const stepId = (event.invocationState as Record<string, unknown>)[INVOCATION_STEP_ID_KEY];
+      if (typeof stepId !== "string") return;
+      const toolCall = await memory.reasoning.recordToolCall(
+        stepId,
+        event.toolUse.name,
+        event.toolUse.input as Record<string, unknown>,
+        { status: "pending" },
+      );
+      const map = (event.invocationState as Record<string, unknown>)[TOOL_CALL_MAP_KEY];
+      if (map instanceof Map) {
+        map.set(event.toolUse.toolUseId, toolCall.id);
+      }
+    } catch {
+      /* best-effort */
+    }
+  });
+
+  agent.addHook(strands.AfterToolCallEvent, async (event: AfterToolCallEventType) => {
+    try {
+      const stepId = (event.invocationState as Record<string, unknown>)[INVOCATION_STEP_ID_KEY];
+      if (typeof stepId !== "string") return;
+      // We don't have a public updateToolCall API yet either — record a
+      // follow-up tool-call entry with the resolved status. Pair-up via
+      // the same toolUseId-keyed map for future updateToolCall support.
+      await memory.reasoning.recordToolCall(
+        stepId,
+        event.toolUse.name,
+        event.toolUse.input as Record<string, unknown>,
+        {
+          status: event.error ? "failure" : "success",
+          error: event.error?.message,
+        },
+      );
+    } catch {
+      /* best-effort */
+    }
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Convenience factory
+// ---------------------------------------------------------------------------
+
+/** Result of {@link connectMemoryToAgent} — spread directly into `new Agent({ ... })`. */
+export interface ConnectMemoryToAgentResult {
+  sessionManager: SessionManagerType;
+  /**
+   * Typed as `StrandsConversationManager` (the abstract base) so callers
+   * can spread the result straight into `new Agent({ ... })` without
+   * casts. At runtime this is a {@link Neo4jConversationManager}.
+   */
+  conversationManager: StrandsConversationManager;
+}
+
+/**
+ * One-shot helper that wires the SessionStorage, the ConversationManager, and
+ * (lazily) the reasoning hooks against a NAMS `MemoryClient`. Spread the
+ * return value into `new Agent({ ... })`.
+ *
+ * Reasoning hooks attach themselves automatically when the conversation
+ * manager's `initAgent` runs — no separate registration step required.
+ */
+export async function connectMemoryToAgent(
+  memory: MemoryClient,
+  options: StrandsIntegrationOptions,
+): Promise<ConnectMemoryToAgentResult> {
+  const strands = await loadStrands();
+  const sessionManager = new strands.SessionManager({
+    sessionId: options.conversationId,
+    storage: { snapshot: new Neo4jSessionStorage(memory) },
+  } satisfies SessionManagerConfig);
+
+  // Wrap Neo4jConversationManager so its initAgent ALSO registers the
+  // reasoning hooks. Cleaner than asking the caller to do two things.
+  const baseManager = new Neo4jConversationManager(memory, options);
+  const originalInit = baseManager.initAgent.bind(baseManager);
+  baseManager.initAgent = async (agent: LocalAgent) => {
+    await originalInit(agent);
+    await registerReasoningHooksOnAgent(memory, agent, {
+      conversationId: options.conversationId,
+    });
+  };
+
+  return {
+    sessionManager,
+    conversationManager: baseManager as unknown as StrandsConversationManager,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function defaultManifest(): SnapshotManifest {
+  return {
+    schemaVersion: "1.0",
+    updatedAt: new Date().toISOString(),
+  };
+}
+
+function pickStrandsMessages(snapshot: Snapshot): StrandsMessage[] {
+  const data = snapshot.data as { messages?: unknown } | undefined;
+  if (!data || !Array.isArray(data.messages)) return [];
+  return data.messages as StrandsMessage[];
+}
+
+function stripMessagesFromSnapshot(snapshot: Snapshot): Snapshot {
+  // Defensive shallow copy; messages live in the graph from here on.
+  const nextData = { ...(snapshot.data ?? {}) };
+  delete (nextData as Record<string, unknown>).messages;
+  return { ...snapshot, data: nextData };
+}
+
+function mergeMessagesIntoSnapshot(
+  blob: Snapshot,
+  messages: StrandsMessage[],
+): Snapshot {
+  // Cast through unknown — Snapshot.data is typed as Record<string, JSONValue>
+  // but Strands itself stores messages there, so the runtime shape matches.
+  return {
+    ...blob,
+    data: { ...(blob.data ?? {}), messages: messages as unknown as never },
+  };
+}
+
+function strandsMessageToText(msg: StrandsMessage): string {
+  // Strands messages carry ContentBlock[]. Flatten plain-text blocks into a
+  // single string; non-text blocks (images, tool uses) are described by tag.
+  const blocks = (msg as unknown as { content: unknown[] }).content ?? [];
+  if (!Array.isArray(blocks)) return "";
+  const parts: string[] = [];
+  for (const b of blocks) {
+    if (b && typeof b === "object") {
+      const block = b as { text?: unknown; type?: string };
+      if (typeof block.text === "string") {
+        parts.push(block.text);
+      } else if (block.type) {
+        parts.push(`[${block.type}]`);
+      }
+    }
+  }
+  return parts.join("\n");
+}
+
+function toStrandsMessage(m: { role: string; content: string }): StrandsMessage {
+  return {
+    role: m.role as StrandsMessage["role"],
+    content: [{ text: m.content }] as unknown as StrandsMessage["content"],
+  } as StrandsMessage;
+}
+
+function contextInjectionMessage(text: string): StrandsMessage {
+  return {
+    role: "system" as StrandsMessage["role"],
+    content: [{ text }] as unknown as StrandsMessage["content"],
+  } as StrandsMessage;
+}
+
+function sameStateBlob(a: StrandsStateBlob, b: StrandsStateBlob): boolean {
+  return (
+    a.snapshotId === b.snapshotId &&
+    a.isLatest === b.isLatest &&
+    jsonLikeEqual(a.snapshot, b.snapshot)
+  );
+}
+
+function findLastStateBlobForSnapshotId(
+  blobs: StrandsStateBlob[],
+  snapshotId: string,
+): StrandsStateBlob | undefined {
+  for (let i = blobs.length - 1; i >= 0; i--) {
+    if (blobs[i]?.snapshotId === snapshotId) return blobs[i];
+  }
+  return undefined;
+}
+
+function jsonLikeEqual(a: unknown, b: unknown): boolean {
+  if (Object.is(a, b)) return true;
+  if (typeof a !== typeof b) return false;
+  if (Array.isArray(a) || Array.isArray(b)) {
+    if (!Array.isArray(a) || !Array.isArray(b) || a.length !== b.length) return false;
+    return a.every((value, index) => jsonLikeEqual(value, b[index]));
+  }
+  if (a && b && typeof a === "object" && typeof b === "object") {
+    const aRecord = a as Record<string, unknown>;
+    const bRecord = b as Record<string, unknown>;
+    const aKeys = Object.keys(aRecord);
+    const bKeys = Object.keys(bRecord);
+    if (aKeys.length !== bKeys.length) return false;
+    return aKeys.every((key) => key in bRecord && jsonLikeEqual(aRecord[key], bRecord[key]));
+  }
+  return false;
+}

--- a/typescript/src/long-term/index.ts
+++ b/typescript/src/long-term/index.ts
@@ -1,0 +1,386 @@
+/**
+ * Long-term memory operations.
+ *
+ * Bridge methods (Silver tier) plus Volume 5 / hosted-native methods for
+ * entity feedback, history, merge-by-id, graph view, and provenance.
+ */
+
+import type { Transport } from "../transport/index.js";
+import type {
+  AddRelationshipOptions,
+  Entity,
+  EntityFeedbackResult,
+  EntityGraph,
+  EntityGraphEdge,
+  EntityGraphNode,
+  EntityHistory,
+  EntityMention,
+  EntityMergeResult,
+  EntityRelationshipRef,
+  Fact,
+  GetRelatedEntitiesOptions,
+  ListEntitiesOptions,
+  Preference,
+  Relationship,
+  SearchEntitiesOptions,
+  SearchPreferencesOptions,
+  SetEntityFeedbackOptions,
+  UpdateEntityOptions,
+} from "../types.js";
+
+interface WireEntity {
+  id: string;
+  name: string;
+  type: string;
+  subtype?: string;
+  description?: string;
+  embedding?: number[];
+  canonical_name?: string;
+  created_at?: string;
+  updated_at?: string;
+  confidence?: number;
+  source_stage?: string;
+  relationships?: WireEntityRelRef[];
+}
+
+interface WireEntityRelRef {
+  id: string;
+  type: string;
+  target_id: string;
+  target_name?: string;
+  properties?: Record<string, unknown>;
+}
+
+interface WirePreference {
+  id: string;
+  category: string;
+  preference: string;
+  context?: string;
+  embedding?: number[];
+}
+
+interface WireFact {
+  id: string;
+  subject: string;
+  predicate: string;
+  object: string;
+  embedding?: number[];
+}
+
+interface WireRelationship {
+  id: string;
+  source_id: string;
+  target_id: string;
+  relationship_type: string;
+  properties?: Record<string, unknown>;
+}
+
+interface WireEntityHistory {
+  entity_id: string;
+  mentions: WireMention[];
+}
+
+interface WireMention {
+  conversation_id: string;
+  message_id?: string;
+  content: string;
+  timestamp: string;
+}
+
+interface WireGraphNode {
+  id: string;
+  name: string;
+  type: string;
+}
+
+interface WireGraphEdge {
+  id: string;
+  source: string;
+  target: string;
+  type: string;
+}
+
+interface WireGraph {
+  nodes?: WireGraphNode[];
+  edges?: WireGraphEdge[];
+}
+
+function toEntity(w: WireEntity): Entity {
+  return {
+    id: w.id,
+    name: w.name,
+    type: w.type,
+    subtype: w.subtype,
+    description: w.description,
+    embedding: w.embedding,
+    canonicalName: w.canonical_name,
+    createdAt: w.created_at ?? "",
+    updatedAt: w.updated_at,
+    confidence: w.confidence,
+    sourceStage: w.source_stage,
+    relationships: w.relationships?.map(toRelRef),
+  };
+}
+
+function toRelRef(w: WireEntityRelRef): EntityRelationshipRef {
+  return {
+    id: w.id,
+    type: w.type,
+    targetId: w.target_id,
+    targetName: w.target_name,
+    properties: w.properties,
+  };
+}
+
+function toPreference(w: WirePreference): Preference {
+  return {
+    id: w.id,
+    category: w.category,
+    preference: w.preference,
+    context: w.context,
+    embedding: w.embedding,
+  };
+}
+
+function toFact(w: WireFact): Fact {
+  return {
+    id: w.id,
+    subject: w.subject,
+    predicate: w.predicate,
+    object: w.object,
+    embedding: w.embedding,
+  };
+}
+
+function toRelationship(w: WireRelationship): Relationship {
+  return {
+    id: w.id,
+    sourceId: w.source_id,
+    targetId: w.target_id,
+    relationshipType: w.relationship_type,
+    properties: w.properties ?? {},
+  };
+}
+
+function toMention(w: WireMention): EntityMention {
+  return {
+    conversationId: w.conversation_id,
+    messageId: w.message_id,
+    content: w.content,
+    timestamp: w.timestamp,
+  };
+}
+
+function toGraphNode(w: WireGraphNode): EntityGraphNode {
+  return { id: w.id, name: w.name, type: w.type };
+}
+
+function toGraphEdge(w: WireGraphEdge): EntityGraphEdge {
+  return { id: w.id, source: w.source, target: w.target, type: w.type };
+}
+
+export class LongTermMemory {
+  constructor(private readonly transport: Transport) {}
+
+  // ---- Silver tier (bridge) ----------------------------------------------
+
+  async addEntity(
+    name: string,
+    entityType: string,
+    options?: { description?: string },
+  ): Promise<Entity> {
+    const wire = await this.transport.request<WireEntity>("add_entity", {
+      name,
+      entity_type: entityType,
+      type: entityType,
+      description: options?.description,
+    });
+    return toEntity(wire);
+  }
+
+  async addPreference(
+    category: string,
+    preference: string,
+    options?: { context?: string },
+  ): Promise<Preference> {
+    const wire = await this.transport.request<WirePreference>("add_preference", {
+      category,
+      preference,
+      context: options?.context,
+    });
+    return toPreference(wire);
+  }
+
+  async addFact(subject: string, predicate: string, obj: string): Promise<Fact> {
+    const wire = await this.transport.request<WireFact>("add_fact", {
+      subject,
+      predicate,
+      obj,
+    });
+    return toFact(wire);
+  }
+
+  async searchEntities(query: string, options?: SearchEntitiesOptions): Promise<Entity[]> {
+    const wire = await this.transport.request<WireEntity[]>("search_entities", {
+      query,
+      type: options?.type,
+      limit: options?.limit ?? 10,
+    });
+    return wire.map(toEntity);
+  }
+
+  async searchPreferences(
+    query: string,
+    options?: SearchPreferencesOptions,
+  ): Promise<Preference[]> {
+    const wire = await this.transport.request<WirePreference[]>("search_preferences", {
+      query,
+      category: options?.category,
+      limit: options?.limit ?? 10,
+    });
+    return wire.map(toPreference);
+  }
+
+  async getEntityByName(name: string): Promise<Entity | null> {
+    const wire = await this.transport.request<WireEntity | null>("get_entity_by_name", {
+      name,
+    });
+    return wire ? toEntity(wire) : null;
+  }
+
+  async getRelatedEntities(
+    entityId: string,
+    options?: GetRelatedEntitiesOptions,
+  ): Promise<Entity[]> {
+    const wire = await this.transport.request<WireEntity[]>("get_related_entities", {
+      entity_id: entityId,
+      relationship_type: options?.relationshipType,
+      depth: options?.depth ?? 1,
+    });
+    return wire.map(toEntity);
+  }
+
+  async addRelationship(
+    sourceId: string,
+    targetId: string,
+    relationshipType: string,
+    options?: AddRelationshipOptions,
+  ): Promise<Relationship> {
+    const wire = await this.transport.request<WireRelationship>("add_relationship", {
+      source_id: sourceId,
+      target_id: targetId,
+      relationship_type: relationshipType,
+      properties: options?.properties,
+    });
+    return toRelationship(wire);
+  }
+
+  async mergeDuplicateEntities(
+    sourceId: string,
+    targetId: string,
+    options?: { canonicalName?: string },
+  ): Promise<Entity> {
+    const wire = await this.transport.request<WireEntity>("merge_duplicate_entities", {
+      source_id: sourceId,
+      target_id: targetId,
+      canonical_name: options?.canonicalName,
+    });
+    return toEntity(wire);
+  }
+
+  // ---- Volume 5 / hosted-native methods -----------------------------------
+
+  /** List all entities, optionally filtered by entity type. */
+  async listEntities(options?: ListEntitiesOptions): Promise<Entity[]> {
+    const wire = await this.transport.request<WireEntity[]>("list_entities", {
+      type: options?.type,
+      limit: options?.limit,
+    });
+    return wire.map(toEntity);
+  }
+
+  /** Fetch one entity (with relationships) by id. */
+  async getEntity(entityId: string): Promise<Entity> {
+    const wire = await this.transport.request<WireEntity>("get_entity", {
+      entity_id: entityId,
+    });
+    return toEntity(wire);
+  }
+
+  /** Update an existing entity's name and/or description.
+   *
+   * The hosted PUT /v1/entities/{id} returns `{status: "updated"}` rather
+   * than the full entity, so when the response lacks an `id` we follow up
+   * with a GET to keep the SDK contract — "update returns the updated
+   * Entity". Bridge transports return the entity directly, so we tolerate
+   * both shapes.
+   */
+  async updateEntity(entityId: string, options: UpdateEntityOptions): Promise<Entity> {
+    const wire = await this.transport.request<WireEntity | { status: string }>(
+      "update_entity",
+      {
+        entity_id: entityId,
+        name: options.name,
+        description: options.description,
+      },
+    );
+    if (wire && typeof wire === "object" && "id" in wire && (wire as WireEntity).id) {
+      return toEntity(wire as WireEntity);
+    }
+    return this.getEntity(entityId);
+  }
+
+  /** Delete an entity and its relationships. */
+  async deleteEntity(entityId: string): Promise<void> {
+    await this.transport.request("delete_entity", { entity_id: entityId });
+  }
+
+  /** Score an entity 0-1 and optionally mark it human-confirmed. */
+  async setEntityFeedback(
+    entityId: string,
+    options: SetEntityFeedbackOptions,
+  ): Promise<EntityFeedbackResult> {
+    const result = await this.transport.request<{ id: string; updated: boolean }>(
+      "set_entity_feedback",
+      {
+        entity_id: entityId,
+        user_score: options.userScore,
+        confirmed: options.confirmed,
+      },
+    );
+    return { id: result.id, updated: result.updated };
+  }
+
+  /** All cross-conversation mentions of this entity. */
+  async getEntityHistory(entityId: string): Promise<EntityHistory> {
+    const wire = await this.transport.request<WireEntityHistory>("get_entity_history", {
+      entity_id: entityId,
+    });
+    return {
+      entityId: wire.entity_id,
+      mentions: (wire.mentions ?? []).map(toMention),
+    };
+  }
+
+  /** Merge `sourceId` into `targetId`, leaving a SAME_AS provenance link. */
+  async mergeEntities(sourceId: string, targetId: string): Promise<EntityMergeResult> {
+    const wire = await this.transport.request<{
+      source_id: string;
+      target_id: string;
+      status: string;
+    }>("merge_entities", {
+      source_id: sourceId,
+      target_id: targetId,
+    });
+    return { sourceId: wire.source_id, targetId: wire.target_id, status: wire.status };
+  }
+
+  /** Full-graph view of all entities + edges. Pair with NVL for visualization. */
+  async getEntityGraph(): Promise<EntityGraph> {
+    const wire = await this.transport.request<WireGraph>("get_entity_graph", {});
+    return {
+      nodes: (wire.nodes ?? []).map(toGraphNode),
+      edges: (wire.edges ?? []).map(toGraphEdge),
+    };
+  }
+}

--- a/typescript/src/mcp/index.ts
+++ b/typescript/src/mcp/index.ts
@@ -1,0 +1,328 @@
+/**
+ * MCP (Model Context Protocol) tool definitions for neo4j-agent-memory.
+ *
+ * Mirrors the 12 tools exposed by the hosted MCP server at
+ * `https://memory.neo4jlabs.com/mcp`. Use this to either:
+ *
+ *   - Register the same tool surface against your own MCP server, or
+ *   - Programmatically dispatch tool calls to a `MemoryClient`.
+ *
+ * The 12 standard tools — `memory_create_conversation`, `memory_add_messages`,
+ * `memory_get_context`, `memory_search_messages`, `memory_search_entities`,
+ * `memory_get_entity`, `memory_add_entity`, `memory_get_entity_history`,
+ * `memory_record_step`, `memory_record_tool_call`, `memory_get_trace`,
+ * `memory_explain_decision`.
+ *
+ * @example
+ * ```ts
+ * import { MemoryClient } from "@neo4j-labs/agent-memory";
+ * import { createMemoryTools, handleMemoryToolCall } from "@neo4j-labs/agent-memory/mcp";
+ *
+ * const client = new MemoryClient({
+ *   endpoint: "https://memory.neo4jlabs.com/v1",
+ *   apiKey: process.env.MEMORY_API_KEY!,
+ * });
+ *
+ * const tools = createMemoryTools();           // 12 standard tools
+ * await handleMemoryToolCall(client, "memory_get_context", { conversation_id });
+ * ```
+ */
+
+import type { MemoryClient } from "../client.js";
+
+export interface McpToolDefinition {
+  name: string;
+  description: string;
+  inputSchema: {
+    type: "object";
+    properties: Record<string, unknown>;
+    required?: string[];
+  };
+}
+
+/** Build the 12-tool MCP surface that matches memory.neo4jlabs.com/mcp. */
+export function createMemoryTools(): McpToolDefinition[] {
+  return [
+    // ---- Short-Term -----------------------------------------------------
+    {
+      name: "memory_create_conversation",
+      description: "Create a new conversation session for a user.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          user_id: { type: "string", description: "User identifier" },
+          metadata: { type: "object", additionalProperties: true },
+        },
+        required: ["user_id"],
+      },
+    },
+    {
+      name: "memory_add_messages",
+      description: "Append one or more messages to a conversation.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          conversation_id: { type: "string" },
+          messages: {
+            type: "array",
+            items: {
+              type: "object",
+              properties: {
+                role: { type: "string", enum: ["user", "assistant", "system"] },
+                content: { type: "string" },
+                metadata: { type: "object", additionalProperties: true },
+              },
+              required: ["role", "content"],
+            },
+          },
+        },
+        required: ["conversation_id", "messages"],
+      },
+    },
+    {
+      name: "memory_get_context",
+      description:
+        "Three-tier context (reflections + observations + recent messages) for a conversation.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          conversation_id: { type: "string" },
+        },
+        required: ["conversation_id"],
+      },
+    },
+    {
+      name: "memory_search_messages",
+      description: "Search messages within a conversation by similarity or keywords.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          conversation_id: { type: "string" },
+          query: { type: "string" },
+          limit: { type: "number" },
+        },
+        required: ["conversation_id", "query"],
+      },
+    },
+    // ---- Long-Term ------------------------------------------------------
+    {
+      name: "memory_search_entities",
+      description: "Search the knowledge graph for entities by name or concept.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          query: { type: "string" },
+          type: { type: "string" },
+          limit: { type: "number" },
+        },
+        required: ["query"],
+      },
+    },
+    {
+      name: "memory_get_entity",
+      description: "Fetch one entity (with its relationships) by id.",
+      inputSchema: {
+        type: "object",
+        properties: { entity_id: { type: "string" } },
+        required: ["entity_id"],
+      },
+    },
+    {
+      name: "memory_add_entity",
+      description: "Manually create an entity.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          name: { type: "string" },
+          type: { type: "string" },
+          description: { type: "string" },
+        },
+        required: ["name", "type"],
+      },
+    },
+    {
+      name: "memory_get_entity_history",
+      description: "All conversations that mentioned this entity.",
+      inputSchema: {
+        type: "object",
+        properties: { entity_id: { type: "string" } },
+        required: ["entity_id"],
+      },
+    },
+    // ---- Reasoning ------------------------------------------------------
+    {
+      name: "memory_record_step",
+      description: "Log a reasoning step under a conversation.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          conversation_id: { type: "string" },
+          reasoning: { type: "string" },
+          action_taken: { type: "string" },
+          result: { type: "string" },
+        },
+        required: ["conversation_id", "reasoning", "action_taken"],
+      },
+    },
+    {
+      name: "memory_record_tool_call",
+      description: "Log a tool invocation tied to a reasoning step.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          step_id: { type: "string" },
+          tool_name: { type: "string" },
+          input: { type: "string" },
+          output: { type: "string" },
+          status: { type: "string", enum: ["success", "error", "timeout"] },
+          duration_ms: { type: "number" },
+        },
+        required: ["tool_name", "status"],
+      },
+    },
+    {
+      name: "memory_get_trace",
+      description: "Full reasoning trace for a conversation (steps + tool calls).",
+      inputSchema: {
+        type: "object",
+        properties: { conversation_id: { type: "string" } },
+        required: ["conversation_id"],
+      },
+    },
+    {
+      name: "memory_explain_decision",
+      description:
+        "Detailed explanation of one reasoning step — tool calls + entities it influenced.",
+      inputSchema: {
+        type: "object",
+        properties: { step_id: { type: "string" } },
+        required: ["step_id"],
+      },
+    },
+  ];
+}
+
+/**
+ * Dispatch one of the 12 standard MCP tool calls to a `MemoryClient`.
+ *
+ * Old `memory.<verb>` names from v0.1 are kept as deprecated aliases for one
+ * minor version; they emit a console warning and forward to the new tool.
+ */
+export async function handleMemoryToolCall(
+  client: MemoryClient,
+  toolName: string,
+  args: Record<string, unknown>,
+): Promise<unknown> {
+  const aliased = LEGACY_ALIASES[toolName];
+  if (aliased) {
+    if (typeof console !== "undefined") {
+      console.warn(
+        `[neo4j-agent-memory] MCP tool '${toolName}' is deprecated; use '${aliased}'.`,
+      );
+    }
+    toolName = aliased;
+  }
+
+  switch (toolName) {
+    case "memory_create_conversation":
+      return client.shortTerm.createConversation({
+        userId: args["user_id"] as string,
+        metadata: args["metadata"] as Record<string, unknown> | undefined,
+      });
+
+    case "memory_add_messages": {
+      const conversationId = args["conversation_id"] as string;
+      const msgs = args["messages"] as
+        | Array<{ role: string; content: string; metadata?: Record<string, unknown> }>
+        | undefined;
+      if (!msgs || msgs.length === 0) return [];
+      if (msgs.length === 1) {
+        const m = msgs[0]!;
+        return [
+          await client.shortTerm.addMessage(
+            conversationId,
+            m.role as "user" | "assistant" | "system",
+            m.content,
+            { metadata: m.metadata },
+          ),
+        ];
+      }
+      return client.shortTerm.bulkAddMessages(
+        conversationId,
+        msgs.map((m) => ({
+          role: m.role as "user" | "assistant" | "system",
+          content: m.content,
+          metadata: m.metadata,
+        })),
+      );
+    }
+
+    case "memory_get_context":
+      return client.shortTerm.getContext(args["conversation_id"] as string);
+
+    case "memory_search_messages":
+      return client.shortTerm.searchMessages(args["query"] as string, {
+        sessionId: args["conversation_id"] as string,
+        limit: args["limit"] as number | undefined,
+      });
+
+    case "memory_search_entities":
+      return client.longTerm.searchEntities(args["query"] as string, {
+        type: args["type"] as string | undefined,
+        limit: args["limit"] as number | undefined,
+      });
+
+    case "memory_get_entity":
+      return client.longTerm.getEntity(args["entity_id"] as string);
+
+    case "memory_add_entity":
+      return client.longTerm.addEntity(args["name"] as string, args["type"] as string, {
+        description: args["description"] as string | undefined,
+      });
+
+    case "memory_get_entity_history":
+      return client.longTerm.getEntityHistory(args["entity_id"] as string);
+
+    case "memory_record_step":
+      return client.reasoning.recordStep({
+        conversationId: args["conversation_id"] as string,
+        reasoning: args["reasoning"] as string,
+        actionTaken: args["action_taken"] as string,
+        result: args["result"] as string | undefined,
+      });
+
+    case "memory_record_tool_call":
+      return client.reasoning.recordToolCall(
+        (args["step_id"] as string) ?? "",
+        args["tool_name"] as string,
+        typeof args["input"] === "object" && args["input"] !== null
+          ? (args["input"] as Record<string, unknown>)
+          : { input: args["input"] },
+        {
+          result: args["output"],
+          status: (args["status"] as "success" | "error" | "timeout") ?? "success",
+          durationMs: args["duration_ms"] as number | undefined,
+        },
+      );
+
+    case "memory_get_trace":
+      return client.reasoning.getTraceByConversation(args["conversation_id"] as string);
+
+    case "memory_explain_decision":
+      return client.reasoning.explainStep(args["step_id"] as string);
+
+    default:
+      throw new Error(`Unknown memory tool: ${toolName}`);
+  }
+}
+
+/**
+ * v0.1 → v0.2 deprecated tool aliases. Will be removed in v0.3.
+ */
+const LEGACY_ALIASES: Record<string, string> = {
+  "memory.addMessage": "memory_add_messages",
+  "memory.getConversation": "memory_get_context",
+  "memory.searchMessages": "memory_search_messages",
+  "memory.addEntity": "memory_add_entity",
+  "memory.searchEntities": "memory_search_entities",
+};

--- a/typescript/src/middleware/vercel-ai.ts
+++ b/typescript/src/middleware/vercel-ai.ts
@@ -1,0 +1,214 @@
+/**
+ * Vercel AI SDK middleware for automatic memory integration.
+ *
+ * The middleware automatically:
+ *   - Injects three-tier conversational context (reflections + observations +
+ *     recent messages) ahead of every model call when a `conversationId` is
+ *     supplied — falls back to flat history for bridge transports.
+ *   - Persists the user's input message before generation.
+ *   - Persists the assistant's response (and tool calls) after generation.
+ *   - Lazily creates a conversation on first call when the caller didn't
+ *     pre-create one (only available with RestTransport).
+ *
+ * @example
+ * ```ts
+ * import { generateText } from "ai";
+ * import { MemoryClient } from "@neo4j-labs/agent-memory";
+ * import { agentMemoryMiddleware } from "@neo4j-labs/agent-memory/middleware/vercel-ai";
+ *
+ * const client = new MemoryClient({
+ *   endpoint: "https://memory.neo4jlabs.com/v1",
+ *   apiKey: process.env.MEMORY_API_KEY!,
+ * });
+ *
+ * const middleware = agentMemoryMiddleware(client, {
+ *   conversationId: "conv-uuid",      // or sessionId for bridge transport
+ *   userId: "alice@example.com",      // used if a conversation is created
+ *   includeContext: true,
+ * });
+ *
+ * const result = await generateText({
+ *   model: yourModel,
+ *   experimental_middleware: middleware,
+ *   messages: [{ role: "user", content: "Hello!" }],
+ * });
+ * ```
+ *
+ * Compatible with the Vercel AI SDK v4+ `LanguageModelV1Middleware` shape.
+ */
+
+import type { MemoryClient } from "../client.js";
+import { NotSupportedError } from "../errors.js";
+import type { Message, MessageRole } from "../types.js";
+
+export interface AgentMemoryMiddlewareOptions {
+  /**
+   * Conversation id (REST transport) or session id (bridge transport).
+   * Can be a string or a function that returns one.
+   */
+  conversationId?: string | (() => string);
+
+  /** @deprecated Use `conversationId`. Kept for backwards compatibility. */
+  sessionId?: string | (() => string);
+
+  /**
+   * User id used when lazily creating a conversation. Only consulted if
+   * `conversationId` is not supplied and the transport is REST.
+   */
+  userId?: string;
+
+  /**
+   * Include three-tier context (reflections + observations + recent messages).
+   * If false, falls back to flat history. Default: true on REST, false on
+   * bridge (where context endpoints aren't implemented).
+   */
+  includeContext?: boolean;
+
+  /** Maximum messages to include from flat history (bridge fallback). */
+  historyLimit?: number;
+
+  /** Persist user input before generation. Default: true. */
+  persistInput?: boolean;
+
+  /** Persist assistant response after generation. Default: true. */
+  persistResponses?: boolean;
+}
+
+export interface AgentMemoryLanguageModelMiddleware {
+  transformParams?: (options: { params: Record<string, unknown> }) => Promise<
+    Record<string, unknown>
+  >;
+  wrapGenerate?: (options: {
+    doGenerate: () => Promise<{ text?: string; [key: string]: unknown }>;
+  }) => Promise<{ text?: string; [key: string]: unknown }>;
+}
+
+function resolve(value?: string | (() => string)): string | undefined {
+  if (typeof value === "function") return value();
+  return value;
+}
+
+/** Memory-augmented LanguageModelV1 middleware. */
+export function agentMemoryMiddleware(
+  client: MemoryClient,
+  options?: AgentMemoryMiddlewareOptions,
+): AgentMemoryLanguageModelMiddleware {
+  const persistResponses = options?.persistResponses ?? true;
+  const persistInput = options?.persistInput ?? true;
+  const includeContext = options?.includeContext ?? true;
+  let resolvedId: string | undefined =
+    resolve(options?.conversationId) ?? resolve(options?.sessionId);
+
+  // Lazy-create a conversation on REST transports if none was supplied.
+  async function ensureConversationId(): Promise<string> {
+    if (resolvedId) return resolvedId;
+    try {
+      const conv = await client.shortTerm.createConversation({
+        userId: options?.userId ?? "anonymous",
+      });
+      resolvedId = conv.id;
+      return resolvedId;
+    } catch (err) {
+      if (err instanceof NotSupportedError) {
+        // Bridge transport — synthesize a session ID
+        resolvedId = `session-${cryptoRandom()}`;
+        return resolvedId;
+      }
+      throw err;
+    }
+  }
+
+  return {
+    transformParams: async ({ params }) => {
+      const id = await ensureConversationId();
+
+      let historyMessages: Array<{ role: string; content: string }> = [];
+      if (includeContext) {
+        try {
+          const ctx = await client.shortTerm.getContext(id);
+          for (const r of ctx.reflections) {
+            historyMessages.push({ role: "system", content: `[reflection] ${r.content}` });
+          }
+          for (const o of ctx.observations) {
+            historyMessages.push({ role: "system", content: `[observation] ${o.content}` });
+          }
+          for (const m of ctx.recentMessages) {
+            historyMessages.push({ role: m.role, content: m.content });
+          }
+        } catch (err) {
+          if (!(err instanceof NotSupportedError)) {
+            // Non-fatal — fall back to flat history below.
+          }
+          historyMessages = [];
+        }
+      }
+
+      // Bridge fallback or empty REST context → use flat conversation history.
+      if (historyMessages.length === 0) {
+        try {
+          const conv = await client.shortTerm.getConversation(id, {
+            limit: options?.historyLimit,
+          });
+          historyMessages = conv.messages.map((msg: Message) => ({
+            role: msg.role,
+            content: msg.content,
+          }));
+        } catch {
+          // No history — proceed without.
+        }
+      }
+
+      // Best-effort: persist the user's input message.
+      if (persistInput) {
+        const incoming = (params["prompt"] as Array<{ role: string; content: string }>) ?? [];
+        const lastUser = [...incoming].reverse().find((m) => m.role === "user");
+        if (lastUser) {
+          try {
+            await client.shortTerm.addMessage(id, lastUser.role as MessageRole, lastUser.content);
+          } catch {
+            // Non-fatal.
+          }
+        }
+      }
+
+      if (historyMessages.length === 0) return params;
+
+      const existing = (params["prompt"] as unknown[]) ?? [];
+      return {
+        ...params,
+        prompt: [...historyMessages, ...existing],
+      };
+    },
+
+    wrapGenerate: async ({ doGenerate }) => {
+      const result = await doGenerate();
+      if (persistResponses && result.text) {
+        const id = await ensureConversationId();
+        try {
+          await client.shortTerm.addMessage(id, "assistant", result.text);
+        } catch {
+          // Non-fatal.
+        }
+      }
+      return result;
+    },
+  };
+}
+
+function cryptoRandom(): string {
+  // Every supported runtime (Node 20+, Bun, Deno, Workers, modern browsers)
+  // exposes crypto.randomUUID. We fall back to crypto.getRandomValues with
+  // base36 encoding for older or stripped-down environments — both APIs use
+  // the platform CSPRNG. Math.random would be cryptographically insecure.
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID();
+  }
+  if (typeof crypto !== "undefined" && typeof crypto.getRandomValues === "function") {
+    const buf = new Uint8Array(16);
+    crypto.getRandomValues(buf);
+    return Array.from(buf, (b) => b.toString(16).padStart(2, "0")).join("");
+  }
+  throw new Error(
+    "Secure randomness is unavailable in this runtime; supply an explicit conversationId.",
+  );
+}

--- a/typescript/src/observability.ts
+++ b/typescript/src/observability.ts
@@ -1,0 +1,90 @@
+/**
+ * Observability primitives — User-Agent header building and the typed
+ * logger event stream emitted by both transports.
+ */
+
+import { VERSION } from "./version.js";
+
+/**
+ * Build the default User-Agent string. Mirrors the convention used by other
+ * Anthropic / OpenAI SDKs: `<package>/<version> (<runtime>; <platform>)`.
+ *
+ * Detection is best-effort and silently degrades on edge runtimes where
+ * `process` is unavailable.
+ */
+export function defaultUserAgent(): string {
+  const runtime = detectRuntime();
+  return runtime
+    ? `@neo4j-labs/agent-memory/${VERSION} (${runtime})`
+    : `@neo4j-labs/agent-memory/${VERSION}`;
+}
+
+export function supportsUserAgentHeader(): boolean {
+  return detectRuntime() !== null;
+}
+
+function detectRuntime(): string | null {
+  // Deno
+  const denoObj = (globalThis as { Deno?: { version?: { deno?: string } } }).Deno;
+  if (denoObj?.version?.deno) {
+    return `deno/${denoObj.version.deno}`;
+  }
+  // Bun
+  const bunObj = (globalThis as { Bun?: { version?: string } }).Bun;
+  if (bunObj?.version) {
+    return `bun/${bunObj.version}`;
+  }
+  // Node
+  if (typeof process !== "undefined" && process.versions?.node) {
+    const platform = process.platform ?? "unknown";
+    return `node/${process.versions.node}; ${platform}`;
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Logger
+// ---------------------------------------------------------------------------
+
+/** Single event emitted to the user-supplied logger. */
+export type LogEvent =
+  | {
+      kind: "request";
+      method: string;
+      url: string;
+      httpMethod?: string;
+    }
+  | {
+      kind: "response";
+      method: string;
+      url: string;
+      status: number;
+      requestId?: string;
+      durationMs: number;
+    }
+  | {
+      kind: "error";
+      method: string;
+      url: string;
+      status?: number;
+      requestId?: string;
+      durationMs: number;
+      message: string;
+    };
+
+export type Logger = (event: LogEvent) => void;
+
+/**
+ * Extract a request-id from a Response. The hosted service emits one of
+ * `x-request-id`, `request-id`, or `x-amzn-RequestId` depending on the edge
+ * the request lands on. Caller-side correlation works as long as one is
+ * present.
+ */
+export function extractRequestId(headers: Headers): string | undefined {
+  return (
+    headers.get("x-request-id") ??
+    headers.get("request-id") ??
+    headers.get("x-amzn-requestid") ??
+    undefined
+  );
+}

--- a/typescript/src/query/index.ts
+++ b/typescript/src/query/index.ts
@@ -1,0 +1,39 @@
+/**
+ * Cypher query console — read-only access to the underlying graph.
+ *
+ * Hosted service only: write operations are rejected with HTTP 400.
+ */
+
+import type { Transport } from "../transport/index.js";
+import type { CypherResult } from "../types.js";
+
+interface WireCypherResult {
+  columns?: string[];
+  rows?: unknown[][];
+  stats?: Record<string, unknown>;
+}
+
+export class QueryConsole {
+  constructor(private readonly transport: Transport) {}
+
+  /**
+   * Execute a read-only Cypher query.
+   *
+   * @example
+   * const r = await client.query.cypher({
+   *   cypher: "MATCH (e:Entity) RETURN e.name AS name LIMIT $n",
+   *   params: { n: 10 },
+   * });
+   */
+  async cypher(input: { cypher: string; params?: Record<string, unknown> }): Promise<CypherResult> {
+    const wire = await this.transport.request<WireCypherResult>("cypher_query", {
+      cypher: input.cypher,
+      params: input.params ?? {},
+    });
+    return {
+      columns: wire.columns ?? [],
+      rows: wire.rows ?? [],
+      stats: wire.stats,
+    };
+  }
+}

--- a/typescript/src/reasoning/index.ts
+++ b/typescript/src/reasoning/index.ts
@@ -1,0 +1,330 @@
+/**
+ * Reasoning memory operations.
+ *
+ * Bridge methods (Silver tier) wrap traces. Volume 5 / hosted-native methods
+ * are flatter — steps belong directly to a conversation, with explain &
+ * provenance views for the reasoning trail behind any entity.
+ */
+
+import type { Transport } from "../transport/index.js";
+import type {
+  AgentStep,
+  AgentStepExplanation,
+  CompleteTraceOptions,
+  ConversationTrace,
+  Entity,
+  EntityProvenance,
+  GetSimilarTracesOptions,
+  ListTracesOptions,
+  ReasoningStep,
+  ReasoningTrace,
+  RecordStepInput,
+  RecordToolCallOptions,
+  ToolCall,
+  ToolCallStatus,
+  ToolStats,
+} from "../types.js";
+
+interface WireToolCall {
+  id: string;
+  tool_name?: string;
+  toolName?: string;
+  arguments?: Record<string, unknown>;
+  input?: string;
+  result?: unknown;
+  output?: unknown;
+  status: string;
+  duration_ms?: number;
+  durationMs?: number;
+  error?: string;
+  step_id?: string;
+}
+
+interface WireStep {
+  id: string;
+  trace_id?: string;
+  step_number?: number;
+  thought?: string;
+  action?: string;
+  observation?: string;
+  tool_calls?: WireToolCall[];
+}
+
+interface WireTrace {
+  id: string;
+  session_id?: string;
+  task?: string;
+  steps?: WireStep[];
+  outcome?: string;
+  success?: boolean;
+  started_at?: string;
+  completed_at?: string;
+}
+
+interface WireToolStats {
+  name: string;
+  total_calls: number;
+  successful_calls: number;
+  failed_calls: number;
+  success_rate: number;
+  avg_duration_ms?: number;
+}
+
+interface WireAgentStep {
+  id: string;
+  conversation_id: string;
+  reasoning: string;
+  action_taken: string;
+  result?: string;
+  created_at?: string;
+}
+
+interface WireAgentStepExplanation extends WireAgentStep {
+  tool_calls?: WireToolCall[];
+  influenced_entities?: Array<Record<string, unknown>>;
+}
+
+interface WireConversationTrace {
+  conversation_id: string;
+  steps?: WireAgentStep[];
+  tool_calls?: WireToolCall[];
+}
+
+interface WireEntityProvenance {
+  entity_id: string;
+  steps?: WireAgentStep[];
+}
+
+function toToolCall(w: WireToolCall): ToolCall {
+  return {
+    id: w.id,
+    toolName: w.tool_name ?? w.toolName ?? "",
+    arguments:
+      w.arguments ??
+      (w.input ? safeParseObject(w.input) : {}) ??
+      {},
+    result: w.result ?? w.output,
+    status: (w.status ?? "success") as ToolCallStatus,
+    durationMs: w.duration_ms ?? w.durationMs,
+    error: w.error,
+  };
+}
+
+function safeParseObject(input: string): Record<string, unknown> {
+  try {
+    const parsed = JSON.parse(input);
+    return typeof parsed === "object" && parsed !== null
+      ? (parsed as Record<string, unknown>)
+      : { value: parsed };
+  } catch {
+    return { raw: input };
+  }
+}
+
+function toStep(w: WireStep): ReasoningStep {
+  return {
+    id: w.id,
+    traceId: w.trace_id ?? "",
+    stepNumber: w.step_number ?? 0,
+    thought: w.thought,
+    action: w.action,
+    observation: w.observation,
+    toolCalls: (w.tool_calls ?? []).map(toToolCall),
+  };
+}
+
+function toTrace(w: WireTrace): ReasoningTrace {
+  return {
+    id: w.id,
+    sessionId: w.session_id ?? "",
+    task: w.task ?? "",
+    steps: (w.steps ?? []).map(toStep),
+    outcome: w.outcome,
+    success: w.success,
+    startedAt: w.started_at ?? "",
+    completedAt: w.completed_at,
+  };
+}
+
+function toToolStats(w: WireToolStats): ToolStats {
+  return {
+    name: w.name,
+    totalCalls: w.total_calls,
+    successfulCalls: w.successful_calls,
+    failedCalls: w.failed_calls,
+    successRate: w.success_rate,
+    avgDurationMs: w.avg_duration_ms,
+  };
+}
+
+function toAgentStep(w: WireAgentStep): AgentStep {
+  return {
+    id: w.id,
+    conversationId: w.conversation_id,
+    reasoning: w.reasoning,
+    actionTaken: w.action_taken,
+    result: w.result,
+    createdAt: w.created_at ?? "",
+  };
+}
+
+export class ReasoningMemory {
+  constructor(private readonly transport: Transport) {}
+
+  // ---- Silver tier (bridge) ----------------------------------------------
+
+  async startTrace(sessionId: string, task: string): Promise<ReasoningTrace> {
+    const wire = await this.transport.request<WireTrace>("start_trace", {
+      session_id: sessionId,
+      task,
+    });
+    return toTrace(wire);
+  }
+
+  async addStep(
+    traceId: string,
+    options?: { thought?: string; action?: string; observation?: string },
+  ): Promise<ReasoningStep> {
+    const wire = await this.transport.request<WireStep>("add_step", {
+      trace_id: traceId,
+      thought: options?.thought,
+      action: options?.action,
+      observation: options?.observation,
+    });
+    return toStep(wire);
+  }
+
+  async recordToolCall(
+    stepId: string,
+    toolName: string,
+    args: Record<string, unknown>,
+    options?: RecordToolCallOptions,
+  ): Promise<ToolCall> {
+    const wire = await this.transport.request<WireToolCall>("record_tool_call", {
+      step_id: stepId,
+      tool_name: toolName,
+      arguments: args,
+      input: typeof args === "string" ? args : JSON.stringify(args),
+      result: options?.result,
+      output: typeof options?.result === "string" ? options.result : undefined,
+      status: options?.status ?? "success",
+      duration_ms: options?.durationMs,
+      error: options?.error,
+    });
+    return toToolCall(wire);
+  }
+
+  async completeTrace(
+    traceId: string,
+    options?: CompleteTraceOptions,
+  ): Promise<ReasoningTrace> {
+    const wire = await this.transport.request<WireTrace>("complete_trace", {
+      trace_id: traceId,
+      outcome: options?.outcome,
+      success: options?.success,
+    });
+    return toTrace(wire);
+  }
+
+  async getTraceWithSteps(traceId: string): Promise<ReasoningTrace | null> {
+    const wire = await this.transport.request<WireTrace | null>("get_trace_with_steps", {
+      trace_id: traceId,
+    });
+    return wire ? toTrace(wire) : null;
+  }
+
+  async listTraces(options?: ListTracesOptions): Promise<ReasoningTrace[]> {
+    const wire = await this.transport.request<WireTrace[]>("list_traces", {
+      session_id: options?.sessionId,
+      limit: options?.limit ?? 100,
+    });
+    return wire.map(toTrace);
+  }
+
+  async getToolStats(toolName?: string): Promise<ToolStats[]> {
+    const wire = await this.transport.request<WireToolStats[]>("get_tool_stats", {
+      tool_name: toolName,
+    });
+    return wire.map(toToolStats);
+  }
+
+  async getSimilarTraces(
+    task: string,
+    options?: GetSimilarTracesOptions,
+  ): Promise<ReasoningTrace[]> {
+    const wire = await this.transport.request<WireTrace[]>("get_similar_traces", {
+      task,
+      limit: options?.limit ?? 5,
+      success_only: options?.successOnly ?? true,
+    });
+    return wire.map(toTrace);
+  }
+
+  // ---- Volume 5 / hosted-native methods -----------------------------------
+
+  /** Record one reasoning step under a conversation (hosted REACT model). */
+  async recordStep(input: RecordStepInput): Promise<AgentStep> {
+    const wire = await this.transport.request<WireAgentStep>("record_step", {
+      conversation_id: input.conversationId,
+      reasoning: input.reasoning,
+      action_taken: input.actionTaken,
+      result: input.result,
+    });
+    return toAgentStep(wire);
+  }
+
+  /** List all reasoning steps for one conversation. */
+  async listSteps(conversationId: string): Promise<AgentStep[]> {
+    const wire = await this.transport.request<WireAgentStep[]>("list_steps", {
+      conversation_id: conversationId,
+    });
+    return wire.map(toAgentStep);
+  }
+
+  /** Detailed step explanation with tool calls and influenced entities. */
+  async explainStep(stepId: string): Promise<AgentStepExplanation> {
+    const wire = await this.transport.request<WireAgentStepExplanation>("explain_step", {
+      step_id: stepId,
+    });
+    return {
+      ...toAgentStep(wire),
+      toolCalls: (wire.tool_calls ?? []).map(toToolCall),
+      influencedEntities: (wire.influenced_entities ?? []).map((e) => ({
+        id: String(e["id"] ?? ""),
+        name: String(e["name"] ?? ""),
+        type: String(e["type"] ?? ""),
+        description: e["description"] as string | undefined,
+        createdAt: String(e["created_at"] ?? ""),
+      })) as Entity[],
+    };
+  }
+
+  /** Full reasoning trace for a conversation (steps + tool calls). */
+  async getTraceByConversation(conversationId: string): Promise<ConversationTrace> {
+    const wire = await this.transport.request<WireConversationTrace>(
+      "get_trace_by_conversation",
+      { conversation_id: conversationId },
+    );
+    return {
+      conversationId: wire.conversation_id,
+      steps: (wire.steps ?? []).map(toAgentStep),
+      toolCalls: (wire.tool_calls ?? []).map(toToolCall),
+    };
+  }
+
+  /** All reasoning steps that influenced an entity's creation.
+   *
+   * Hosted REST returns the chain under `provenance`; bridge / older
+   * responses use `steps`. Accept either.
+   */
+  async getEntityProvenance(entityId: string): Promise<EntityProvenance> {
+    const wire = await this.transport.request<
+      WireEntityProvenance & { provenance?: WireAgentStep[] }
+    >("get_entity_provenance", { entity_id: entityId });
+    const rawSteps = wire.steps ?? wire.provenance ?? [];
+    return {
+      entityId: wire.entity_id,
+      steps: rawSteps.map(toAgentStep),
+    };
+  }
+}

--- a/typescript/src/short-term/index.ts
+++ b/typescript/src/short-term/index.ts
@@ -1,0 +1,279 @@
+/**
+ * Short-term (conversational) memory operations.
+ *
+ * Bridge methods (Bronze tier) speak the TCK BaseAdapter contract.
+ * Hosted methods speak the Volume 5 / Platinum tier hosted service operations.
+ */
+
+import type { Transport } from "../transport/index.js";
+import type {
+  AddMessageOptions,
+  BulkMessageInput,
+  Conversation,
+  ConversationContext,
+  CreateConversationOptions,
+  GetConversationOptions,
+  ListConversationsOptions,
+  ListSessionsOptions,
+  Message,
+  MessageRole,
+  Observation,
+  Reflection,
+  SearchMessagesOptions,
+  SessionInfo,
+} from "../types.js";
+
+/** Wire format from the bridge protocol (snake_case). */
+interface WireMessage {
+  id: string;
+  role: string;
+  content: string;
+  timestamp?: string;
+  created_at?: string;
+  embedding?: number[];
+  metadata?: Record<string, unknown>;
+  conversation_id?: string;
+}
+
+interface WireConversation {
+  id: string;
+  session_id?: string;
+  messages?: WireMessage[];
+  message_count?: number;
+  title?: string;
+  created_at?: string;
+  updated_at?: string;
+  workspace_id?: string;
+  user_id?: string;
+  metadata?: Record<string, unknown>;
+}
+
+interface WireSessionInfo {
+  session_id?: string;
+  id?: string;
+  message_count: number;
+  created_at: string;
+  updated_at?: string;
+  user_id?: string;
+}
+
+interface WireObservation {
+  id: string;
+  conversation_id: string;
+  content: string;
+  window_start?: string;
+  window_end?: string;
+  created_at: string;
+}
+
+interface WireReflection {
+  id: string;
+  conversation_id: string;
+  content: string;
+  created_at: string;
+}
+
+interface WireContext {
+  reflections?: WireReflection[];
+  observations?: WireObservation[];
+  recent_messages?: WireMessage[];
+}
+
+function toMessage(w: WireMessage): Message {
+  return {
+    id: w.id,
+    role: (w.role ?? "user") as MessageRole,
+    content: w.content,
+    timestamp: w.timestamp ?? w.created_at ?? "",
+    embedding: w.embedding,
+    metadata: w.metadata ?? {},
+    conversationId: w.conversation_id,
+  };
+}
+
+function toConversation(w: WireConversation): Conversation {
+  return {
+    id: w.id,
+    sessionId: w.session_id ?? w.id,
+    messages: (w.messages ?? []).map(toMessage),
+    messageCount: w.message_count,
+    title: w.title,
+    createdAt: w.created_at ?? "",
+    updatedAt: w.updated_at,
+    workspaceId: w.workspace_id,
+    userId: w.user_id,
+    metadata: w.metadata,
+  };
+}
+
+function toSessionInfo(w: WireSessionInfo): SessionInfo {
+  return {
+    sessionId: w.session_id ?? w.id ?? "",
+    messageCount: w.message_count ?? 0,
+    createdAt: w.created_at,
+    updatedAt: w.updated_at,
+  };
+}
+
+function toObservation(w: WireObservation): Observation {
+  return {
+    id: w.id,
+    conversationId: w.conversation_id,
+    content: w.content,
+    windowStart: w.window_start,
+    windowEnd: w.window_end,
+    createdAt: w.created_at,
+  };
+}
+
+function toReflection(w: WireReflection): Reflection {
+  return {
+    id: w.id,
+    conversationId: w.conversation_id,
+    content: w.content,
+    createdAt: w.created_at,
+  };
+}
+
+export class ShortTermMemory {
+  constructor(private readonly transport: Transport) {}
+
+  // ---- Bronze tier (bridge) ----------------------------------------------
+
+  async addMessage(
+    sessionId: string,
+    role: MessageRole,
+    content: string,
+    options?: AddMessageOptions,
+  ): Promise<Message> {
+    const wire = await this.transport.request<WireMessage>("add_message", {
+      session_id: sessionId,
+      role,
+      content,
+      metadata: options?.metadata,
+    });
+    return toMessage(wire);
+  }
+
+  async getConversation(
+    sessionId: string,
+    options?: GetConversationOptions,
+  ): Promise<Conversation> {
+    const wire = await this.transport.request<WireConversation>("get_conversation", {
+      session_id: sessionId,
+      limit: options?.limit,
+    });
+    return toConversation(wire);
+  }
+
+  async searchMessages(query: string, options?: SearchMessagesOptions): Promise<Message[]> {
+    const wire = await this.transport.request<WireMessage[]>("search_messages", {
+      query,
+      session_id: options?.sessionId,
+      limit: options?.limit ?? 10,
+      threshold: options?.threshold ?? 0.7,
+    });
+    return wire.map(toMessage);
+  }
+
+  async listSessions(options?: ListSessionsOptions): Promise<SessionInfo[]> {
+    const wire = await this.transport.request<WireSessionInfo[]>("list_sessions", {
+      limit: options?.limit ?? 100,
+    });
+    return wire.map(toSessionInfo);
+  }
+
+  async deleteMessage(messageId: string): Promise<boolean> {
+    const result = await this.transport.request<{ deleted: boolean }>("delete_message", {
+      message_id: messageId,
+    });
+    return result.deleted;
+  }
+
+  async clearSession(sessionId: string): Promise<void> {
+    await this.transport.request("clear_session", { session_id: sessionId });
+  }
+
+  // ---- Volume 5 / hosted-native methods -----------------------------------
+
+  /** Create a new conversation (hosted service). */
+  async createConversation(options: CreateConversationOptions): Promise<Conversation> {
+    const wire = await this.transport.request<WireConversation>("create_conversation", {
+      user_id: options.userId,
+      metadata: options.metadata,
+    });
+    return toConversation(wire);
+  }
+
+  /** List conversations the API key has access to. */
+  async listConversations(options?: ListConversationsOptions): Promise<Conversation[]> {
+    const wire = await this.transport.request<WireConversation[]>("list_conversations", {
+      limit: options?.limit,
+      userId: options?.userId,
+    });
+    return wire.map(toConversation);
+  }
+
+  /** Fetch conversation metadata (no messages). */
+  async getConversationMetadata(conversationId: string): Promise<Conversation> {
+    const wire = await this.transport.request<WireConversation>("get_conversation_metadata", {
+      conversation_id: conversationId,
+    });
+    return toConversation(wire);
+  }
+
+  /** Delete a conversation and all its messages. */
+  async deleteConversation(conversationId: string): Promise<void> {
+    await this.transport.request("delete_conversation", { conversation_id: conversationId });
+  }
+
+  /**
+   * Three-tier conversational context (reflections + observations + recent
+   * messages). The richest input you can hand an LLM about a conversation.
+   */
+  async getContext(conversationId: string): Promise<ConversationContext> {
+    const wire = await this.transport.request<WireContext>("get_context", {
+      conversation_id: conversationId,
+    });
+    return {
+      reflections: (wire.reflections ?? []).map(toReflection),
+      observations: (wire.observations ?? []).map(toObservation),
+      recentMessages: (wire.recent_messages ?? []).map(toMessage),
+    };
+  }
+
+  /** Bulk-add up to 100 messages in one request. */
+  async bulkAddMessages(
+    conversationId: string,
+    messages: BulkMessageInput[],
+  ): Promise<Message[]> {
+    if (messages.length > 100) {
+      throw new Error("bulkAddMessages accepts a maximum of 100 messages per call.");
+    }
+    const wire = await this.transport.request<WireMessage[]>("bulk_add_messages", {
+      conversation_id: conversationId,
+      messages,
+    });
+    return wire.map(toMessage);
+  }
+
+  /** Auto-generated message-window summaries. */
+  async getObservations(
+    conversationId: string,
+    options?: { limit?: number },
+  ): Promise<Observation[]> {
+    const wire = await this.transport.request<WireObservation[]>("get_observations", {
+      conversation_id: conversationId,
+      limit: options?.limit,
+    });
+    return wire.map(toObservation);
+  }
+
+  /** Higher-level reflections derived from observations. */
+  async getReflections(conversationId: string): Promise<Reflection[]> {
+    const wire = await this.transport.request<WireReflection[]>("get_reflections", {
+      conversation_id: conversationId,
+    });
+    return wire.map(toReflection);
+  }
+}

--- a/typescript/src/testing.ts
+++ b/typescript/src/testing.ts
@@ -1,0 +1,12 @@
+/**
+ * Testing-only exports.
+ *
+ * `BridgeTransport` speaks the TCK bridge protocol (POST /{snake_method},
+ * snake_case JSON). Use it for cross-language conformance testing against
+ * the neo4j-agent-memory TCK or a local reference server. Production
+ * applications should use the default `MemoryClient` (which speaks REST to
+ * the hosted Neo4j Agent Memory Service).
+ */
+
+export { BridgeTransport } from "./transport/bridge.js";
+export type { BridgeTransportOptions } from "./transport/bridge.js";

--- a/typescript/src/transport/bridge.ts
+++ b/typescript/src/transport/bridge.ts
@@ -1,0 +1,244 @@
+/**
+ * BridgeTransport — TCK bridge protocol transport.
+ *
+ * Speaks the bridge wire format (POST {endpoint}/{snake_case_method}) used by
+ * conformance servers and the local reference adapter. Compatible with every
+ * fetch-capable runtime (Node 20+, Bun, Deno, Workers, Edge).
+ */
+
+import { AuthenticationError, ConnectionError, TransportError } from "../errors.js";
+import {
+  defaultUserAgent,
+  extractRequestId,
+  supportsUserAgentHeader,
+  type Logger,
+} from "../observability.js";
+import type { Transport } from "./index.js";
+
+/** Strip trailing `/` from a URL without using a polynomial regex. */
+function trimTrailingSlashes(s: string): string {
+  let end = s.length;
+  while (end > 0 && s.charCodeAt(end - 1) === 47) end--;
+  return s.slice(0, end);
+}
+
+function nowMs(): number {
+  if (typeof performance !== "undefined" && typeof performance.now === "function") {
+    return performance.now();
+  }
+  return Date.now();
+}
+
+export interface BridgeTransportOptions {
+  /** Base URL of the bridge endpoint (no trailing /v1). */
+  endpoint: string;
+
+  /** API key for Bearer auth. Optional for local bridge servers. */
+  apiKey?: string;
+
+  /** Request timeout in milliseconds. Default: 30000. */
+  timeout?: number;
+
+  /** Additional headers to include in every request. */
+  headers?: Record<string, string>;
+
+  /** Per-request logger. */
+  logger?: Logger;
+}
+
+export class BridgeTransport implements Transport {
+  private readonly endpoint: string;
+  private readonly apiKey?: string;
+  private readonly timeout: number;
+  private readonly headers: Record<string, string>;
+  private readonly logger?: Logger;
+
+  constructor(options: BridgeTransportOptions) {
+    this.endpoint = trimTrailingSlashes(options.endpoint);
+    this.apiKey = options.apiKey;
+    this.timeout = options.timeout ?? 30_000;
+    this.headers = options.headers ?? {};
+    this.logger = options.logger;
+  }
+
+  async connect(): Promise<void> {
+    const url = `${this.endpoint}/setup`;
+    const start = nowMs();
+    this.emit({ kind: "request", method: "connect", url, httpMethod: "POST" });
+    let response: Response;
+    try {
+      response = await fetch(url, {
+        method: "POST",
+        headers: this.buildHeaders(),
+        signal: AbortSignal.timeout(this.timeout),
+      });
+    } catch (error) {
+      const durationMs = nowMs() - start;
+      if (error instanceof TypeError) {
+        const err = new ConnectionError(
+          `Failed to connect to ${this.endpoint}: ${(error as Error).message}`,
+          { cause: error },
+        );
+        this.emit({ kind: "error", method: "connect", url, durationMs, message: err.message });
+        throw err;
+      }
+      if (error instanceof DOMException && error.name === "TimeoutError") {
+        const err = new ConnectionError(
+          `Connection to ${this.endpoint} timed out after ${this.timeout}ms`,
+          { cause: error },
+        );
+        this.emit({ kind: "error", method: "connect", url, durationMs, message: err.message });
+        throw err;
+      }
+      throw error;
+    }
+    const durationMs = nowMs() - start;
+    const requestId = extractRequestId(response.headers);
+    if (response.status === 401 || response.status === 403) {
+      const err = new AuthenticationError(
+        `Authentication failed: ${response.status} ${response.statusText}`,
+        { requestId },
+      );
+      this.emit({
+        kind: "error",
+        method: "connect",
+        url,
+        status: response.status,
+        requestId,
+        durationMs,
+        message: err.message,
+      });
+      throw err;
+    }
+    this.emit({
+      kind: "response",
+      method: "connect",
+      url,
+      status: response.status,
+      requestId,
+      durationMs,
+    });
+  }
+
+  async close(): Promise<void> {}
+
+  async request<T>(method: string, params: Record<string, unknown>): Promise<T> {
+    const url = `${this.endpoint}/${method}`;
+
+    const body: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(params)) {
+      if (value !== undefined && value !== null) {
+        body[key] = value;
+      }
+    }
+
+    const start = nowMs();
+    this.emit({ kind: "request", method, url, httpMethod: "POST" });
+    let response: Response;
+    try {
+      response = await fetch(url, {
+        method: "POST",
+        headers: this.buildHeaders(),
+        body: JSON.stringify(body),
+        signal: AbortSignal.timeout(this.timeout),
+      });
+    } catch (error) {
+      const durationMs = nowMs() - start;
+      if (error instanceof TypeError) {
+        const err = new ConnectionError(
+          `Request to ${url} failed: ${(error as Error).message}`,
+          { cause: error },
+        );
+        this.emit({ kind: "error", method, url, durationMs, message: err.message });
+        throw err;
+      }
+      throw error;
+    }
+
+    const requestId = extractRequestId(response.headers);
+    const durationMs = nowMs() - start;
+
+    if (response.status === 401 || response.status === 403) {
+      const err = new AuthenticationError(
+        `Authentication failed: ${response.status} ${response.statusText}`,
+        { requestId },
+      );
+      this.emit({
+        kind: "error",
+        method,
+        url,
+        status: response.status,
+        requestId,
+        durationMs,
+        message: err.message,
+      });
+      throw err;
+    }
+
+    if (response.status === 204) {
+      this.emit({ kind: "response", method, url, status: 204, requestId, durationMs });
+      return undefined as T;
+    }
+
+    const text = await response.text();
+
+    if (!response.ok) {
+      let errorBody: unknown;
+      try {
+        errorBody = JSON.parse(text);
+      } catch {
+        errorBody = text;
+      }
+      const errorMessage =
+        typeof errorBody === "object" && errorBody !== null && "error" in errorBody
+          ? String((errorBody as Record<string, unknown>)["error"])
+          : `HTTP ${response.status}`;
+      const err = new TransportError(
+        `${method} failed: ${errorMessage}`,
+        response.status,
+        errorBody,
+        { requestId },
+      );
+      this.emit({
+        kind: "error",
+        method,
+        url,
+        status: response.status,
+        requestId,
+        durationMs,
+        message: err.message,
+      });
+      throw err;
+    }
+
+    this.emit({ kind: "response", method, url, status: response.status, requestId, durationMs });
+
+    if (!text) return undefined as T;
+    return JSON.parse(text) as T;
+  }
+
+  private emit(event: Parameters<Logger>[0]): void {
+    if (!this.logger) return;
+    try {
+      this.logger(event);
+    } catch {
+      // Logger errors must never propagate.
+    }
+  }
+
+  private buildHeaders(): Record<string, string> {
+    const headers: Record<string, string> = { "Content-Type": "application/json" };
+    const canSendUserAgent = supportsUserAgentHeader();
+    for (const [key, value] of Object.entries(this.headers)) {
+      if (key.toLowerCase() === "user-agent" && !canSendUserAgent) continue;
+      headers[key] = value;
+    }
+    if (canSendUserAgent && !Object.keys(headers).some((key) => key.toLowerCase() === "user-agent")) {
+      headers["User-Agent"] = defaultUserAgent();
+    }
+    if (this.apiKey) {
+      headers["Authorization"] = `Bearer ${this.apiKey}`;
+    }
+    return headers;
+  }
+}

--- a/typescript/src/transport/casing.ts
+++ b/typescript/src/transport/casing.ts
@@ -1,0 +1,45 @@
+/**
+ * snake_case ↔ camelCase translation for wire payloads.
+ *
+ * Keep deeply nested structures (arrays, objects, primitives) intact.
+ * Pure helpers — no transport dependencies.
+ */
+
+const SNAKE_RE = /_([a-z0-9])/g;
+const CAMEL_RE = /([A-Z])/g;
+
+function snakeKey(key: string): string {
+  return key.replace(CAMEL_RE, (_, c) => `_${(c as string).toLowerCase()}`);
+}
+
+function camelKey(key: string): string {
+  return key.replace(SNAKE_RE, (_, c) => (c as string).toUpperCase());
+}
+
+export function snakeToCamel<T = unknown>(value: unknown): T {
+  if (Array.isArray(value)) {
+    return value.map((v) => snakeToCamel(v)) as T;
+  }
+  if (value !== null && typeof value === "object") {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value)) {
+      out[camelKey(k)] = snakeToCamel(v);
+    }
+    return out as T;
+  }
+  return value as T;
+}
+
+export function camelToSnake<T = unknown>(value: unknown): T {
+  if (Array.isArray(value)) {
+    return value.map((v) => camelToSnake(v)) as T;
+  }
+  if (value !== null && typeof value === "object") {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value)) {
+      out[snakeKey(k)] = camelToSnake(v);
+    }
+    return out as T;
+  }
+  return value as T;
+}

--- a/typescript/src/transport/index.ts
+++ b/typescript/src/transport/index.ts
@@ -1,0 +1,22 @@
+/**
+ * Transport abstraction layer.
+ *
+ * RestTransport speaks the hosted REST API at https://memory.neo4jlabs.com/v1
+ * and is the transport every application should use. BridgeTransport speaks
+ * the TCK bridge protocol and is exposed via the `./testing` subpath for
+ * conformance testing only.
+ */
+
+export interface Transport {
+  /** Send a request to the backend and return the parsed response. */
+  request<T>(method: string, params: Record<string, unknown>): Promise<T>;
+
+  /** Establish the connection. */
+  connect(): Promise<void>;
+
+  /** Close the connection and release resources. */
+  close(): Promise<void>;
+}
+
+export { RestTransport } from "./rest.js";
+export type { RestTransportOptions, TokenProvider } from "./rest.js";

--- a/typescript/src/transport/rest.ts
+++ b/typescript/src/transport/rest.ts
@@ -1,0 +1,616 @@
+/**
+ * RestTransport — talks to the hosted Neo4j Agent Memory Service REST API.
+ *
+ * Endpoint should be the v1 root, e.g. `https://memory.neo4jlabs.com/v1`.
+ * Routes the bridge-style `request(method, params)` calls to the appropriate
+ * REST endpoints with snake_case ↔ camelCase translation on the wire.
+ *
+ * Hosted-native methods (added in Volume 5 of the spec) are routed natively.
+ * Legacy bridge-only methods (add_preference, add_fact, etc.) throw
+ * NotSupportedError because the hosted service has no equivalent.
+ */
+
+import {
+  AuthenticationError,
+  ConnectionError,
+  NotSupportedError,
+  TransportError,
+} from "../errors.js";
+import {
+  defaultUserAgent,
+  extractRequestId,
+  supportsUserAgentHeader,
+  type Logger,
+} from "../observability.js";
+import { camelToSnake, snakeToCamel } from "./casing.js";
+import type { Transport } from "./index.js";
+
+/** Strip trailing `/` from a URL without using a polynomial regex. */
+function trimTrailingSlashes(s: string): string {
+  let end = s.length;
+  while (end > 0 && s.charCodeAt(end - 1) === 47) end--;
+  return s.slice(0, end);
+}
+
+/** Monotonic-ish timestamp for duration measurement. Works on all runtimes. */
+function nowMs(): number {
+  if (typeof performance !== "undefined" && typeof performance.now === "function") {
+    return performance.now();
+  }
+  return Date.now();
+}
+
+/** snake_case → camelCase, single-key form (no recursion into objects). */
+function snakeToCamelKey(s: string): string {
+  return s.replace(/_([a-z0-9])/g, (_, c) => (c as string).toUpperCase());
+}
+
+export type TokenProvider = () => string | Promise<string>;
+
+export interface RestTransportOptions {
+  /** Base URL — should end in /v1, e.g. https://memory.neo4jlabs.com/v1 */
+  endpoint: string;
+
+  /** Static `nams_*` API key. */
+  apiKey?: string;
+
+  /** Token provider (overrides apiKey if both supplied) — for OAuth refresh flows. */
+  tokenProvider?: TokenProvider;
+
+  /** Request timeout in milliseconds. Default: 30000. */
+  timeout?: number;
+
+  /** Additional headers to include in every request. */
+  headers?: Record<string, string>;
+
+  /** Per-request logger; see {@link Logger}. */
+  logger?: Logger;
+}
+
+type HttpMethod = "GET" | "POST" | "PUT" | "DELETE";
+
+interface RestCall {
+  method: HttpMethod;
+  /** Path template; tokens like `{conversationId}` are replaced from params (camel-cased). */
+  path: string;
+  /** Param names that go in the URL path (camelCase) — stripped from the body. */
+  pathParams?: string[];
+  /** Param names that become query string parameters (camelCase). */
+  queryParams?: string[];
+  /** GET/DELETE → no body. */
+  hasBody?: boolean;
+  /** Optional response shaper for endpoints whose payload doesn't match bridge wire. */
+  shape?: (raw: unknown, camelParams: Record<string, unknown>) => unknown;
+}
+
+/**
+ * Bridge-method-name → REST-call mapping.
+ *
+ * Keys are snake_case bridge method names. Values describe how to dispatch.
+ */
+const ROUTES: Record<string, RestCall | "noop" | "unsupported"> = {
+  // Lifecycle ----------------------------------------------------------------
+  setup: "noop",
+  teardown: "noop",
+  // Hosted has no global clear; we delete every conversation owned by the API
+  // key. This is best-effort — see clearAllData() for the implementation.
+  clear_all_data: "noop",
+
+  // Short-Term — legacy bridge methods (mapped where a clean REST equivalent
+  // exists; bridge sessionId is treated as the conversationId UUID).
+  add_message: {
+    method: "POST",
+    path: "/conversations/{sessionId}/messages",
+    pathParams: ["sessionId"],
+    hasBody: true,
+  },
+  get_conversation: {
+    method: "GET",
+    path: "/conversations/{sessionId}/messages",
+    pathParams: ["sessionId"],
+    queryParams: ["limit"],
+    shape: (raw, p) => {
+      const messages = (raw as { messages?: unknown[] })?.messages ?? raw ?? [];
+      return {
+        id: p["sessionId"],
+        session_id: p["sessionId"],
+        messages,
+        created_at: null,
+      };
+    },
+  },
+  list_sessions: {
+    method: "GET",
+    path: "/conversations",
+    queryParams: ["limit"],
+    shape: (raw) => {
+      const conversations = (raw as { conversations?: unknown[] })?.conversations ?? [];
+      return conversations.map((c) => {
+        const conv = c as Record<string, unknown>;
+        return {
+          session_id: conv["id"],
+          message_count: conv["messageCount"] ?? 0,
+          created_at: conv["createdAt"],
+          updated_at: conv["updatedAt"],
+        };
+      });
+    },
+  },
+  search_messages: {
+    method: "POST",
+    path: "/conversations/{sessionId}/search",
+    pathParams: ["sessionId"],
+    hasBody: true,
+    shape: (raw) => (raw as { messages?: unknown[] })?.messages ?? [],
+  },
+  clear_session: {
+    method: "DELETE",
+    path: "/conversations/{sessionId}",
+    pathParams: ["sessionId"],
+  },
+  delete_message: "unsupported",
+
+  // Long-Term — legacy mapped methods
+  add_entity: {
+    method: "POST",
+    path: "/entities",
+    hasBody: true,
+  },
+  search_entities: {
+    method: "POST",
+    path: "/entities/search",
+    hasBody: true,
+    shape: (raw) => (raw as { entities?: unknown[] })?.entities ?? [],
+  },
+  add_preference: "unsupported",
+  add_fact: "unsupported",
+  search_preferences: "unsupported",
+  get_entity_by_name: "unsupported",
+  get_related_entities: "unsupported",
+  add_relationship: "unsupported",
+  merge_duplicate_entities: "unsupported",
+
+  // Reasoning — legacy not directly representable in REST
+  start_trace: "unsupported",
+  add_step: "unsupported",
+  record_tool_call: {
+    method: "POST",
+    path: "/reasoning/tool-calls",
+    hasBody: true,
+  },
+  complete_trace: "unsupported",
+  get_trace_with_steps: "unsupported",
+  list_traces: "unsupported",
+  get_tool_stats: "unsupported",
+  get_similar_traces: "unsupported",
+
+  // ---- Hosted-native methods (Volume 5 / Platinum tier) --------------------
+  create_conversation: {
+    method: "POST",
+    path: "/conversations",
+    hasBody: true,
+  },
+  list_conversations: {
+    method: "GET",
+    path: "/conversations",
+    queryParams: ["limit", "user_id"],
+    shape: (raw) => (raw as { conversations?: unknown[] })?.conversations ?? raw,
+  },
+  get_conversation_metadata: {
+    method: "GET",
+    path: "/conversations/{conversationId}",
+    pathParams: ["conversationId"],
+  },
+  delete_conversation: {
+    method: "DELETE",
+    path: "/conversations/{conversationId}",
+    pathParams: ["conversationId"],
+  },
+  get_context: {
+    method: "GET",
+    path: "/conversations/{conversationId}/context",
+    pathParams: ["conversationId"],
+  },
+  bulk_add_messages: {
+    method: "POST",
+    path: "/conversations/{conversationId}/messages/bulk",
+    pathParams: ["conversationId"],
+    hasBody: true,
+    shape: (raw) => (raw as { messages?: unknown[] })?.messages ?? raw,
+  },
+  get_observations: {
+    method: "GET",
+    path: "/conversations/{conversationId}/observations",
+    pathParams: ["conversationId"],
+    queryParams: ["limit"],
+    shape: (raw) => (raw as { observations?: unknown[] })?.observations ?? raw,
+  },
+  get_reflections: {
+    method: "GET",
+    path: "/conversations/{conversationId}/reflections",
+    pathParams: ["conversationId"],
+    shape: (raw) => (raw as { reflections?: unknown[] })?.reflections ?? raw,
+  },
+  list_entities: {
+    method: "GET",
+    path: "/entities",
+    queryParams: ["type", "limit"],
+    shape: (raw) => (raw as { entities?: unknown[] })?.entities ?? raw,
+  },
+  get_entity: {
+    method: "GET",
+    path: "/entities/{entityId}",
+    pathParams: ["entityId"],
+  },
+  update_entity: {
+    method: "PUT",
+    path: "/entities/{entityId}",
+    pathParams: ["entityId"],
+    hasBody: true,
+  },
+  delete_entity: {
+    method: "DELETE",
+    path: "/entities/{entityId}",
+    pathParams: ["entityId"],
+  },
+  set_entity_feedback: {
+    method: "PUT",
+    path: "/entities/{entityId}/feedback",
+    pathParams: ["entityId"],
+    hasBody: true,
+  },
+  get_entity_history: {
+    method: "GET",
+    path: "/entities/{entityId}/history",
+    pathParams: ["entityId"],
+  },
+  merge_entities: {
+    method: "POST",
+    path: "/entities/{sourceId}/merge",
+    pathParams: ["sourceId"],
+    hasBody: true,
+  },
+  get_entity_graph: {
+    method: "GET",
+    path: "/entities/graph",
+  },
+  explain_step: {
+    method: "GET",
+    path: "/reasoning/explain/{stepId}",
+    pathParams: ["stepId"],
+  },
+  get_trace_by_conversation: {
+    method: "GET",
+    path: "/reasoning/trace/{conversationId}",
+    pathParams: ["conversationId"],
+  },
+  get_entity_provenance: {
+    method: "GET",
+    path: "/reasoning/provenance/{entityId}",
+    pathParams: ["entityId"],
+  },
+  record_step: {
+    method: "POST",
+    path: "/reasoning/steps",
+    hasBody: true,
+  },
+  list_steps: {
+    method: "GET",
+    path: "/reasoning/steps",
+    queryParams: ["conversation_id"],
+    shape: (raw) => (raw as { steps?: unknown[] })?.steps ?? raw,
+  },
+  cypher_query: {
+    method: "POST",
+    path: "/query",
+    hasBody: true,
+  },
+
+  // Auth
+  list_api_keys: {
+    method: "GET",
+    path: "/auth/api-keys",
+    queryParams: ["workspace_id"],
+    shape: (raw) => {
+      const r = raw as { keys?: unknown[]; api_keys?: unknown[] };
+      return r?.keys ?? r?.api_keys ?? raw;
+    },
+  },
+  create_api_key: {
+    method: "POST",
+    path: "/auth/api-keys",
+    hasBody: true,
+  },
+  revoke_api_key: {
+    method: "DELETE",
+    path: "/auth/api-keys/{keyId}",
+    pathParams: ["keyId"],
+  },
+  reveal_api_key: {
+    method: "GET",
+    path: "/auth/api-keys/{keyId}/reveal",
+    pathParams: ["keyId"],
+    queryParams: ["workspace_id"],
+  },
+  refresh_access_token: {
+    method: "POST",
+    path: "/auth/refresh",
+    hasBody: true,
+  },
+};
+
+export class RestTransport implements Transport {
+  private readonly endpoint: string;
+  private readonly apiKey?: string;
+  private readonly tokenProvider?: TokenProvider;
+  private readonly timeout: number;
+  private readonly headers: Record<string, string>;
+  private readonly logger?: Logger;
+
+  constructor(options: RestTransportOptions) {
+    this.endpoint = trimTrailingSlashes(options.endpoint);
+    this.apiKey = options.apiKey;
+    this.tokenProvider = options.tokenProvider;
+    this.timeout = options.timeout ?? 30_000;
+    this.headers = options.headers ?? {};
+    this.logger = options.logger;
+  }
+
+  async connect(): Promise<void> {
+    const url = `${this.endpoint}/conversations?limit=1`;
+    const start = nowMs();
+    this.emit({ kind: "request", method: "connect", url, httpMethod: "GET" });
+    let response: Response;
+    try {
+      response = await fetch(url, {
+        method: "GET",
+        headers: await this.buildHeaders(),
+        signal: AbortSignal.timeout(this.timeout),
+      });
+    } catch (error) {
+      const durationMs = nowMs() - start;
+      if (error instanceof TypeError) {
+        const err = new ConnectionError(
+          `Failed to connect to ${this.endpoint}: ${(error as Error).message}`,
+          { cause: error },
+        );
+        this.emit({ kind: "error", method: "connect", url, durationMs, message: err.message });
+        throw err;
+      }
+      if (error instanceof DOMException && error.name === "TimeoutError") {
+        const err = new ConnectionError(
+          `Connection to ${this.endpoint} timed out after ${this.timeout}ms`,
+          { cause: error },
+        );
+        this.emit({ kind: "error", method: "connect", url, durationMs, message: err.message });
+        throw err;
+      }
+      throw error;
+    }
+    const durationMs = nowMs() - start;
+    const requestId = extractRequestId(response.headers);
+    if (response.status === 401 || response.status === 403) {
+      const err = new AuthenticationError(
+        `Authentication failed against ${this.endpoint}: ${response.status} ${response.statusText}`,
+        { requestId },
+      );
+      this.emit({
+        kind: "error",
+        method: "connect",
+        url,
+        status: response.status,
+        requestId,
+        durationMs,
+        message: err.message,
+      });
+      throw err;
+    }
+    if (!response.ok && response.status >= 500) {
+      const err = new ConnectionError(
+        `Server error from ${this.endpoint}: ${response.status} ${response.statusText}`,
+        { requestId },
+      );
+      this.emit({
+        kind: "error",
+        method: "connect",
+        url,
+        status: response.status,
+        requestId,
+        durationMs,
+        message: err.message,
+      });
+      throw err;
+    }
+    this.emit({
+      kind: "response",
+      method: "connect",
+      url,
+      status: response.status,
+      requestId,
+      durationMs,
+    });
+  }
+
+  async close(): Promise<void> {}
+
+  async request<T>(method: string, params: Record<string, unknown>): Promise<T> {
+    const route = ROUTES[method];
+    if (!route) {
+      throw new NotSupportedError(
+        `Method '${method}' is not implemented by RestTransport. ` +
+          `Use BridgeTransport for full TCK conformance, or call a hosted-native method.`,
+      );
+    }
+    if (route === "noop") return undefined as T;
+    if (route === "unsupported") {
+      throw new NotSupportedError(
+        `Method '${method}' has no equivalent in the hosted Neo4j Agent Memory REST API. ` +
+          `It is supported by BridgeTransport only.`,
+      );
+    }
+
+    const original = params ?? {};
+    const camelParams = snakeToCamel<Record<string, unknown>>(original);
+
+    // Substitute path params (placeholders match camelCase route literals).
+    let path = route.path;
+    const consumed = new Set<string>();
+    for (const name of route.pathParams ?? []) {
+      const v = camelParams[name];
+      if (v === undefined || v === null || v === "") {
+        throw new TransportError(
+          `Missing required path parameter '${name}' for method '${method}'`,
+          400,
+          camelParams,
+        );
+      }
+      path = path.replace(`{${name}}`, encodeURIComponent(String(v)));
+      consumed.add(name);
+    }
+
+    // Build query string. The hosted REST API uses snake_case for query
+    // params (conversation_id, workspace_id) — NOT camelCase. Look up by
+    // the snake_case name from the original params; fall back to the
+    // camelCase form if the caller already passed it that way.
+    const queryEntries: [string, string][] = [];
+    for (const name of route.queryParams ?? []) {
+      let v: unknown = original[name];
+      if (v === undefined || v === null) {
+        const camel = snakeToCamelKey(name);
+        v = camelParams[camel];
+      }
+      if (v !== undefined && v !== null) {
+        queryEntries.push([name, String(v)]);
+        consumed.add(name);
+        consumed.add(snakeToCamelKey(name));
+      }
+    }
+    const query = queryEntries.length
+      ? "?" + queryEntries.map(([k, v]) => `${k}=${encodeURIComponent(v)}`).join("&")
+      : "";
+
+    // Build body (anything not consumed)
+    let body: string | undefined;
+    if (route.hasBody) {
+      const bodyObj: Record<string, unknown> = {};
+      for (const [k, v] of Object.entries(camelParams)) {
+        if (!consumed.has(k) && v !== undefined && v !== null) {
+          bodyObj[k] = v;
+        }
+      }
+      body = JSON.stringify(bodyObj);
+    }
+
+    const url = `${this.endpoint}${path}${query}`;
+    const start = nowMs();
+    this.emit({ kind: "request", method, url, httpMethod: route.method });
+    let response: Response;
+    try {
+      response = await fetch(url, {
+        method: route.method,
+        headers: await this.buildHeaders(route.hasBody),
+        body,
+        signal: AbortSignal.timeout(this.timeout),
+      });
+    } catch (error) {
+      const durationMs = nowMs() - start;
+      if (error instanceof TypeError) {
+        const err = new ConnectionError(
+          `Request to ${url} failed: ${(error as Error).message}`,
+          { cause: error },
+        );
+        this.emit({ kind: "error", method, url, durationMs, message: err.message });
+        throw err;
+      }
+      throw error;
+    }
+
+    const requestId = extractRequestId(response.headers);
+    const durationMs = nowMs() - start;
+
+    if (response.status === 401 || response.status === 403) {
+      const err = new AuthenticationError(
+        `Authentication failed: ${response.status} ${response.statusText}`,
+        { requestId },
+      );
+      this.emit({
+        kind: "error",
+        method,
+        url,
+        status: response.status,
+        requestId,
+        durationMs,
+        message: err.message,
+      });
+      throw err;
+    }
+
+    if (response.status === 204) {
+      this.emit({ kind: "response", method, url, status: 204, requestId, durationMs });
+      return undefined as T;
+    }
+
+    const text = await response.text();
+
+    if (!response.ok) {
+      let errorBody: unknown;
+      try {
+        errorBody = JSON.parse(text);
+      } catch {
+        errorBody = text;
+      }
+      const errMsg =
+        typeof errorBody === "object" && errorBody !== null && "error" in errorBody
+          ? String((errorBody as Record<string, unknown>)["error"])
+          : `HTTP ${response.status}`;
+      const err = new TransportError(
+        `${method} failed: ${errMsg}`,
+        response.status,
+        errorBody,
+        { requestId },
+      );
+      this.emit({
+        kind: "error",
+        method,
+        url,
+        status: response.status,
+        requestId,
+        durationMs,
+        message: err.message,
+      });
+      throw err;
+    }
+
+    this.emit({ kind: "response", method, url, status: response.status, requestId, durationMs });
+
+    if (!text) return undefined as T;
+    let parsed: unknown = JSON.parse(text);
+    if (route.shape) parsed = route.shape(parsed, camelParams);
+    return camelToSnake<T>(parsed);
+  }
+
+  private emit(event: Parameters<Logger>[0]): void {
+    if (!this.logger) return;
+    try {
+      this.logger(event);
+    } catch {
+      // Logger errors must never propagate.
+    }
+  }
+
+  private async buildHeaders(includeContentType = false): Promise<Record<string, string>> {
+    const headers: Record<string, string> = {};
+    const canSendUserAgent = supportsUserAgentHeader();
+    for (const [key, value] of Object.entries(this.headers)) {
+      if (key.toLowerCase() === "user-agent" && !canSendUserAgent) continue;
+      headers[key] = value;
+    }
+    if (canSendUserAgent && !Object.keys(headers).some((key) => key.toLowerCase() === "user-agent")) {
+      headers["User-Agent"] = defaultUserAgent();
+    }
+    if (includeContentType) headers["Content-Type"] = "application/json";
+    const token = this.tokenProvider ? await this.tokenProvider() : this.apiKey;
+    if (token) headers["Authorization"] = `Bearer ${token}`;
+    return headers;
+  }
+}

--- a/typescript/src/types.ts
+++ b/typescript/src/types.ts
@@ -1,0 +1,444 @@
+/**
+ * Core type definitions for neo4j-agent-memory TypeScript client.
+ *
+ * Canonical types use camelCase. Wire format depends on transport:
+ *   - BridgeTransport: snake_case JSON
+ *   - RestTransport: camelCase JSON (matches the hosted service)
+ *
+ * Sub-clients translate between wire and canonical forms.
+ */
+
+// ---------------------------------------------------------------------------
+// Enums
+// ---------------------------------------------------------------------------
+
+export type MessageRole = "user" | "assistant" | "system";
+
+export type ToolCallStatus =
+  | "pending"
+  | "success"
+  | "failure"
+  | "error"
+  | "timeout"
+  | "cancelled";
+
+// ---------------------------------------------------------------------------
+// Short-Term Memory Types
+// ---------------------------------------------------------------------------
+
+export interface Message {
+  id: string;
+  role: MessageRole;
+  content: string;
+  timestamp: string;
+  embedding?: number[];
+  metadata: Record<string, unknown>;
+  /** Hosted service: link back to the conversation. */
+  conversationId?: string;
+}
+
+export interface Conversation {
+  id: string;
+  /** Bridge protocol session identifier (free-form string). */
+  sessionId: string;
+  messages: Message[];
+  /** Hosted service: message count when returned by list/metadata endpoints. */
+  messageCount?: number;
+  title?: string;
+  createdAt: string;
+  updatedAt?: string;
+  /** Hosted service: workspace owning this conversation. */
+  workspaceId?: string;
+  /** Hosted service: user the conversation belongs to. */
+  userId?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface SessionInfo {
+  sessionId: string;
+  messageCount: number;
+  createdAt: string;
+  updatedAt?: string;
+}
+
+/** A 3-tier conversational context window — hosted service. */
+export interface ConversationContext {
+  reflections: Reflection[];
+  observations: Observation[];
+  recentMessages: Message[];
+}
+
+export interface Observation {
+  id: string;
+  conversationId: string;
+  content: string;
+  windowStart?: string;
+  windowEnd?: string;
+  createdAt: string;
+}
+
+export interface Reflection {
+  id: string;
+  conversationId: string;
+  content: string;
+  createdAt: string;
+}
+
+// ---------------------------------------------------------------------------
+// Long-Term Memory Types
+// ---------------------------------------------------------------------------
+
+/** Bridge taxonomy. */
+export type EntityType = "PERSON" | "ORGANIZATION" | "LOCATION" | "EVENT" | "OBJECT";
+
+/** Hosted-service entity taxonomy. */
+export type HostedEntityType =
+  | "person"
+  | "organization"
+  | "location"
+  | "concept"
+  | "tool"
+  | "custom";
+
+export interface Entity {
+  id: string;
+  name: string;
+  type: string;
+  subtype?: string;
+  description?: string;
+  embedding?: number[];
+  canonicalName?: string;
+  createdAt: string;
+  /** Hosted service. */
+  updatedAt?: string;
+  /** Hosted service: confidence score (0-1). */
+  confidence?: number;
+  /** Hosted service: which extraction stage produced the entity. */
+  sourceStage?: string;
+  /** Hosted service: relationships referenced by getEntity. */
+  relationships?: EntityRelationshipRef[];
+}
+
+export interface EntityRelationshipRef {
+  id: string;
+  type: string;
+  targetId: string;
+  targetName?: string;
+  properties?: Record<string, unknown>;
+}
+
+export interface EntityHistory {
+  entityId: string;
+  mentions: EntityMention[];
+}
+
+export interface EntityMention {
+  conversationId: string;
+  messageId?: string;
+  content: string;
+  timestamp: string;
+}
+
+export interface EntityGraphNode {
+  id: string;
+  name: string;
+  type: string;
+}
+
+export interface EntityGraphEdge {
+  id: string;
+  source: string;
+  target: string;
+  type: string;
+}
+
+export interface EntityGraph {
+  nodes: EntityGraphNode[];
+  edges: EntityGraphEdge[];
+}
+
+export interface EntityFeedbackResult {
+  id: string;
+  updated: boolean;
+}
+
+export interface EntityMergeResult {
+  sourceId: string;
+  targetId: string;
+  status: string;
+}
+
+export interface Preference {
+  id: string;
+  category: string;
+  preference: string;
+  context?: string;
+  embedding?: number[];
+}
+
+export interface Fact {
+  id: string;
+  subject: string;
+  predicate: string;
+  object: string;
+  embedding?: number[];
+}
+
+export interface Relationship {
+  id: string;
+  sourceId: string;
+  targetId: string;
+  relationshipType: string;
+  properties: Record<string, unknown>;
+}
+
+// ---------------------------------------------------------------------------
+// Reasoning Memory Types
+// ---------------------------------------------------------------------------
+
+export interface ReasoningTrace {
+  id: string;
+  sessionId: string;
+  task: string;
+  steps: ReasoningStep[];
+  outcome?: string;
+  success?: boolean;
+  startedAt: string;
+  completedAt?: string;
+}
+
+export interface ReasoningStep {
+  id: string;
+  traceId: string;
+  stepNumber: number;
+  thought?: string;
+  action?: string;
+  observation?: string;
+  toolCalls: ToolCall[];
+}
+
+export interface ToolCall {
+  id: string;
+  /** Reasoning step this tool call hangs off (hosted service exposes this). */
+  stepId?: string;
+  toolName: string;
+  arguments: Record<string, unknown>;
+  result?: unknown;
+  status: ToolCallStatus;
+  durationMs?: number;
+  error?: string;
+}
+
+export interface ToolStats {
+  name: string;
+  totalCalls: number;
+  successfulCalls: number;
+  failedCalls: number;
+  successRate: number;
+  avgDurationMs?: number;
+}
+
+/** Hosted-service flat reasoning step (per-conversation, no trace wrapper). */
+export interface AgentStep {
+  id: string;
+  conversationId: string;
+  reasoning: string;
+  actionTaken: string;
+  result?: string;
+  createdAt: string;
+}
+
+/** Hosted: detailed step with tool calls + influenced entities. */
+export interface AgentStepExplanation extends AgentStep {
+  toolCalls: ToolCall[];
+  influencedEntities: Entity[];
+}
+
+/** Hosted: flat reasoning trace (steps + tool calls under one conversation). */
+export interface ConversationTrace {
+  conversationId: string;
+  steps: AgentStep[];
+  toolCalls: ToolCall[];
+}
+
+/** Hosted: provenance of an entity's creation. */
+export interface EntityProvenance {
+  entityId: string;
+  steps: AgentStep[];
+}
+
+// ---------------------------------------------------------------------------
+// Query Console
+// ---------------------------------------------------------------------------
+
+export interface CypherResult {
+  columns: string[];
+  rows: unknown[][];
+  stats?: Record<string, unknown>;
+}
+
+// ---------------------------------------------------------------------------
+// Auth / API Keys (hosted service)
+// ---------------------------------------------------------------------------
+
+export interface ApiKey {
+  id: string;
+  label: string;
+  scopes: string[];
+  workspaceId: string;
+  createdAt: string;
+  expiresAt?: string;
+  /** Plaintext key — only present at creation time. */
+  key?: string;
+}
+
+export interface AccessTokenPair {
+  accessToken: string;
+  refreshToken: string;
+  expiresIn: number;
+}
+
+// ---------------------------------------------------------------------------
+// Client Configuration
+// ---------------------------------------------------------------------------
+
+export type TransportMode = "auto" | "bridge" | "rest";
+
+export interface MemoryClientOptions {
+  /** Service base URL (bridge endpoint, or `https://.../v1` for REST). */
+  endpoint?: string;
+
+  /** API key for authentication. */
+  apiKey?: string;
+
+  /** Override transport selection. Default: "auto" (REST if endpoint contains /v1). */
+  transport?: TransportMode;
+
+  /** OAuth refresh-token-aware token provider. Overrides apiKey when supplied. */
+  tokenProvider?: () => string | Promise<string>;
+
+  /** Shared entity namespace for multi-agent collaboration. */
+  namespace?: string;
+
+  /** Request timeout in milliseconds. Default: 30000. */
+  timeout?: number;
+
+  /** Additional headers to include in every request. */
+  headers?: Record<string, string>;
+
+  /**
+   * Optional logger invoked once per request / response / error. Useful for
+   * tracing requests in development. Caller controls log level by ignoring
+   * unwanted event kinds. See {@link LogEvent}.
+   */
+  logger?: import("./observability.js").Logger;
+}
+
+// ---------------------------------------------------------------------------
+// Operation Options
+// ---------------------------------------------------------------------------
+
+export interface AddMessageOptions {
+  metadata?: Record<string, unknown>;
+}
+
+export interface GetConversationOptions {
+  limit?: number;
+}
+
+export interface SearchMessagesOptions {
+  sessionId?: string;
+  limit?: number;
+  threshold?: number;
+}
+
+export interface ListSessionsOptions {
+  limit?: number;
+}
+
+export interface SearchEntitiesOptions {
+  limit?: number;
+  type?: string;
+}
+
+export interface SearchPreferencesOptions {
+  category?: string;
+  limit?: number;
+}
+
+export interface GetRelatedEntitiesOptions {
+  relationshipType?: string;
+  depth?: number;
+}
+
+export interface ListTracesOptions {
+  sessionId?: string;
+  limit?: number;
+}
+
+export interface RecordToolCallOptions {
+  result?: unknown;
+  status?: ToolCallStatus;
+  durationMs?: number;
+  error?: string;
+}
+
+export interface CompleteTraceOptions {
+  outcome?: string;
+  success?: boolean;
+}
+
+export interface AddRelationshipOptions {
+  properties?: Record<string, unknown>;
+}
+
+export interface GetSimilarTracesOptions {
+  limit?: number;
+  successOnly?: boolean;
+}
+
+// Hosted-service options ----------------------------------------------------
+
+export interface CreateConversationOptions {
+  userId: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface ListConversationsOptions {
+  limit?: number;
+  userId?: string;
+}
+
+export interface BulkMessageInput {
+  role: MessageRole;
+  content: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface ListEntitiesOptions {
+  type?: HostedEntityType | string;
+  limit?: number;
+}
+
+export interface UpdateEntityOptions {
+  name?: string;
+  description?: string;
+}
+
+export interface SetEntityFeedbackOptions {
+  userScore: number;
+  confirmed: boolean;
+}
+
+export interface RecordStepInput {
+  conversationId: string;
+  reasoning: string;
+  actionTaken: string;
+  result?: string;
+}
+
+export interface CreateApiKeyInput {
+  label: string;
+  scopes: string[];
+  workspaceId: string;
+}

--- a/typescript/src/version.ts
+++ b/typescript/src/version.ts
@@ -1,0 +1,6 @@
+/**
+ * Package version constant. Kept in sync with package.json via a
+ * dedicated version-check script run in CI. Imported by the transports to build
+ * the default User-Agent header.
+ */
+export const VERSION = "0.3.0";

--- a/typescript/test/e2e/hosted-service.test.ts
+++ b/typescript/test/e2e/hosted-service.test.ts
@@ -1,0 +1,799 @@
+/**
+ * Comprehensive end-to-end tests against the live hosted Neo4j Agent Memory
+ * Service.
+ *
+ * Mirrors the Python suite at clients/python/tests/e2e/test_hosted_service.py
+ * — same scenarios, same fixtures, same skip patterns. Skipped wholesale
+ * when MEMORY_API_KEY is unset; individual tests skip themselves when the
+ * service rejects an operation that requires elevated workspace scope.
+ *
+ * Each test creates short-lived data (conversations / entities tagged with
+ * the `tck-e2e-ts-` user prefix) and tears it down via afterAll. Failures
+ * during cleanup are swallowed.
+ */
+
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+} from "vitest";
+import { MemoryClient } from "../../src/client.js";
+import {
+  AuthenticationError,
+  NotFoundError,
+  TransportError,
+  ValidationError,
+} from "../../src/errors.js";
+import type { Entity } from "../../src/types.js";
+import {
+  metadataFor,
+  provenanceReasoning,
+  provenanceResult,
+  tagDescription,
+} from "./tck-provenance.js";
+
+const API_KEY = (process.env.MEMORY_API_KEY ?? "").trim();
+const ENDPOINT = process.env.MEMORY_ENDPOINT ?? "https://memory.neo4jlabs.com/v1";
+const HAS_KEY = API_KEY.length > 0;
+
+const describeOrSkip = HAS_KEY ? describe : describe.skip;
+
+const UNIQUE_TAG = randomHex(8);
+const USER_PREFIX = process.env.MEMORY_E2E_USER_ID ?? "tck-e2e-ts";
+
+function userId(suffix = ""): string {
+  const rand = randomHex(6);
+  const base = `${USER_PREFIX}-${UNIQUE_TAG}-${rand}`;
+  return suffix ? `${base}-${suffix}` : base;
+}
+
+function randomHex(n: number): string {
+  if (typeof crypto !== "undefined" && typeof crypto.getRandomValues === "function") {
+    const buf = new Uint8Array(Math.ceil(n / 2));
+    crypto.getRandomValues(buf);
+    return Array.from(buf, (b) => b.toString(16).padStart(2, "0")).join("").slice(0, n);
+  }
+  return Date.now().toString(16).slice(-n);
+}
+
+async function waitUntil<T>(
+  predicate: () => Promise<T | null | undefined>,
+  { timeout = 12_000, interval = 1_000 }: { timeout?: number; interval?: number } = {},
+): Promise<T | null> {
+  const deadline = Date.now() + timeout;
+  let last: T | null | undefined = null;
+  while (Date.now() < deadline) {
+    last = await predicate();
+    if (last) return last;
+    await new Promise((r) => setTimeout(r, interval));
+  }
+  return last ?? null;
+}
+
+describeOrSkip("hosted service e2e", () => {
+  let client: MemoryClient;
+  let currentTestName = "unknown";
+  const cleanupConversations: string[] = [];
+  const cleanupEntities: string[] = [];
+
+  beforeAll(async () => {
+    client = new MemoryClient({ endpoint: ENDPOINT, apiKey: API_KEY });
+    await client.connect();
+  });
+
+  // Capture the current test name for provenance tagging. Vitest exposes
+  // the task on the context handed to each test; we mirror it into a
+  // closure variable so newConv / newEntity helpers can read it.
+  beforeEach((ctx) => {
+    currentTestName = ctx?.task?.name ?? "unknown";
+  });
+
+  afterAll(async () => {
+    for (const id of cleanupConversations) {
+      try {
+        await client.shortTerm.deleteConversation(id);
+      } catch {
+        // best-effort
+      }
+    }
+    for (const id of cleanupEntities) {
+      try {
+        await client.longTerm.deleteEntity(id);
+      } catch {
+        // best-effort
+      }
+    }
+    await client.close();
+  });
+
+  /**
+   * Create a conversation tagged with full provenance metadata + record an
+   * `record_step` on it so the hosted reasoning graph can trace this
+   * conversation back to the originating test (client + run + sha).
+   */
+  async function newConv(opts?: { userId?: string; metadata?: Record<string, unknown> }) {
+    const baseMeta = metadataFor(currentTestName, { tck_phase: "fixture" });
+    const conv = await client.shortTerm.createConversation({
+      userId: opts?.userId ?? userId(),
+      metadata: { ...baseMeta, ...(opts?.metadata ?? {}) },
+    });
+    cleanupConversations.push(conv.id);
+    // Provenance is best-effort — never fail a test on tagging noise.
+    try {
+      await client.reasoning.recordStep({
+        conversationId: conv.id,
+        reasoning: provenanceReasoning(currentTestName, "setup"),
+        actionTaken: "create_conversation",
+        result: provenanceResult(currentTestName, { conversation_id: conv.id }),
+      });
+    } catch {
+      // ignore
+    }
+    return conv;
+  }
+
+  /**
+   * Create an entity whose `description` is prefixed with a provenance tag
+   * (e.g. `[tck:typescript:run123:test_name] tck e2e probe entity`) so even
+   * a workspace operator without graph access can grep for test data.
+   */
+  async function newEntity(opts?: {
+    name?: string;
+    entityType?: string;
+    description?: string;
+  }): Promise<Entity> {
+    const description = tagDescription(
+      currentTestName,
+      opts?.description ?? "tck e2e probe entity",
+    );
+    const e = await client.longTerm.addEntity(
+      opts?.name ?? `TCK-Probe-${randomHex(8)}`,
+      opts?.entityType ?? "concept",
+      { description },
+    );
+    cleanupEntities.push(e.id);
+    return e;
+  }
+
+  // =====================================================================
+  // 1. Connection + auth
+  // =====================================================================
+
+  describe("Connection and auth", () => {
+    it("connect succeeds with valid key", () => {
+      expect(client).toBeDefined();
+    });
+
+    it("invalid api key throws AuthenticationError", async () => {
+      const bad = new MemoryClient({
+        endpoint: ENDPOINT,
+        apiKey: "nams_obviously_not_real_token",
+      });
+      try {
+        await expect(bad.connect()).rejects.toBeInstanceOf(AuthenticationError);
+      } finally {
+        await bad.close();
+      }
+    });
+
+    it("empty api key throws AuthenticationError", async () => {
+      const bad = new MemoryClient({ endpoint: ENDPOINT, apiKey: "" });
+      try {
+        await expect(bad.connect()).rejects.toBeInstanceOf(AuthenticationError);
+      } finally {
+        await bad.close();
+      }
+    });
+  });
+
+  // =====================================================================
+  // 2. Conversation lifecycle
+  // =====================================================================
+
+  describe("Conversation lifecycle", () => {
+    it("create returns uuid + user_id + workspace_id", async () => {
+      const uid = userId("create");
+      const conv = await newConv({ userId: uid, metadata: { source: "e2e", seq: 1 } });
+      expect(conv.id.length).toBeGreaterThanOrEqual(8);
+      expect(conv.userId).toBe(uid);
+      expect(conv.workspaceId).toBeTruthy();
+    });
+
+    it("get_metadata round-trips user_id", async () => {
+      const conv = await newConv();
+      const meta = await client.shortTerm.getConversationMetadata(conv.id);
+      expect(meta.id).toBe(conv.id);
+      expect(meta.userId).toBe(conv.userId);
+    });
+
+    it("list includes freshly created conversation", async () => {
+      const conv = await newConv({ userId: userId("list-probe") });
+      const listed = await client.shortTerm.listConversations({ limit: 200 });
+      expect(listed.some((x) => x.id === conv.id)).toBe(true);
+    });
+
+    it("delete is idempotent", async () => {
+      const conv = await newConv();
+      await client.shortTerm.deleteConversation(conv.id);
+      // Second call must not throw
+      await client.shortTerm.deleteConversation(conv.id);
+    });
+  });
+
+  // =====================================================================
+  // 3. Short-term memory: messages
+  // =====================================================================
+
+  describe("Message basics", () => {
+    it("addMessage returns id + role", async () => {
+      const conv = await newConv();
+      const msg = await client.shortTerm.addMessage(conv.id, "user", "hello world");
+      expect(msg.id).toBeTruthy();
+      expect(msg.role).toBe("user");
+      expect(msg.content).toBe("hello world");
+    });
+
+    it("getConversation returns added messages", async () => {
+      const conv = await newConv();
+      const contents = ["one", "two", "three", "four", "five"];
+      for (const c of contents) {
+        await client.shortTerm.addMessage(conv.id, "user", c);
+      }
+      const got = await client.shortTerm.getConversation(conv.id);
+      const seen = got.messages.map((m) => m.content);
+      for (const c of contents) {
+        expect(seen).toContain(c);
+      }
+    });
+
+    it("searchMessages returns array", async () => {
+      const conv = await newConv();
+      await client.shortTerm.addMessage(
+        conv.id,
+        "user",
+        "Marie Curie won the Nobel Prize in Physics in 1903.",
+      );
+      const results = await client.shortTerm.searchMessages("Nobel", {
+        sessionId: conv.id,
+        limit: 5,
+        threshold: 0.0,
+      });
+      expect(Array.isArray(results)).toBe(true);
+    });
+  });
+
+  describe("Message roles", () => {
+    for (const role of ["user", "assistant", "system"] as const) {
+      it(`role round-trip: ${role}`, async () => {
+        const conv = await newConv();
+        const msg = await client.shortTerm.addMessage(conv.id, role, `role ${role}`);
+        expect(msg.role).toBe(role);
+      });
+    }
+  });
+
+  describe("Content fidelity", () => {
+    it("unicode preserved", async () => {
+      const conv = await newConv();
+      const content = "你好 🚀 émoji ñ ç ø";
+      const msg = await client.shortTerm.addMessage(conv.id, "user", content);
+      expect(msg.content).toBe(content);
+    });
+
+    it("long content (10k chars) preserved", async () => {
+      const conv = await newConv();
+      const content = "x".repeat(10_000);
+      const msg = await client.shortTerm.addMessage(conv.id, "user", content);
+      expect(msg.content).toBe(content);
+      expect(msg.content.length).toBe(10_000);
+    });
+
+    it("special chars preserved", async () => {
+      const conv = await newConv();
+      const content = 'quote " backslash \\ newline\nreturn\r tab\t json {"a":1}';
+      const msg = await client.shortTerm.addMessage(conv.id, "user", content);
+      expect(msg.content).toBe(content);
+    });
+
+    it("metadata round-trips without error", async () => {
+      const conv = await newConv();
+      const msg = await client.shortTerm.addMessage(conv.id, "user", "with-meta", {
+        metadata: { source: "tck-e2e", priority: "high", count: 42, active: true },
+      });
+      expect(msg.content).toBe("with-meta");
+    });
+  });
+
+  // =====================================================================
+  // 4. Bulk operations
+  // =====================================================================
+
+  describe("Bulk add messages", () => {
+    it("bulk add 5 messages", async () => {
+      const conv = await newConv();
+      const msgs = Array.from({ length: 5 }, (_, i) => ({
+        role: "user" as const,
+        content: `bulk-${i}`,
+      }));
+      const out = await client.shortTerm.bulkAddMessages(conv.id, msgs);
+      expect(out).toHaveLength(5);
+    });
+
+    it("bulk add 50 messages", async () => {
+      const conv = await newConv();
+      const msgs = Array.from({ length: 50 }, (_, i) => ({
+        role: "user" as const,
+        content: `big-bulk-${i}`,
+      }));
+      const out = await client.shortTerm.bulkAddMessages(conv.id, msgs);
+      expect(out).toHaveLength(50);
+    });
+
+    it("rejects more than 100 messages", async () => {
+      const conv = await newConv();
+      const msgs = Array.from({ length: 101 }, (_, i) => ({
+        role: "user" as const,
+        content: `x-${i}`,
+      }));
+      await expect(client.shortTerm.bulkAddMessages(conv.id, msgs)).rejects.toThrow();
+    });
+  });
+
+  // =====================================================================
+  // 5. Three-tier context
+  // =====================================================================
+
+  describe("Context endpoints", () => {
+    it("getContext returns three-tier shape", async () => {
+      const conv = await newConv();
+      await client.shortTerm.addMessage(conv.id, "user", "Hello world");
+      const ctx = await client.shortTerm.getContext(conv.id);
+      expect(ctx).toHaveProperty("reflections");
+      expect(ctx).toHaveProperty("observations");
+      expect(ctx).toHaveProperty("recentMessages");
+      expect(Array.isArray(ctx.recentMessages)).toBe(true);
+    });
+
+    it("getObservations returns list", async () => {
+      const conv = await newConv();
+      const obs = await client.shortTerm.getObservations(conv.id, { limit: 10 });
+      expect(Array.isArray(obs)).toBe(true);
+    });
+
+    it("getReflections returns list", async () => {
+      const conv = await newConv();
+      const refl = await client.shortTerm.getReflections(conv.id);
+      expect(Array.isArray(refl)).toBe(true);
+    });
+
+    it("recent_messages includes added message", async () => {
+      const conv = await newConv();
+      await client.shortTerm.addMessage(conv.id, "user", "context-probe-message");
+      const ctx = await client.shortTerm.getContext(conv.id);
+      const contents = ctx.recentMessages.map((m) => m.content);
+      expect(contents).toContain("context-probe-message");
+    });
+  });
+
+  // =====================================================================
+  // 6. Long-term: entities CRUD + search
+  // =====================================================================
+
+  describe("Entity CRUD", () => {
+    it("addEntity returns id + fields", async () => {
+      const e = await newEntity({ name: "TCK Alice", description: "test person" });
+      expect(e.id.length).toBeGreaterThanOrEqual(8);
+      expect(e.name).toBe("TCK Alice");
+      // newEntity tags the description with a tck-provenance prefix; the
+      // original payload is preserved at the end of the string.
+      expect(e.description ?? "").toMatch(/test person$/);
+      expect(e.description ?? "").toContain("tck:typescript");
+    });
+
+    it("listEntities returns array", async () => {
+      const ents = await client.longTerm.listEntities({ limit: 5 });
+      expect(Array.isArray(ents)).toBe(true);
+    });
+
+    it("listEntities with type filter", async () => {
+      const ents = await client.longTerm.listEntities({ type: "person", limit: 5 });
+      expect(Array.isArray(ents)).toBe(true);
+      for (const e of ents) {
+        expect(e.type).toBe("person");
+      }
+    });
+
+    it("getEntity returns relationships array", async () => {
+      const e = await newEntity();
+      const full = await client.longTerm.getEntity(e.id);
+      expect(full.id).toBe(e.id);
+      // relationships may be undefined or an array.
+      if (full.relationships !== undefined) {
+        expect(Array.isArray(full.relationships)).toBe(true);
+      }
+    });
+
+    it("updateEntity changes description", async () => {
+      const e = await newEntity({ description: "orig" });
+      const updated = await client.longTerm.updateEntity(e.id, {
+        description: "rewritten",
+      });
+      expect(updated.id).toBe(e.id);
+      expect(updated.description).toBe("rewritten");
+    });
+
+    it("updateEntity changes name", async () => {
+      const e = await newEntity({ name: `Original-${randomHex(6)}` });
+      const newName = `Renamed-${randomHex(6)}`;
+      const updated = await client.longTerm.updateEntity(e.id, { name: newName });
+      expect(updated.name).toBe(newName);
+    });
+
+    it("deleteEntity removes it", async () => {
+      const e = await newEntity();
+      await client.longTerm.deleteEntity(e.id);
+      try {
+        const after = await client.longTerm.getEntity(e.id);
+        // soft-delete: id should still match
+        expect(after.id).toBe(e.id);
+      } catch (err) {
+        if (err instanceof NotFoundError || err instanceof TransportError) {
+          return;
+        }
+        throw err;
+      }
+    });
+  });
+
+  describe("Entity search", () => {
+    it("searchEntities returns array", async () => {
+      const results = await client.longTerm.searchEntities("anything", { limit: 5 });
+      expect(Array.isArray(results)).toBe(true);
+    });
+
+    it("search finds freshly created entity", async (ctx) => {
+      const marker = `TCK-Probe-${randomHex(8)}`;
+      const e = await newEntity({ name: marker });
+      const found = await waitUntil(async () => {
+        const hits = await client.longTerm.searchEntities(marker, { limit: 10 });
+        return hits.find((h) => h.id === e.id) ?? null;
+      });
+      if (!found) {
+        ctx.skip();
+        return;
+      }
+      expect(found.id).toBe(e.id);
+    });
+
+    it("search with type filter returns array", async () => {
+      const e = await newEntity({
+        entityType: "concept",
+        name: `TCKConcept-${randomHex(6)}`,
+      });
+      const hits = await client.longTerm.searchEntities(e.name, {
+        type: "concept",
+        limit: 5,
+      });
+      expect(Array.isArray(hits)).toBe(true);
+    });
+  });
+
+  describe("Entity feedback", () => {
+    it("setEntityFeedback returns updated", async () => {
+      const e = await newEntity();
+      const result = await client.longTerm.setEntityFeedback(e.id, {
+        userScore: 0.93,
+        confirmed: true,
+      });
+      expect(result.id).toBe(e.id);
+      expect(result.updated).toBe(true);
+    });
+
+    it("setEntityFeedback with score 0", async () => {
+      const e = await newEntity();
+      const result = await client.longTerm.setEntityFeedback(e.id, {
+        userScore: 0.0,
+        confirmed: false,
+      });
+      expect(result.id).toBe(e.id);
+    });
+  });
+
+  describe("Entity history + provenance", () => {
+    it("getEntityHistory returns shape", async () => {
+      const e = await newEntity();
+      const hist = await client.longTerm.getEntityHistory(e.id);
+      expect(hist.entityId).toBe(e.id);
+      expect(Array.isArray(hist.mentions)).toBe(true);
+    });
+
+    it("getEntityProvenance returns shape", async () => {
+      const e = await newEntity();
+      const prov = await client.reasoning.getEntityProvenance(e.id);
+      expect(prov.entityId).toBe(e.id);
+      expect(Array.isArray(prov.steps)).toBe(true);
+    });
+  });
+
+  describe("Entity graph", () => {
+    it("getEntityGraph returns nodes + edges", async () => {
+      const graph = await client.longTerm.getEntityGraph();
+      expect(Array.isArray(graph.nodes)).toBe(true);
+      expect(Array.isArray(graph.edges)).toBe(true);
+      if (graph.nodes.length > 0) {
+        expect(graph.nodes[0]!.id).toBeTruthy();
+      }
+    });
+  });
+
+  describe("Entity merge", () => {
+    it("mergeEntities returns status", async (ctx) => {
+      const a = await newEntity({ name: `MergeA-${randomHex(6)}` });
+      const b = await newEntity({ name: `MergeB-${randomHex(6)}` });
+      try {
+        const result = await client.longTerm.mergeEntities(a.id, b.id);
+        expect(result.sourceId).toBeTruthy();
+        expect(result.targetId).toBeTruthy();
+        expect(result.status).toBeTruthy();
+      } catch (err) {
+        if (err instanceof TransportError || err instanceof AuthenticationError) {
+          ctx.skip();
+          return;
+        }
+        throw err;
+      }
+    });
+  });
+
+  // =====================================================================
+  // 7. Reasoning memory
+  // =====================================================================
+
+  describe("Reasoning steps", () => {
+    it("recordStep persists", async () => {
+      const conv = await newConv();
+      const step = await client.reasoning.recordStep({
+        conversationId: conv.id,
+        reasoning: "hypothesizing user's intent",
+        actionTaken: "lookup_user_profile",
+        result: "found profile",
+      });
+      expect(step.id).toBeTruthy();
+      expect(step.conversationId).toBe(conv.id);
+      expect(step.reasoning).toMatch(/hypothesizing/);
+    });
+
+    it("recordStep without result", async () => {
+      const conv = await newConv();
+      const step = await client.reasoning.recordStep({
+        conversationId: conv.id,
+        reasoning: "r",
+        actionTaken: "a",
+      });
+      expect(step.id).toBeTruthy();
+    });
+
+    it("listSteps returns recorded steps", async () => {
+      const conv = await newConv();
+      const s1 = await client.reasoning.recordStep({
+        conversationId: conv.id,
+        reasoning: "r1",
+        actionTaken: "a1",
+      });
+      const s2 = await client.reasoning.recordStep({
+        conversationId: conv.id,
+        reasoning: "r2",
+        actionTaken: "a2",
+      });
+      const steps = await client.reasoning.listSteps(conv.id);
+      const ids = new Set(steps.map((s) => s.id));
+      expect(ids.has(s1.id)).toBe(true);
+      expect(ids.has(s2.id)).toBe(true);
+    });
+  });
+
+  describe("Reasoning explain", () => {
+    it("explainStep returns tool_calls + influenced_entities arrays", async () => {
+      const conv = await newConv();
+      const step = await client.reasoning.recordStep({
+        conversationId: conv.id,
+        reasoning: "r",
+        actionTaken: "a",
+      });
+      const explanation = await client.reasoning.explainStep(step.id);
+      expect(explanation.id).toBe(step.id);
+      expect(Array.isArray(explanation.toolCalls)).toBe(true);
+      expect(Array.isArray(explanation.influencedEntities)).toBe(true);
+    });
+  });
+
+  describe("Reasoning trace", () => {
+    it("getTraceByConversation works for empty conversation", async () => {
+      const conv = await newConv();
+      const trace = await client.reasoning.getTraceByConversation(conv.id);
+      expect(trace.conversationId).toBe(conv.id);
+      expect(Array.isArray(trace.steps)).toBe(true);
+      expect(Array.isArray(trace.toolCalls)).toBe(true);
+    });
+
+    it("getTraceByConversation includes recorded step", async () => {
+      const conv = await newConv();
+      await client.reasoning.recordStep({
+        conversationId: conv.id,
+        reasoning: "r",
+        actionTaken: "a",
+      });
+      const trace = await client.reasoning.getTraceByConversation(conv.id);
+      expect(trace.steps.some((s) => s.reasoning.includes("r"))).toBe(true);
+    });
+  });
+
+  // =====================================================================
+  // 8. Cypher console (skipped on 403)
+  // =====================================================================
+
+  describe("Cypher console", () => {
+    it("count query returns total column", async (ctx) => {
+      try {
+        const result = await client.query.cypher({
+          cypher: "MATCH (n) RETURN count(n) AS total",
+        });
+        expect(result.columns).toContain("total");
+        expect(result.rows.length).toBeGreaterThanOrEqual(1);
+      } catch (err) {
+        if (err instanceof AuthenticationError) {
+          ctx.skip();
+          return;
+        }
+        throw err;
+      }
+    });
+
+    it("parameterised query returns columns", async (ctx) => {
+      try {
+        const result = await client.query.cypher({
+          cypher: "MATCH (n) RETURN $label AS label LIMIT 1",
+          params: { label: "tck-e2e" },
+        });
+        expect(Array.isArray(result.columns)).toBe(true);
+      } catch (err) {
+        if (err instanceof AuthenticationError) {
+          ctx.skip();
+          return;
+        }
+        throw err;
+      }
+    });
+  });
+
+  // =====================================================================
+  // 9. Auth API (skipped on 403)
+  // =====================================================================
+
+  describe("Auth API keys", () => {
+    it("listApiKeys returns array (or skips on scope)", async (taskCtx) => {
+      const conv = await newConv();
+      const meta = await client.shortTerm.getConversationMetadata(conv.id);
+      const ws = meta.workspaceId;
+      if (!ws) {
+        taskCtx.skip();
+        return;
+      }
+      try {
+        const keys = await client.auth.listApiKeys(ws);
+        expect(Array.isArray(keys)).toBe(true);
+      } catch (err) {
+        if (err instanceof AuthenticationError) {
+          taskCtx.skip();
+          return;
+        }
+        throw err;
+      }
+    });
+  });
+
+  // =====================================================================
+  // 10. Cross-feature workflows
+  // =====================================================================
+
+  describe("Agent workflows", () => {
+    it("message flow extracts entities asynchronously", async (ctx) => {
+      const conv = await newConv({ userId: userId("agent-flow") });
+      const uniqueName = `TCKMercury${randomHex(8)}`;
+      await client.shortTerm.addMessage(
+        conv.id,
+        "user",
+        `${uniqueName} is the smallest planet in the solar system.`,
+      );
+      await client.shortTerm.addMessage(
+        conv.id,
+        "assistant",
+        `Yes, ${uniqueName} has a thin atmosphere.`,
+      );
+      const found = await waitUntil(
+        async () => {
+          const hits = await client.longTerm.searchEntities(uniqueName, { limit: 10 });
+          return hits.find((h) =>
+            h.name.toLowerCase().includes(uniqueName.toLowerCase()),
+          )
+            ? hits
+            : null;
+        },
+        { timeout: 20_000, interval: 2_000 },
+      );
+      if (!found) {
+        ctx.skip();
+        return;
+      }
+      expect(
+        found.some((e) => e.name.toLowerCase().includes(uniqueName.toLowerCase())),
+      ).toBe(true);
+    });
+
+    it("multi-step reasoning trace round-trip", async () => {
+      const conv = await newConv();
+      const steps = [];
+      for (let i = 0; i < 3; i++) {
+        steps.push(
+          await client.reasoning.recordStep({
+            conversationId: conv.id,
+            reasoning: `step ${i} reasoning`,
+            actionTaken: `action_${i}`,
+            result: `result_${i}`,
+          }),
+        );
+      }
+      const trace = await client.reasoning.getTraceByConversation(conv.id);
+      const recorded = new Set(steps.map((s) => s.id));
+      const tracedIds = new Set(trace.steps.map((s) => s.id));
+      for (const id of recorded) {
+        expect(tracedIds.has(id)).toBe(true);
+      }
+    });
+
+    it("multi-turn conversation appears in context", async () => {
+      const conv = await newConv();
+      const turns: [string, string][] = [
+        ["user", "I'm planning a trip to Tokyo next month."],
+        ["assistant", "Tokyo is great in autumn — what are your interests?"],
+        ["user", "Mostly food and historical sites."],
+        ["assistant", "Visit Tsukiji Outer Market and Senso-ji."],
+        ["user", "How long should I stay?"],
+      ];
+      for (const [role, content] of turns) {
+        await client.shortTerm.addMessage(conv.id, role as any, content);
+      }
+      const ctx = await client.shortTerm.getContext(conv.id);
+      const allContent = ctx.recentMessages.map((m) => m.content).join(" ");
+      expect(/Tokyo|Tsukiji/.test(allContent)).toBe(true);
+    });
+  });
+
+  // =====================================================================
+  // 11. Concurrency
+  // =====================================================================
+
+  describe("Concurrency", () => {
+    it("concurrent addMessage calls each get unique ids", async () => {
+      const conv = await newConv();
+      const results = await Promise.all(
+        Array.from({ length: 8 }, (_, i) =>
+          client.shortTerm.addMessage(conv.id, "user", `concurrent-${i}`),
+        ),
+      );
+      const ids = new Set(results.map((m) => m.id));
+      expect(ids.size).toBe(8);
+    });
+
+    it("concurrent createConversation calls each get unique ids", async () => {
+      const results = await Promise.all(
+        Array.from({ length: 4 }, (_, i) => newConv({ userId: userId(`concur-${i}`) })),
+      );
+      const ids = new Set(results.map((c) => c.id));
+      expect(ids.size).toBe(4);
+    });
+  });
+});

--- a/typescript/test/e2e/strands.test.ts
+++ b/typescript/test/e2e/strands.test.ts
@@ -1,0 +1,495 @@
+/**
+ * End-to-end tests for the Strands integration against the live
+ * hosted Neo4j Agent Memory Service.
+ *
+ * Mirrors the hosted-service.test.ts conventions:
+ *   - Skipped wholesale when MEMORY_API_KEY is unset.
+ *   - Every conversation tagged with provenance metadata + `tck-e2e-ts-strands-`
+ *     user prefix, deleted via afterAll. Failures during cleanup are swallowed.
+ *
+ * Exercises the integration's three surfaces against real NAMS:
+ *   1. Neo4jSessionStorage — full SnapshotStorage round-trip
+ *   2. Neo4jConversationManager — three-tier context injection
+ *   3. registerReasoningHooks — step + tool-call capture
+ *
+ * The reasoning hooks scenario fires Strands events DIRECTLY rather than
+ * driving a full `agent.invoke()` loop. This is intentional: we test the
+ * integration code's behaviour against the real service without depending
+ * on a working Strands model provider (which would need its own stub plus
+ * an LLM key in CI).
+ */
+
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import type { Snapshot, SnapshotLocation } from "@strands-agents/sdk";
+import {
+  AfterInvocationEvent,
+  AfterToolCallEvent,
+  BeforeInvocationEvent,
+  BeforeToolCallEvent,
+  NullConversationManager,
+  type LocalAgent,
+} from "@strands-agents/sdk";
+import { MemoryClient } from "../../src/client.js";
+import {
+  Neo4jConversationManager,
+  Neo4jSessionStorage,
+  registerReasoningHooks,
+} from "../../src/integrations/strands.js";
+import { metadataFor } from "./tck-provenance.js";
+
+const API_KEY = (process.env.MEMORY_API_KEY ?? "").trim();
+const ENDPOINT = process.env.MEMORY_ENDPOINT ?? "https://memory.neo4jlabs.com/v1";
+const HAS_KEY = API_KEY.length > 0;
+
+const describeOrSkip = HAS_KEY ? describe : describe.skip;
+
+const UNIQUE_TAG = randomHex(8);
+const USER_PREFIX = process.env.MEMORY_E2E_USER_ID ?? "tck-e2e-ts-strands";
+
+function randomHex(n: number): string {
+  if (typeof crypto !== "undefined" && typeof crypto.getRandomValues === "function") {
+    const buf = new Uint8Array(Math.ceil(n / 2));
+    crypto.getRandomValues(buf);
+    return Array.from(buf, (b) => b.toString(16).padStart(2, "0")).join("").slice(0, n);
+  }
+  return Date.now().toString(16).slice(-n);
+}
+
+function userId(suffix = ""): string {
+  const rand = randomHex(6);
+  const base = `${USER_PREFIX}-${UNIQUE_TAG}-${rand}`;
+  return suffix ? `${base}-${suffix}` : base;
+}
+
+async function waitUntil<T>(
+  predicate: () => Promise<T | null | undefined>,
+  { timeout = 20_000, interval = 1_500 }: { timeout?: number; interval?: number } = {},
+): Promise<T | null> {
+  const deadline = Date.now() + timeout;
+  let last: T | null | undefined = null;
+  while (Date.now() < deadline) {
+    last = await predicate();
+    if (last) return last;
+    await new Promise((r) => setTimeout(r, interval));
+  }
+  return last ?? null;
+}
+
+function location(sessionId: string): SnapshotLocation {
+  return { sessionId, scope: "agent" as const, scopeId: "agent-1" };
+}
+
+function snap(opts: {
+  messages?: Array<{ role: string; content: Array<{ text: string }> }>;
+  agentState?: Record<string, unknown>;
+  appData?: Record<string, unknown>;
+}): Snapshot {
+  return {
+    scope: "agent",
+    schemaVersion: "1.0",
+    createdAt: new Date().toISOString(),
+    data: {
+      ...(opts.agentState ?? {}),
+      messages: opts.messages ?? [],
+    } as unknown as Snapshot["data"],
+    appData: (opts.appData ?? {}) as Snapshot["appData"],
+  };
+}
+
+function makeAgentStub(messages: Array<Record<string, unknown>> = []) {
+  const hooks = new Map<unknown, Array<(e: unknown) => Promise<void> | void>>();
+  const agent = {
+    id: "a",
+    messages,
+    addHook(eventClass: unknown, cb: (e: unknown) => Promise<void> | void) {
+      const list = hooks.get(eventClass) ?? [];
+      list.push(cb);
+      hooks.set(eventClass, list);
+      return () => {};
+    },
+  } as unknown as LocalAgent;
+  return { agent, hooks };
+}
+
+describeOrSkip("Strands integration e2e — live NAMS", () => {
+  let client: MemoryClient;
+  let currentTestName = "unknown";
+  const cleanupConversations: string[] = [];
+
+  beforeAll(async () => {
+    client = new MemoryClient({ endpoint: ENDPOINT, apiKey: API_KEY });
+    await client.connect();
+  }, 30_000);
+
+  beforeEach((ctx) => {
+    currentTestName = ctx?.task?.name ?? "unknown";
+  });
+
+  afterAll(async () => {
+    for (const id of cleanupConversations) {
+      try {
+        await client.shortTerm.deleteConversation(id);
+      } catch {
+        // best-effort
+      }
+    }
+    await client.close();
+  }, 60_000);
+
+  async function newConv(opts?: { suffix?: string }) {
+    const meta = metadataFor(currentTestName, { tck_phase: "fixture", surface: "strands" });
+    const conv = await client.shortTerm.createConversation({
+      userId: userId(opts?.suffix ?? ""),
+      metadata: meta,
+    });
+    cleanupConversations.push(conv.id);
+    return conv;
+  }
+
+  // ====================================================================
+  // 1. Neo4jSessionStorage against live NAMS
+  // ====================================================================
+
+  describe("Neo4jSessionStorage", () => {
+    it("saveSnapshot + loadSnapshot round-trip", async () => {
+      const conv = await newConv({ suffix: "ssr" });
+      const storage = new Neo4jSessionStorage(client);
+      const loc = location(conv.id);
+
+      const snapshot = snap({
+        messages: [
+          { role: "user", content: [{ text: "hello from strands e2e" }] },
+          { role: "assistant", content: [{ text: "hi! how can I help?" }] },
+        ],
+        agentState: { stepCount: 1, customField: "value" },
+        appData: { userMarker: "tck-e2e" },
+      });
+
+      await storage.saveSnapshot({
+        location: loc,
+        snapshotId: "s1",
+        isLatest: true,
+        snapshot,
+      });
+
+      const loaded = await storage.loadSnapshot({ location: loc });
+      expect(loaded).not.toBeNull();
+      expect(loaded!.appData).toMatchObject({ userMarker: "tck-e2e" });
+      expect((loaded!.data as Record<string, unknown>).customField).toBe("value");
+      const messages = (loaded!.data as { messages?: unknown[] }).messages;
+      expect(Array.isArray(messages)).toBe(true);
+      expect((messages ?? []).length).toBeGreaterThanOrEqual(2);
+    }, 30_000);
+
+    it("listSnapshotIds returns IDs in saved order", async () => {
+      const conv = await newConv({ suffix: "list" });
+      const storage = new Neo4jSessionStorage(client);
+      const loc = location(conv.id);
+
+      for (const id of ["s1", "s2", "s3"]) {
+        await storage.saveSnapshot({
+          location: loc,
+          snapshotId: id,
+          isLatest: id === "s3",
+          snapshot: snap({ messages: [] }),
+        });
+      }
+
+      const all = await storage.listSnapshotIds({ location: loc });
+      expect(all).toEqual(["s1", "s2", "s3"]);
+
+      const page = await storage.listSnapshotIds({ location: loc, startAfter: "s1", limit: 2 });
+      expect(page).toEqual(["s2", "s3"]);
+    }, 30_000);
+
+    it("loadSnapshot honors an explicit snapshotId", async () => {
+      const conv = await newConv({ suffix: "explicit" });
+      const storage = new Neo4jSessionStorage(client);
+      const loc = location(conv.id);
+
+      await storage.saveSnapshot({
+        location: loc,
+        snapshotId: "first",
+        isLatest: false,
+        snapshot: snap({ messages: [], agentState: { tag: "first" } }),
+      });
+      await storage.saveSnapshot({
+        location: loc,
+        snapshotId: "second",
+        isLatest: true,
+        snapshot: snap({ messages: [], agentState: { tag: "second" } }),
+      });
+
+      const first = await storage.loadSnapshot({ location: loc, snapshotId: "first" });
+      const second = await storage.loadSnapshot({ location: loc, snapshotId: "second" });
+      expect((first!.data as Record<string, unknown>).tag).toBe("first");
+      expect((second!.data as Record<string, unknown>).tag).toBe("second");
+    }, 30_000);
+
+    it("manifest round-trip", async () => {
+      const conv = await newConv({ suffix: "manifest" });
+      const storage = new Neo4jSessionStorage(client);
+      const loc = location(conv.id);
+      const manifest = {
+        schemaVersion: "1.0",
+        updatedAt: new Date().toISOString(),
+      };
+
+      await storage.saveManifest({ location: loc, manifest });
+      const loaded = await storage.loadManifest({ location: loc });
+      expect(loaded.schemaVersion).toBe("1.0");
+      expect(loaded.updatedAt).toBe(manifest.updatedAt);
+    }, 30_000);
+
+    it("deleteSession removes the conversation", async () => {
+      const conv = await newConv({ suffix: "delete" });
+      const storage = new Neo4jSessionStorage(client);
+      await storage.deleteSession({ sessionId: conv.id });
+
+      // Remove from cleanup list since it's already deleted.
+      const idx = cleanupConversations.indexOf(conv.id);
+      if (idx >= 0) cleanupConversations.splice(idx, 1);
+
+      // The deleted conversation should no longer be retrievable. The
+      // hosted service may either 404 or return tombstoned metadata; we
+      // assert *something* surfaces as failure.
+      let observed = false;
+      try {
+        await client.shortTerm.getConversationMetadata(conv.id);
+      } catch {
+        observed = true;
+      }
+      expect(observed).toBe(true);
+    }, 30_000);
+  });
+
+  // ====================================================================
+  // 2. Neo4jConversationManager against live NAMS
+  // ====================================================================
+
+  describe("Neo4jConversationManager — context injection", () => {
+    it("getContext on a fresh conversation prepends empty context (no-op)", async () => {
+      const conv = await newConv({ suffix: "cm-empty" });
+      const cm = new Neo4jConversationManager(client, {
+        conversationId: conv.id,
+        inner: new NullConversationManager(),
+      });
+      const { agent, hooks } = makeAgentStub([{ role: "user", content: [{ text: "hi" }] }]);
+      await cm.initAgent(agent);
+
+      const callbacks = hooks.get(BeforeInvocationEvent) ?? [];
+      for (const cb of callbacks) {
+        await cb(
+          new BeforeInvocationEvent({
+            agent: agent as unknown as ConstructorParameters<typeof BeforeInvocationEvent>[0]["agent"],
+            invocationState: {},
+          }),
+        );
+      }
+
+      // A brand-new conversation has no observations/reflections yet, so
+      // the agent.messages should be unchanged.
+      const messages = (agent as unknown as { messages: Array<Record<string, unknown>> })
+        .messages;
+      expect(messages).toHaveLength(1);
+    }, 30_000);
+
+    it("after a multi-turn conversation, context injection includes service-extracted reflections/observations", async () => {
+      const conv = await newConv({ suffix: "cm-rich" });
+
+      // Drive a 5-turn conversation so the service has signal to extract
+      // reflections + observations from.
+      const turns: Array<["user" | "assistant", string]> = [
+        ["user", "I'm planning a 7-day trip to Lisbon."],
+        ["assistant", "Great choice! Are you more interested in food, history, or coastal areas?"],
+        ["user", "Mostly food and history — I love seafood and museums."],
+        ["assistant", "Tsukiji-style seafood markets and Belém's monasteries are perfect for you."],
+        ["user", "What's the best way to get around?"],
+      ];
+      for (const [role, content] of turns) {
+        await client.shortTerm.addMessage(conv.id, role, content);
+      }
+
+      // Poll getContext until the service produces something — observation
+      // extraction is asynchronous. Skip if no signal arrives within window.
+      const populated = await waitUntil(
+        async () => {
+          const ctx = await client.shortTerm.getContext(conv.id);
+          if (ctx.observations.length > 0 || ctx.reflections.length > 0) return ctx;
+          return null;
+        },
+        { timeout: 20_000, interval: 2_000 },
+      );
+
+      if (!populated) {
+        // Service hasn't extracted yet — record as soft-skip, not a fail.
+        return;
+      }
+
+      // Now exercise the conversation manager.
+      const cm = new Neo4jConversationManager(client, {
+        conversationId: conv.id,
+        inner: new NullConversationManager(),
+      });
+      const { agent, hooks } = makeAgentStub([{ role: "user", content: [{ text: "next turn" }] }]);
+      await cm.initAgent(agent);
+      const callbacks = hooks.get(BeforeInvocationEvent) ?? [];
+      for (const cb of callbacks) {
+        await cb(
+          new BeforeInvocationEvent({
+            agent: agent as unknown as ConstructorParameters<typeof BeforeInvocationEvent>[0]["agent"],
+            invocationState: {},
+          }),
+        );
+      }
+
+      const messages = (agent as unknown as { messages: Array<Record<string, unknown>> })
+        .messages;
+      const texts = messages.map((m) =>
+        ((m.content as Array<{ text?: string }>)[0]?.text ?? "") as string,
+      );
+      const hasInjection = texts.some(
+        (t) => t.startsWith("[reflection]") || t.startsWith("[observation]"),
+      );
+      expect(hasInjection).toBe(true);
+    }, 60_000);
+  });
+
+  // ====================================================================
+  // 3. registerReasoningHooks against live NAMS
+  // ====================================================================
+
+  describe("registerReasoningHooks — reasoning capture", () => {
+    it("BeforeInvocation creates a step, BeforeToolCall + AfterToolCall record tool calls", async () => {
+      const conv = await newConv({ suffix: "hooks" });
+      const { agent, hooks } = makeAgentStub();
+      await registerReasoningHooks(client, agent, { conversationId: conv.id });
+
+      const inv: Record<string, unknown> = {};
+      // Fire BeforeInvocation.
+      const beforeInvCb = (hooks.get(BeforeInvocationEvent) ?? [])[0]!;
+      await beforeInvCb(
+        new BeforeInvocationEvent({
+          agent: agent as unknown as ConstructorParameters<typeof BeforeInvocationEvent>[0]["agent"],
+          invocationState: inv,
+        }),
+      );
+      expect(typeof inv["__neo4jReasoningStepId"]).toBe("string");
+
+      // Fire tool call lifecycle.
+      const beforeToolCb = (hooks.get(BeforeToolCallEvent) ?? [])[0]!;
+      const afterToolCb = (hooks.get(AfterToolCallEvent) ?? [])[0]!;
+      await beforeToolCb(
+        new BeforeToolCallEvent({
+          agent: {} as ConstructorParameters<typeof BeforeToolCallEvent>[0]["agent"],
+          toolUse: { toolUseId: "tu-1", name: "search_entities", input: { query: "Lisbon" } },
+          tool: undefined,
+          invocationState: inv,
+        } as unknown as ConstructorParameters<typeof BeforeToolCallEvent>[0]),
+      );
+      await afterToolCb(
+        new AfterToolCallEvent({
+          agent: {} as ConstructorParameters<typeof AfterToolCallEvent>[0]["agent"],
+          toolUse: { toolUseId: "tu-1", name: "search_entities", input: { query: "Lisbon" } },
+          tool: undefined,
+          result: {
+            toolUseId: "tu-1",
+            content: [],
+            status: "success",
+          } as ConstructorParameters<typeof AfterToolCallEvent>[0]["result"],
+          error: undefined,
+          invocationState: inv,
+        } as unknown as ConstructorParameters<typeof AfterToolCallEvent>[0]),
+      );
+
+      // Fire AfterInvocation.
+      const afterInvCb = (hooks.get(AfterInvocationEvent) ?? [])[0]!;
+      await afterInvCb(
+        new AfterInvocationEvent({
+          agent: {} as ConstructorParameters<typeof AfterInvocationEvent>[0]["agent"],
+          invocationState: inv,
+        }),
+      );
+
+      // Verify the reasoning trace landed in NAMS.
+      const trace = await client.reasoning.getTraceByConversation(conv.id);
+      expect(trace.conversationId).toBe(conv.id);
+      expect(trace.steps.length).toBeGreaterThanOrEqual(1);
+      const reasoningTexts = trace.steps.map((s) => s.reasoning ?? "");
+      expect(reasoningTexts.some((t) => t.includes("agent invocation started"))).toBe(true);
+    }, 30_000);
+  });
+
+  // ====================================================================
+  // 4. Multi-conversation isolation
+  // ====================================================================
+
+  describe("Multi-conversation isolation", () => {
+    it("two independent conversations don't cross-pollute reasoning state", async () => {
+      const convA = await newConv({ suffix: "iso-a" });
+      const convB = await newConv({ suffix: "iso-b" });
+      const { agent: agentA, hooks: hooksA } = makeAgentStub();
+      const { agent: agentB, hooks: hooksB } = makeAgentStub();
+      await registerReasoningHooks(client, agentA, { conversationId: convA.id });
+      await registerReasoningHooks(client, agentB, { conversationId: convB.id });
+
+      const invA: Record<string, unknown> = {};
+      const invB: Record<string, unknown> = {};
+      await (hooksA.get(BeforeInvocationEvent) ?? [])[0]!(
+        new BeforeInvocationEvent({
+          agent: agentA as unknown as ConstructorParameters<typeof BeforeInvocationEvent>[0]["agent"],
+          invocationState: invA,
+        }),
+      );
+      await (hooksB.get(BeforeInvocationEvent) ?? [])[0]!(
+        new BeforeInvocationEvent({
+          agent: agentB as unknown as ConstructorParameters<typeof BeforeInvocationEvent>[0]["agent"],
+          invocationState: invB,
+        }),
+      );
+
+      const traceA = await client.reasoning.getTraceByConversation(convA.id);
+      const traceB = await client.reasoning.getTraceByConversation(convB.id);
+      expect(traceA.conversationId).toBe(convA.id);
+      expect(traceB.conversationId).toBe(convB.id);
+      // Each trace has its own steps; cross-references should not happen.
+      const aIds = new Set(traceA.steps.map((s) => s.id));
+      const bIds = new Set(traceB.steps.map((s) => s.id));
+      for (const id of aIds) expect(bIds.has(id)).toBe(false);
+    }, 45_000);
+  });
+
+  // ====================================================================
+  // 5. Auth error surface
+  // ====================================================================
+
+  describe("Auth error surface", () => {
+    it("a deliberately bad API key surfaces AuthenticationError with requestId on Strands operations", async () => {
+      const { AuthenticationError } = await import("../../src/errors.js");
+      const badClient = new MemoryClient({
+        endpoint: ENDPOINT,
+        apiKey: "nams_obviously_not_real",
+      });
+      const storage = new Neo4jSessionStorage(badClient);
+      try {
+        await storage.loadSnapshot({ location: location("conv-doesnt-matter") });
+        throw new Error("expected throw");
+      } catch (e) {
+        if (e instanceof AuthenticationError) {
+          // requestId may or may not be populated depending on edge.
+          expect(typeof e.message).toBe("string");
+          return;
+        }
+        // Some service deployments return 4xx for missing conversations
+        // rather than 401; accept TransportError as a valid path here.
+        // The contract being tested is "the integration surfaces the
+        // failure cleanly", not the specific status code.
+        const { TransportError } = await import("../../src/errors.js");
+        if (e instanceof TransportError) return;
+        throw e;
+      } finally {
+        await badClient.close();
+      }
+    }, 30_000);
+  });
+});

--- a/typescript/test/e2e/tck-provenance.ts
+++ b/typescript/test/e2e/tck-provenance.ts
@@ -1,0 +1,69 @@
+/**
+ * Provenance tagging for e2e tests.
+ *
+ * Every conversation, entity, and reasoning step the e2e suite creates is
+ * tagged with metadata that traces it back to:
+ *
+ *   - the language client            (tck_client)
+ *   - the specific test              (tck_test)
+ *   - the GitHub Actions run         (tck_run_id, tck_run_attempt)
+ *   - the commit SHA + branch        (tck_sha, tck_branch)
+ *   - the suite start time           (tck_started_at)
+ *   - the runner / hostname          (tck_host)
+ *
+ * Querying provenance after the fact (with workspace-admin Cypher access):
+ *
+ *     MATCH (c:Conversation) WHERE c.metadata.tck_run_id = '12345' RETURN c
+ *     MATCH (e:Entity) WHERE e.description STARTS WITH '[tck:typescript' RETURN e
+ *     MATCH (s:AgentStep) WHERE s.reasoning STARTS WITH 'TCK e2e' RETURN s
+ */
+
+import { hostname } from "node:os";
+
+export const CLIENT_NAME = "typescript";
+
+let cachedRunInfo: Record<string, string> | null = null;
+
+export function runInfo(): Record<string, string> {
+  if (cachedRunInfo) return cachedRunInfo;
+  const sha = (process.env.GITHUB_SHA ?? "local").slice(0, 7);
+  cachedRunInfo = {
+    tck_client: CLIENT_NAME,
+    tck_run_id: process.env.GITHUB_RUN_ID ?? "local",
+    tck_run_attempt: process.env.GITHUB_RUN_ATTEMPT ?? "1",
+    tck_workflow: process.env.GITHUB_WORKFLOW ?? "local",
+    tck_sha: sha,
+    tck_branch: process.env.GITHUB_REF_NAME ?? "local",
+    tck_started_at: new Date().toISOString(),
+    tck_host: process.env.RUNNER_NAME ?? hostname(),
+  };
+  return cachedRunInfo;
+}
+
+export function metadataFor(
+  testName: string,
+  extra: Record<string, unknown> = {},
+): Record<string, unknown> {
+  return { ...runInfo(), tck_test: testName, ...extra };
+}
+
+export function tagDescription(testName: string, description: string): string {
+  const info = runInfo();
+  return `[tck:${info.tck_client}:${info.tck_run_id}:${testName}] ${description}`;
+}
+
+export function provenanceReasoning(testName: string, phase = "setup"): string {
+  const info = runInfo();
+  return (
+    `TCK e2e test ${phase}: ${testName} ` +
+    `[client=${info.tck_client}, run=${info.tck_run_id}, ` +
+    `sha=${info.tck_sha}, branch=${info.tck_branch}]`
+  );
+}
+
+export function provenanceResult(
+  testName: string,
+  extra: Record<string, unknown> = {},
+): string {
+  return JSON.stringify(metadataFor(testName, extra));
+}

--- a/typescript/test/integration/mcp-dispatch.test.ts
+++ b/typescript/test/integration/mcp-dispatch.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Integration tests — MCP tool dispatch routes correctly through MemoryClient.
+ */
+
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { http, HttpResponse } from "msw";
+import { setupServer } from "msw/node";
+import { MemoryClient } from "../../src/client.js";
+import { handleMemoryToolCall } from "../../src/mcp/index.js";
+
+const ENDPOINT = "https://memory.test/v1";
+
+const server = setupServer();
+
+beforeAll(() => server.listen({ onUnhandledRequest: "error" }));
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+describe("handleMemoryToolCall", () => {
+  it("memory_create_conversation routes to POST /conversations", async () => {
+    let body: unknown = null;
+    server.use(
+      http.post(`${ENDPOINT}/conversations`, async ({ request }) => {
+        body = await request.json();
+        return HttpResponse.json({ id: "c1", userId: "alice", createdAt: "x" });
+      }),
+    );
+
+    const client = new MemoryClient({ endpoint: ENDPOINT, apiKey: "k" });
+    const result = await handleMemoryToolCall(client, "memory_create_conversation", {
+      user_id: "alice",
+    });
+    await client.close();
+
+    expect(body).toMatchObject({ userId: "alice" });
+    expect((result as { id: string }).id).toBe("c1");
+  });
+
+  it("memory_get_context routes to GET /conversations/{id}/context", async () => {
+    server.use(
+      http.get(`${ENDPOINT}/conversations/c1/context`, () =>
+        HttpResponse.json({
+          reflections: [],
+          observations: [],
+          recentMessages: [{ id: "m1", role: "user", content: "hi" }],
+        }),
+      ),
+    );
+
+    const client = new MemoryClient({ endpoint: ENDPOINT, apiKey: "k" });
+    const result = (await handleMemoryToolCall(client, "memory_get_context", {
+      conversation_id: "c1",
+    })) as { recentMessages: unknown[] };
+    await client.close();
+
+    expect(result.recentMessages).toHaveLength(1);
+  });
+
+  it("rejects unknown tool names", async () => {
+    const client = new MemoryClient({ endpoint: ENDPOINT, apiKey: "k" });
+    await expect(
+      handleMemoryToolCall(client, "memory_unknown_tool", {}),
+    ).rejects.toThrow(/Unknown memory tool/);
+    await client.close();
+  });
+
+  it("v0.1 alias forwards to new tool with deprecation warning", async () => {
+    server.use(
+      http.get(`${ENDPOINT}/conversations/c1/context`, () =>
+        HttpResponse.json({ reflections: [], observations: [], recentMessages: [] }),
+      ),
+    );
+
+    const warn = console.warn;
+    const messages: string[] = [];
+    console.warn = (msg: string) => messages.push(String(msg));
+
+    try {
+      const client = new MemoryClient({ endpoint: ENDPOINT, apiKey: "k" });
+      await handleMemoryToolCall(client, "memory.getConversation", {
+        conversation_id: "c1",
+      });
+      await client.close();
+
+      expect(messages.join("\n")).toMatch(/deprecated/i);
+    } finally {
+      console.warn = warn;
+    }
+  });
+});

--- a/typescript/test/integration/observability.test.ts
+++ b/typescript/test/integration/observability.test.ts
@@ -1,0 +1,175 @@
+/**
+ * Integration tests — User-Agent header, request-id propagation, and the
+ * logger event stream against an MSW-mocked RestTransport.
+ */
+
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { http, HttpResponse } from "msw";
+import { setupServer } from "msw/node";
+import { MemoryClient } from "../../src/client.js";
+import {
+  AuthenticationError,
+  MemoryError,
+  TransportError,
+} from "../../src/errors.js";
+import type { LogEvent } from "../../src/observability.js";
+import { VERSION } from "../../src/version.js";
+
+const ENDPOINT = "https://memory.test/v1";
+const API_KEY = "nams_test_key";
+
+const server = setupServer();
+beforeAll(() => server.listen({ onUnhandledRequest: "error" }));
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+describe("RestTransport observability", () => {
+  it("sends a default User-Agent header containing the package version", async () => {
+    let observedUA: string | null = null;
+    server.use(
+      http.post(`${ENDPOINT}/conversations`, ({ request }) => {
+        observedUA = request.headers.get("user-agent");
+        return HttpResponse.json({ id: "c", userId: "u", createdAt: "x" });
+      }),
+    );
+
+    const client = new MemoryClient({ endpoint: ENDPOINT, apiKey: API_KEY });
+    await client.shortTerm.createConversation({ userId: "u" });
+
+    expect(observedUA).toMatch(/@neo4j-labs\/agent-memory\/\d+\.\d+\.\d+/);
+    expect(observedUA).toContain(VERSION);
+  });
+
+  it("caller-supplied User-Agent header takes precedence", async () => {
+    let observedUA: string | null = null;
+    server.use(
+      http.post(`${ENDPOINT}/conversations`, ({ request }) => {
+        observedUA = request.headers.get("user-agent");
+        return HttpResponse.json({ id: "c", userId: "u", createdAt: "x" });
+      }),
+    );
+
+    const client = new MemoryClient({
+      endpoint: ENDPOINT,
+      apiKey: API_KEY,
+      headers: { "User-Agent": "my-wrapper/1.0" },
+    });
+    await client.shortTerm.createConversation({ userId: "u" });
+
+    expect(observedUA).toBe("my-wrapper/1.0");
+  });
+
+  it("attaches requestId from x-request-id to TransportError on 5xx", async () => {
+    server.use(
+      http.post(`${ENDPOINT}/conversations`, () =>
+        HttpResponse.json(
+          { error: "kaboom" },
+          { status: 500, headers: { "x-request-id": "req-xyz" } },
+        ),
+      ),
+    );
+
+    const client = new MemoryClient({ endpoint: ENDPOINT, apiKey: API_KEY });
+    try {
+      await client.shortTerm.createConversation({ userId: "u" });
+      throw new Error("expected throw");
+    } catch (e) {
+      expect(e).toBeInstanceOf(TransportError);
+      expect((e as MemoryError).requestId).toBe("req-xyz");
+      expect(String(e)).toContain("req-xyz");
+    }
+  });
+
+  it("attaches requestId to AuthenticationError on 401", async () => {
+    server.use(
+      http.post(`${ENDPOINT}/conversations`, () =>
+        new HttpResponse("nope", {
+          status: 401,
+          headers: { "x-request-id": "req-auth" },
+        }),
+      ),
+    );
+
+    const client = new MemoryClient({ endpoint: ENDPOINT, apiKey: API_KEY });
+    try {
+      await client.shortTerm.createConversation({ userId: "u" });
+      throw new Error("expected throw");
+    } catch (e) {
+      expect(e).toBeInstanceOf(AuthenticationError);
+      expect((e as MemoryError).requestId).toBe("req-auth");
+    }
+  });
+
+  it("emits request → response logger events on success", async () => {
+    server.use(
+      http.post(`${ENDPOINT}/conversations`, () =>
+        HttpResponse.json(
+          { id: "c", userId: "u", createdAt: "x" },
+          { headers: { "x-request-id": "req-ok" } },
+        ),
+      ),
+    );
+
+    const events: LogEvent[] = [];
+    const client = new MemoryClient({
+      endpoint: ENDPOINT,
+      apiKey: API_KEY,
+      logger: (e) => events.push(e),
+    });
+    await client.shortTerm.createConversation({ userId: "u" });
+
+    expect(events).toHaveLength(2);
+    expect(events[0]!.kind).toBe("request");
+    expect(events[1]!.kind).toBe("response");
+    if (events[1]!.kind === "response") {
+      expect(events[1].status).toBe(200);
+      expect(events[1].requestId).toBe("req-ok");
+      expect(events[1].durationMs).toBeGreaterThanOrEqual(0);
+    }
+  });
+
+  it("emits request → error logger event on failure", async () => {
+    server.use(
+      http.post(`${ENDPOINT}/conversations`, () =>
+        HttpResponse.json(
+          { error: "boom" },
+          { status: 500, headers: { "x-request-id": "req-err" } },
+        ),
+      ),
+    );
+
+    const events: LogEvent[] = [];
+    const logger = vi.fn((e: LogEvent) => events.push(e));
+    const client = new MemoryClient({ endpoint: ENDPOINT, apiKey: API_KEY, logger });
+    await expect(client.shortTerm.createConversation({ userId: "u" })).rejects.toBeInstanceOf(
+      TransportError,
+    );
+
+    expect(events).toHaveLength(2);
+    expect(events[1]!.kind).toBe("error");
+    if (events[1]!.kind === "error") {
+      expect(events[1].status).toBe(500);
+      expect(events[1].requestId).toBe("req-err");
+    }
+  });
+
+  it("logger exceptions never propagate", async () => {
+    server.use(
+      http.post(`${ENDPOINT}/conversations`, () =>
+        HttpResponse.json({ id: "c", userId: "u", createdAt: "x" }),
+      ),
+    );
+
+    const client = new MemoryClient({
+      endpoint: ENDPOINT,
+      apiKey: API_KEY,
+      logger: () => {
+        throw new Error("logger boom");
+      },
+    });
+
+    await expect(client.shortTerm.createConversation({ userId: "u" })).resolves.toMatchObject({
+      id: "c",
+    });
+  });
+});

--- a/typescript/test/integration/rest-transport.test.ts
+++ b/typescript/test/integration/rest-transport.test.ts
@@ -1,0 +1,244 @@
+/**
+ * Integration tests — RestTransport against an in-process MSW mock server.
+ *
+ * Validates that bridge-style method calls hit the right REST endpoints,
+ * send camelCase bodies, attach Bearer auth, and parse responses back into
+ * the canonical snake_case-shaped types.
+ */
+
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { http, HttpResponse } from "msw";
+import { setupServer } from "msw/node";
+import { MemoryClient } from "../../src/client.js";
+import { AuthenticationError, NotSupportedError, TransportError } from "../../src/errors.js";
+
+const ENDPOINT = "https://memory.test/v1";
+const API_KEY = "nams_test_key";
+
+const server = setupServer();
+
+beforeAll(() => server.listen({ onUnhandledRequest: "error" }));
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+function newClient(opts?: Partial<{ apiKey: string }>): MemoryClient {
+  return new MemoryClient({ endpoint: ENDPOINT, apiKey: opts?.apiKey ?? API_KEY });
+}
+
+describe("RestTransport — short-term", () => {
+  it("createConversation POSTs camelCase body and parses response", async () => {
+    let observedAuth: string | null = null;
+    let observedBody: unknown = null;
+    server.use(
+      http.post(`${ENDPOINT}/conversations`, async ({ request }) => {
+        observedAuth = request.headers.get("authorization");
+        observedBody = await request.json();
+        return HttpResponse.json({
+          id: "conv-1",
+          userId: "alice",
+          workspaceId: "ws",
+          createdAt: "2026-05-07T00:00:00Z",
+        });
+      }),
+    );
+
+    const client = newClient();
+    const conv = await client.shortTerm.createConversation({
+      userId: "alice",
+      metadata: { source: "test" },
+    });
+    await client.close();
+
+    expect(observedAuth).toBe(`Bearer ${API_KEY}`);
+    expect(observedBody).toMatchObject({ userId: "alice", metadata: { source: "test" } });
+    expect(conv.id).toBe("conv-1");
+    expect(conv.userId).toBe("alice");
+    expect(conv.workspaceId).toBe("ws");
+  });
+
+  it("getContext substitutes path param and returns 3-tier context", async () => {
+    server.use(
+      http.get(`${ENDPOINT}/conversations/conv-42/context`, () =>
+        HttpResponse.json({
+          reflections: [
+            { id: "r1", conversationId: "conv-42", content: "user values clarity", createdAt: "x" },
+          ],
+          observations: [
+            { id: "o1", conversationId: "conv-42", content: "long-form messages", createdAt: "x" },
+          ],
+          recentMessages: [{ id: "m1", role: "user", content: "hello" }],
+        }),
+      ),
+    );
+
+    const client = newClient();
+    const ctx = await client.shortTerm.getContext("conv-42");
+    await client.close();
+
+    expect(ctx.reflections).toHaveLength(1);
+    expect(ctx.observations).toHaveLength(1);
+    expect(ctx.recentMessages).toHaveLength(1);
+    expect(ctx.reflections[0]!.conversationId).toBe("conv-42");
+  });
+
+  it("listConversations unwraps the {conversations: [...]} envelope", async () => {
+    server.use(
+      http.get(`${ENDPOINT}/conversations`, () =>
+        HttpResponse.json({
+          conversations: [
+            { id: "c1", userId: "alice", createdAt: "x" },
+            { id: "c2", userId: "bob", createdAt: "y" },
+          ],
+        }),
+      ),
+    );
+
+    const client = newClient();
+    const convs = await client.shortTerm.listConversations({ limit: 10 });
+    await client.close();
+
+    expect(convs).toHaveLength(2);
+    expect(convs[0]!.id).toBe("c1");
+    expect(convs[1]!.userId).toBe("bob");
+  });
+
+  it("listConversations forwards the optional userId filter as user_id", async () => {
+    let observedUserId: string | null = null;
+    server.use(
+      http.get(`${ENDPOINT}/conversations`, ({ request }) => {
+        observedUserId = new URL(request.url).searchParams.get("user_id");
+        return HttpResponse.json({ conversations: [] });
+      }),
+    );
+
+    const client = newClient();
+    await client.shortTerm.listConversations({ limit: 10, userId: "alice" });
+    await client.close();
+
+    expect(observedUserId).toBe("alice");
+  });
+});
+
+describe("RestTransport — long-term", () => {
+  it("searchEntities unwraps envelope and returns Entity[]", async () => {
+    server.use(
+      http.post(`${ENDPOINT}/entities/search`, () =>
+        HttpResponse.json({
+          entities: [
+            { id: "e1", name: "Alice", type: "person", createdAt: "x" },
+          ],
+        }),
+      ),
+    );
+
+    const client = newClient();
+    const entities = await client.longTerm.searchEntities("alice");
+    await client.close();
+
+    expect(entities).toHaveLength(1);
+    expect(entities[0]!.name).toBe("Alice");
+  });
+
+  it("setEntityFeedback PUTs to /entities/{id}/feedback", async () => {
+    let observedBody: unknown = null;
+    server.use(
+      http.put(`${ENDPOINT}/entities/e1/feedback`, async ({ request }) => {
+        observedBody = await request.json();
+        return HttpResponse.json({ id: "e1", updated: true });
+      }),
+    );
+
+    const client = newClient();
+    const result = await client.longTerm.setEntityFeedback("e1", {
+      userScore: 0.95,
+      confirmed: true,
+    });
+    await client.close();
+
+    expect(observedBody).toEqual({ userScore: 0.95, confirmed: true });
+    expect(result).toEqual({ id: "e1", updated: true });
+  });
+
+  it("getEntityGraph returns nodes and edges", async () => {
+    server.use(
+      http.get(`${ENDPOINT}/entities/graph`, () =>
+        HttpResponse.json({
+          nodes: [{ id: "n1", name: "Alice", type: "person" }],
+          edges: [{ id: "edge1", source: "n1", target: "n1", type: "SELF" }],
+        }),
+      ),
+    );
+
+    const client = newClient();
+    const graph = await client.longTerm.getEntityGraph();
+    await client.close();
+
+    expect(graph.nodes).toHaveLength(1);
+    expect(graph.edges).toHaveLength(1);
+  });
+});
+
+describe("RestTransport — error handling", () => {
+  it("returns AuthenticationError on 401", async () => {
+    server.use(
+      http.get(`${ENDPOINT}/conversations`, () =>
+        HttpResponse.json({ error: "bad token" }, { status: 401 }),
+      ),
+    );
+
+    const client = newClient();
+    await expect(client.shortTerm.listConversations()).rejects.toBeInstanceOf(
+      AuthenticationError,
+    );
+    await client.close();
+  });
+
+  it("returns TransportError on 500 with status code", async () => {
+    server.use(
+      http.post(`${ENDPOINT}/conversations`, () =>
+        HttpResponse.json({ error: "boom" }, { status: 500 }),
+      ),
+    );
+
+    const client = newClient();
+    try {
+      await client.shortTerm.createConversation({ userId: "x" });
+      throw new Error("expected throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(TransportError);
+      expect((err as TransportError).statusCode).toBe(500);
+    }
+    await client.close();
+  });
+
+  it("legacy bridge-only methods throw NotSupportedError", async () => {
+    const client = newClient();
+    await expect(
+      client.longTerm.addPreference("style", "concise"),
+    ).rejects.toBeInstanceOf(NotSupportedError);
+    await client.close();
+  });
+});
+
+describe("RestTransport — auth flows", () => {
+  it("calls tokenProvider per request", async () => {
+    let observed: string[] = [];
+    server.use(
+      http.get(`${ENDPOINT}/conversations`, ({ request }) => {
+        observed.push(request.headers.get("authorization") ?? "");
+        return HttpResponse.json({ conversations: [] });
+      }),
+    );
+
+    let n = 0;
+    const provider = vi.fn(async () => `nams_token_${++n}`);
+    const client = new MemoryClient({ endpoint: ENDPOINT, tokenProvider: provider });
+
+    await client.shortTerm.listConversations();
+    await client.shortTerm.listConversations();
+    await client.close();
+
+    expect(provider).toHaveBeenCalledTimes(2);
+    expect(observed).toEqual(["Bearer nams_token_1", "Bearer nams_token_2"]);
+  });
+});

--- a/typescript/test/integration/strands-conversation-manager.test.ts
+++ b/typescript/test/integration/strands-conversation-manager.test.ts
@@ -1,0 +1,234 @@
+/**
+ * Integration tests — Neo4jConversationManager against an MSW-mocked
+ * /v1/conversations/:id/context endpoint. Asserts:
+ *  - Reflections + observations prepended in canonical order
+ *  - Empty context leaves messages untouched
+ *  - getContext failure falls back silently
+ *  - includeReflections/Observations toggles
+ *  - Inner manager defaults to the lazy SlidingWindow
+ */
+
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { http, HttpResponse } from "msw";
+import { setupServer } from "msw/node";
+import {
+  BeforeInvocationEvent,
+  type LocalAgent,
+} from "@strands-agents/sdk";
+import { MemoryClient } from "../../src/client.js";
+import { Neo4jConversationManager } from "../../src/integrations/strands.js";
+
+const ENDPOINT = "https://memory.test/v1";
+const API_KEY = "nams_test_key";
+const CONV = "conv-cm";
+
+const server = setupServer();
+beforeAll(() => server.listen({ onUnhandledRequest: "error" }));
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+function makeAgent(messages: Array<Record<string, unknown>>) {
+  let beforeInv:
+    | ((event: BeforeInvocationEvent) => Promise<void> | void)
+    | null = null;
+  const agent = {
+    id: "a",
+    messages,
+    addHook(_event: unknown, cb: (event: BeforeInvocationEvent) => Promise<void> | void) {
+      beforeInv = cb;
+      return () => {};
+    },
+  } as unknown as LocalAgent;
+  return {
+    agent,
+    fire: async () => {
+      if (!beforeInv) throw new Error("hook not registered");
+      const event = new BeforeInvocationEvent({
+        agent: agent as unknown as ConstructorParameters<typeof BeforeInvocationEvent>[0]["agent"],
+        invocationState: {},
+      });
+      await beforeInv(event);
+    },
+  };
+}
+
+function getMessages(agent: LocalAgent): Array<Record<string, unknown>> {
+  return (agent as unknown as { messages: Array<Record<string, unknown>> }).messages;
+}
+
+function mountContext(opts: {
+  reflections?: Array<{ id: string; content: string; conversationId?: string }>;
+  observations?: Array<{ id: string; content: string; conversationId?: string }>;
+  status?: number;
+}) {
+  server.use(
+    http.get(`${ENDPOINT}/conversations/${CONV}/context`, () => {
+      if (opts.status && opts.status >= 400) {
+        return new HttpResponse("err", { status: opts.status });
+      }
+      return HttpResponse.json({
+        reflections: (opts.reflections ?? []).map((r) => ({
+          id: r.id,
+          conversationId: r.conversationId ?? CONV,
+          content: r.content,
+          createdAt: "x",
+        })),
+        observations: (opts.observations ?? []).map((o) => ({
+          id: o.id,
+          conversationId: o.conversationId ?? CONV,
+          content: o.content,
+          createdAt: "x",
+        })),
+        recentMessages: [],
+      });
+    }),
+  );
+}
+
+function client(): MemoryClient {
+  return new MemoryClient({ endpoint: ENDPOINT, apiKey: API_KEY });
+}
+
+describe("Neo4jConversationManager — three-tier injection", () => {
+  it("prepends reflections + observations in canonical order", async () => {
+    mountContext({
+      reflections: [{ id: "r1", content: "user prefers concise" }],
+      observations: [{ id: "o1", content: "asks about graphs" }],
+    });
+    const cm = new Neo4jConversationManager(client(), { conversationId: CONV });
+    const { agent, fire } = makeAgent([{ role: "user", content: [{ text: "now" }] }]);
+    await cm.initAgent(agent);
+    await fire();
+
+    const msgs = getMessages(agent);
+    expect(msgs).toHaveLength(3);
+    const texts = msgs.map((m) =>
+      ((m.content as Array<{ text?: string }>)[0]?.text ?? "") as string,
+    );
+    expect(msgs[0]?.role).toBe("system");
+    expect(msgs[1]?.role).toBe("system");
+    expect(texts).toEqual([
+      "[reflection] user prefers concise",
+      "[observation] asks about graphs",
+      "now",
+    ]);
+  });
+
+  it("empty context leaves messages untouched", async () => {
+    mountContext({});
+    const cm = new Neo4jConversationManager(client(), { conversationId: CONV });
+    const { agent, fire } = makeAgent([{ role: "user", content: [{ text: "now" }] }]);
+    await cm.initAgent(agent);
+    await fire();
+    expect(getMessages(agent)).toHaveLength(1);
+  });
+
+  it("getContext 5xx is swallowed silently — agent run continues with no prepend", async () => {
+    mountContext({ status: 500 });
+    const cm = new Neo4jConversationManager(client(), { conversationId: CONV });
+    const { agent, fire } = makeAgent([{ role: "user", content: [{ text: "x" }] }]);
+    await cm.initAgent(agent);
+    await fire();
+    expect(getMessages(agent)).toHaveLength(1);
+  });
+
+  it("getContext 401 is also swallowed (best-effort)", async () => {
+    mountContext({ status: 401 });
+    const cm = new Neo4jConversationManager(client(), { conversationId: CONV });
+    const { agent, fire } = makeAgent([{ role: "user", content: [{ text: "x" }] }]);
+    await cm.initAgent(agent);
+    await fire();
+    expect(getMessages(agent)).toHaveLength(1);
+  });
+
+  it("includeReflections=false skips reflections, keeps observations", async () => {
+    mountContext({
+      reflections: [{ id: "r1", content: "skip" }],
+      observations: [{ id: "o1", content: "keep" }],
+    });
+    const cm = new Neo4jConversationManager(client(), {
+      conversationId: CONV,
+      includeReflections: false,
+    });
+    const { agent, fire } = makeAgent([{ role: "user", content: [{ text: "now" }] }]);
+    await cm.initAgent(agent);
+    await fire();
+    const texts = getMessages(agent).map((m) =>
+      ((m.content as Array<{ text?: string }>)[0]?.text ?? "") as string,
+    );
+    expect(texts.some((t) => t.startsWith("[reflection]"))).toBe(false);
+    expect(texts.some((t) => t.startsWith("[observation] keep"))).toBe(true);
+  });
+
+  it("includeObservations=false skips observations, keeps reflections", async () => {
+    mountContext({
+      reflections: [{ id: "r1", content: "keep" }],
+      observations: [{ id: "o1", content: "skip" }],
+    });
+    const cm = new Neo4jConversationManager(client(), {
+      conversationId: CONV,
+      includeObservations: false,
+    });
+    const { agent, fire } = makeAgent([{ role: "user", content: [{ text: "now" }] }]);
+    await cm.initAgent(agent);
+    await fire();
+    const texts = getMessages(agent).map((m) =>
+      ((m.content as Array<{ text?: string }>)[0]?.text ?? "") as string,
+    );
+    expect(texts.some((t) => t.startsWith("[reflection] keep"))).toBe(true);
+    expect(texts.some((t) => t.startsWith("[observation]"))).toBe(false);
+  });
+});
+
+describe("Neo4jConversationManager — inner manager", () => {
+  it("inner defaults to SlidingWindow (lazily constructed)", async () => {
+    mountContext({});
+    const cm = new Neo4jConversationManager(client(), { conversationId: CONV });
+    const { agent } = makeAgent([]);
+    // initAgent triggers inner construction.
+    await cm.initAgent(agent);
+    // The inner manager should now exist.
+    const inner = (cm as unknown as { inner: { name: string } | null }).inner;
+    expect(inner).not.toBeNull();
+    // SlidingWindow's name in Strands v1.2 — best-effort assertion.
+    expect(typeof inner!.name).toBe("string");
+  });
+
+  it("inner manager's initAgent is delegated through", async () => {
+    mountContext({});
+    let innerInitCalled = false;
+    const fakeInner = {
+      name: "fake-inner",
+      reduce: async () => false,
+      initAgent: async () => {
+        innerInitCalled = true;
+      },
+    };
+    const cm = new Neo4jConversationManager(client(), {
+      conversationId: CONV,
+      inner: fakeInner as unknown as ConstructorParameters<typeof Neo4jConversationManager>[1]["inner"],
+    });
+    const { agent } = makeAgent([]);
+    await cm.initAgent(agent);
+    expect(innerInitCalled).toBe(true);
+  });
+
+  it("reduce() delegates to inner", async () => {
+    let reduceCalled = false;
+    const fakeInner = {
+      name: "fake-inner",
+      reduce: async () => {
+        reduceCalled = true;
+        return true;
+      },
+      initAgent: async () => {},
+    };
+    const cm = new Neo4jConversationManager(client(), {
+      conversationId: CONV,
+      inner: fakeInner as unknown as ConstructorParameters<typeof Neo4jConversationManager>[1]["inner"],
+    });
+    const result = await cm.reduce({} as Parameters<typeof cm.reduce>[0]);
+    expect(reduceCalled).toBe(true);
+    expect(result).toBe(true);
+  });
+});

--- a/typescript/test/integration/strands-factory.test.ts
+++ b/typescript/test/integration/strands-factory.test.ts
@@ -1,0 +1,175 @@
+/**
+ * Integration tests — connectMemoryToAgent + Neo4jConversationManager
+ * against MSW. Drives the integration end-to-end with all three surfaces
+ * (SessionStorage, ConversationManager, reasoning hooks) reaching the
+ * mocked NAMS endpoint.
+ *
+ * The second test uses Neo4jConversationManager directly with a
+ * NullConversationManager inner so SlidingWindow's own hooks (which need
+ * agent internals our stub doesn't model) don't fire during the assertions.
+ */
+
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { http, HttpResponse } from "msw";
+import { setupServer } from "msw/node";
+import {
+  BeforeInvocationEvent,
+  BeforeToolCallEvent,
+  AfterToolCallEvent,
+  AfterInvocationEvent,
+  NullConversationManager,
+  type LocalAgent,
+} from "@strands-agents/sdk";
+import { MemoryClient } from "../../src/client.js";
+import {
+  Neo4jConversationManager,
+  connectMemoryToAgent,
+  registerReasoningHooks,
+} from "../../src/integrations/strands.js";
+
+const ENDPOINT = "https://memory.test/v1";
+const API_KEY = "nams_test_key";
+const CONV = "conv-factory";
+
+const server = setupServer();
+beforeAll(() => server.listen({ onUnhandledRequest: "error" }));
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+function makeAgentStub() {
+  const hooks = new Map<unknown, Array<(e: unknown) => Promise<void> | void>>();
+  const messages: Array<Record<string, unknown>> = [
+    { role: "user", content: [{ text: "Hello" }] },
+  ];
+  const agent = {
+    id: "a",
+    messages,
+    addHook(eventClass: unknown, cb: (e: unknown) => Promise<void> | void) {
+      const list = hooks.get(eventClass) ?? [];
+      list.push(cb);
+      hooks.set(eventClass, list);
+      return () => {};
+    },
+  } as unknown as LocalAgent;
+  return { agent, hooks };
+}
+
+describe("connectMemoryToAgent — return shape", () => {
+  it("returns sessionManager + conversationManager ready to spread into new Agent", async () => {
+    server.use(
+      http.get(`${ENDPOINT}/conversations/${CONV}/context`, () =>
+        HttpResponse.json({ reflections: [], observations: [], recentMessages: [] }),
+      ),
+    );
+    const memory = new MemoryClient({ endpoint: ENDPOINT, apiKey: API_KEY });
+    const { sessionManager, conversationManager } = await connectMemoryToAgent(memory, {
+      conversationId: CONV,
+    });
+
+    expect(sessionManager).toBeDefined();
+    expect(conversationManager).toBeDefined();
+    expect(conversationManager.name).toBe("neo4j:context-injection");
+    expect(typeof conversationManager.initAgent).toBe("function");
+    expect(typeof conversationManager.reduce).toBe("function");
+  });
+});
+
+describe("Neo4jConversationManager + reasoning hooks — end-to-end against MSW", () => {
+  it("context injection, reasoning step, and tool call all wire through to NAMS", async () => {
+    const steps: Array<Record<string, unknown>> = [];
+    const toolCalls: Array<Record<string, unknown>> = [];
+
+    server.use(
+      http.get(`${ENDPOINT}/conversations/${CONV}/context`, () =>
+        HttpResponse.json({
+          reflections: [{ id: "r1", conversationId: CONV, content: "be concise", createdAt: "x" }],
+          observations: [],
+          recentMessages: [],
+        }),
+      ),
+      http.post(`${ENDPOINT}/reasoning/steps`, async ({ request }) => {
+        const body = (await request.json()) as Record<string, unknown>;
+        steps.push(body);
+        return HttpResponse.json({ id: `step-${steps.length}`, created_at: "x" });
+      }),
+      http.post(`${ENDPOINT}/reasoning/tool-calls`, async ({ request }) => {
+        const body = (await request.json()) as Record<string, unknown>;
+        toolCalls.push(body);
+        return HttpResponse.json({ id: `tc-${toolCalls.length}`, created_at: "x" });
+      }),
+    );
+
+    const memory = new MemoryClient({ endpoint: ENDPOINT, apiKey: API_KEY });
+    // Build the conversation manager directly with a Null inner so the
+    // assertions below don't trip over SlidingWindow's internal hooks.
+    const cm = new Neo4jConversationManager(memory, {
+      conversationId: CONV,
+      inner: new NullConversationManager(),
+    });
+    const { agent, hooks } = makeAgentStub();
+    await cm.initAgent(agent);
+    // Reasoning hooks would normally be attached by the factory's
+    // initAgent wrapper. Attach them explicitly to match the same
+    // composition.
+    await registerReasoningHooks(memory, agent, { conversationId: CONV });
+
+    // Fire BeforeInvocation — context injection AND reasoning step.
+    const inv: Record<string, unknown> = {};
+    const event = new BeforeInvocationEvent({
+      agent: agent as unknown as ConstructorParameters<typeof BeforeInvocationEvent>[0]["agent"],
+      invocationState: inv,
+    });
+    const beforeInvCallbacks = hooks.get(BeforeInvocationEvent) ?? [];
+    expect(beforeInvCallbacks.length).toBeGreaterThanOrEqual(2);
+    for (const cb of beforeInvCallbacks) await cb(event);
+
+    // Assertion 1 — context injection.
+    const texts = (agent as unknown as { messages: Array<Record<string, unknown>> })
+      .messages.map((m) => ((m.content as Array<{ text?: string }>)[0]?.text ?? "") as string);
+    expect(texts[0]).toBe("[reflection] be concise");
+    expect(texts[texts.length - 1]).toBe("Hello");
+
+    // Assertion 2 — reasoning step recorded.
+    expect(steps).toHaveLength(1);
+    expect(inv["__neo4jReasoningStepId"]).toBe("step-1");
+
+    // Fire BeforeToolCall + AfterToolCall.
+    const beforeToolCb = (hooks.get(BeforeToolCallEvent) ?? [])[0]!;
+    const afterToolCb = (hooks.get(AfterToolCallEvent) ?? [])[0]!;
+    await beforeToolCb(
+      new BeforeToolCallEvent({
+        agent: {} as ConstructorParameters<typeof BeforeToolCallEvent>[0]["agent"],
+        toolUse: { toolUseId: "tu", name: "search", input: { q: "neo4j" } },
+        tool: undefined,
+        invocationState: inv,
+      } as unknown as ConstructorParameters<typeof BeforeToolCallEvent>[0]),
+    );
+    await afterToolCb(
+      new AfterToolCallEvent({
+        agent: {} as ConstructorParameters<typeof AfterToolCallEvent>[0]["agent"],
+        toolUse: { toolUseId: "tu", name: "search", input: { q: "neo4j" } },
+        tool: undefined,
+        result: {
+          toolUseId: "tu",
+          content: [],
+          status: "success",
+        } as ConstructorParameters<typeof AfterToolCallEvent>[0]["result"],
+        error: undefined,
+        invocationState: inv,
+      } as unknown as ConstructorParameters<typeof AfterToolCallEvent>[0]),
+    );
+    expect(toolCalls).toHaveLength(2);
+    expect(toolCalls[0]!.status).toBe("pending");
+    expect(toolCalls[1]!.status).toBe("success");
+
+    // Fire AfterInvocation — closing step recorded.
+    const afterInvCb = (hooks.get(AfterInvocationEvent) ?? [])[0]!;
+    await afterInvCb(
+      new AfterInvocationEvent({
+        agent: {} as ConstructorParameters<typeof AfterInvocationEvent>[0]["agent"],
+        invocationState: inv,
+      }),
+    );
+    expect(steps).toHaveLength(2);
+  });
+});

--- a/typescript/test/integration/strands-hooks.test.ts
+++ b/typescript/test/integration/strands-hooks.test.ts
@@ -1,0 +1,275 @@
+/**
+ * Integration tests — registerReasoningHooks against MSW-mocked
+ * /v1/reasoning/steps and /v1/reasoning/tool-calls. Exercises the full
+ * Strands hook lifecycle through the real RestTransport.
+ */
+
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { http, HttpResponse } from "msw";
+import { setupServer } from "msw/node";
+import {
+  AfterInvocationEvent,
+  AfterToolCallEvent,
+  BeforeInvocationEvent,
+  BeforeToolCallEvent,
+  type LocalAgent,
+} from "@strands-agents/sdk";
+import { MemoryClient } from "../../src/client.js";
+import { registerReasoningHooks } from "../../src/integrations/strands.js";
+
+const ENDPOINT = "https://memory.test/v1";
+const API_KEY = "nams_test_key";
+const CONV = "conv-hooks";
+
+const server = setupServer();
+beforeAll(() => server.listen({ onUnhandledRequest: "error" }));
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+/**
+ * The RestTransport snakeToCamel-transforms outgoing bodies, so what MSW
+ * actually sees in `await request.json()` uses camelCase keys.
+ */
+interface CapturedStep {
+  conversationId?: string;
+  reasoning?: string;
+  actionTaken?: string;
+  result?: string;
+}
+
+interface CapturedToolCall {
+  stepId?: string;
+  toolName?: string;
+  arguments?: Record<string, unknown>;
+  status?: string;
+  error?: string;
+}
+
+function mountReasoning(state: {
+  steps: CapturedStep[];
+  toolCalls: CapturedToolCall[];
+  failNext?: boolean;
+}) {
+  server.use(
+    http.post(`${ENDPOINT}/reasoning/steps`, async ({ request }) => {
+      if (state.failNext) {
+        state.failNext = false;
+        return new HttpResponse("nope", { status: 500 });
+      }
+      const body = (await request.json()) as Record<string, unknown>;
+      state.steps.push(body as CapturedStep);
+      return HttpResponse.json({
+        id: `step-${state.steps.length}`,
+        conversation_id: (body as CapturedStep).conversationId,
+        reasoning: (body as CapturedStep).reasoning,
+        action_taken: (body as CapturedStep).actionTaken,
+        result: (body as CapturedStep).result,
+        created_at: "x",
+      });
+    }),
+    http.post(`${ENDPOINT}/reasoning/tool-calls`, async ({ request }) => {
+      const body = (await request.json()) as Record<string, unknown>;
+      state.toolCalls.push(body as CapturedToolCall);
+      return HttpResponse.json({
+        id: `tc-${state.toolCalls.length}`,
+        step_id: (body as CapturedToolCall).stepId,
+        tool_name: (body as CapturedToolCall).toolName,
+        arguments: (body as CapturedToolCall).arguments,
+        status: (body as CapturedToolCall).status ?? "pending",
+        created_at: "x",
+      });
+    }),
+  );
+}
+
+interface HookSlots {
+  beforeInv?: (e: BeforeInvocationEvent) => Promise<void>;
+  afterInv?: (e: AfterInvocationEvent) => Promise<void>;
+  beforeTool?: (e: BeforeToolCallEvent) => Promise<void>;
+  afterTool?: (e: AfterToolCallEvent) => Promise<void>;
+}
+
+function makeAgent(): { agent: LocalAgent; slots: HookSlots } {
+  const slots: HookSlots = {};
+  const agent = {
+    id: "a",
+    addHook(eventClass: unknown, cb: (e: unknown) => Promise<void>) {
+      if (eventClass === BeforeInvocationEvent) slots.beforeInv = cb as HookSlots["beforeInv"];
+      else if (eventClass === AfterInvocationEvent) slots.afterInv = cb as HookSlots["afterInv"];
+      else if (eventClass === BeforeToolCallEvent) slots.beforeTool = cb as HookSlots["beforeTool"];
+      else if (eventClass === AfterToolCallEvent) slots.afterTool = cb as HookSlots["afterTool"];
+      return () => {};
+    },
+  } as unknown as LocalAgent;
+  return { agent, slots };
+}
+
+function beforeInvEvent(state: Record<string, unknown>): BeforeInvocationEvent {
+  return new BeforeInvocationEvent({
+    agent: {} as ConstructorParameters<typeof BeforeInvocationEvent>[0]["agent"],
+    invocationState: state,
+  });
+}
+
+function beforeToolEvent(
+  state: Record<string, unknown>,
+  toolUseId: string,
+  name: string,
+  input: Record<string, unknown>,
+): BeforeToolCallEvent {
+  return new BeforeToolCallEvent({
+    agent: {} as ConstructorParameters<typeof BeforeToolCallEvent>[0]["agent"],
+    toolUse: { toolUseId, name, input },
+    tool: undefined,
+    invocationState: state,
+  } as unknown as ConstructorParameters<typeof BeforeToolCallEvent>[0]);
+}
+
+function afterToolEvent(
+  state: Record<string, unknown>,
+  toolUseId: string,
+  name: string,
+  input: Record<string, unknown>,
+  error?: Error,
+): AfterToolCallEvent {
+  return new AfterToolCallEvent({
+    agent: {} as ConstructorParameters<typeof AfterToolCallEvent>[0]["agent"],
+    toolUse: { toolUseId, name, input },
+    tool: undefined,
+    result: { toolUseId, content: [], status: "success" } as ConstructorParameters<typeof AfterToolCallEvent>[0]["result"],
+    error,
+    invocationState: state,
+  } as unknown as ConstructorParameters<typeof AfterToolCallEvent>[0]);
+}
+
+function afterInvEvent(state: Record<string, unknown>): AfterInvocationEvent {
+  return new AfterInvocationEvent({
+    agent: {} as ConstructorParameters<typeof AfterInvocationEvent>[0]["agent"],
+    invocationState: state,
+  });
+}
+
+describe("registerReasoningHooks — full lifecycle", () => {
+  it("BeforeInvocation creates a step and stashes the id on invocationState", async () => {
+    const state = { steps: [] as CapturedStep[], toolCalls: [] as CapturedToolCall[] };
+    mountReasoning(state);
+    const memory = new MemoryClient({ endpoint: ENDPOINT, apiKey: API_KEY });
+    const { agent, slots } = makeAgent();
+    await registerReasoningHooks(memory, agent, { conversationId: CONV });
+
+    const inv: Record<string, unknown> = {};
+    await slots.beforeInv!(beforeInvEvent(inv));
+
+    expect(state.steps).toHaveLength(1);
+    expect(state.steps[0]).toMatchObject({
+      conversationId: CONV,
+      actionTaken: "invoke_agent",
+    });
+    expect(inv["__neo4jReasoningStepId"]).toBe("step-1");
+  });
+
+  it("BeforeToolCall records a tool call against the current step", async () => {
+    const state = { steps: [] as CapturedStep[], toolCalls: [] as CapturedToolCall[] };
+    mountReasoning(state);
+    const memory = new MemoryClient({ endpoint: ENDPOINT, apiKey: API_KEY });
+    const { agent, slots } = makeAgent();
+    await registerReasoningHooks(memory, agent, { conversationId: CONV });
+
+    const inv: Record<string, unknown> = {};
+    await slots.beforeInv!(beforeInvEvent(inv));
+    await slots.beforeTool!(beforeToolEvent(inv, "tu-1", "search_entities", { query: "neo4j" }));
+
+    expect(state.toolCalls).toHaveLength(1);
+    expect(state.toolCalls[0]).toMatchObject({
+      stepId: "step-1",
+      toolName: "search_entities",
+      status: "pending",
+    });
+  });
+
+  it("AfterToolCall records a follow-up entry with the resolved status", async () => {
+    const state = { steps: [] as CapturedStep[], toolCalls: [] as CapturedToolCall[] };
+    mountReasoning(state);
+    const memory = new MemoryClient({ endpoint: ENDPOINT, apiKey: API_KEY });
+    const { agent, slots } = makeAgent();
+    await registerReasoningHooks(memory, agent, { conversationId: CONV });
+
+    const inv: Record<string, unknown> = {};
+    await slots.beforeInv!(beforeInvEvent(inv));
+    await slots.beforeTool!(beforeToolEvent(inv, "tu", "fetch", {}));
+    await slots.afterTool!(afterToolEvent(inv, "tu", "fetch", {}));
+
+    expect(state.toolCalls).toHaveLength(2);
+    expect(state.toolCalls[0]!.status).toBe("pending");
+    expect(state.toolCalls[1]!.status).toBe("success");
+  });
+
+  it("AfterToolCall with error records failure status", async () => {
+    const state = { steps: [] as CapturedStep[], toolCalls: [] as CapturedToolCall[] };
+    mountReasoning(state);
+    const memory = new MemoryClient({ endpoint: ENDPOINT, apiKey: API_KEY });
+    const { agent, slots } = makeAgent();
+    await registerReasoningHooks(memory, agent, { conversationId: CONV });
+
+    const inv: Record<string, unknown> = {};
+    await slots.beforeInv!(beforeInvEvent(inv));
+    await slots.beforeTool!(beforeToolEvent(inv, "tu", "fail-tool", {}));
+    await slots.afterTool!(afterToolEvent(inv, "tu", "fail-tool", {}, new Error("kaboom")));
+
+    const last = state.toolCalls[state.toolCalls.length - 1]!;
+    expect(last.status).toBe("failure");
+    expect(last.error).toBe("kaboom");
+  });
+
+  it("AfterInvocation records a closing step", async () => {
+    const state = { steps: [] as CapturedStep[], toolCalls: [] as CapturedToolCall[] };
+    mountReasoning(state);
+    const memory = new MemoryClient({ endpoint: ENDPOINT, apiKey: API_KEY });
+    const { agent, slots } = makeAgent();
+    await registerReasoningHooks(memory, agent, { conversationId: CONV });
+
+    const inv: Record<string, unknown> = {};
+    await slots.beforeInv!(beforeInvEvent(inv));
+    await slots.afterInv!(afterInvEvent(inv));
+
+    expect(state.steps).toHaveLength(2);
+    expect(state.steps[1]!.actionTaken).toBe("invocation_complete");
+    expect(state.steps[1]!.result).toBe("ok");
+  });
+
+  it("concurrent invocations record under separate step ids", async () => {
+    const state = { steps: [] as CapturedStep[], toolCalls: [] as CapturedToolCall[] };
+    mountReasoning(state);
+    const memory = new MemoryClient({ endpoint: ENDPOINT, apiKey: API_KEY });
+    const { agent, slots } = makeAgent();
+    await registerReasoningHooks(memory, agent, { conversationId: CONV });
+
+    const a: Record<string, unknown> = {};
+    const b: Record<string, unknown> = {};
+    await slots.beforeInv!(beforeInvEvent(a));
+    await slots.beforeInv!(beforeInvEvent(b));
+    await slots.beforeTool!(beforeToolEvent(a, "tu-a", "fA", {}));
+    await slots.beforeTool!(beforeToolEvent(b, "tu-b", "fB", {}));
+
+    expect(state.toolCalls).toHaveLength(2);
+    expect(state.toolCalls[0]!.stepId).toBe("step-1");
+    expect(state.toolCalls[1]!.stepId).toBe("step-2");
+  });
+
+  it("recordStep failure is swallowed (agent run continues)", async () => {
+    const state = {
+      steps: [] as CapturedStep[],
+      toolCalls: [] as CapturedToolCall[],
+      failNext: true,
+    };
+    mountReasoning(state);
+    const memory = new MemoryClient({ endpoint: ENDPOINT, apiKey: API_KEY });
+    const { agent, slots } = makeAgent();
+    await registerReasoningHooks(memory, agent, { conversationId: CONV });
+
+    const inv: Record<string, unknown> = {};
+    // First recordStep fails; should not throw.
+    await expect(slots.beforeInv!(beforeInvEvent(inv))).resolves.toBeUndefined();
+    expect(inv["__neo4jReasoningStepId"]).toBeUndefined();
+  });
+});

--- a/typescript/test/integration/strands-session-storage.test.ts
+++ b/typescript/test/integration/strands-session-storage.test.ts
@@ -1,0 +1,453 @@
+/**
+ * Integration tests — Neo4jSessionStorage drives the real RestTransport
+ * against an MSW-mocked /v1 server.
+ *
+ * Storage shape post-pivot: state is carried in synthetic `role: "user"`
+ * messages whose content has the form
+ * `__strands_state__:{base64(JSON.stringify(blob))}`. No conversation-
+ * level metadata is written (NAMS doesn't expose that endpoint) and no
+ * per-message metadata is used (the live service doesn't reliably
+ * round-trip it).
+ *
+ * Exercises:
+ *   - Save → read back of synthetic messages
+ *   - listSnapshotIds order + paging
+ *   - loadSnapshot by explicit id + latest fallback
+ *   - Manifest round-trip
+ *   - Auth + transport error propagation
+ *   - deleteSession via DELETE /conversations/:id
+ *   - Idempotency: re-saving doesn't duplicate real messages
+ */
+
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { http, HttpResponse } from "msw";
+import { setupServer } from "msw/node";
+import type { Snapshot } from "@strands-agents/sdk";
+import { MemoryClient } from "../../src/client.js";
+import {
+  AuthenticationError,
+  TransportError,
+} from "../../src/errors.js";
+import { Neo4jSessionStorage } from "../../src/integrations/strands.js";
+
+const ENDPOINT = "https://memory.test/v1";
+const API_KEY = "nams_test_key";
+const SESSION_ID = "conv-strands-session";
+
+const server = setupServer();
+beforeAll(() => server.listen({ onUnhandledRequest: "error" }));
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+function newStorage() {
+  const client = new MemoryClient({ endpoint: ENDPOINT, apiKey: API_KEY });
+  return new Neo4jSessionStorage(client);
+}
+
+function snap(opts: {
+  messages?: Array<{ role: string; content: Array<{ text: string }> }>;
+  agentState?: Record<string, unknown>;
+} = {}): Snapshot {
+  return {
+    scope: "agent",
+    schemaVersion: "1.0",
+    createdAt: new Date().toISOString(),
+    data: {
+      ...(opts.agentState ?? {}),
+      messages: opts.messages ?? [],
+    } as unknown as Snapshot["data"],
+    appData: {} as Snapshot["appData"],
+  };
+}
+
+const LOCATION = { sessionId: SESSION_ID, scope: "agent" as const, scopeId: "a1" };
+
+interface ServerMessage {
+  id: string;
+  role: string;
+  content: string;
+  metadata?: Record<string, unknown>;
+}
+
+interface ServerState {
+  messages: ServerMessage[];
+}
+
+/**
+ * Mount handlers that act like the hosted service's
+ * GET /conversations/:id/messages + POST /conversations/:id/messages,
+ * plus DELETE. No metadata routes — those don't exist on NAMS.
+ */
+function mountConversationHandlers(state: ServerState) {
+  server.use(
+    http.get(`${ENDPOINT}/conversations/${SESSION_ID}/messages`, () =>
+      HttpResponse.json({ messages: state.messages.map((m) => ({ ...m })) }),
+    ),
+    http.post(`${ENDPOINT}/conversations/${SESSION_ID}/messages`, async ({ request }) => {
+      const body = (await request.json()) as {
+        role: string;
+        content: string;
+        metadata?: Record<string, unknown>;
+      };
+      const id = `m${state.messages.length + 1}`;
+      const m: ServerMessage = {
+        id,
+        role: body.role,
+        content: body.content,
+        metadata: body.metadata,
+      };
+      state.messages.push(m);
+      return HttpResponse.json(m);
+    }),
+    http.delete(`${ENDPOINT}/conversations/${SESSION_ID}`, () =>
+      new HttpResponse(null, { status: 204 }),
+    ),
+  );
+}
+
+function decodeStateBlob<T>(msg: ServerMessage): T {
+  const prefix = "__strands_state__:";
+  if (!msg.content.startsWith(prefix)) throw new Error("missing state prefix");
+  const b64 = msg.content.slice(prefix.length);
+  return JSON.parse(Buffer.from(b64, "base64").toString("utf8")) as T;
+}
+
+function decodeManifestBlob<T>(msg: ServerMessage): T {
+  const prefix = "__strands_manifest__:";
+  if (!msg.content.startsWith(prefix)) throw new Error("missing manifest prefix");
+  const b64 = msg.content.slice(prefix.length);
+  return JSON.parse(Buffer.from(b64, "base64").toString("utf8")) as T;
+}
+
+function encodeBlobContent(prefix: string, blob: unknown): string {
+  return `${prefix}${Buffer.from(JSON.stringify(blob), "utf8").toString("base64")}`;
+}
+
+describe("Neo4jSessionStorage — synthetic-message storage", () => {
+  it("saveSnapshot writes one synthetic user message for a distinct snapshot + the real conversation messages", async () => {
+    const state: ServerState = { messages: [] };
+    mountConversationHandlers(state);
+    const storage = newStorage();
+
+    await storage.saveSnapshot({
+      location: LOCATION,
+      snapshotId: "s1",
+      isLatest: true,
+      snapshot: snap({
+        messages: [
+          { role: "user", content: [{ text: "hello" }] },
+          { role: "assistant", content: [{ text: "hi" }] },
+        ],
+        agentState: { fooBar: 1 },
+      }),
+    });
+
+    // Real messages persisted as Message nodes (synthetic marker filtered out).
+    const real = state.messages.filter(
+      (m) =>
+        (m.role === "user" || m.role === "assistant") &&
+        !m.content.startsWith("__strands_state__:") &&
+        !m.content.startsWith("__strands_manifest__:"),
+    );
+    expect(real).toHaveLength(2);
+    expect(real[0]).toMatchObject({ role: "user", content: "hello" });
+
+    // One synthetic state message with our marker.
+    const synthetic = state.messages.filter((m) =>
+      m.content.startsWith("__strands_state__:"),
+    );
+    expect(synthetic).toHaveLength(1);
+    const blob = decodeStateBlob<{
+      snapshotId: string;
+      isLatest: boolean;
+      snapshot: Snapshot;
+    }>(synthetic[0]!);
+    expect(blob.snapshotId).toBe("s1");
+    expect(blob.isLatest).toBe(true);
+    expect(blob.snapshot.data).toMatchObject({ fooBar: 1 });
+    expect((blob.snapshot.data as Record<string, unknown>).messages).toBeUndefined();
+  });
+
+  it("loadSnapshot returns the latest blob + real messages (synthetic markers filtered)", async () => {
+    const state: ServerState = { messages: [] };
+    mountConversationHandlers(state);
+    const storage = newStorage();
+
+    await storage.saveSnapshot({
+      location: LOCATION,
+      snapshotId: "s1",
+      isLatest: true,
+      snapshot: snap({
+        messages: [{ role: "user", content: [{ text: "hello" }] }],
+        agentState: { stored: 1 },
+      }),
+    });
+
+    const loaded = await storage.loadSnapshot({ location: LOCATION });
+    expect(loaded).not.toBeNull();
+    expect((loaded!.data as Record<string, unknown>).stored).toBe(1);
+    const messages = (loaded!.data as { messages?: unknown[] }).messages;
+    // Should contain the real user message; should NOT contain the synthetic state marker.
+    expect(Array.isArray(messages)).toBe(true);
+    expect(messages).toHaveLength(1);
+  });
+
+  it("loadSnapshot honors an explicit snapshotId", async () => {
+    const state: ServerState = { messages: [] };
+    mountConversationHandlers(state);
+    const storage = newStorage();
+
+    await storage.saveSnapshot({
+      location: LOCATION,
+      snapshotId: "first",
+      isLatest: false,
+      snapshot: snap({ messages: [], agentState: { tag: "first" } }),
+    });
+    await storage.saveSnapshot({
+      location: LOCATION,
+      snapshotId: "second",
+      isLatest: true,
+      snapshot: snap({ messages: [], agentState: { tag: "second" } }),
+    });
+
+    const a = await storage.loadSnapshot({ location: LOCATION, snapshotId: "first" });
+    const b = await storage.loadSnapshot({ location: LOCATION, snapshotId: "second" });
+    expect((a!.data as Record<string, unknown>).tag).toBe("first");
+    expect((b!.data as Record<string, unknown>).tag).toBe("second");
+  });
+
+  it("loadSnapshot returns null when conversation has no synthetic state messages", async () => {
+    const state: ServerState = {
+      messages: [
+        { id: "m1", role: "user", content: "regular message", metadata: undefined },
+      ],
+    };
+    mountConversationHandlers(state);
+    const storage = newStorage();
+    const loaded = await storage.loadSnapshot({ location: LOCATION });
+    expect(loaded).toBeNull();
+  });
+
+  it("listSnapshotIds returns IDs in save order", async () => {
+    const state: ServerState = { messages: [] };
+    mountConversationHandlers(state);
+    const storage = newStorage();
+
+    for (const id of ["a", "b", "c", "d"]) {
+      await storage.saveSnapshot({
+        location: LOCATION,
+        snapshotId: id,
+        isLatest: id === "d",
+        snapshot: snap({ messages: [] }),
+      });
+    }
+
+    expect(await storage.listSnapshotIds({ location: LOCATION })).toEqual(["a", "b", "c", "d"]);
+    expect(await storage.listSnapshotIds({ location: LOCATION, limit: 2 })).toEqual(["a", "b"]);
+    expect(
+      await storage.listSnapshotIds({ location: LOCATION, startAfter: "b", limit: 2 }),
+    ).toEqual(["c", "d"]);
+  });
+
+  it("deleteSession issues DELETE /conversations/:id", async () => {
+    let deleted = false;
+    server.use(
+      http.delete(`${ENDPOINT}/conversations/${SESSION_ID}`, () => {
+        deleted = true;
+        return new HttpResponse(null, { status: 204 });
+      }),
+    );
+    const storage = newStorage();
+    await storage.deleteSession({ sessionId: SESSION_ID });
+    expect(deleted).toBe(true);
+  });
+
+  it("manifest round-trip via a synthetic user message", async () => {
+    const state: ServerState = { messages: [] };
+    mountConversationHandlers(state);
+    const storage = newStorage();
+    const manifest = { schemaVersion: "1.0", updatedAt: "2026-05-16T00:00:00Z" };
+
+    await storage.saveManifest({ location: LOCATION, manifest });
+    const loaded = await storage.loadManifest({ location: LOCATION });
+    expect(loaded).toEqual(manifest);
+
+    const synthetic = state.messages.filter((m) =>
+      m.content.startsWith("__strands_manifest__:"),
+    );
+    expect(synthetic).toHaveLength(1);
+    const blob = decodeManifestBlob<{
+      scopeId: string;
+      manifest: { schemaVersion: string; updatedAt: string };
+    }>(synthetic[0]!);
+    expect(blob.scopeId).toBe("a1");
+    expect(blob.manifest).toEqual(manifest);
+  });
+});
+
+describe("Neo4jSessionStorage — idempotency + error surface", () => {
+  it("re-saving the same snapshotId does not duplicate real messages or synthetic markers", async () => {
+    const state: ServerState = { messages: [] };
+    mountConversationHandlers(state);
+    const storage = newStorage();
+    const snapshot = snap({
+      messages: [{ role: "user", content: [{ text: "hello" }] }],
+    });
+
+    await storage.saveSnapshot({
+      location: LOCATION,
+      snapshotId: "s1",
+      isLatest: true,
+      snapshot,
+    });
+    await storage.saveSnapshot({
+      location: LOCATION,
+      snapshotId: "s1",
+      isLatest: true,
+      snapshot,
+    });
+
+    const real = state.messages.filter(
+      (m) =>
+        (m.role === "user" || m.role === "assistant") &&
+        !m.content.startsWith("__strands_state__:") &&
+        !m.content.startsWith("__strands_manifest__:"),
+    );
+    // The user message is added only once (dedupe by role+content).
+    expect(real).toHaveLength(1);
+    const synthetic = state.messages.filter((m) =>
+      m.content.startsWith("__strands_state__:"),
+    );
+    expect(synthetic).toHaveLength(1);
+    expect(await storage.listSnapshotIds({ location: LOCATION })).toEqual(["s1"]);
+  });
+
+  it("loadSnapshot prefers the latest stored blob for an explicit snapshotId", async () => {
+    const state: ServerState = {
+      messages: [
+        {
+          id: "m1",
+          role: "user",
+          content: encodeBlobContent("__strands_state__:", {
+            snapshotId: "s1",
+            isLatest: false,
+            snapshot: snap({ agentState: { version: 1 } }),
+            savedAt: "2026-05-16T00:00:00Z",
+          }),
+        },
+        {
+          id: "m2",
+          role: "user",
+          content: encodeBlobContent("__strands_state__:", {
+            snapshotId: "s1",
+            isLatest: true,
+            snapshot: snap({ agentState: { version: 2 } }),
+            savedAt: "2026-05-16T00:01:00Z",
+          }),
+        },
+      ],
+    };
+    mountConversationHandlers(state);
+    const storage = newStorage();
+
+    const loaded = await storage.loadSnapshot({ location: LOCATION, snapshotId: "s1" });
+    expect((loaded!.data as Record<string, unknown>).version).toBe(2);
+  });
+
+  it("auth failure on read propagates AuthenticationError with requestId", async () => {
+    server.use(
+      http.get(`${ENDPOINT}/conversations/${SESSION_ID}/messages`, () =>
+        new HttpResponse("nope", {
+          status: 401,
+          headers: { "x-request-id": "req-401" },
+        }),
+      ),
+    );
+    const storage = newStorage();
+    try {
+      await storage.loadSnapshot({ location: LOCATION });
+      throw new Error("expected throw");
+    } catch (e) {
+      expect(e).toBeInstanceOf(AuthenticationError);
+      expect((e as AuthenticationError).requestId).toBe("req-401");
+    }
+  });
+
+  it("5xx on save surfaces as TransportError with requestId", async () => {
+    server.use(
+      // GET must succeed (the integration reads existing messages before
+      // dedup-and-write) so we can reach the POST that fails.
+      http.get(`${ENDPOINT}/conversations/${SESSION_ID}/messages`, () =>
+        HttpResponse.json({ messages: [] }),
+      ),
+      http.post(`${ENDPOINT}/conversations/${SESSION_ID}/messages`, () =>
+        HttpResponse.json(
+          { error: "boom" },
+          { status: 503, headers: { "x-request-id": "req-503" } },
+        ),
+      ),
+    );
+    const storage = newStorage();
+    try {
+      await storage.saveSnapshot({
+        location: LOCATION,
+        snapshotId: "s1",
+        isLatest: true,
+        snapshot: snap({ messages: [{ role: "user", content: [{ text: "hi" }] }] }),
+      });
+      throw new Error("expected throw");
+    } catch (e) {
+      expect(e).toBeInstanceOf(TransportError);
+      expect((e as TransportError).statusCode).toBe(503);
+      expect((e as TransportError).requestId).toBe("req-503");
+    }
+  });
+});
+
+describe("Neo4jSessionStorage — bridge-transport compatibility", () => {
+  it("listSnapshotIds reads via the snake_case method on bridge transport", async () => {
+    const bridgeRoot = "http://bridge.test";
+    server.use(
+      http.post(`${bridgeRoot}/get_conversation`, async ({ request }) => {
+        const body = (await request.json()) as { session_id?: string };
+        expect(body.session_id).toBe(SESSION_ID);
+        const emptySnap = {
+          scope: "agent",
+          schemaVersion: "1.0",
+          createdAt: "x",
+          data: {},
+          appData: {},
+        };
+        return HttpResponse.json({
+          session_id: SESSION_ID,
+          messages: [
+            {
+              id: "m1",
+              role: "user",
+              content: encodeBlobContent("__strands_state__:", {
+                snapshotId: "x",
+                isLatest: true,
+                snapshot: emptySnap,
+                savedAt: "x",
+              }),
+            },
+            {
+              id: "m2",
+              role: "user",
+              content: encodeBlobContent("__strands_state__:", {
+                snapshotId: "y",
+                isLatest: false,
+                snapshot: emptySnap,
+                savedAt: "x",
+              }),
+            },
+          ],
+        });
+      }),
+    );
+    const client = new MemoryClient({ endpoint: bridgeRoot });
+    const storage = new Neo4jSessionStorage(client);
+    const ids = await storage.listSnapshotIds({ location: LOCATION });
+    expect(ids).toEqual(["x", "y"]);
+  });
+});

--- a/typescript/test/integration/vercel-ai-middleware.test.ts
+++ b/typescript/test/integration/vercel-ai-middleware.test.ts
@@ -1,0 +1,167 @@
+/**
+ * Smoke test — Vercel AI middleware drives transformParams / wrapGenerate
+ * end-to-end against an MSW-mocked hosted service.
+ *
+ * Asserts the four contract points that adopters depend on:
+ *  - user input is persisted before generation
+ *  - context (or flat history) is injected into the prompt
+ *  - assistant output is persisted after generation
+ *  - wrapGenerate forwards the doGenerate result unchanged
+ */
+
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { http, HttpResponse } from "msw";
+import { setupServer } from "msw/node";
+import { MemoryClient } from "../../src/client.js";
+import { agentMemoryMiddleware } from "../../src/middleware/vercel-ai.js";
+
+const ENDPOINT = "https://memory.test/v1";
+const API_KEY = "nams_test_key";
+const CONV_ID = "conv-vercel-ai";
+
+const server = setupServer();
+beforeAll(() => server.listen({ onUnhandledRequest: "error" }));
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+interface CapturedMessage {
+  role: string;
+  content: string;
+}
+
+describe("Vercel AI middleware — smoke test", () => {
+  it("injects context, persists user input, and persists assistant output", async () => {
+    const persistedMessages: CapturedMessage[] = [];
+
+    server.use(
+      // Three-tier context endpoint
+      http.get(`${ENDPOINT}/conversations/${CONV_ID}/context`, () =>
+        HttpResponse.json({
+          reflections: [
+            { id: "r1", conversationId: CONV_ID, content: "user values concise replies", createdAt: "x" },
+          ],
+          observations: [
+            { id: "o1", conversationId: CONV_ID, content: "asks about Neo4j", createdAt: "x" },
+          ],
+          recentMessages: [{ id: "m1", role: "user", content: "previously: hello" }],
+        }),
+      ),
+      // Add-message endpoint — record what got persisted
+      http.post(`${ENDPOINT}/conversations/${CONV_ID}/messages`, async ({ request }) => {
+        const body = (await request.json()) as CapturedMessage;
+        persistedMessages.push(body);
+        return HttpResponse.json({
+          id: `m-${persistedMessages.length}`,
+          role: body.role,
+          content: body.content,
+        });
+      }),
+    );
+
+    const client = new MemoryClient({ endpoint: ENDPOINT, apiKey: API_KEY });
+    const middleware = agentMemoryMiddleware(client, {
+      conversationId: CONV_ID,
+      includeContext: true,
+    });
+
+    // Driver: simulate the shape Vercel AI's middleware contract uses.
+    const incomingPrompt = [{ role: "user", content: "Tell me about graphs." }];
+    const transformed = await middleware.transformParams!({
+      params: { prompt: incomingPrompt, model: "stub" },
+    });
+
+    // 1. Context was prepended — system messages from reflections/observations,
+    //    plus the recent message, then the incoming user prompt at the end.
+    const transformedPrompt = transformed["prompt"] as CapturedMessage[];
+    expect(transformedPrompt.length).toBeGreaterThan(incomingPrompt.length);
+    const allContent = transformedPrompt.map((m) => m.content).join("\n");
+    expect(allContent).toContain("[reflection] user values concise replies");
+    expect(allContent).toContain("[observation] asks about Neo4j");
+    expect(allContent).toContain("previously: hello");
+    expect(allContent).toContain("Tell me about graphs.");
+
+    // 2. User input was persisted.
+    expect(persistedMessages.find((m) => m.role === "user" && m.content === "Tell me about graphs.")).toBeDefined();
+
+    // 3. wrapGenerate forwards the model result and persists assistant text.
+    const fakeResult = { text: "Graphs model relationships.", finishReason: "stop" };
+    const wrapped = await middleware.wrapGenerate!({
+      doGenerate: async () => fakeResult,
+    });
+    expect(wrapped).toEqual(fakeResult);
+
+    // 4. Assistant message was persisted.
+    expect(
+      persistedMessages.find(
+        (m) => m.role === "assistant" && m.content === "Graphs model relationships.",
+      ),
+    ).toBeDefined();
+  });
+
+  it("falls back to flat history when context fetch fails", async () => {
+    let contextCalled = false;
+    let historyCalled = false;
+
+    server.use(
+      http.get(`${ENDPOINT}/conversations/${CONV_ID}/context`, () => {
+        contextCalled = true;
+        return new HttpResponse("nope", { status: 500 });
+      }),
+      http.get(`${ENDPOINT}/conversations/${CONV_ID}/messages`, () => {
+        historyCalled = true;
+        return HttpResponse.json({
+          messages: [{ id: "m1", role: "user", content: "earlier flat message" }],
+        });
+      }),
+      http.post(`${ENDPOINT}/conversations/${CONV_ID}/messages`, () =>
+        HttpResponse.json({ id: "x", role: "user", content: "" }),
+      ),
+    );
+
+    const client = new MemoryClient({ endpoint: ENDPOINT, apiKey: API_KEY });
+    const middleware = agentMemoryMiddleware(client, {
+      conversationId: CONV_ID,
+      includeContext: true,
+    });
+
+    const transformed = await middleware.transformParams!({
+      params: { prompt: [{ role: "user", content: "now" }] },
+    });
+
+    expect(contextCalled).toBe(true);
+    expect(historyCalled).toBe(true);
+    const transformedPrompt = transformed["prompt"] as CapturedMessage[];
+    expect(transformedPrompt.some((m) => m.content === "earlier flat message")).toBe(true);
+  });
+
+  it("skips persistence when persistInput=false and persistResponses=false", async () => {
+    const persistedMessages: CapturedMessage[] = [];
+
+    server.use(
+      http.get(`${ENDPOINT}/conversations/${CONV_ID}/context`, () =>
+        HttpResponse.json({ reflections: [], observations: [], recentMessages: [] }),
+      ),
+      http.get(`${ENDPOINT}/conversations/${CONV_ID}/messages`, () =>
+        HttpResponse.json({ messages: [] }),
+      ),
+      http.post(`${ENDPOINT}/conversations/${CONV_ID}/messages`, async ({ request }) => {
+        const body = (await request.json()) as CapturedMessage;
+        persistedMessages.push(body);
+        return HttpResponse.json({ id: "x", role: body.role, content: body.content });
+      }),
+    );
+
+    const client = new MemoryClient({ endpoint: ENDPOINT, apiKey: API_KEY });
+    const middleware = agentMemoryMiddleware(client, {
+      conversationId: CONV_ID,
+      includeContext: true,
+      persistInput: false,
+      persistResponses: false,
+    });
+
+    await middleware.transformParams!({ params: { prompt: [{ role: "user", content: "x" }] } });
+    await middleware.wrapGenerate!({ doGenerate: async () => ({ text: "y" }) });
+
+    expect(persistedMessages).toHaveLength(0);
+  });
+});

--- a/typescript/test/tck/bronze.test.ts
+++ b/typescript/test/tck/bronze.test.ts
@@ -1,0 +1,883 @@
+/**
+ * Bronze Tier TCK Conformance Tests.
+ *
+ * These tests mirror the Python TCK test suite (tck/tests/v1/test_schema.py
+ * and tck/tests/v1/test_short_term.py) and validate the TypeScript client
+ * against the same behavioral contracts.
+ *
+ * Requires a running conformance server or the hosted service.
+ * Set MEMORY_ENDPOINT env var to configure the target.
+ */
+
+import { describe, it, expect, beforeEach, beforeAll, afterAll } from "vitest";
+import { MemoryClient } from "../../src/client.js";
+import type { Message } from "../../src/types.js";
+import {
+  SESSION_A,
+  SESSION_B,
+  SESSION_C,
+  CONVERSATION_MESSAGES,
+  LONG_CONTENT,
+  UNICODE_CONTENT,
+  SPECIAL_CHARS_CONTENT,
+  EMPTY_CONTENT,
+  NESTED_METADATA,
+  ENTITIES,
+  PREFERENCES,
+  FACTS,
+} from "./testdata.js";
+
+const ENDPOINT = process.env["MEMORY_ENDPOINT"] ?? "http://localhost:3001";
+const RUN_TCK = process.env["RUN_TCK_BRIDGE"] === "1";
+
+const describeOrSkip = RUN_TCK ? describe : describe.skip;
+
+describeOrSkip("Bronze Tier", () => {
+  let client: MemoryClient;
+
+  beforeAll(async () => {
+    client = new MemoryClient({ endpoint: ENDPOINT });
+    await client.connect();
+  });
+
+  afterAll(async () => {
+    await client.close();
+  });
+
+  beforeEach(async () => {
+    await client.shortTerm.clearSession(SESSION_A);
+    await client.shortTerm.clearSession(SESSION_B);
+    await client.shortTerm.clearSession(SESSION_C);
+  });
+
+  // =====================================================================
+  // Schema Tests (test_schema.py)
+  // =====================================================================
+
+  describe("SchemaConversationCreation", () => {
+    it("SPEC-1.1.1: first message creates conversation", async () => {
+      await client.shortTerm.addMessage(SESSION_A, "user", "Hello");
+      const conv = await client.shortTerm.getConversation(SESSION_A);
+      expect(conv.sessionId).toBe(SESSION_A);
+      expect(conv.messages).toHaveLength(1);
+    });
+
+    it("SPEC-1.1.2: subsequent messages reuse conversation", async () => {
+      await client.shortTerm.addMessage(SESSION_A, "user", "First message");
+      await client.shortTerm.addMessage(SESSION_A, "assistant", "Second message");
+      const conv = await client.shortTerm.getConversation(SESSION_A);
+      expect(conv.messages).toHaveLength(2);
+    });
+
+    it("SPEC-1.1.5: conversation id is valid UUID", async () => {
+      await client.shortTerm.addMessage(SESSION_A, "user", "Hello");
+      const conv = await client.shortTerm.getConversation(SESSION_A);
+      expect(conv.id).toBeDefined();
+      expect(typeof conv.id).toBe("string");
+      expect(conv.id).toMatch(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i,
+      );
+    });
+
+    it("SPEC-1.1.6: conversation created_at is set", async () => {
+      const before = new Date(Date.now() - 5000);
+      await client.shortTerm.addMessage(SESSION_A, "user", "Hello");
+      const conv = await client.shortTerm.getConversation(SESSION_A);
+      expect(conv.createdAt).toBeDefined();
+    });
+
+    it("SPEC-1.1.7: conversation title is optional", async () => {
+      await client.shortTerm.addMessage(SESSION_A, "user", "Hello");
+      const conv = await client.shortTerm.getConversation(SESSION_A);
+      expect(conv.title === null || conv.title === undefined || typeof conv.title === "string").toBe(true);
+    });
+
+    it("SPEC-1.1.8: same session reuses same conversation id", async () => {
+      await client.shortTerm.addMessage(SESSION_A, "user", "First");
+      const conv1 = await client.shortTerm.getConversation(SESSION_A);
+      await client.shortTerm.addMessage(SESSION_A, "user", "Second");
+      const conv2 = await client.shortTerm.getConversation(SESSION_A);
+      expect(conv1.id).toBe(conv2.id);
+    });
+  });
+
+  describe("SchemaSessionIsolation", () => {
+    it("SPEC-1.1.3: messages isolated between sessions", async () => {
+      await client.shortTerm.addMessage(SESSION_A, "user", "Message in session A");
+      await client.shortTerm.addMessage(SESSION_B, "user", "Message in session B");
+      const convA = await client.shortTerm.getConversation(SESSION_A);
+      const convB = await client.shortTerm.getConversation(SESSION_B);
+      expect(convA.messages).toHaveLength(1);
+      expect(convB.messages).toHaveLength(1);
+      expect(convA.messages[0]!.content).toBe("Message in session A");
+      expect(convB.messages[0]!.content).toBe("Message in session B");
+    });
+
+    it("SPEC-1.1.9: different sessions have different conversation ids", async () => {
+      await client.shortTerm.addMessage(SESSION_A, "user", "Alpha");
+      await client.shortTerm.addMessage(SESSION_B, "user", "Beta");
+      const convA = await client.shortTerm.getConversation(SESSION_A);
+      const convB = await client.shortTerm.getConversation(SESSION_B);
+      expect(convA.id).not.toBe(convB.id);
+    });
+  });
+
+  describe("SchemaMessageDeletion", () => {
+    it("SPEC-1.1.4: deleted message not retrievable", async () => {
+      const msg = await client.shortTerm.addMessage(SESSION_A, "user", "Delete me");
+      const deleted = await client.shortTerm.deleteMessage(msg.id);
+      expect(deleted).toBe(true);
+      const conv = await client.shortTerm.getConversation(SESSION_A);
+      const ids = conv.messages.map((m: Message) => m.id);
+      expect(ids).not.toContain(msg.id);
+    });
+
+    it("SPEC-1.1.10: deletion does not affect other messages", async () => {
+      await client.shortTerm.addMessage(SESSION_A, "user", "Keep me");
+      const msg2 = await client.shortTerm.addMessage(SESSION_A, "user", "Delete me");
+      await client.shortTerm.addMessage(SESSION_A, "user", "Keep me too");
+      await client.shortTerm.deleteMessage(msg2.id);
+      const conv = await client.shortTerm.getConversation(SESSION_A);
+      expect(conv.messages).toHaveLength(2);
+      expect(conv.messages[0]!.content).toBe("Keep me");
+      expect(conv.messages[1]!.content).toBe("Keep me too");
+    });
+  });
+
+  describe("SchemaMessageProperties", () => {
+    it("SPEC-1.1.11: message has id", async () => {
+      const msg = await client.shortTerm.addMessage(SESSION_A, "user", "Hello");
+      expect(msg.id).toBeDefined();
+    });
+
+    it("SPEC-1.1.12: message has role matching input", async () => {
+      const msg = await client.shortTerm.addMessage(SESSION_A, "user", "Hello");
+      expect(msg.role).toBe("user");
+    });
+
+    it("SPEC-1.1.13: message has content matching input", async () => {
+      const msg = await client.shortTerm.addMessage(SESSION_A, "user", "Hello world");
+      expect(msg.content).toBe("Hello world");
+    });
+
+    it("SPEC-1.1.14: message has timestamp", async () => {
+      const msg = await client.shortTerm.addMessage(SESSION_A, "user", "Hello");
+      expect(msg.timestamp).toBeDefined();
+    });
+  });
+
+  describe("SchemaEntityCreation", () => {
+    it("SPEC-1.2.1: entity created with required fields", async () => {
+      const e = ENTITIES[0]!;
+      const entity = await client.longTerm.addEntity(e.name, e.type, { description: e.description });
+      expect(entity.id).toBeDefined();
+      expect(entity.name).toBe(e.name);
+      expect(entity.type).toBe(e.type);
+      expect(entity.createdAt).toBeDefined();
+    });
+
+    it("SPEC-1.2.2: entity id is valid UUID", async () => {
+      const entity = await client.longTerm.addEntity("Test Entity", "PERSON");
+      expect(entity.id).toMatch(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i,
+      );
+    });
+
+    it("SPEC-1.2.3: PERSON entity type", async () => {
+      const entity = await client.longTerm.addEntity("Alice", "PERSON");
+      expect(entity.type).toBe("PERSON");
+      expect(entity.name).toBe("Alice");
+    });
+
+    it("SPEC-1.2.4: ORGANIZATION entity type", async () => {
+      const entity = await client.longTerm.addEntity("Acme", "ORGANIZATION");
+      expect(entity.type).toBe("ORGANIZATION");
+    });
+
+    it("SPEC-1.2.5: LOCATION entity type", async () => {
+      const entity = await client.longTerm.addEntity("NYC", "LOCATION");
+      expect(entity.type).toBe("LOCATION");
+    });
+
+    it("SPEC-1.2.6: EVENT entity type", async () => {
+      const entity = await client.longTerm.addEntity("Launch", "EVENT");
+      expect(entity.type).toBe("EVENT");
+    });
+
+    it("SPEC-1.2.7: OBJECT entity type", async () => {
+      const entity = await client.longTerm.addEntity("Laptop", "OBJECT");
+      expect(entity.type).toBe("OBJECT");
+    });
+
+    it("SPEC-1.2.8: entity created_at is set", async () => {
+      const entity = await client.longTerm.addEntity("Timestamped", "PERSON");
+      expect(entity.createdAt).toBeDefined();
+    });
+  });
+
+  describe("SchemaPreferenceCreation", () => {
+    it("SPEC-1.3.1: preference has required fields", async () => {
+      const pref = await client.longTerm.addPreference("language", "Prefers Python");
+      expect(pref.id).toBeDefined();
+      expect(pref.category).toBe("language");
+      expect(pref.preference).toBe("Prefers Python");
+    });
+
+    it("SPEC-1.3.2: preference id is valid UUID", async () => {
+      const pref = await client.longTerm.addPreference("food", "Likes pizza");
+      expect(pref.id).toMatch(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i,
+      );
+    });
+  });
+
+  describe("SchemaFactCreation", () => {
+    it("SPEC-1.4.1: fact has required fields", async () => {
+      const fact = await client.longTerm.addFact("Alice", "WORKS_AT", "Acme");
+      expect(fact.id).toBeDefined();
+      expect(fact.subject).toBe("Alice");
+      expect(fact.predicate).toBe("WORKS_AT");
+      expect(fact.object).toBe("Acme");
+    });
+
+    it("SPEC-1.4.2: fact id is valid UUID", async () => {
+      const fact = await client.longTerm.addFact("Bob", "KNOWS", "Alice");
+      expect(fact.id).toMatch(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i,
+      );
+    });
+  });
+
+  // =====================================================================
+  // Short-Term Memory Tests (test_short_term.py)
+  // =====================================================================
+
+  describe("AddMessage", () => {
+    it("SPEC-2.1.1: returns valid message with UUID and timestamp", async () => {
+      const msg = await client.shortTerm.addMessage(SESSION_A, "user", "Hello, world!");
+      expect(msg.id).toBeDefined();
+      expect(msg.role).toBe("user");
+      expect(msg.content).toBe("Hello, world!");
+      expect(msg.timestamp).toBeDefined();
+    });
+
+    it("SPEC-2.1.2: accepts user role", async () => {
+      const msg = await client.shortTerm.addMessage(SESSION_A, "user", "User message");
+      expect(msg.role).toBe("user");
+    });
+
+    it("SPEC-2.1.3: accepts assistant role", async () => {
+      const msg = await client.shortTerm.addMessage(SESSION_A, "assistant", "Assistant message");
+      expect(msg.role).toBe("assistant");
+    });
+
+    it("SPEC-2.1.4: accepts system role", async () => {
+      const msg = await client.shortTerm.addMessage(SESSION_A, "system", "System prompt");
+      expect(msg.role).toBe("system");
+    });
+
+    it("SPEC-2.1.5: preserves metadata", async () => {
+      const metadata = { source: "test", priority: "high" };
+      const msg = await client.shortTerm.addMessage(SESSION_A, "user", "With meta", { metadata });
+      expect(msg.metadata["source"]).toBe("test");
+      expect(msg.metadata["priority"]).toBe("high");
+    });
+
+    it("SPEC-2.1.6: creates conversation on first call", async () => {
+      await client.shortTerm.addMessage(SESSION_A, "user", "First message");
+      const conv = await client.shortTerm.getConversation(SESSION_A);
+      expect(conv.sessionId).toBe(SESSION_A);
+      expect(conv.messages).toHaveLength(1);
+    });
+
+    it("SPEC-2.1.7: accepts empty string content", async () => {
+      const msg = await client.shortTerm.addMessage(SESSION_A, "user", EMPTY_CONTENT);
+      expect(msg.content).toBe("");
+    });
+
+    it("SPEC-2.1.8: preserves long content (10K+ chars)", async () => {
+      const msg = await client.shortTerm.addMessage(SESSION_A, "user", LONG_CONTENT);
+      expect(msg.content.length).toBe(10_000);
+    });
+
+    it("SPEC-2.1.9: preserves unicode and emoji", async () => {
+      const msg = await client.shortTerm.addMessage(SESSION_A, "user", UNICODE_CONTENT);
+      expect(msg.content).toBe(UNICODE_CONTENT);
+    });
+
+    it("SPEC-2.1.10: preserves special characters", async () => {
+      const msg = await client.shortTerm.addMessage(SESSION_A, "user", SPECIAL_CHARS_CONTENT);
+      expect(msg.content).toBe(SPECIAL_CHARS_CONTENT);
+    });
+
+    it("SPEC-2.1.11: empty dict metadata succeeds", async () => {
+      const msg = await client.shortTerm.addMessage(SESSION_A, "user", "Empty meta", { metadata: {} });
+      expect(typeof msg.metadata).toBe("object");
+    });
+
+    it("SPEC-2.1.12: preserves nested metadata", async () => {
+      const msg = await client.shortTerm.addMessage(SESSION_A, "user", "Nested", { metadata: NESTED_METADATA });
+      expect(msg.metadata["source"]).toBe("test");
+      expect(msg.metadata["count"]).toBe(42);
+      expect(msg.metadata["active"]).toBe(true);
+    });
+
+    it("SPEC-2.1.13: null metadata defaults to empty dict", async () => {
+      const msg = await client.shortTerm.addMessage(SESSION_A, "user", "No meta");
+      expect(typeof msg.metadata).toBe("object");
+    });
+
+    it("SPEC-2.1.14: returns valid UUID for message id", async () => {
+      const msg = await client.shortTerm.addMessage(SESSION_A, "user", "UUID check");
+      expect(msg.id).toMatch(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i,
+      );
+    });
+
+    it("SPEC-2.1.15: timestamp is recent", async () => {
+      const before = Date.now() - 60_000;
+      const msg = await client.shortTerm.addMessage(SESSION_A, "user", "Timestamp check");
+      const ts = new Date(msg.timestamp).getTime();
+      const after = Date.now() + 60_000;
+      expect(ts).toBeGreaterThanOrEqual(before);
+      expect(ts).toBeLessThanOrEqual(after);
+    });
+
+    it("SPEC-2.1.16: 50 rapid messages all stored and ordered", async () => {
+      for (let i = 0; i < 50; i++) {
+        await client.shortTerm.addMessage(SESSION_A, "user", `Rapid message ${i}`);
+      }
+      const conv = await client.shortTerm.getConversation(SESSION_A);
+      expect(conv.messages).toHaveLength(50);
+      for (let i = 0; i < 50; i++) {
+        expect(conv.messages[i]!.content).toBe(`Rapid message ${i}`);
+      }
+    });
+  });
+
+  describe("GetConversation", () => {
+    it("SPEC-2.2.1: returns messages in insertion order", async () => {
+      for (const msg of CONVERSATION_MESSAGES) {
+        await client.shortTerm.addMessage(SESSION_A, msg.role, msg.content);
+      }
+      const conv = await client.shortTerm.getConversation(SESSION_A);
+      expect(conv.messages).toHaveLength(CONVERSATION_MESSAGES.length);
+      for (let i = 0; i < conv.messages.length; i++) {
+        expect(conv.messages[i]!.content).toBe(CONVERSATION_MESSAGES[i]!.content);
+      }
+    });
+
+    it("SPEC-2.2.2: respects limit parameter", async () => {
+      for (const msg of CONVERSATION_MESSAGES) {
+        await client.shortTerm.addMessage(SESSION_A, msg.role, msg.content);
+      }
+      const conv = await client.shortTerm.getConversation(SESSION_A, { limit: 2 });
+      expect(conv.messages).toHaveLength(2);
+    });
+
+    it("SPEC-2.2.3: returns empty for non-existent session", async () => {
+      const conv = await client.shortTerm.getConversation("tck-nonexistent");
+      expect(conv.messages).toHaveLength(0);
+    });
+
+    it("SPEC-2.2.4: isolates sessions", async () => {
+      await client.shortTerm.addMessage(SESSION_A, "user", "Alpha message 1");
+      await client.shortTerm.addMessage(SESSION_A, "user", "Alpha message 2");
+      await client.shortTerm.addMessage(SESSION_B, "user", "Beta message 1");
+
+      const convA = await client.shortTerm.getConversation(SESSION_A);
+      const convB = await client.shortTerm.getConversation(SESSION_B);
+
+      expect(convA.messages).toHaveLength(2);
+      expect(convB.messages).toHaveLength(1);
+    });
+
+    it("SPEC-2.2.5: limit exceeding count returns all", async () => {
+      await client.shortTerm.addMessage(SESSION_A, "user", "Only one");
+      const conv = await client.shortTerm.getConversation(SESSION_A, { limit: 100 });
+      expect(conv.messages).toHaveLength(1);
+    });
+
+    it("SPEC-2.2.6: limit=1 returns exactly one", async () => {
+      for (const msg of CONVERSATION_MESSAGES) {
+        await client.shortTerm.addMessage(SESSION_A, msg.role, msg.content);
+      }
+      const conv = await client.shortTerm.getConversation(SESSION_A, { limit: 1 });
+      expect(conv.messages).toHaveLength(1);
+    });
+
+    it("SPEC-2.2.7: preserves content fidelity (unicode + special chars)", async () => {
+      await client.shortTerm.addMessage(SESSION_A, "user", UNICODE_CONTENT);
+      await client.shortTerm.addMessage(SESSION_A, "user", SPECIAL_CHARS_CONTENT);
+      const conv = await client.shortTerm.getConversation(SESSION_A);
+      expect(conv.messages[0]!.content).toBe(UNICODE_CONTENT);
+      expect(conv.messages[1]!.content).toBe(SPECIAL_CHARS_CONTENT);
+    });
+
+    it("SPEC-2.2.8: preserves metadata on retrieved messages", async () => {
+      const metadata = { key: "value", num: 99 };
+      await client.shortTerm.addMessage(SESSION_A, "user", "With meta", { metadata });
+      const conv = await client.shortTerm.getConversation(SESSION_A);
+      expect(conv.messages[0]!.metadata["key"]).toBe("value");
+      expect(conv.messages[0]!.metadata["num"]).toBe(99);
+    });
+
+    it("SPEC-2.2.9: preserves roles", async () => {
+      await client.shortTerm.addMessage(SESSION_A, "system", "System");
+      await client.shortTerm.addMessage(SESSION_A, "user", "User");
+      await client.shortTerm.addMessage(SESSION_A, "assistant", "Assistant");
+
+      const conv = await client.shortTerm.getConversation(SESSION_A);
+      expect(conv.messages[0]!.role).toBe("system");
+      expect(conv.messages[1]!.role).toBe("user");
+      expect(conv.messages[2]!.role).toBe("assistant");
+    });
+
+    it("SPEC-2.2.10: 20 messages maintain order", async () => {
+      for (let i = 0; i < 20; i++) {
+        await client.shortTerm.addMessage(SESSION_A, "user", `Message ${String(i).padStart(3, "0")}`);
+      }
+      const conv = await client.shortTerm.getConversation(SESSION_A);
+      expect(conv.messages).toHaveLength(20);
+      for (let i = 0; i < 20; i++) {
+        expect(conv.messages[i]!.content).toBe(`Message ${String(i).padStart(3, "0")}`);
+      }
+    });
+
+    it("SPEC-2.2.11: returns valid conversation id", async () => {
+      await client.shortTerm.addMessage(SESSION_A, "user", "Hello");
+      const conv = await client.shortTerm.getConversation(SESSION_A);
+      expect(conv.id).toMatch(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i,
+      );
+    });
+
+    it("SPEC-2.2.12: three sessions fully isolated", async () => {
+      await client.shortTerm.addMessage(SESSION_A, "user", "Alpha");
+      await client.shortTerm.addMessage(SESSION_B, "user", "Beta 1");
+      await client.shortTerm.addMessage(SESSION_B, "user", "Beta 2");
+      await client.shortTerm.addMessage(SESSION_C, "user", "Gamma 1");
+      await client.shortTerm.addMessage(SESSION_C, "user", "Gamma 2");
+      await client.shortTerm.addMessage(SESSION_C, "user", "Gamma 3");
+
+      const convA = await client.shortTerm.getConversation(SESSION_A);
+      const convB = await client.shortTerm.getConversation(SESSION_B);
+      const convC = await client.shortTerm.getConversation(SESSION_C);
+
+      expect(convA.messages).toHaveLength(1);
+      expect(convB.messages).toHaveLength(2);
+      expect(convC.messages).toHaveLength(3);
+    });
+  });
+
+  describe("SearchMessages", () => {
+    it("SPEC-2.3.1: finds relevant messages", async () => {
+      await client.shortTerm.addMessage(SESSION_A, "user", "I love programming in Python");
+      await client.shortTerm.addMessage(SESSION_A, "user", "The weather is sunny today");
+      await client.shortTerm.addMessage(SESSION_A, "user", "Python is great for data science");
+
+      const results = await client.shortTerm.searchMessages("Python programming", {
+        limit: 10,
+        threshold: 0.0,
+      });
+      expect(results.length).toBeGreaterThan(0);
+      expect(results.some((r: Message) => r.content.includes("Python"))).toBe(true);
+    });
+
+    it("SPEC-2.3.2: session filter restricts results", async () => {
+      await client.shortTerm.addMessage(SESSION_A, "user", "Python in session A");
+      await client.shortTerm.addMessage(SESSION_B, "user", "Python in session B");
+
+      const results = await client.shortTerm.searchMessages("Python", {
+        sessionId: SESSION_A,
+        limit: 10,
+        threshold: 0.0,
+      });
+      for (const msg of results) {
+        expect(msg.content.includes("session A") || msg.content.includes("Python")).toBe(true);
+      }
+    });
+
+    it("SPEC-2.3.3: respects limit", async () => {
+      for (let i = 0; i < 5; i++) {
+        await client.shortTerm.addMessage(SESSION_A, "user", `Test message number ${i}`);
+      }
+      const results = await client.shortTerm.searchMessages("Test message", {
+        limit: 2,
+        threshold: 0.0,
+      });
+      expect(results.length).toBeLessThanOrEqual(2);
+    });
+
+    it("SPEC-2.3.4: no results returns empty list", async () => {
+      await client.shortTerm.addMessage(SESSION_A, "user", "The sky is blue");
+      const results = await client.shortTerm.searchMessages(
+        "quantum cryptography algorithms",
+        { limit: 10, threshold: 0.99 },
+      );
+      expect(Array.isArray(results)).toBe(true);
+    });
+
+    it("SPEC-2.3.5: limit=1 returns at most 1", async () => {
+      for (let i = 0; i < 5; i++) {
+        await client.shortTerm.addMessage(SESSION_A, "user", `Searchable content ${i}`);
+      }
+      const results = await client.shortTerm.searchMessages("Searchable content", {
+        limit: 1,
+        threshold: 0.0,
+      });
+      expect(results.length).toBeLessThanOrEqual(1);
+    });
+
+    it("SPEC-2.3.6: empty database returns empty list", async () => {
+      const results = await client.shortTerm.searchMessages("anything", {
+        limit: 10,
+        threshold: 0.0,
+      });
+      expect(results).toEqual([]);
+    });
+
+    it("SPEC-2.3.7: searches across sessions without filter", async () => {
+      await client.shortTerm.addMessage(SESSION_A, "user", "Alpha Python topic");
+      await client.shortTerm.addMessage(SESSION_B, "user", "Beta Python topic");
+
+      const results = await client.shortTerm.searchMessages("Python topic", {
+        limit: 10,
+        threshold: 0.0,
+      });
+      expect(results.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  describe("ListSessions", () => {
+    it("SPEC-2.4.1: returns all active sessions", async () => {
+      await client.shortTerm.addMessage(SESSION_A, "user", "Alpha");
+      await client.shortTerm.addMessage(SESSION_B, "user", "Beta");
+
+      const sessions = await client.shortTerm.listSessions();
+      const ids = sessions.map((s) => s.sessionId);
+      expect(ids).toContain(SESSION_A);
+      expect(ids).toContain(SESSION_B);
+    });
+
+    it("SPEC-2.4.2: includes accurate message counts", async () => {
+      await client.shortTerm.addMessage(SESSION_A, "user", "One");
+      await client.shortTerm.addMessage(SESSION_A, "assistant", "Two");
+      await client.shortTerm.addMessage(SESSION_A, "user", "Three");
+
+      const sessions = await client.shortTerm.listSessions();
+      const sessionA = sessions.find((s) => s.sessionId === SESSION_A);
+      expect(sessionA?.messageCount).toBe(3);
+    });
+
+    it("SPEC-2.4.3: empty returns empty list", async () => {
+      const sessions = await client.shortTerm.listSessions();
+      expect(sessions).toEqual([]);
+    });
+
+    it("SPEC-2.4.4: single session returns one entry", async () => {
+      await client.shortTerm.addMessage(SESSION_A, "user", "Solo");
+      const sessions = await client.shortTerm.listSessions();
+      expect(sessions).toHaveLength(1);
+      expect(sessions[0]!.sessionId).toBe(SESSION_A);
+    });
+
+    it("SPEC-2.4.5: respects limit", async () => {
+      await client.shortTerm.addMessage(SESSION_A, "user", "Alpha");
+      await client.shortTerm.addMessage(SESSION_B, "user", "Beta");
+      await client.shortTerm.addMessage(SESSION_C, "user", "Gamma");
+
+      const sessions = await client.shortTerm.listSessions({ limit: 2 });
+      expect(sessions.length).toBeLessThanOrEqual(2);
+    });
+
+    it("SPEC-2.4.6: entries have created_at", async () => {
+      await client.shortTerm.addMessage(SESSION_A, "user", "Timestamped");
+      const sessions = await client.shortTerm.listSessions();
+      expect(sessions.length).toBeGreaterThanOrEqual(1);
+      expect(sessions[0]!.createdAt).toBeDefined();
+    });
+
+    it("SPEC-2.4.7: message count reflects deletion", async () => {
+      const msg1 = await client.shortTerm.addMessage(SESSION_A, "user", "One");
+      await client.shortTerm.addMessage(SESSION_A, "user", "Two");
+      await client.shortTerm.addMessage(SESSION_A, "user", "Three");
+      await client.shortTerm.deleteMessage(msg1.id);
+
+      const sessions = await client.shortTerm.listSessions();
+      const sessionA = sessions.find((s) => s.sessionId === SESSION_A);
+      expect(sessionA?.messageCount).toBe(2);
+    });
+
+    it("SPEC-2.4.8: independent counts per session", async () => {
+      await client.shortTerm.addMessage(SESSION_A, "user", "A1");
+      await client.shortTerm.addMessage(SESSION_A, "user", "A2");
+      await client.shortTerm.addMessage(SESSION_B, "user", "B1");
+
+      const sessions = await client.shortTerm.listSessions();
+      const sessionA = sessions.find((s) => s.sessionId === SESSION_A);
+      const sessionB = sessions.find((s) => s.sessionId === SESSION_B);
+      expect(sessionA?.messageCount).toBe(2);
+      expect(sessionB?.messageCount).toBe(1);
+    });
+  });
+
+  describe("DeleteMessage", () => {
+    it("SPEC-2.5.1: returns true for existing message", async () => {
+      const msg = await client.shortTerm.addMessage(SESSION_A, "user", "Delete me");
+      const result = await client.shortTerm.deleteMessage(msg.id);
+      expect(result).toBe(true);
+    });
+
+    it("SPEC-2.5.2: removes from conversation", async () => {
+      const msg1 = await client.shortTerm.addMessage(SESSION_A, "user", "Keep");
+      const msg2 = await client.shortTerm.addMessage(SESSION_A, "user", "Delete");
+      await client.shortTerm.deleteMessage(msg2.id);
+
+      const conv = await client.shortTerm.getConversation(SESSION_A);
+      expect(conv.messages).toHaveLength(1);
+      expect(conv.messages[0]!.id).toBe(msg1.id);
+    });
+
+    it("SPEC-2.5.3: returns false for non-existent", async () => {
+      const result = await client.shortTerm.deleteMessage(crypto.randomUUID());
+      expect(result).toBe(false);
+    });
+
+    it("SPEC-2.5.4: preserves remaining order", async () => {
+      const msgs: Message[] = [];
+      for (const content of ["First", "Second", "Third", "Fourth"]) {
+        msgs.push(await client.shortTerm.addMessage(SESSION_A, "user", content));
+      }
+      await client.shortTerm.deleteMessage(msgs[1]!.id);
+
+      const conv = await client.shortTerm.getConversation(SESSION_A);
+      expect(conv.messages).toHaveLength(3);
+      expect(conv.messages[0]!.content).toBe("First");
+      expect(conv.messages[1]!.content).toBe("Third");
+      expect(conv.messages[2]!.content).toBe("Fourth");
+    });
+
+    it("SPEC-2.5.5: deleting first message preserves rest", async () => {
+      const msgs: Message[] = [];
+      for (const content of ["First", "Second", "Third"]) {
+        msgs.push(await client.shortTerm.addMessage(SESSION_A, "user", content));
+      }
+      await client.shortTerm.deleteMessage(msgs[0]!.id);
+
+      const conv = await client.shortTerm.getConversation(SESSION_A);
+      expect(conv.messages).toHaveLength(2);
+      expect(conv.messages[0]!.content).toBe("Second");
+      expect(conv.messages[1]!.content).toBe("Third");
+    });
+
+    it("SPEC-2.5.6: deleting last message preserves earlier", async () => {
+      const msgs: Message[] = [];
+      for (const content of ["First", "Second", "Third"]) {
+        msgs.push(await client.shortTerm.addMessage(SESSION_A, "user", content));
+      }
+      await client.shortTerm.deleteMessage(msgs[2]!.id);
+
+      const conv = await client.shortTerm.getConversation(SESSION_A);
+      expect(conv.messages).toHaveLength(2);
+      expect(conv.messages[0]!.content).toBe("First");
+      expect(conv.messages[1]!.content).toBe("Second");
+    });
+
+    it("SPEC-2.5.7: deleting middle message repairs chain", async () => {
+      const msgs: Message[] = [];
+      for (const content of ["First", "Second", "Third"]) {
+        msgs.push(await client.shortTerm.addMessage(SESSION_A, "user", content));
+      }
+      await client.shortTerm.deleteMessage(msgs[1]!.id);
+
+      const conv = await client.shortTerm.getConversation(SESSION_A);
+      expect(conv.messages).toHaveLength(2);
+      expect(conv.messages[0]!.content).toBe("First");
+      expect(conv.messages[1]!.content).toBe("Third");
+    });
+
+    it("SPEC-2.5.8: deleting all messages one by one leaves empty", async () => {
+      const msgs: Message[] = [];
+      for (const content of ["One", "Two", "Three"]) {
+        msgs.push(await client.shortTerm.addMessage(SESSION_A, "user", content));
+      }
+      for (const msg of msgs) {
+        const result = await client.shortTerm.deleteMessage(msg.id);
+        expect(result).toBe(true);
+      }
+      const conv = await client.shortTerm.getConversation(SESSION_A);
+      expect(conv.messages).toHaveLength(0);
+    });
+
+    it("SPEC-2.5.9: second delete returns false", async () => {
+      const msg = await client.shortTerm.addMessage(SESSION_A, "user", "Once");
+      expect(await client.shortTerm.deleteMessage(msg.id)).toBe(true);
+      expect(await client.shortTerm.deleteMessage(msg.id)).toBe(false);
+    });
+  });
+
+  describe("ClearSession", () => {
+    it("SPEC-2.6.1: removes all messages", async () => {
+      await client.shortTerm.addMessage(SESSION_A, "user", "One");
+      await client.shortTerm.addMessage(SESSION_A, "assistant", "Two");
+      await client.shortTerm.addMessage(SESSION_A, "user", "Three");
+      await client.shortTerm.clearSession(SESSION_A);
+
+      const conv = await client.shortTerm.getConversation(SESSION_A);
+      expect(conv.messages).toHaveLength(0);
+    });
+
+    it("SPEC-2.6.2: preserves other sessions", async () => {
+      await client.shortTerm.addMessage(SESSION_A, "user", "Alpha");
+      await client.shortTerm.addMessage(SESSION_B, "user", "Beta");
+      await client.shortTerm.clearSession(SESSION_A);
+
+      const convA = await client.shortTerm.getConversation(SESSION_A);
+      const convB = await client.shortTerm.getConversation(SESSION_B);
+      expect(convA.messages).toHaveLength(0);
+      expect(convB.messages).toHaveLength(1);
+      expect(convB.messages[0]!.content).toBe("Beta");
+    });
+
+    it("SPEC-2.6.3: idempotent on empty session", async () => {
+      await client.shortTerm.clearSession(SESSION_A);
+      const conv = await client.shortTerm.getConversation(SESSION_A);
+      expect(conv.messages).toHaveLength(0);
+    });
+
+    it("SPEC-2.6.4: accepts new messages after clear", async () => {
+      await client.shortTerm.addMessage(SESSION_A, "user", "Before");
+      await client.shortTerm.clearSession(SESSION_A);
+      await client.shortTerm.addMessage(SESSION_A, "user", "After");
+
+      const conv = await client.shortTerm.getConversation(SESSION_A);
+      expect(conv.messages).toHaveLength(1);
+      expect(conv.messages[0]!.content).toBe("After");
+    });
+
+    it("SPEC-2.6.5: clearing one of three sessions preserves others", async () => {
+      await client.shortTerm.addMessage(SESSION_A, "user", "Alpha");
+      await client.shortTerm.addMessage(SESSION_B, "user", "Beta");
+      await client.shortTerm.addMessage(SESSION_C, "user", "Gamma");
+      await client.shortTerm.clearSession(SESSION_B);
+
+      const convA = await client.shortTerm.getConversation(SESSION_A);
+      const convB = await client.shortTerm.getConversation(SESSION_B);
+      const convC = await client.shortTerm.getConversation(SESSION_C);
+
+      expect(convA.messages).toHaveLength(1);
+      expect(convB.messages).toHaveLength(0);
+      expect(convC.messages).toHaveLength(1);
+    });
+  });
+
+  describe("MessageChainStructure", () => {
+    it("SPEC-2.7.1: maintains insertion order", async () => {
+      const contents = ["First", "Second", "Third", "Fourth", "Fifth"];
+      for (const content of contents) {
+        await client.shortTerm.addMessage(SESSION_A, "user", content);
+      }
+      const conv = await client.shortTerm.getConversation(SESSION_A);
+      expect(conv.messages).toHaveLength(5);
+      for (let i = 0; i < contents.length; i++) {
+        expect(conv.messages[i]!.content).toBe(contents[i]);
+      }
+    });
+
+    it("SPEC-2.7.2: timestamps are monotonically increasing", async () => {
+      for (const content of ["First", "Second", "Third"]) {
+        await client.shortTerm.addMessage(SESSION_A, "user", content);
+      }
+      const conv = await client.shortTerm.getConversation(SESSION_A);
+      for (let i = 1; i < conv.messages.length; i++) {
+        const prev = new Date(conv.messages[i - 1]!.timestamp).getTime();
+        const curr = new Date(conv.messages[i]!.timestamp).getTime();
+        expect(curr).toBeGreaterThanOrEqual(prev);
+      }
+    });
+
+    it("SPEC-2.7.3: single message retrievable", async () => {
+      await client.shortTerm.addMessage(SESSION_A, "user", "Solo");
+      const conv = await client.shortTerm.getConversation(SESSION_A);
+      expect(conv.messages).toHaveLength(1);
+      expect(conv.messages[0]!.content).toBe("Solo");
+    });
+
+    it("SPEC-2.7.4: two messages correctly ordered", async () => {
+      await client.shortTerm.addMessage(SESSION_A, "user", "First");
+      await client.shortTerm.addMessage(SESSION_A, "assistant", "Second");
+      const conv = await client.shortTerm.getConversation(SESSION_A);
+      expect(conv.messages).toHaveLength(2);
+      expect(conv.messages[0]!.content).toBe("First");
+      expect(conv.messages[1]!.content).toBe("Second");
+    });
+
+    it("SPEC-2.7.5: chain integrity after middle delete", async () => {
+      const msgs: Message[] = [];
+      for (const c of ["A", "B", "C", "D", "E"]) {
+        msgs.push(await client.shortTerm.addMessage(SESSION_A, "user", c));
+      }
+      await client.shortTerm.deleteMessage(msgs[2]!.id);
+
+      const conv = await client.shortTerm.getConversation(SESSION_A);
+      expect(conv.messages).toHaveLength(4);
+      expect(conv.messages.map((m: Message) => m.content)).toEqual(["A", "B", "D", "E"]);
+    });
+
+    it("SPEC-2.7.6: 100 messages maintain order", async () => {
+      for (let i = 0; i < 100; i++) {
+        await client.shortTerm.addMessage(SESSION_A, "user", `Msg-${String(i).padStart(4, "0")}`);
+      }
+      const conv = await client.shortTerm.getConversation(SESSION_A);
+      expect(conv.messages).toHaveLength(100);
+      for (let i = 0; i < 100; i++) {
+        expect(conv.messages[i]!.content).toBe(`Msg-${String(i).padStart(4, "0")}`);
+      }
+    });
+
+    it("SPEC-2.7.7: mixed roles maintain order", async () => {
+      const sequence: [string, string][] = [
+        ["system", "You are helpful"],
+        ["user", "Hello"],
+        ["assistant", "Hi there"],
+        ["user", "How are you?"],
+        ["assistant", "I'm doing well"],
+      ];
+      for (const [role, content] of sequence) {
+        await client.shortTerm.addMessage(SESSION_A, role, content);
+      }
+      const conv = await client.shortTerm.getConversation(SESSION_A);
+      expect(conv.messages).toHaveLength(5);
+      for (let i = 0; i < sequence.length; i++) {
+        expect(conv.messages[i]!.role).toBe(sequence[i]![0]);
+        expect(conv.messages[i]!.content).toBe(sequence[i]![1]);
+      }
+    });
+  });
+
+  describe("Idempotency", () => {
+    it("SPEC-2.8.1: each add_message returns unique ID", async () => {
+      const msg1 = await client.shortTerm.addMessage(SESSION_A, "user", "Same");
+      const msg2 = await client.shortTerm.addMessage(SESSION_A, "user", "Same");
+      expect(msg1.id).not.toBe(msg2.id);
+    });
+
+    it("SPEC-2.8.2: duplicate content stored separately", async () => {
+      await client.shortTerm.addMessage(SESSION_A, "user", "Dup");
+      await client.shortTerm.addMessage(SESSION_A, "user", "Dup");
+      await client.shortTerm.addMessage(SESSION_A, "user", "Dup");
+
+      const conv = await client.shortTerm.getConversation(SESSION_A);
+      expect(conv.messages).toHaveLength(3);
+    });
+
+    it("SPEC-2.8.3: clear_session is idempotent", async () => {
+      await client.shortTerm.addMessage(SESSION_A, "user", "Data");
+      await client.shortTerm.clearSession(SESSION_A);
+      await client.shortTerm.clearSession(SESSION_A);
+      const conv = await client.shortTerm.getConversation(SESSION_A);
+      expect(conv.messages).toHaveLength(0);
+    });
+  });
+});

--- a/typescript/test/tck/testdata.ts
+++ b/typescript/test/tck/testdata.ts
@@ -1,0 +1,54 @@
+/**
+ * Deterministic test data for TCK conformance tests.
+ *
+ * These constants mirror tck/fixtures/data.py exactly to ensure
+ * cross-language test consistency.
+ */
+
+export const SESSION_A = "tck-session-alpha";
+export const SESSION_B = "tck-session-beta";
+export const SESSION_C = "tck-session-gamma";
+
+export const LONG_CONTENT = "x".repeat(10_000);
+export const UNICODE_CONTENT = "Hello \u4e16\u754c \ud83c\udf0d \u00e9\u00e8\u00ea \u00fc\u00f6\u00e4 \u2603\ufe0f \u2764\ufe0f\u200d\ud83d\udd25";
+export const SPECIAL_CHARS_CONTENT = 'Line1\nLine2\tTabbed "quoted" \'single\' back\\slash';
+export const EMPTY_CONTENT = "";
+
+export const NESTED_METADATA = {
+  source: "test",
+  priority: "high",
+  tags: ["memory", "tck", "bronze"],
+  nested: { level2: { level3: "deep_value" } },
+  count: 42,
+  active: true,
+};
+
+export const ENTITIES = [
+  { name: "Alice Johnson", type: "PERSON", description: "Software engineer at Acme Corp" },
+  { name: "Bob Smith", type: "PERSON", description: "Project manager" },
+  { name: "Acme Corp", type: "ORGANIZATION", description: "Technology company" },
+  { name: "San Francisco", type: "LOCATION", description: "City in California" },
+  { name: "Product Launch", type: "EVENT", description: "Annual product launch event" },
+];
+
+export const PREFERENCES = [
+  { category: "language", preference: "Prefers Python over JavaScript", context: "programming" },
+  { category: "communication", preference: "Prefers async communication", context: "work" },
+  { category: "food", preference: "Vegetarian diet", context: "dietary restrictions" },
+];
+
+export const FACTS = [
+  { subject: "Alice Johnson", predicate: "WORKS_AT", object: "Acme Corp" },
+  { subject: "Acme Corp", predicate: "LOCATED_IN", object: "San Francisco" },
+  { subject: "Bob Smith", predicate: "MANAGES", object: "Product Launch" },
+];
+
+export const CONVERSATION_MESSAGES = [
+  { role: "user" as const, content: "Hello, I'm working on the agent memory project." },
+  { role: "assistant" as const, content: "I can help with the agent memory project. What do you need?" },
+  { role: "user" as const, content: "I need to add entity extraction for people and organizations." },
+  { role: "assistant" as const, content: "Entity extraction can identify people like Alice and organizations like Acme Corp from text." },
+  { role: "user" as const, content: "Great, let's start with the Person entity type." },
+];
+
+export const TRACE_TASK = "Find information about Alice Johnson's role at Acme Corp";

--- a/typescript/test/unit/casing.test.ts
+++ b/typescript/test/unit/casing.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Unit tests — snake_case ↔ camelCase translation.
+ */
+
+import { describe, it, expect } from "vitest";
+import { camelToSnake, snakeToCamel } from "../../src/transport/casing.js";
+
+describe("snakeToCamel", () => {
+  it("converts top-level keys", () => {
+    expect(snakeToCamel({ user_id: "x" })).toEqual({ userId: "x" });
+  });
+
+  it("leaves camelCase unchanged", () => {
+    expect(snakeToCamel({ userId: "x" })).toEqual({ userId: "x" });
+  });
+
+  it("handles nested objects", () => {
+    expect(snakeToCamel({ outer_key: { inner_key: 1 } })).toEqual({
+      outerKey: { innerKey: 1 },
+    });
+  });
+
+  it("handles arrays of objects", () => {
+    expect(snakeToCamel([{ a_b: 1 }, { c_d: 2 }])).toEqual([
+      { aB: 1 },
+      { cD: 2 },
+    ]);
+  });
+
+  it("returns primitives unchanged", () => {
+    expect(snakeToCamel("hello")).toBe("hello");
+    expect(snakeToCamel(42)).toBe(42);
+    expect(snakeToCamel(null)).toBeNull();
+    expect(snakeToCamel(true)).toBe(true);
+  });
+
+  it("handles empty objects and arrays", () => {
+    expect(snakeToCamel({})).toEqual({});
+    expect(snakeToCamel([])).toEqual([]);
+  });
+});
+
+describe("camelToSnake", () => {
+  it("converts top-level keys", () => {
+    expect(camelToSnake({ userId: "x" })).toEqual({ user_id: "x" });
+  });
+
+  it("leaves snake_case unchanged", () => {
+    expect(camelToSnake({ user_id: "x" })).toEqual({ user_id: "x" });
+  });
+
+  it("handles nested objects", () => {
+    expect(camelToSnake({ outerKey: { innerKey: 1 } })).toEqual({
+      outer_key: { inner_key: 1 },
+    });
+  });
+
+  it("handles arrays", () => {
+    expect(camelToSnake([{ aB: 1 }])).toEqual([{ a_b: 1 }]);
+  });
+
+  it("roundtrips snake → camel → snake", () => {
+    const original = { user_id: "alice", metadata: { is_active: true, tags: ["a", "b"] } };
+    expect(camelToSnake(snakeToCamel(original))).toEqual(original);
+  });
+});

--- a/typescript/test/unit/constructor-ux.test.ts
+++ b/typescript/test/unit/constructor-ux.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Unit tests — zero-config construction, env-fallback API key, lazy connect.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { MemoryClient } from "../../src/client.js";
+import { RestTransport } from "../../src/transport/rest.js";
+
+function getInternalTransport(client: MemoryClient): unknown {
+  const t = (client as unknown as { transport: unknown }).transport;
+  if (t && typeof t === "object" && "inner" in t) {
+    return (t as { inner: unknown }).inner;
+  }
+  return t;
+}
+
+function getEndpoint(client: MemoryClient): string {
+  const inner = getInternalTransport(client) as { endpoint?: string };
+  return inner.endpoint ?? "";
+}
+
+function getApiKey(client: MemoryClient): string | undefined {
+  const inner = getInternalTransport(client) as { apiKey?: string };
+  return inner.apiKey;
+}
+
+describe("MemoryClient zero-config", () => {
+  const originalKey = process.env.MEMORY_API_KEY;
+
+  beforeEach(() => {
+    delete process.env.MEMORY_API_KEY;
+  });
+
+  afterEach(() => {
+    if (originalKey === undefined) {
+      delete process.env.MEMORY_API_KEY;
+    } else {
+      process.env.MEMORY_API_KEY = originalKey;
+    }
+  });
+
+  it("defaults endpoint to the hosted service when omitted", () => {
+    const c = new MemoryClient({ apiKey: "k" });
+    expect(getEndpoint(c)).toBe("https://memory.neo4jlabs.com/v1");
+    expect(getInternalTransport(c)).toBeInstanceOf(RestTransport);
+  });
+
+  it("reads MEMORY_API_KEY from env when apiKey is omitted", () => {
+    process.env.MEMORY_API_KEY = "env-key";
+    const c = new MemoryClient();
+    expect(getApiKey(c)).toBe("env-key");
+  });
+
+  it("explicit apiKey wins over env var", () => {
+    process.env.MEMORY_API_KEY = "env-key";
+    const c = new MemoryClient({ apiKey: "explicit-key" });
+    expect(getApiKey(c)).toBe("explicit-key");
+  });
+
+  it("explicit empty apiKey is preserved (does NOT fall back to env)", () => {
+    process.env.MEMORY_API_KEY = "env-key";
+    const c = new MemoryClient({ apiKey: "" });
+    expect(getApiKey(c)).toBe("");
+  });
+
+  it("zero-arg construction works without any env var", () => {
+    expect(() => new MemoryClient()).not.toThrow();
+  });
+});
+
+describe("MemoryClient lazy connect", () => {
+  it("requests are issued without an implicit connect probe", async () => {
+    let connectCalls = 0;
+    const fakeInner = {
+      request: vi.fn(async () => ({})),
+      connect: vi.fn(async () => {
+        connectCalls++;
+      }),
+      close: vi.fn(async () => {}),
+    };
+
+    const c = new MemoryClient();
+    const lazyWrapper = (c as unknown as { transport: { inner: unknown } }).transport;
+    (lazyWrapper as { inner: unknown }).inner = fakeInner;
+
+    await Promise.all([
+      c.shortTerm.listConversations({ limit: 1 }).catch(() => null),
+      c.shortTerm.listConversations({ limit: 1 }).catch(() => null),
+      c.shortTerm.listConversations({ limit: 1 }).catch(() => null),
+    ]);
+
+    expect(connectCalls).toBe(0);
+  });
+
+  it("explicit connect() is idempotent across concurrent callers", async () => {
+    let connectCalls = 0;
+    const fakeInner = {
+      request: vi.fn(async () => ({})),
+      connect: vi.fn(async () => {
+        connectCalls++;
+      }),
+      close: vi.fn(async () => {}),
+    };
+
+    const c = new MemoryClient();
+    const lazyWrapper = (c as unknown as { transport: { inner: unknown } }).transport;
+    (lazyWrapper as { inner: unknown }).inner = fakeInner;
+
+    await Promise.all([c.connect(), c.connect(), c.connect()]);
+
+    expect(connectCalls).toBe(1);
+  });
+
+  it("failed connect clears the cached promise so a retry can re-attempt", async () => {
+    let calls = 0;
+    const fakeInner = {
+      request: vi.fn(async () => ({})),
+      connect: vi.fn(async () => {
+        calls++;
+        if (calls === 1) throw new Error("transient");
+      }),
+      close: vi.fn(async () => {}),
+    };
+
+    const c = new MemoryClient();
+    const lazyWrapper = (c as unknown as { transport: { inner: unknown } }).transport;
+    (lazyWrapper as { inner: unknown }).inner = fakeInner;
+
+    await expect(c.connect()).rejects.toThrow("transient");
+    await expect(c.connect()).resolves.toBeUndefined();
+    expect(calls).toBe(2);
+  });
+
+  it("user-supplied Transport is NOT wrapped in lazy connect", () => {
+    const fake = {
+      request: async () => ({}),
+      connect: async () => {},
+      close: async () => {},
+    };
+    const c = new MemoryClient(fake);
+    expect(getInternalTransport(c)).toBe(fake);
+  });
+});

--- a/typescript/test/unit/edge-runtime.test.ts
+++ b/typescript/test/unit/edge-runtime.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Edge-runtime sanity tests — verifies the package can be constructed and
+ * issue a request in an environment where `process` is undefined.
+ *
+ * A full Cloudflare Workers harness lives outside this unit suite; this
+ * file is the cheap canary that catches the most common edge regression
+ * (an accidental unguarded `process.env` read in the construction path).
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { MemoryClient } from "../../src/client.js";
+import { RestTransport } from "../../src/transport/rest.js";
+
+describe("Edge runtime: process is undefined", () => {
+  let savedProcess: unknown;
+
+  beforeEach(() => {
+    savedProcess = (globalThis as { process?: unknown }).process;
+    // Simulate edge: `process` does not exist at all.
+    delete (globalThis as { process?: unknown }).process;
+  });
+
+  afterEach(() => {
+    (globalThis as { process?: unknown }).process = savedProcess;
+  });
+
+  it("constructs without throwing when process is undefined", () => {
+    expect(() => new MemoryClient({ apiKey: "k" })).not.toThrow();
+  });
+
+  it("zero-arg construction works without process", () => {
+    expect(() => new MemoryClient()).not.toThrow();
+  });
+
+  it("explicit apiKey is used (no env lookup attempted)", () => {
+    const c = new MemoryClient({ apiKey: "explicit-key" });
+    const inner = (c as unknown as { transport: { inner: { apiKey?: string } } }).transport.inner;
+    expect(inner.apiKey).toBe("explicit-key");
+  });
+});
+
+describe("Edge runtime: User-Agent without process", () => {
+  let savedProcess: unknown;
+
+  beforeEach(() => {
+    savedProcess = (globalThis as { process?: unknown }).process;
+    delete (globalThis as { process?: unknown }).process;
+  });
+
+  afterEach(() => {
+    (globalThis as { process?: unknown }).process = savedProcess;
+  });
+
+  it("defaultUserAgent works without process", async () => {
+    const { defaultUserAgent } = await import("../../src/observability.js");
+    const ua = defaultUserAgent();
+    expect(ua).toMatch(/@neo4j-labs\/agent-memory\/\d+\.\d+\.\d+/);
+  });
+
+  it("does not add a User-Agent header when the runtime forbids it", async () => {
+    const transport = new RestTransport({ endpoint: "https://memory.test/v1", apiKey: "k" });
+    const headers = await (
+      transport as unknown as {
+        buildHeaders: (includeContentType?: boolean) => Promise<Record<string, string>>;
+      }
+    ).buildHeaders();
+    expect(Object.keys(headers).some((key) => key.toLowerCase() === "user-agent")).toBe(false);
+  });
+
+  it("drops caller-supplied User-Agent headers when the runtime forbids them", async () => {
+    const transport = new RestTransport({
+      endpoint: "https://memory.test/v1",
+      apiKey: "k",
+      headers: { "User-Agent": "wrapper/1.0" },
+    });
+    const headers = await (
+      transport as unknown as {
+        buildHeaders: (includeContentType?: boolean) => Promise<Record<string, string>>;
+      }
+    ).buildHeaders();
+    expect(Object.keys(headers).some((key) => key.toLowerCase() === "user-agent")).toBe(false);
+  });
+});

--- a/typescript/test/unit/mcp-tools.test.ts
+++ b/typescript/test/unit/mcp-tools.test.ts
@@ -1,0 +1,47 @@
+/**
+ * Unit tests — the 12-tool MCP surface.
+ */
+
+import { describe, it, expect } from "vitest";
+import { createMemoryTools } from "../../src/mcp/index.js";
+
+describe("createMemoryTools", () => {
+  const tools = createMemoryTools();
+
+  it("returns exactly 12 tools matching memory.neo4jlabs.com/mcp", () => {
+    expect(tools).toHaveLength(12);
+  });
+
+  it("uses snake_case tool names", () => {
+    for (const t of tools) {
+      expect(t.name).toMatch(/^memory_[a-z_]+$/);
+    }
+  });
+
+  it("includes all 12 standard tools", () => {
+    const names = tools.map((t) => t.name).sort();
+    expect(names).toEqual(
+      [
+        "memory_add_entity",
+        "memory_add_messages",
+        "memory_create_conversation",
+        "memory_explain_decision",
+        "memory_get_context",
+        "memory_get_entity",
+        "memory_get_entity_history",
+        "memory_get_trace",
+        "memory_record_step",
+        "memory_record_tool_call",
+        "memory_search_entities",
+        "memory_search_messages",
+      ].sort(),
+    );
+  });
+
+  it("each tool has an inputSchema with required fields", () => {
+    for (const t of tools) {
+      expect(t.inputSchema.type).toBe("object");
+      expect(t.inputSchema.properties).toBeDefined();
+    }
+  });
+});

--- a/typescript/test/unit/strands/conversation-rendering.test.ts
+++ b/typescript/test/unit/strands/conversation-rendering.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Pure-logic tests for context injection: given a synthetic
+ * `BeforeInvocationEvent`, verify the Neo4jConversationManager prepends
+ * reflections + observations to `agent.messages` in the right order, and
+ * falls back gracefully when context fetch fails or returns empty.
+ */
+
+import { describe, it, expect } from "vitest";
+import { BeforeInvocationEvent } from "@strands-agents/sdk";
+import { Neo4jConversationManager } from "../../../src/integrations/strands.js";
+
+function makeMemoryStub(ctx: unknown | (() => Promise<unknown>)) {
+  return {
+    shortTerm: {
+      getContext: async () =>
+        typeof ctx === "function" ? await (ctx as () => Promise<unknown>)() : ctx,
+    },
+  } as unknown as ConstructorParameters<typeof Neo4jConversationManager>[0];
+}
+
+function makeAgent(messages: Array<Record<string, unknown>>) {
+  let hookCb:
+    | ((event: BeforeInvocationEvent) => Promise<void> | void)
+    | null = null;
+  const agent = {
+    id: "a1",
+    messages,
+    addHook(_eventClass: unknown, cb: (event: BeforeInvocationEvent) => Promise<void> | void) {
+      hookCb = cb;
+      return () => {};
+    },
+  } as unknown as Parameters<Neo4jConversationManager["initAgent"]>[0];
+  return { agent, fire: () => hookCb };
+}
+
+async function runHook(
+  cm: Neo4jConversationManager,
+  messages: Array<Record<string, unknown>>,
+): Promise<Array<Record<string, unknown>>> {
+  const { agent, fire } = makeAgent(messages);
+  await cm.initAgent(agent);
+  const cb = fire();
+  if (!cb) throw new Error("hook was not registered");
+  const event = new BeforeInvocationEvent({
+    agent: agent as unknown as ConstructorParameters<typeof BeforeInvocationEvent>[0]["agent"],
+    invocationState: {},
+  });
+  await cb(event);
+  // Read the mutated messages off the agent stub.
+  return (agent as unknown as { messages: Array<Record<string, unknown>> }).messages;
+}
+
+describe("Neo4jConversationManager — context injection", () => {
+  it("prepends reflections + observations in the canonical order", async () => {
+    const memory = makeMemoryStub({
+      reflections: [{ id: "r1", content: "user prefers concise replies" }],
+      observations: [{ id: "o1", content: "asks about graphs" }],
+      recentMessages: [],
+    });
+    const cm = new Neo4jConversationManager(memory, { conversationId: "c1" });
+    const result = await runHook(cm, [{ role: "user", content: [{ text: "now" }] }]);
+    expect(result).toHaveLength(3);
+    expect(result[0]).toMatchObject({
+      content: [{ text: "[reflection] user prefers concise replies" }],
+    });
+    expect(result[1]).toMatchObject({
+      content: [{ text: "[observation] asks about graphs" }],
+    });
+    expect(result[2]).toMatchObject({ role: "user" });
+  });
+
+  it("empty context leaves messages untouched", async () => {
+    const memory = makeMemoryStub({ reflections: [], observations: [], recentMessages: [] });
+    const cm = new Neo4jConversationManager(memory, { conversationId: "c1" });
+    const result = await runHook(cm, [{ role: "user", content: [{ text: "now" }] }]);
+    expect(result).toHaveLength(1);
+  });
+
+  it("includeReflections=false skips reflections, keeps observations", async () => {
+    const memory = makeMemoryStub({
+      reflections: [{ id: "r1", content: "skip me" }],
+      observations: [{ id: "o1", content: "keep me" }],
+      recentMessages: [],
+    });
+    const cm = new Neo4jConversationManager(memory, {
+      conversationId: "c1",
+      includeReflections: false,
+    });
+    const result = await runHook(cm, [{ role: "user", content: [{ text: "now" }] }]);
+    const texts = result.map((m) =>
+      ((m.content as Array<{ text?: string }>)[0]?.text ?? "") as string,
+    );
+    expect(texts.some((t) => t.startsWith("[reflection]"))).toBe(false);
+    expect(texts.some((t) => t.startsWith("[observation] keep me"))).toBe(true);
+  });
+
+  it("includeObservations=false skips observations, keeps reflections", async () => {
+    const memory = makeMemoryStub({
+      reflections: [{ id: "r1", content: "keep me" }],
+      observations: [{ id: "o1", content: "skip me" }],
+      recentMessages: [],
+    });
+    const cm = new Neo4jConversationManager(memory, {
+      conversationId: "c1",
+      includeObservations: false,
+    });
+    const result = await runHook(cm, [{ role: "user", content: [{ text: "now" }] }]);
+    const texts = result.map((m) =>
+      ((m.content as Array<{ text?: string }>)[0]?.text ?? "") as string,
+    );
+    expect(texts.some((t) => t.startsWith("[reflection] keep me"))).toBe(true);
+    expect(texts.some((t) => t.startsWith("[observation]"))).toBe(false);
+  });
+
+  it("getContext failure is swallowed silently", async () => {
+    const memory = makeMemoryStub(() => Promise.reject(new Error("transient")));
+    const cm = new Neo4jConversationManager(memory, { conversationId: "c1" });
+    const result = await runHook(cm, [{ role: "user", content: [{ text: "x" }] }]);
+    expect(result).toHaveLength(1);
+  });
+
+  it("preserves stable order across multiple reflections + observations", async () => {
+    const memory = makeMemoryStub({
+      reflections: [
+        { id: "r1", content: "first" },
+        { id: "r2", content: "second" },
+      ],
+      observations: [
+        { id: "o1", content: "alpha" },
+        { id: "o2", content: "beta" },
+      ],
+      recentMessages: [],
+    });
+    const cm = new Neo4jConversationManager(memory, { conversationId: "c1" });
+    const result = await runHook(cm, [{ role: "user", content: [{ text: "go" }] }]);
+    const texts = result.map((m) =>
+      ((m.content as Array<{ text?: string }>)[0]?.text ?? "") as string,
+    );
+    expect(texts).toEqual([
+      "[reflection] first",
+      "[reflection] second",
+      "[observation] alpha",
+      "[observation] beta",
+      "go",
+    ]);
+  });
+});

--- a/typescript/test/unit/strands/factory-shape.test.ts
+++ b/typescript/test/unit/strands/factory-shape.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Pure-logic tests for connectMemoryToAgent — confirms the factory returns
+ * the right shape for spreading into `new Agent({ ... })` and that its
+ * conversation manager registers BOTH the context injection hook and the
+ * reasoning hooks when initAgent runs.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  BeforeInvocationEvent,
+  AfterInvocationEvent,
+  BeforeToolCallEvent,
+  AfterToolCallEvent,
+  type LocalAgent,
+} from "@strands-agents/sdk";
+import { connectMemoryToAgent } from "../../../src/integrations/strands.js";
+
+function makeMemoryStub() {
+  return {
+    transport: { async request() { return undefined; } },
+    shortTerm: {
+      async getContext() {
+        return { reflections: [], observations: [], recentMessages: [] };
+      },
+      async getConversation() { return { id: "c", messages: [] }; },
+      async getConversationMetadata() { return { id: "c", metadata: {} }; },
+      async addMessage() { return { id: "m", role: "user", content: "" }; },
+      async deleteConversation() { return undefined; },
+    },
+    reasoning: {
+      async recordStep() { return { id: "s1" } as unknown as { id: string }; },
+      async recordToolCall() { return { id: "t1" } as unknown as { id: string }; },
+    },
+  } as unknown as Parameters<typeof connectMemoryToAgent>[0];
+}
+
+function makeAgent() {
+  const hooks = new Map<unknown, Array<(e: unknown) => Promise<void> | void>>();
+  const agent = {
+    id: "a",
+    messages: [],
+    addHook(eventClass: unknown, cb: (e: unknown) => Promise<void> | void) {
+      const list = hooks.get(eventClass) ?? [];
+      list.push(cb);
+      hooks.set(eventClass, list);
+      return () => {};
+    },
+  } as unknown as LocalAgent;
+  return { agent, hooks };
+}
+
+describe("connectMemoryToAgent — factory shape", () => {
+  it("returns sessionManager + conversationManager", async () => {
+    const memory = makeMemoryStub();
+    const result = await connectMemoryToAgent(memory, { conversationId: "c1" });
+    expect(result).toHaveProperty("sessionManager");
+    expect(result).toHaveProperty("conversationManager");
+    expect(typeof result.conversationManager.initAgent).toBe("function");
+  });
+
+  it("conversationManager.initAgent registers all four reasoning hooks + context injection", async () => {
+    const memory = makeMemoryStub();
+    const { conversationManager } = await connectMemoryToAgent(memory, {
+      conversationId: "c1",
+    });
+    const { agent, hooks } = makeAgent();
+    await conversationManager.initAgent(agent);
+
+    // Context-injection hook registers BeforeInvocationEvent;
+    // reasoning hooks register all four — so the BeforeInvocation registry
+    // should have at least 2 callbacks (context + reasoning).
+    expect((hooks.get(BeforeInvocationEvent) ?? []).length).toBeGreaterThanOrEqual(2);
+    expect(hooks.get(AfterInvocationEvent)?.length ?? 0).toBeGreaterThanOrEqual(1);
+    expect(hooks.get(BeforeToolCallEvent)?.length ?? 0).toBeGreaterThanOrEqual(1);
+    expect(hooks.get(AfterToolCallEvent)?.length ?? 0).toBeGreaterThanOrEqual(1);
+  });
+
+  it("conversationManager has a stable name", async () => {
+    const memory = makeMemoryStub();
+    const { conversationManager } = await connectMemoryToAgent(memory, {
+      conversationId: "c1",
+    });
+    expect(conversationManager.name).toBe("neo4j:context-injection");
+  });
+});

--- a/typescript/test/unit/strands/hook-state-isolation.test.ts
+++ b/typescript/test/unit/strands/hook-state-isolation.test.ts
@@ -1,0 +1,195 @@
+/**
+ * Pure-logic tests for the reasoning hooks: when two invocations are
+ * interleaved, the per-invocation state (stepId, tool-call map) stays
+ * isolated. The test drives the hook callbacks directly against synthetic
+ * `BeforeInvocationEvent` / `BeforeToolCallEvent` / `AfterToolCallEvent`
+ * objects, with distinct `invocationState` bags per simulated invocation.
+ *
+ * No HTTP. The MemoryClient is replaced with a stub that records every
+ * call but never errors.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import {
+  BeforeInvocationEvent,
+  BeforeToolCallEvent,
+  AfterToolCallEvent,
+  AfterInvocationEvent,
+  type LocalAgent,
+} from "@strands-agents/sdk";
+import { registerReasoningHooks } from "../../../src/integrations/strands.js";
+
+type Recorded = { kind: string; args: unknown[] };
+
+function makeMemoryStub() {
+  const recorded: Recorded[] = [];
+  let stepCounter = 0;
+  let toolCounter = 0;
+  const memory = {
+    reasoning: {
+      async recordStep(args: unknown) {
+        stepCounter++;
+        recorded.push({ kind: "recordStep", args: [args] });
+        return { id: `step-${stepCounter}` } as unknown as { id: string };
+      },
+      async recordToolCall(...args: unknown[]) {
+        toolCounter++;
+        recorded.push({ kind: "recordToolCall", args });
+        return { id: `tool-${toolCounter}` } as unknown as { id: string };
+      },
+    },
+  } as unknown as Parameters<typeof registerReasoningHooks>[0];
+  return { memory, recorded };
+}
+
+interface HookSlot {
+  beforeInv?: (e: BeforeInvocationEvent) => Promise<void>;
+  afterInv?: (e: AfterInvocationEvent) => Promise<void>;
+  beforeTool?: (e: BeforeToolCallEvent) => Promise<void>;
+  afterTool?: (e: AfterToolCallEvent) => Promise<void>;
+}
+
+function makeAgent(): { agent: LocalAgent; slot: HookSlot } {
+  const slot: HookSlot = {};
+  const agent = {
+    addHook(eventClass: unknown, cb: (e: unknown) => Promise<void>) {
+      if (eventClass === BeforeInvocationEvent)
+        slot.beforeInv = cb as HookSlot["beforeInv"];
+      else if (eventClass === AfterInvocationEvent)
+        slot.afterInv = cb as HookSlot["afterInv"];
+      else if (eventClass === BeforeToolCallEvent)
+        slot.beforeTool = cb as HookSlot["beforeTool"];
+      else if (eventClass === AfterToolCallEvent)
+        slot.afterTool = cb as HookSlot["afterTool"];
+      return () => {};
+    },
+  } as unknown as LocalAgent;
+  return { agent, slot };
+}
+
+function makeBeforeInvEvent(state: Record<string, unknown>): BeforeInvocationEvent {
+  return new BeforeInvocationEvent({
+    agent: {} as ConstructorParameters<typeof BeforeInvocationEvent>[0]["agent"],
+    invocationState: state,
+  });
+}
+
+function makeBeforeToolEvent(
+  state: Record<string, unknown>,
+  toolUseId: string,
+  name: string,
+  input: Record<string, unknown>,
+): BeforeToolCallEvent {
+  return new BeforeToolCallEvent({
+    agent: {} as ConstructorParameters<typeof BeforeToolCallEvent>[0]["agent"],
+    toolUse: { toolUseId, name, input },
+    tool: undefined,
+    invocationState: state,
+  } as unknown as ConstructorParameters<typeof BeforeToolCallEvent>[0]);
+}
+
+function makeAfterToolEvent(
+  state: Record<string, unknown>,
+  toolUseId: string,
+  name: string,
+  input: Record<string, unknown>,
+  err?: Error,
+): AfterToolCallEvent {
+  return new AfterToolCallEvent({
+    agent: {} as ConstructorParameters<typeof AfterToolCallEvent>[0]["agent"],
+    toolUse: { toolUseId, name, input },
+    tool: undefined,
+    result: { toolUseId, content: [], status: "success" } as ConstructorParameters<typeof AfterToolCallEvent>[0]["result"],
+    error: err,
+    invocationState: state,
+  } as unknown as ConstructorParameters<typeof AfterToolCallEvent>[0]);
+}
+
+describe("registerReasoningHooks — state isolation", () => {
+  it("two interleaved invocations get distinct step ids", async () => {
+    const { memory, recorded } = makeMemoryStub();
+    const { agent, slot } = makeAgent();
+    await registerReasoningHooks(memory, agent, { conversationId: "c1" });
+
+    const state1: Record<string, unknown> = {};
+    const state2: Record<string, unknown> = {};
+
+    await slot.beforeInv!(makeBeforeInvEvent(state1));
+    await slot.beforeInv!(makeBeforeInvEvent(state2));
+
+    expect(state1["__neo4jReasoningStepId"]).toBe("step-1");
+    expect(state2["__neo4jReasoningStepId"]).toBe("step-2");
+    expect(recorded.filter((r) => r.kind === "recordStep")).toHaveLength(2);
+  });
+
+  it("tool calls map to the step of their own invocation", async () => {
+    const { memory, recorded } = makeMemoryStub();
+    const { agent, slot } = makeAgent();
+    await registerReasoningHooks(memory, agent, { conversationId: "c1" });
+
+    const stateA: Record<string, unknown> = {};
+    const stateB: Record<string, unknown> = {};
+
+    await slot.beforeInv!(makeBeforeInvEvent(stateA));
+    await slot.beforeInv!(makeBeforeInvEvent(stateB));
+
+    await slot.beforeTool!(makeBeforeToolEvent(stateA, "tu-a", "search", { q: "neo4j" }));
+    await slot.beforeTool!(makeBeforeToolEvent(stateB, "tu-b", "fetch", { url: "x" }));
+
+    const toolRecords = recorded.filter((r) => r.kind === "recordToolCall");
+    expect(toolRecords).toHaveLength(2);
+    // First arg is the stepId.
+    expect(toolRecords[0]!.args[0]).toBe("step-1");
+    expect(toolRecords[1]!.args[0]).toBe("step-2");
+  });
+
+  it("AfterToolCall with an error records a failure status", async () => {
+    const { memory, recorded } = makeMemoryStub();
+    const { agent, slot } = makeAgent();
+    await registerReasoningHooks(memory, agent, { conversationId: "c1" });
+
+    const state: Record<string, unknown> = {};
+    await slot.beforeInv!(makeBeforeInvEvent(state));
+    await slot.beforeTool!(makeBeforeToolEvent(state, "tu", "fail-tool", {}));
+    await slot.afterTool!(
+      makeAfterToolEvent(state, "tu", "fail-tool", {}, new Error("boom")),
+    );
+
+    const last = recorded.filter((r) => r.kind === "recordToolCall").pop();
+    expect(last).toBeDefined();
+    const opts = last!.args[3] as { status: string; error: string };
+    expect(opts.status).toBe("failure");
+    expect(opts.error).toBe("boom");
+  });
+
+  it("reasoning recordStep failure does not propagate", async () => {
+    const failingMemory = {
+      reasoning: {
+        async recordStep() {
+          throw new Error("nams down");
+        },
+        async recordToolCall() {
+          throw new Error("nams down");
+        },
+      },
+    } as unknown as Parameters<typeof registerReasoningHooks>[0];
+
+    const { agent, slot } = makeAgent();
+    await registerReasoningHooks(failingMemory, agent, { conversationId: "c1" });
+
+    const state: Record<string, unknown> = {};
+    await expect(slot.beforeInv!(makeBeforeInvEvent(state))).resolves.toBeUndefined();
+    await expect(slot.beforeTool!(makeBeforeToolEvent(state, "tu", "x", {}))).resolves.toBeUndefined();
+    await expect(slot.afterTool!(makeAfterToolEvent(state, "tu", "x", {}))).resolves.toBeUndefined();
+    await expect(
+      slot.afterInv!(
+        new AfterInvocationEvent({
+          agent: {} as ConstructorParameters<typeof AfterInvocationEvent>[0]["agent"],
+          invocationState: state,
+        }),
+      ),
+    ).resolves.toBeUndefined();
+  });
+});
+
+void vi;

--- a/typescript/test/unit/strands/snapshot-serialization.test.ts
+++ b/typescript/test/unit/strands/snapshot-serialization.test.ts
@@ -1,0 +1,502 @@
+/**
+ * Pure-logic tests for Snapshot serialization. We feed synthetic Snapshot
+ * objects through Neo4jSessionStorage with a mocked MemoryClient that
+ * records every addMessage call, and assert the message extraction +
+ * synthetic-state-message behaviour. No HTTP involved.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import type { Snapshot } from "@strands-agents/sdk";
+import {
+  Neo4jSessionStorage,
+  isSyntheticStrandsMessage,
+} from "../../../src/integrations/strands.js";
+
+interface StoredMessage {
+  id: string;
+  role: string;
+  content: string;
+  metadata?: Record<string, unknown>;
+}
+
+function makeFakeClient(opts: {
+  initialMessages?: StoredMessage[];
+} = {}) {
+  const messages: StoredMessage[] = (opts.initialMessages ?? []).map((m) => ({ ...m }));
+  const addCalls: Array<{
+    convId: string;
+    role: string;
+    content: string;
+    metadata?: Record<string, unknown>;
+  }> = [];
+
+  const fake = {
+    shortTerm: {
+      async getConversation(_id: string) {
+        return { id: _id, messages: messages.map((m) => ({ ...m })) };
+      },
+      async addMessage(
+        convId: string,
+        role: string,
+        content: string,
+        addOpts?: { metadata?: Record<string, unknown> },
+      ) {
+        const id = `m${messages.length + 1}`;
+        const m: StoredMessage = { id, role, content, metadata: addOpts?.metadata };
+        messages.push(m);
+        addCalls.push({ convId, role, content, metadata: addOpts?.metadata });
+        return m;
+      },
+      async deleteConversation(_convId: string) {
+        return undefined;
+      },
+    },
+  };
+
+  return {
+    client: fake as unknown as ConstructorParameters<typeof Neo4jSessionStorage>[0],
+    addCalls,
+    getMessages: () => messages,
+  };
+}
+
+function snapshotWith(opts: {
+  messages?: Array<{ role: string; content: Array<{ text?: string; type?: string }> }>;
+  data?: Record<string, unknown>;
+  appData?: Record<string, unknown>;
+}): Snapshot {
+  return {
+    scope: "agent",
+    schemaVersion: "1.0",
+    createdAt: new Date().toISOString(),
+    data: {
+      ...(opts.data ?? {}),
+      messages: opts.messages ?? [],
+    } as unknown as Snapshot["data"],
+    appData: (opts.appData ?? {}) as Snapshot["appData"],
+  };
+}
+
+const LOCATION = { sessionId: "conv-1", scope: "agent" as const, scopeId: "agent-1" };
+
+/**
+ * Decode the JSON blob from a synthetic state message's content.
+ * Mirrors the integration's `decodeBlob` for prefix `__strands_state__:`.
+ */
+function decodeStateContent(msg: StoredMessage): {
+  snapshotId: string;
+  isLatest: boolean;
+  snapshot: Snapshot;
+  savedAt: string;
+} {
+  const prefix = "__strands_state__:";
+  if (!msg.content.startsWith(prefix)) {
+    throw new Error("expected __strands_state__ content prefix");
+  }
+  const b64 = msg.content.slice(prefix.length);
+  return JSON.parse(Buffer.from(b64, "base64").toString("utf8"));
+}
+
+/** Encode a state blob into the synthetic content format the integration uses. */
+function encodeStateContent(blob: object): string {
+  return `__strands_state__:${Buffer.from(JSON.stringify(blob), "utf8").toString("base64")}`;
+}
+
+describe("Neo4jSessionStorage — message extraction", () => {
+  it("extracts text-block messages and persists each via addMessage", async () => {
+    const { client, addCalls } = makeFakeClient();
+    const storage = new Neo4jSessionStorage(client);
+    const snap = snapshotWith({
+      messages: [
+        { role: "user", content: [{ text: "hello" }] },
+        { role: "assistant", content: [{ text: "hi there" }] },
+      ],
+    });
+
+    await storage.saveSnapshot({
+      location: LOCATION,
+      snapshotId: "s1",
+      isLatest: true,
+      snapshot: snap,
+    });
+
+    // Two real messages + one synthetic state message.
+    const realAddCalls = addCalls.filter(
+      (c) =>
+        (c.role === "user" || c.role === "assistant") &&
+        !c.content.startsWith("__strands_state__:") &&
+        !c.content.startsWith("__strands_manifest__:"),
+    );
+    expect(realAddCalls).toHaveLength(2);
+    expect(realAddCalls[0]).toMatchObject({ role: "user", content: "hello" });
+    expect(realAddCalls[1]).toMatchObject({ role: "assistant", content: "hi there" });
+  });
+
+  it("dedupes against existing conversation messages (ignoring synthetic state markers)", async () => {
+    const { client, addCalls } = makeFakeClient({
+      initialMessages: [
+        { id: "m0", role: "user", content: "hello" },
+        // A prior state marker should NOT count as a real message for dedup.
+        {
+          id: "m-state",
+          role: "user",
+          content: "__strands_state__:prior",
+          metadata: { strands_state: "{}" },
+        },
+      ],
+    });
+    const storage = new Neo4jSessionStorage(client);
+    const snap = snapshotWith({
+      messages: [
+        { role: "user", content: [{ text: "hello" }] },
+        { role: "assistant", content: [{ text: "new" }] },
+      ],
+    });
+
+    await storage.saveSnapshot({
+      location: LOCATION,
+      snapshotId: "s1",
+      isLatest: true,
+      snapshot: snap,
+    });
+
+    const realAddCalls = addCalls.filter(
+      (c) =>
+        (c.role === "user" || c.role === "assistant") &&
+        !c.content.startsWith("__strands_state__:") &&
+        !c.content.startsWith("__strands_manifest__:"),
+    );
+    expect(realAddCalls).toHaveLength(1);
+    expect(realAddCalls[0]).toMatchObject({ role: "assistant", content: "new" });
+  });
+
+  it("handles snapshots with zero messages — still writes a state marker", async () => {
+    const { client, addCalls } = makeFakeClient();
+    const storage = new Neo4jSessionStorage(client);
+    await storage.saveSnapshot({
+      location: LOCATION,
+      snapshotId: "s1",
+      isLatest: true,
+      snapshot: snapshotWith({ messages: [] }),
+    });
+    const real = addCalls.filter((c) => c.role !== "user" && c.content.startsWith("__strands_state__:") === false);
+    expect(real).toHaveLength(0);
+    // The synthetic state marker still got written.
+    const synthetic = addCalls.filter(
+      (c) => c.content.startsWith("__strands_state__:"),
+    );
+    expect(synthetic).toHaveLength(1);
+  });
+
+  it("handles malformed snapshots (missing messages field) without throwing", async () => {
+    const { client } = makeFakeClient();
+    const storage = new Neo4jSessionStorage(client);
+    const malformed = {
+      scope: "agent",
+      schemaVersion: "1.0",
+      createdAt: "x",
+      data: {} as Snapshot["data"],
+      appData: {} as Snapshot["appData"],
+    } as Snapshot;
+    await expect(
+      storage.saveSnapshot({
+        location: LOCATION,
+        snapshotId: "s1",
+        isLatest: true,
+        snapshot: malformed,
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("preserves non-message snapshot state in the synthetic message metadata", async () => {
+    const { client, getMessages } = makeFakeClient();
+    const storage = new Neo4jSessionStorage(client);
+
+    await storage.saveSnapshot({
+      location: LOCATION,
+      snapshotId: "s1",
+      isLatest: true,
+      snapshot: snapshotWith({
+        messages: [{ role: "user", content: [{ text: "hi" }] }],
+        data: { agentState: { foo: 1 } },
+        appData: { userCounter: 42 },
+      }),
+    });
+
+    const synthetic = getMessages().find(
+      (m) => m.content.startsWith("__strands_state__:"),
+    );
+    expect(synthetic).toBeDefined();
+    const blob = decodeStateContent(synthetic!);
+    expect(blob.snapshotId).toBe("s1");
+    expect(blob.isLatest).toBe(true);
+    expect(blob.snapshot.appData).toMatchObject({ userCounter: 42 });
+    expect(blob.snapshot.data).toMatchObject({ agentState: { foo: 1 } });
+    // messages field stripped from the persisted snapshot
+    expect((blob.snapshot.data as Record<string, unknown>).messages).toBeUndefined();
+  });
+
+  it("each distinct snapshotId writes a synthetic state message in order", async () => {
+    const { client, getMessages } = makeFakeClient();
+    const storage = new Neo4jSessionStorage(client);
+
+    await storage.saveSnapshot({
+      location: LOCATION,
+      snapshotId: "s1",
+      isLatest: false,
+      snapshot: snapshotWith({ messages: [] }),
+    });
+    await storage.saveSnapshot({
+      location: LOCATION,
+      snapshotId: "s2",
+      isLatest: true,
+      snapshot: snapshotWith({ messages: [] }),
+    });
+
+    const states = getMessages().filter(
+      (m) => m.content.startsWith("__strands_state__:"),
+    );
+    expect(states).toHaveLength(2);
+    expect(decodeStateContent(states[0]!).snapshotId).toBe("s1");
+    expect(decodeStateContent(states[0]!).isLatest).toBe(false);
+    expect(decodeStateContent(states[1]!).snapshotId).toBe("s2");
+    expect(decodeStateContent(states[1]!).isLatest).toBe(true);
+  });
+
+  it("re-saving the same snapshotId with the same state is a no-op for synthetic markers", async () => {
+    const { client, getMessages } = makeFakeClient();
+    const storage = new Neo4jSessionStorage(client);
+    const snapshot = snapshotWith({ messages: [{ role: "user", content: [{ text: "hi" }] }] });
+
+    await storage.saveSnapshot({
+      location: LOCATION,
+      snapshotId: "s1",
+      isLatest: true,
+      snapshot,
+    });
+    await storage.saveSnapshot({
+      location: LOCATION,
+      snapshotId: "s1",
+      isLatest: true,
+      snapshot,
+    });
+
+    const states = getMessages().filter((m) => m.content.startsWith("__strands_state__:"));
+    expect(states).toHaveLength(1);
+  });
+});
+
+describe("Neo4jSessionStorage — load + list + delete", () => {
+  function seedConversationWithSnapshot(
+    snapshotId: string,
+    isLatest: boolean,
+    snapshot: Snapshot,
+  ): StoredMessage {
+    return {
+      id: `state-${snapshotId}`,
+      role: "user",
+      content: encodeStateContent({
+        snapshotId,
+        isLatest,
+        snapshot,
+        savedAt: new Date().toISOString(),
+      }),
+    };
+  }
+
+  it("loadSnapshot returns the stashed blob + current messages merged in", async () => {
+    const seededSnap: Snapshot = {
+      scope: "agent",
+      schemaVersion: "1.0",
+      createdAt: "x",
+      data: { agentState: { foo: 1 } } as unknown as Snapshot["data"],
+      appData: { stored: true } as unknown as Snapshot["appData"],
+    };
+    const { client } = makeFakeClient({
+      initialMessages: [
+        { id: "m1", role: "user", content: "hi" },
+        seedConversationWithSnapshot("s1", true, seededSnap),
+      ],
+    });
+    const storage = new Neo4jSessionStorage(client);
+    const snap = await storage.loadSnapshot({ location: LOCATION });
+    expect(snap).not.toBeNull();
+    expect(snap!.data).toMatchObject({ agentState: { foo: 1 } });
+    const messages = (snap!.data as { messages?: unknown[] }).messages;
+    expect(Array.isArray(messages)).toBe(true);
+    expect(messages).toHaveLength(1); // only the real message; synthetic marker filtered out
+  });
+
+  it("loadSnapshot returns null when no snapshots exist", async () => {
+    const { client } = makeFakeClient();
+    const storage = new Neo4jSessionStorage(client);
+    const snap = await storage.loadSnapshot({ location: LOCATION });
+    expect(snap).toBeNull();
+  });
+
+  it("loadSnapshot prefers the latest stored blob for an explicit snapshotId", async () => {
+    const baseSnapshot: Snapshot = {
+      scope: "agent",
+      schemaVersion: "1.0",
+      createdAt: "x",
+      data: {} as Snapshot["data"],
+      appData: {} as Snapshot["appData"],
+    };
+    const { client } = makeFakeClient({
+      initialMessages: [
+        seedConversationWithSnapshot("s1", false, {
+          ...baseSnapshot,
+          data: { version: 1 } as Snapshot["data"],
+        }),
+        seedConversationWithSnapshot("s1", true, {
+          ...baseSnapshot,
+          data: { version: 2 } as Snapshot["data"],
+        }),
+      ],
+    });
+    const storage = new Neo4jSessionStorage(client);
+
+    const snap = await storage.loadSnapshot({ location: LOCATION, snapshotId: "s1" });
+    expect((snap!.data as Record<string, unknown>).version).toBe(2);
+  });
+
+  it("listSnapshotIds respects limit + startAfter", async () => {
+    const { client } = makeFakeClient({
+      initialMessages: ["a", "b", "c", "d", "e"].map((id) =>
+        seedConversationWithSnapshot(id, id === "e", {
+          scope: "agent",
+          schemaVersion: "1.0",
+          createdAt: "x",
+          data: {} as Snapshot["data"],
+          appData: {} as Snapshot["appData"],
+        }),
+      ),
+    });
+    const storage = new Neo4jSessionStorage(client);
+    expect(await storage.listSnapshotIds({ location: LOCATION })).toEqual([
+      "a", "b", "c", "d", "e",
+    ]);
+    expect(await storage.listSnapshotIds({ location: LOCATION, limit: 2 })).toEqual(["a", "b"]);
+    expect(
+      await storage.listSnapshotIds({ location: LOCATION, startAfter: "b" }),
+    ).toEqual(["c", "d", "e"]);
+    expect(
+      await storage.listSnapshotIds({ location: LOCATION, startAfter: "b", limit: 2 }),
+    ).toEqual(["c", "d"]);
+  });
+
+  it("deleteSession calls deleteConversation", async () => {
+    const { client } = makeFakeClient();
+    const storage = new Neo4jSessionStorage(client);
+    // Wire a spy by re-binding deleteConversation:
+    const calls: string[] = [];
+    (client as unknown as { shortTerm: { deleteConversation: (id: string) => Promise<void> } })
+      .shortTerm.deleteConversation = async (id: string) => {
+      calls.push(id);
+    };
+    await storage.deleteSession({ sessionId: "conv-1" });
+    expect(calls).toEqual(["conv-1"]);
+  });
+});
+
+describe("Neo4jSessionStorage — manifest", () => {
+  it("manifest round-trip via a synthetic manifest message", async () => {
+    const { client } = makeFakeClient();
+    const storage = new Neo4jSessionStorage(client);
+    const manifest = { schemaVersion: "1.0", updatedAt: "2026-05-16T00:00:00Z" };
+    await storage.saveManifest({ location: LOCATION, manifest });
+    const loaded = await storage.loadManifest({ location: LOCATION });
+    expect(loaded).toEqual(manifest);
+  });
+
+  it("loadManifest returns a default when none stored", async () => {
+    const { client } = makeFakeClient();
+    const storage = new Neo4jSessionStorage(client);
+    const loaded = await storage.loadManifest({ location: LOCATION });
+    expect(loaded.schemaVersion).toBe("1.0");
+    expect(typeof loaded.updatedAt).toBe("string");
+  });
+
+  it("last-write-wins per scopeId", async () => {
+    const { client } = makeFakeClient();
+    const storage = new Neo4jSessionStorage(client);
+    await storage.saveManifest({
+      location: LOCATION,
+      manifest: { schemaVersion: "1.0", updatedAt: "first" },
+    });
+    await storage.saveManifest({
+      location: LOCATION,
+      manifest: { schemaVersion: "1.0", updatedAt: "second" },
+    });
+    const loaded = await storage.loadManifest({ location: LOCATION });
+    expect(loaded.updatedAt).toBe("second");
+  });
+});
+
+describe("Neo4jSessionStorage — unicode + long content", () => {
+  it("preserves unicode through extraction + persistence", async () => {
+    const { client, addCalls } = makeFakeClient();
+    const storage = new Neo4jSessionStorage(client);
+    const content = "你好 🚀 émoji ñ ç ø";
+    await storage.saveSnapshot({
+      location: LOCATION,
+      snapshotId: "s1",
+      isLatest: true,
+      snapshot: snapshotWith({
+        messages: [{ role: "user", content: [{ text: content }] }],
+      }),
+    });
+    const real = addCalls.filter((c) => c.role === "user");
+    expect(real[0]).toMatchObject({ content });
+  });
+
+  it("preserves a thousand messages without loss", async () => {
+    const { client, addCalls } = makeFakeClient();
+    const storage = new Neo4jSessionStorage(client);
+    const big = Array.from({ length: 1000 }, (_, i) => ({
+      role: i % 2 === 0 ? "user" : "assistant",
+      content: [{ text: `msg-${i}` }],
+    }));
+    await storage.saveSnapshot({
+      location: LOCATION,
+      snapshotId: "s1",
+      isLatest: true,
+      snapshot: snapshotWith({ messages: big }),
+    });
+    const real = addCalls.filter(
+      (c) =>
+        (c.role === "user" || c.role === "assistant") &&
+        !c.content.startsWith("__strands_state__:") &&
+        !c.content.startsWith("__strands_manifest__:"),
+    );
+    expect(real).toHaveLength(1000);
+  });
+});
+
+describe("isSyntheticStrandsMessage", () => {
+  it("recognizes state and manifest markers on any role", () => {
+    // The integration writes role=user; we match on content prefix alone
+    // for resilience against role normalization on the service side.
+    expect(
+      isSyntheticStrandsMessage({ role: "user", content: "__strands_state__:s1" }),
+    ).toBe(true);
+    expect(
+      isSyntheticStrandsMessage({ role: "system", content: "__strands_state__:s1" }),
+    ).toBe(true);
+    expect(
+      isSyntheticStrandsMessage({ role: "user", content: "__strands_manifest__:agent-1" }),
+    ).toBe(true);
+  });
+
+  it("rejects messages without the prefix", () => {
+    expect(
+      isSyntheticStrandsMessage({ role: "user", content: "real user message" }),
+    ).toBe(false);
+    expect(
+      isSyntheticStrandsMessage({ role: "system", content: "real system message" }),
+    ).toBe(false);
+  });
+});
+
+// Silence unused warning on vi when unused in this file.
+void vi;

--- a/typescript/test/unit/strands/type-compatibility.test.ts
+++ b/typescript/test/unit/strands/type-compatibility.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Compile-time type assertions: our integration classes implement the real
+ * Strands interfaces. This test exists to catch upstream type drift on
+ * `npm install` of a new Strands version — if Strands renames or reshapes
+ * one of the interfaces we wrap, this test fails at build time.
+ */
+
+import { describe, it, expect } from "vitest";
+import type {
+  SnapshotStorage,
+  ConversationManager,
+} from "@strands-agents/sdk";
+import {
+  Neo4jConversationManager,
+  Neo4jSessionStorage,
+} from "../../../src/integrations/strands.js";
+import { MemoryClient } from "../../../src/client.js";
+
+describe("Strands type compatibility", () => {
+  it("Neo4jSessionStorage satisfies SnapshotStorage", () => {
+    const memory = new MemoryClient({ apiKey: "k" });
+    const storage: SnapshotStorage = new Neo4jSessionStorage(memory);
+    // Touch every method so unused-warning rules can't elide them.
+    expect(typeof storage.saveSnapshot).toBe("function");
+    expect(typeof storage.loadSnapshot).toBe("function");
+    expect(typeof storage.listSnapshotIds).toBe("function");
+    expect(typeof storage.deleteSession).toBe("function");
+    expect(typeof storage.loadManifest).toBe("function");
+    expect(typeof storage.saveManifest).toBe("function");
+  });
+
+  it("Neo4jConversationManager satisfies the ConversationManager shape", () => {
+    const memory = new MemoryClient({ apiKey: "k" });
+    // Strands' ConversationManager is an abstract class. We duck-type to the
+    // shape it requires: `name`, `reduce(opts)`, `initAgent(agent)`.
+    const cm = new Neo4jConversationManager(memory, {
+      conversationId: "c1",
+    });
+    const ducktyped: Pick<ConversationManager, "name" | "reduce" | "initAgent"> = cm;
+    expect(ducktyped.name).toBe("neo4j:context-injection");
+    expect(typeof ducktyped.reduce).toBe("function");
+    expect(typeof ducktyped.initAgent).toBe("function");
+  });
+});

--- a/typescript/test/unit/transport-selection.test.ts
+++ b/typescript/test/unit/transport-selection.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Unit tests — auto-selection of BridgeTransport vs RestTransport.
+ */
+
+import { describe, it, expect } from "vitest";
+import { MemoryClient } from "../../src/client.js";
+import { ValidationError } from "../../src/errors.js";
+import { RestTransport } from "../../src/transport/index.js";
+import { BridgeTransport } from "../../src/transport/bridge.js";
+
+function getInternalTransport(client: MemoryClient): unknown {
+  const t = (client as unknown as { transport: unknown }).transport;
+  // Auto-created transports are wrapped in LazyConnectTransport; unwrap for the
+  // instanceof check. User-supplied transports are passed through as-is.
+  if (t && typeof t === "object" && "inner" in t) {
+    return (t as { inner: unknown }).inner;
+  }
+  return t;
+}
+
+describe("transport auto-selection", () => {
+  it("selects RestTransport for /v1 endpoints", () => {
+    const c = new MemoryClient({
+      endpoint: "https://memory.neo4jlabs.com/v1",
+      apiKey: "k",
+    });
+    expect(getInternalTransport(c)).toBeInstanceOf(RestTransport);
+  });
+
+  it("selects RestTransport for /v2 endpoints", () => {
+    const c = new MemoryClient({
+      endpoint: "https://memory.neo4jlabs.com/v2",
+      apiKey: "k",
+    });
+    expect(getInternalTransport(c)).toBeInstanceOf(RestTransport);
+  });
+
+  it("selects BridgeTransport for localhost:3001", () => {
+    const c = new MemoryClient({ endpoint: "http://localhost:3001" });
+    expect(getInternalTransport(c)).toBeInstanceOf(BridgeTransport);
+  });
+
+  it("explicit transport: 'bridge' overrides auto-detection", () => {
+    const c = new MemoryClient({
+      endpoint: "https://memory.neo4jlabs.com/v1",
+      transport: "bridge",
+    });
+    expect(getInternalTransport(c)).toBeInstanceOf(BridgeTransport);
+  });
+
+  it("explicit transport: 'rest' overrides auto-detection", () => {
+    const c = new MemoryClient({
+      endpoint: "http://localhost:3001",
+      transport: "rest",
+      apiKey: "k",
+    });
+    expect(getInternalTransport(c)).toBeInstanceOf(RestTransport);
+  });
+
+  it("accepts a custom Transport instance", () => {
+    const fake = {
+      request: async () => ({}),
+      connect: async () => {},
+      close: async () => {},
+    };
+    const c = new MemoryClient(fake);
+    expect(getInternalTransport(c)).toBe(fake);
+  });
+
+  it("requires an explicit endpoint for bridge transport", () => {
+    expect(() => new MemoryClient({ transport: "bridge" })).toThrowError(ValidationError);
+  });
+});

--- a/typescript/tsconfig.json
+++ b/typescript/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noUncheckedIndexedAccess": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "test", "conformance"]
+}

--- a/typescript/tsup.config.ts
+++ b/typescript/tsup.config.ts
@@ -1,0 +1,28 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: {
+    index: "src/index.ts",
+    "middleware/vercel-ai": "src/middleware/vercel-ai.ts",
+    "mcp/index": "src/mcp/index.ts",
+    "integrations/langchain": "src/integrations/langchain.ts",
+    "integrations/mastra": "src/integrations/mastra.ts",
+    "integrations/strands": "src/integrations/strands.ts",
+    testing: "src/testing.ts",
+  },
+  format: ["esm"],
+  dts: true,
+  sourcemap: true,
+  clean: true,
+  target: "es2022",
+  splitting: true,
+  treeshake: true,
+  // Never bundle the framework adapters' peer SDKs into our dist —
+  // they live in user devDependencies (or peer dependencies of theirs).
+  external: [
+    "@strands-agents/sdk",
+    "@opentelemetry/api",
+    "@modelcontextprotocol/sdk",
+    "@ai-sdk/provider",
+  ],
+});

--- a/typescript/typedoc.json
+++ b/typescript/typedoc.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://typedoc.org/schema.json",
+  "entryPoints": [
+    "src/index.ts",
+    "src/middleware/vercel-ai.ts",
+    "src/mcp/index.ts",
+    "src/integrations/langchain.ts",
+    "src/integrations/mastra.ts",
+    "src/integrations/strands.ts",
+    "src/testing.ts"
+  ],
+  "out": "docs-api",
+  "name": "@neo4j-labs/agent-memory",
+  "includeVersion": true,
+  "excludePrivate": true,
+  "excludeInternal": true,
+  "excludeExternals": true,
+  "categorizeByGroup": true,
+  "navigationLinks": {
+    "GitHub": "https://github.com/neo4j-labs/agent-memory",
+    "Docs": "https://neo4j.com/labs/agent-memory/sdks/typescript",
+    "Community": "https://community.neo4j.com"
+  }
+}

--- a/typescript/vitest.config.ts
+++ b/typescript/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["test/**/*.test.ts"],
+    globals: true,
+    testTimeout: 30_000,
+    hookTimeout: 30_000,
+  },
+});


### PR DESCRIPTION
Summary

 - Relocates @neo4j-labs/agent-memory (TypeScript) from agent-memory-tck/clients/typescript/ (TCK source SHA 4603b91f) into typescript/ in this repo, alongside the Python SDK. Same memory model, same NAMS backend, same package name, same exports — install path doesn't change for downstream users (once the first
 typescript-v0.3.0 tag publishes to npm).
 - Adds path-filtered CI per package, namespaced release tags (python-v*, typescript-v*), and a unified Antora docs site at neo4j.com/labs/agent-memory/ with a new SDKs axis. The Python release pipeline keeps its install path, API surface, and docs URLs; only the workflow filename and tag prefix change.
 - Closes one half of the move. A companion PR against neo4j-labs/agent-memory-tck (Step 7 below) deletes clients/typescript/, retargets the TCK suite at the published npm package, and is gated on the first npm publish from this PR's tag.

 What changed

 111 files changed, +19,848 / −21 lines.

 TypeScript SDK — typescript/ (77 files, new)

 Verbatim copy of agent-memory-tck/clients/typescript/ at SHA 4603b91f with three targeted edits:

 - typescript/package.json — repository.url → https://github.com/neo4j-labs/agent-memory, repository.directory → typescript, homepage → https://neo4j.com/labs/agent-memory/sdks/typescript. Everything else (name, version 0.3.0, exports, deps, scripts, engines) preserved.
 - typescript/README.md — banner pointing readers from the old TCK location to the new home; doc links repointed from ../../docs/* relative paths to absolute neo4j.com/labs/agent-memory/* URLs; issue tracker URL updated.
 - typescript/CHANGELOG.md — [Unreleased] entry documenting the move (no code changes).
 - typescript/typedoc.json — navigationLinks.GitHub repointed at the new repo.
 - typescript/package-lock.json — regenerated. The TCK-side lockfile was out-of-sync with package.json (a TypeScript version drift); npm install repaired it in-place.

 No code under typescript/src/, typescript/test/, typescript/conformance/, typescript/examples/, or typescript/scripts/ was modified. All internal imports are relative and stayed valid.

 CI/CD — .github/workflows/ (6 changes)

 - ci.yml → ci-python.yml — renamed via git mv so history follows; on: block now path-filtered to src/**, tests/**, benchmarks/**, examples/**, docs/**, scripts/**, pyproject.toml, uv.lock, Makefile, docker-compose.test.yml, codecov.yml. TypeScript-only PRs no longer trigger the Python test matrix.
 - release.yml → publish-python.yml — renamed; tag filter changed from v* to python-v* so the two publish flows can never collide.
 - ci-typescript.yml (new) — path-filtered to typescript/**. Node 20 + 22 matrix. Runs npm ci, lint, test:unit, test:integration, build, and npm pack --dry-run (the cheap mitigation for missing-files regressions on publish).
 - publish-typescript.yml (new) — triggered on typescript-v* tags. npm publish --provenance --access public to the npm GitHub environment; creates a GitHub Release labelled "TypeScript SDK ${tag}".
 - docs-typedoc.yml (new) — path-filtered to typescript/src/**, typescript/typedoc.json, typescript/package.json and typescript-v* tags. Builds TypeDoc from typescript/docs-api/ and deploys to GitHub Pages at neo4j-labs.github.io/agent-memory/typescript/.
 - tck-conformance.yml (new) — nightly + workflow_dispatch. Checks out agent-memory-tck, installs @neo4j-labs/agent-memory@latest from npm, runs the Bronze suite against the published package, and files a GitHub issue on scheduled failure. Gated to manual-only until the TCK companion PR (Step 7) lands.

 Docs — docs/modules/ROOT/ (21 changes)

 17 new pages carried over from the TCK docs tree, with link paths repointed via a single sed pass:

 - tutorials/first-agent-memory-typescript.adoc, tutorials/hosted-quickstart-typescript.adoc
 - how-to/typescript/{authenticate,edge-runtime,handle-errors,observability,troubleshooting,integrations-overview,vercel-ai,mcp,langchain,mastra,strands}.adoc (11 pages)
 - explanation/multi-agent-sharing.adoc
 - reference/rest-api.adoc — new canonical NAMS REST surface, replacing TCK-test-suite framing with cross-SDK framing
 - sdks/python.adoc, sdks/typescript.adoc — new SDK landing pages

 4 reconciled pages — added "See also" cross-links to the corresponding TCK-side spec page (which stays in the TCK repo for spec-curious readers):

 - explanation/memory-types.adoc ←→ TCK explanation/memory-model.adoc
 - explanation/graph-architecture.adoc ←→ TCK explanation/architecture.adoc
 - reference/mcp-tools.adoc ←→ TCK reference/mcp-tools.adoc
 - (The agent-memory versions are already 1.5–5× larger and authoritative; deep editorial folding is left for review — see Follow-ups.)

 nav.adoc — rebuilt with the new SDKs branch under "Getting Started", split Tutorials into Python/TypeScript subtrees, added a TypeScript subtree under How-To, added reference/rest-api.adoc and explanation/multi-agent-sharing.adoc entries.

 Repo-root files (7 changes)

 - README.md — added an "SDKs" section between "What It Does" and "Quick Start" (two-row pip/npm table); added npm version and TypeScript CI badges; repointed Python CI badge URL; added a typescript/ pointer in the footer.
 - CHANGELOG.md — [Unreleased] / Repository entry calling out the polyglot layout, the renamed Python CI workflow, and the new python-v* tag convention.
 - CONTRIBUTING.md — refreshed CI workflow table (7 workflows incl. the new TS ones); split "Publishing" into Python + TypeScript subsections with the new tag prefixes; added a "TypeScript Contributions" section (setup, common commands, in-tree TCK, code style, integration-extension checklist).
 - CLAUDE.md — "Polyglot Layout" section at the top explaining the two-SDK structure, release tag prefixes, path-filtered CI, and TCK conformance arrangement (so agents working in the repo understand the boundary).
 - Makefile — .PHONY extended; added a "TypeScript SDK" section with 10 new ts-* targets (ts-install, ts-build, ts-test, ts-test-unit, ts-test-integration, ts-lint, ts-docs, ts-conformance, ts-pack, ts-clean).
 - .gitignore — added a "TypeScript SDK" block (typescript/node_modules/, typescript/dist/, typescript/.tsbuildinfo, typescript/docs-api/).


 Follow-ups (not in this PR)

 1. npm scope ownership & secret — confirm @neo4j-labs scope on npm and the NPM_TOKEN repo secret before tagging typescript-v0.3.0. The publish workflow uses an npm GitHub environment for review-gating; configure that if not present.
 2. First publish — after merge, tag typescript-v0.3.0 against the merge commit; publish-typescript.yml does the rest. Smoke test with npm install @neo4j-labs/agent-memory in a scratch project (each subpath export imports without error).
 3. TCK companion PR — open against neo4j-labs/agent-memory-tck:
   - Replace clients/typescript/ with a redirect README pointing at the new home (keep indefinitely as a permanent backstop).
   - Update .github/workflows/tck-tests.yml (line ~398) to install @neo4j-labs/agent-memory from npm and run its bridge server instead of the in-tree npx tsx conformance/server.ts.
   - Delete .github/workflows/ts-publish.yml and .github/workflows/ts-typedoc.yml (moved here).
   - Remove the TypeScript job (lines ~53–88) from .github/workflows/client-tests.yml.
   - Pin a sticky issue "TypeScript client has moved" for 90 days.
   - Land after the first npm publish from this repo. Then flip tck-conformance.yml here from workflow_dispatch-only to nightly.
 4. Content reconciliation — the three reconciled pages (memory-types.adoc, graph-architecture.adoc, mcp-tools.adoc) currently link to the TCK-side spec docs via "See also" callouts. A reviewer pass should decide whether any unique paragraphs from the TCK side belong inline.
 5. Asciidoctor {attr} warnings — 26 pre-existing warnings in rest-api.adoc, backends.adoc, and how-to/typescript/strands.adoc from code samples containing {id}, {session_id}, {base64-json}, etc. Fix incrementally with subs="-attributes" blocks; not load-bearing.
 6. eslint missing from devDeps — the existing lint script (tsc --noEmit && eslint src/) references eslint but it isn't in package.json devDependencies (pre-existing from the TCK side). The TS CI runs npm run lint and will fail until either eslint is added or the script is reduced to tsc --noEmit. Decision welcome
 before merge.


 Test plan

 - make ts-test passes locally
 - make ts-build && make ts-pack produces a 31-file, ~84 kB tarball
 - make docs (Antora) completes with 0 errors
 - CI passes: TypeScript CI green on Node 20 + 22; Python CI does not fire on this PR's TS-heavy diff (path filter check); nams-integration.yml green
 - After merge: tag typescript-v0.3.0, watch publish-typescript.yml; confirm npm install @neo4j-labs/agent-memory works in a scratch project
 - After merge: cut a no-op python-v0.4.1 to confirm the renamed publish-python.yml still publishes to PyPI under the new tag convention