### PR TITLE
NAMS SDK alignment: workspace addressing, ontology surface, and the #130 ADK fix (Python + TypeScript)

### DIFF
--- a/.github/workflows/nams-integration.yml
+++ b/.github/workflows/nams-integration.yml
@@ -25,6 +25,13 @@ jobs:
     # Skip on PRs from forks (secrets are unavailable there).
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     timeout-minutes: 20
+    # Job-level env inherited by every step. The memory.neo4jlabs.com
+    # deployment is header-scoped: requests must carry an X-Workspace-Id
+    # (the client derives it from NAMS_SANDBOX_WORKSPACE_ID). Without it the
+    # server returns 503 workspace_not_provisioned. Set the repo variable
+    # NAMS_SANDBOX_WORKSPACE_ID to the provisioned sandbox workspace.
+    env:
+      NAMS_SANDBOX_WORKSPACE_ID: ${{ vars.NAMS_SANDBOX_WORKSPACE_ID }}
     steps:
       - uses: actions/checkout@v4
 
@@ -46,6 +53,9 @@ jobs:
             echo "skip_tests=true" >> "$GITHUB_OUTPUT"
           else
             echo "NAMS_SANDBOX_KEY is set; running live integration tests."
+            if [ -z "$NAMS_SANDBOX_WORKSPACE_ID" ]; then
+              echo "::warning::NAMS_SANDBOX_WORKSPACE_ID variable is not set. The header-scoped memory.neo4jlabs.com deployment will likely return 503 workspace_not_provisioned. Set the repo variable NAMS_SANDBOX_WORKSPACE_ID to the provisioned sandbox workspace."
+            fi
           fi
         id: check-secret
 

--- a/.github/workflows/nams-integration.yml
+++ b/.github/workflows/nams-integration.yml
@@ -89,6 +89,17 @@ jobs:
           echo "::notice::NAMS api key    : set (masked)"
           echo "::notice::NAMS workspace  : ${WS}"
 
+          # 3a. Workspace gate. Both deployments this workflow targets (staging
+          #     nams.development.neo4jsandbox.com and sandbox memory.neo4jlabs.com)
+          #     are workspace-scoped: reads may tolerate a missing workspace but
+          #     writes reject it ('400 workspace_id required' / '503
+          #     workspace_not_provisioned'). A GET probe alone won't catch that,
+          #     so fail now with an actionable message rather than mid-test.
+          if [ -z "${NAMS_SANDBOX_WORKSPACE_ID:-}" ]; then
+            echo "::error::NAMS_SANDBOX_WORKSPACE_ID is not set, but ${URL} is workspace-scoped and rejects writes without it (you saw '400 workspace_id required'). Set the NAMS_SANDBOX_WORKSPACE_ID repository variable (Settings → Secrets and variables → Actions → Variables tab) to a valid workspace id for this environment."
+            exit 1
+          fi
+
           # 4. One authenticated request — fail fast with an actionable message.
           #    Mirrors the client probe: GET /conversations?limit=1 with
           #    Authorization: Bearer <key> and optional X-Workspace-Id. Two
@@ -124,6 +135,13 @@ jobs:
             000)
               echo "::error::Could not reach ${URL} (DNS/network failure). Check the NAMS_SANDBOX_URL variable."
               exit 1
+              ;;
+            400)
+              if echo "${BODY}" | grep -qi "workspace"; then
+                echo "::error::${URL} rejected the workspace (HTTP 400). NAMS_SANDBOX_WORKSPACE_ID may be invalid or not provisioned for this environment. Response: ${BODY}"
+                exit 1
+              fi
+              echo "::warning::Probe returned 400 at ${URL}; continuing so the suite reports detail. Response: ${BODY}"
               ;;
             *)
               echo "::warning::Unexpected probe status ${CODE} at ${URL}; continuing so the suite reports detail. Response: ${BODY}"

--- a/.github/workflows/nams-integration.yml
+++ b/.github/workflows/nams-integration.yml
@@ -2,11 +2,23 @@ name: NAMS Integration
 
 # Runs the NAMS integration test suite against the live sandbox.
 #
-# Uses the NAMS_SANDBOX_KEY repo secret. When the secret is absent
-# (e.g. on PRs from forks), the tests inside the workflow skip cleanly
-# via the env-gate in tests/integration/nams/conftest.py — but we also
-# pre-check the secret and short-circuit the whole job to keep CI logs
-# tidy.
+# Configuration (Settings → Secrets and variables → Actions):
+#   * NAMS_SANDBOX_KEY          (Secret)   — API key. Required; job skips if unset.
+#   * NAMS_SANDBOX_URL          (Variable) — endpoint, e.g.
+#                                            https://nams.development.neo4jsandbox.com/v1
+#                                            Unset → falls back to the suite default below.
+#   * NAMS_SANDBOX_WORKSPACE_ID (Variable) — sent as X-Workspace-Id. Required by
+#                                            header-scoped deployments (e.g.
+#                                            memory.neo4jlabs.com), else 503
+#                                            workspace_not_provisioned.
+#
+# The "Preflight" step resolves and PRINTS the effective config, then makes one
+# authenticated request. It fails fast with a clear message on a bad key
+# (401/403), an unprovisioned workspace (503), or an unreachable endpoint — so a
+# misconfiguration surfaces as an explicit error here rather than a confusing
+# stack trace inside pytest. KEY and WORKSPACE come from job-level env; the
+# resolved URL is exported to $GITHUB_ENV so every later step inherits the SAME
+# endpoint with no per-step `|| fallback` that could silently mask an unset var.
 
 on:
   push:
@@ -25,13 +37,14 @@ jobs:
     # Skip on PRs from forks (secrets are unavailable there).
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     timeout-minutes: 20
-    # Job-level env inherited by every step. The memory.neo4jlabs.com
-    # deployment is header-scoped: requests must carry an X-Workspace-Id
-    # (the client derives it from NAMS_SANDBOX_WORKSPACE_ID). Without it the
-    # server returns 503 workspace_not_provisioned. Set the repo variable
-    # NAMS_SANDBOX_WORKSPACE_ID to the provisioned sandbox workspace.
+    # Inherited by every step. URL is intentionally NOT here — the Preflight
+    # step resolves it (variable → suite default) and exports it to $GITHUB_ENV
+    # so a misconfigured variable can be detected instead of silently masked.
     env:
+      NAMS_SANDBOX_KEY: ${{ secrets.NAMS_SANDBOX_KEY }}
       NAMS_SANDBOX_WORKSPACE_ID: ${{ vars.NAMS_SANDBOX_WORKSPACE_ID }}
+      # Suite default used only when the NAMS_SANDBOX_URL variable is unset.
+      NAMS_DEFAULT_URL: https://nams.development.neo4jsandbox.com/v1
     steps:
       - uses: actions/checkout@v4
 
@@ -44,37 +57,89 @@ jobs:
       - name: Install dependencies
         run: uv sync --group dev --all-extras
 
-      - name: Verify NAMS_SANDBOX_KEY is configured
+      # Resolve config, make it visible, and validate auth/connectivity up front.
+      - name: Preflight — resolve & validate NAMS config
+        id: preflight
         env:
-          NAMS_SANDBOX_KEY: ${{ secrets.NAMS_SANDBOX_KEY }}
+          NAMS_URL_VAR: ${{ vars.NAMS_SANDBOX_URL }}
         run: |
-          if [ -z "$NAMS_SANDBOX_KEY" ]; then
-            echo "::warning::NAMS_SANDBOX_KEY secret is not set. NAMS integration tests will be skipped."
+          set -uo pipefail
+
+          # 1. Key gate — skip cleanly (don't fail) when no key is configured,
+          #    e.g. on branches/forks without the secret.
+          if [ -z "${NAMS_SANDBOX_KEY:-}" ]; then
+            echo "::warning::NAMS_SANDBOX_KEY secret is not set. Skipping NAMS integration tests."
             echo "skip_tests=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "NAMS_SANDBOX_KEY is set; running live integration tests."
-            if [ -z "$NAMS_SANDBOX_WORKSPACE_ID" ]; then
-              echo "::warning::NAMS_SANDBOX_WORKSPACE_ID variable is not set. The header-scoped memory.neo4jlabs.com deployment will likely return 503 workspace_not_provisioned. Set the repo variable NAMS_SANDBOX_WORKSPACE_ID to the provisioned sandbox workspace."
-            fi
+            exit 0
           fi
-        id: check-secret
+
+          # 2. Resolve endpoint: NAMS_SANDBOX_URL variable wins; else suite default.
+          if [ -z "${NAMS_URL_VAR:-}" ]; then
+            echo "::notice::NAMS_SANDBOX_URL variable is not set — using suite default: ${NAMS_DEFAULT_URL}"
+            URL="${NAMS_DEFAULT_URL}"
+          else
+            URL="${NAMS_URL_VAR}"
+          fi
+          # Export for every later step (single source of truth, no fallback masking).
+          echo "NAMS_SANDBOX_URL=${URL}" >> "$GITHUB_ENV"
+
+          # 3. Print the effective config so it's never a mystery in the logs.
+          if [ -n "${NAMS_SANDBOX_WORKSPACE_ID:-}" ]; then WS="set"; else WS="<empty>"; fi
+          echo "::notice::NAMS endpoint   : ${URL}"
+          echo "::notice::NAMS api key    : set (masked)"
+          echo "::notice::NAMS workspace  : ${WS}"
+
+          # 4. One authenticated request — fail fast with an actionable message.
+          #    Mirrors the client probe: GET /conversations?limit=1 with
+          #    Authorization: Bearer <key> and optional X-Workspace-Id. Two
+          #    explicit branches (no array) keep this portable under `set -u`.
+          if [ -n "${NAMS_SANDBOX_WORKSPACE_ID:-}" ]; then
+            CODE=$(curl -sS -o /tmp/nams_probe.txt -w '%{http_code}' \
+              -H "Authorization: Bearer ${NAMS_SANDBOX_KEY}" \
+              -H "X-Workspace-Id: ${NAMS_SANDBOX_WORKSPACE_ID}" \
+              "${URL}/conversations?limit=1" || echo "000")
+          else
+            CODE=$(curl -sS -o /tmp/nams_probe.txt -w '%{http_code}' \
+              -H "Authorization: Bearer ${NAMS_SANDBOX_KEY}" \
+              "${URL}/conversations?limit=1" || echo "000")
+          fi
+          BODY=$(cat /tmp/nams_probe.txt 2>/dev/null || true)
+          echo "Probe: GET ${URL}/conversations?limit=1 -> ${CODE}"
+
+          case "${CODE}" in
+            2*)
+              echo "::notice::NAMS auth + connectivity OK (${CODE})."
+              ;;
+            401|403)
+              echo "::error::NAMS rejected the API key (${CODE}) at ${URL}. The key in NAMS_SANDBOX_KEY and the endpoint NAMS_SANDBOX_URL must be from the SAME environment (a staging key only works against the staging URL). Response: ${BODY}"
+              exit 1
+              ;;
+            503)
+              if echo "${BODY}" | grep -q "workspace_not_provisioned"; then
+                echo "::error::Workspace not provisioned at ${URL}. Set the NAMS_SANDBOX_WORKSPACE_ID repo variable to a provisioned workspace (currently: ${WS}). Response: ${BODY}"
+                exit 1
+              fi
+              echo "::warning::NAMS returned 503 at probe — backend may be transiently down. Letting the suite run so it reports per-test. Response: ${BODY}"
+              ;;
+            000)
+              echo "::error::Could not reach ${URL} (DNS/network failure). Check the NAMS_SANDBOX_URL variable."
+              exit 1
+              ;;
+            *)
+              echo "::warning::Unexpected probe status ${CODE} at ${URL}; continuing so the suite reports detail. Response: ${BODY}"
+              ;;
+          esac
 
       # Smoke test first — fails fast if the basic flow is broken.
       - name: NAMS smoke test
-        if: steps.check-secret.outputs.skip_tests != 'true'
-        env:
-          NAMS_SANDBOX_KEY: ${{ secrets.NAMS_SANDBOX_KEY }}
-          NAMS_SANDBOX_URL: ${{ vars.NAMS_SANDBOX_URL || 'https://memory.neo4jlabs.com/v1' }}
+        if: steps.preflight.outputs.skip_tests != 'true'
         run: |
           uv run pytest tests/integration/nams/test_smoke.py \
             -v --tb=short --timeout=120
 
       # Auth / lifecycle tests — also fast and foundational.
       - name: NAMS auth + lifecycle tests
-        if: steps.check-secret.outputs.skip_tests != 'true'
-        env:
-          NAMS_SANDBOX_KEY: ${{ secrets.NAMS_SANDBOX_KEY }}
-          NAMS_SANDBOX_URL: ${{ vars.NAMS_SANDBOX_URL || 'https://memory.neo4jlabs.com/v1' }}
+        if: steps.preflight.outputs.skip_tests != 'true'
         run: |
           uv run pytest tests/integration/nams/test_auth.py \
             -v --tb=short --timeout=120
@@ -82,50 +147,35 @@ jobs:
       # Full TCK conformance + error suite — collect *all* failures (no -x)
       # so we see every endpoint mismatch in one run.
       - name: NAMS TCK conformance (Bronze)
-        if: steps.check-secret.outputs.skip_tests != 'true'
-        env:
-          NAMS_SANDBOX_KEY: ${{ secrets.NAMS_SANDBOX_KEY }}
-          NAMS_SANDBOX_URL: ${{ vars.NAMS_SANDBOX_URL || 'https://memory.neo4jlabs.com/v1' }}
+        if: steps.preflight.outputs.skip_tests != 'true'
         run: |
           uv run pytest tests/integration/nams/test_tck_bronze.py \
             -v --tb=short --timeout=180
         continue-on-error: true
 
       - name: NAMS TCK conformance (Silver)
-        if: steps.check-secret.outputs.skip_tests != 'true'
-        env:
-          NAMS_SANDBOX_KEY: ${{ secrets.NAMS_SANDBOX_KEY }}
-          NAMS_SANDBOX_URL: ${{ vars.NAMS_SANDBOX_URL || 'https://memory.neo4jlabs.com/v1' }}
+        if: steps.preflight.outputs.skip_tests != 'true'
         run: |
           uv run pytest tests/integration/nams/test_tck_silver.py \
             -v --tb=short --timeout=180
         continue-on-error: true
 
       - name: NAMS TCK conformance (Gold)
-        if: steps.check-secret.outputs.skip_tests != 'true'
-        env:
-          NAMS_SANDBOX_KEY: ${{ secrets.NAMS_SANDBOX_KEY }}
-          NAMS_SANDBOX_URL: ${{ vars.NAMS_SANDBOX_URL || 'https://memory.neo4jlabs.com/v1' }}
+        if: steps.preflight.outputs.skip_tests != 'true'
         run: |
           uv run pytest tests/integration/nams/test_tck_gold.py \
             -v --tb=short --timeout=180
         continue-on-error: true
 
       - name: NAMS TCK conformance (Platinum)
-        if: steps.check-secret.outputs.skip_tests != 'true'
-        env:
-          NAMS_SANDBOX_KEY: ${{ secrets.NAMS_SANDBOX_KEY }}
-          NAMS_SANDBOX_URL: ${{ vars.NAMS_SANDBOX_URL || 'https://memory.neo4jlabs.com/v1' }}
+        if: steps.preflight.outputs.skip_tests != 'true'
         run: |
           uv run pytest tests/integration/nams/test_tck_platinum.py \
             -v --tb=short --timeout=180
         continue-on-error: true
 
       - name: NAMS error-path tests
-        if: steps.check-secret.outputs.skip_tests != 'true'
-        env:
-          NAMS_SANDBOX_KEY: ${{ secrets.NAMS_SANDBOX_KEY }}
-          NAMS_SANDBOX_URL: ${{ vars.NAMS_SANDBOX_URL || 'https://memory.neo4jlabs.com/v1' }}
+        if: steps.preflight.outputs.skip_tests != 'true'
         run: |
           uv run pytest tests/integration/nams/test_errors.py \
             -v --tb=short --timeout=180
@@ -136,10 +186,7 @@ jobs:
       # tier-specific steps above could all fail and the workflow would still
       # report success.
       - name: Consolidated pass/fail check
-        if: steps.check-secret.outputs.skip_tests != 'true'
-        env:
-          NAMS_SANDBOX_KEY: ${{ secrets.NAMS_SANDBOX_KEY }}
-          NAMS_SANDBOX_URL: ${{ vars.NAMS_SANDBOX_URL || 'https://memory.neo4jlabs.com/v1' }}
+        if: steps.preflight.outputs.skip_tests != 'true'
         run: |
           uv run pytest tests/integration/nams/ \
             -v --tb=line --timeout=300 \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,45 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Workspace addressing for NAMS.** `NamsConfig.workspace_id` (and the
+  `MEMORY_WORKSPACE_ID` environment variable) is transmitted automatically
+  as the `X-Workspace-Id` header on every request. This is required by
+  deployments that scope by header (e.g. the development/staging service)
+  rather than encoding the workspace in the API key (production, unchanged).
+  An explicit `X-Workspace-Id` entry in `headers` still wins. The
+  `validate_on_connect` probe sends the header so misconfiguration fails fast.
+- **Ontology surface (`client.ontology`).** Drive the NAMS domain-ontology
+  engine from the SDK: `list()`, `get()`, `get_active()`, `clone()`,
+  `create()`, `update()`, `activate()`, `delete()` over the ~28 system
+  templates, versioned revisions, and `permissive`/`strict` validation modes.
+  Returns typed Pydantic models (`OntologySummary`, `OntologyVersion`,
+  `OntologyDocument`, `EntityTypeDef`, …); `get_active()` surfaces the active
+  version's `validation_mode`. On the bolt backend the accessor raises
+  `NotSupportedError` (define a custom schema with `SchemaModel.CUSTOM`).
+- **`conversation_id` alias** accepted across NAMS short-term methods
+  (`add_message`, `get_conversation`, `search_messages`, `clear_session`,
+  `create_conversation`, `bulk_add_messages`, …) as an alias for `session_id`.
+  `session_id` wins when both are supplied; a clear error names both when
+  neither is. `entity_type` gains `type`/`label` aliases on `add_entity`.
+- **`long_term.wait_for_extraction(...)`** — await the asynchronous NAMS
+  extraction pipeline explicitly (polls entity search for `expected_names` /
+  a `predicate`; returns a boolean, no raise). A no-op returning `True` on
+  bolt, where extraction is synchronous.
+
+### Fixed
+
+- **Google ADK `Neo4jMemoryService` is now NAMS-compatible (#130).**
+  `search_memory()` is conversation-scoped on NAMS (it threads the active
+  session id and skips message search gracefully when none is known, instead
+  of crashing with the unscoped-search `ValueError`); tool events
+  (`FunctionCall`/`FunctionResponse`) are filtered out of the entity pipeline
+  rather than stringified into it, so they no longer produce empty knowledge
+  graphs. Documentation parameter names are reconciled (`session_id` /
+  `conversation_id`, `entity_type` / `type`). `MemoryClient` gains `backend`
+  and `is_nams` properties.
+
 ### Repository
 
 - The repository at `neo4j-labs/agent-memory` is now polyglot. A

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help install install-all install-dev lint format typecheck test test-unit test-integration test-integration-mcp test-e2e test-all test-docker test-ci test-no-docker test-quick test-file test-match test-aws test-nams-unit test-nams-integration test-nams coverage coverage-all coverage-ci coverage-mcp test-examples test-examples-quick test-examples-no-neo4j test-docs test-docs-syntax test-docs-build test-docs-links neo4j-start neo4j-stop neo4j-logs clean build publish docs docs-diagrams-list docs-diagrams-status docs-diagrams-missing docs-diagrams-manifest docs-diagrams-add-refs docs-diagrams-generate example-basic example-resolution example-langchain example-pydantic examples chat-agent-install chat-agent-backend chat-agent-frontend chat-agent ts-install ts-build ts-test ts-test-unit ts-test-integration ts-lint ts-docs ts-conformance ts-pack ts-clean ts-test-examples
+.PHONY: help install install-all install-dev lint format typecheck test test-unit test-integration test-integration-mcp test-e2e test-all test-docker test-ci test-no-docker test-quick test-file test-match test-aws test-nams-unit test-nams-integration test-nams-staging test-nams-sandbox test-nams-local test-nams coverage coverage-all coverage-ci coverage-mcp test-examples test-examples-quick test-examples-no-neo4j test-docs test-docs-syntax test-docs-build test-docs-links neo4j-start neo4j-stop neo4j-logs clean build publish docs docs-diagrams-list docs-diagrams-status docs-diagrams-missing docs-diagrams-manifest docs-diagrams-add-refs docs-diagrams-generate example-basic example-resolution example-langchain example-pydantic examples chat-agent-install chat-agent-backend chat-agent-frontend chat-agent ts-install ts-build ts-test ts-test-unit ts-test-integration ts-lint ts-docs ts-conformance ts-pack ts-clean ts-test-examples
 
 # Default target
 help:
@@ -149,6 +149,17 @@ test-nams-unit:
 test-nams-integration:
 	@echo "Running NAMS integration tests..."
 	uv run pytest tests/integration/nams -v --timeout=300
+
+# NAMS integration against a named environment preset (see conftest
+# _NAMS_ENV_PRESETS). A raw NAMS_SANDBOX_URL still overrides if exported.
+test-nams-staging:
+	NAMS_ENV=staging $(MAKE) test-nams-integration
+
+test-nams-sandbox:
+	NAMS_ENV=sandbox $(MAKE) test-nams-integration
+
+test-nams-local:
+	NAMS_ENV=local $(MAKE) test-nams-integration
 
 # All NAMS tests (unit + integration)
 test-nams: test-nams-unit test-nams-integration

--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -15,6 +15,7 @@
 **** xref:tutorials/mcp-server.adoc[MCP Server for Claude Desktop]
 **** xref:tutorials/microsoft-agent-memory.adoc[Microsoft Agent Memory]
 **** xref:tutorials/nams-quickstart.adoc[NAMS Quickstart (v0.4)]
+**** xref:tutorials/ontology-quickstart.adoc[Ontology Quickstart]
 *** TypeScript
 **** xref:tutorials/first-agent-memory-typescript.adoc[First Agent Memory (TypeScript)]
 **** xref:tutorials/hosted-quickstart-typescript.adoc[Hosted Quickstart]
@@ -34,6 +35,7 @@
 *** Hosted Backend (v0.4)
 **** xref:how-to/use-nams.adoc[Use NAMS]
 **** xref:how-to/migrate-to-nams.adoc[Migrate to NAMS]
+**** xref:how-to/use-ontologies.adoc[Use Ontologies]
 
 *** Core Operations
 **** xref:how-to/messages.adoc[Store & Search Messages]
@@ -68,6 +70,7 @@
 **** xref:how-to/integrations/crewai.adoc[CrewAI]
 **** xref:how-to/integrations/openai-agents.adoc[OpenAI Agents]
 **** xref:how-to/integrations/google-cloud.adoc[Google Cloud]
+**** xref:how-to/integrations/google-adk.adoc[Google ADK]
 **** xref:how-to/integrations/aws-strands.adoc[AWS Strands Agents]
 **** xref:how-to/integrations/aws-bedrock-embeddings.adoc[Amazon Bedrock Embeddings]
 **** xref:how-to/integrations/aws-hybrid-memory.adoc[AWS Hybrid Memory]
@@ -93,6 +96,7 @@
 *** xref:reference/cli.adoc[CLI]
 *** xref:reference/mcp-tools.adoc[MCP Tools]
 *** xref:reference/rest-api.adoc[NAMS REST API]
+*** xref:reference/ontology-api.adoc[Ontology API]
 *** xref:reference/typescript-api.adoc[TypeScript SDK API]
 *** xref:reference/deployment.adoc[Deployment]
 *** xref:reference/extractors.adoc[Extractors]
@@ -110,6 +114,7 @@
 ** xref:explanation/index.adoc[Concepts]
 *** xref:explanation/memory-types.adoc[Memory Types]
 *** xref:explanation/poleo-model.adoc[POLE+O Model]
+*** xref:explanation/ontologies.adoc[Ontologies]
 *** xref:explanation/graph-architecture.adoc[Graph Architecture]
 *** xref:explanation/extraction-pipeline.adoc[Extraction Pipeline]
 *** xref:explanation/resolution-deduplication.adoc[Resolution & Deduplication]

--- a/docs/modules/ROOT/pages/explanation/backends.adoc
+++ b/docs/modules/ROOT/pages/explanation/backends.adoc
@@ -34,7 +34,13 @@ The same `MemoryClient` API runs against two completely different storage backen
 | Not exposed
 | Multi-tenancy
 | `user_identifier` kwarg
-| `user_identifier` (sent as `userId`) + workspace via API key
+| `user_identifier` (sent as `userId`) + workspace via API key or `workspace_id`
+| Workspace addressing
+| n/a
+| `workspace_id` → `X-Workspace-Id` header (for header-scoped deployments)
+| Ontologies
+| `NotSupportedError` (use `SchemaModel.CUSTOM`)
+| `client.ontology` — typed, versioned, validated domain schemas
 | Embeddings / extraction
 | Client-side (your config)
 | Server-side (managed)

--- a/docs/modules/ROOT/pages/explanation/ontologies.adoc
+++ b/docs/modules/ROOT/pages/explanation/ontologies.adoc
@@ -1,0 +1,74 @@
+= Ontologies
+:description: What a NAMS ontology is, how it extends POLE+O, and how validation modes and versioning work.
+
+[NOTE]
+====
+Ontologies are a *NAMS (hosted backend)* capability. On the bolt backend the
+`client.ontology` methods raise `NotSupportedError`; define a custom schema with
+`SchemaModel.CUSTOM` instead. See xref:explanation/backends.adoc[Backends].
+====
+
+== What is an ontology?
+
+An *ontology* is a typed, versioned, validated schema for your knowledge graph.
+Where the base xref:explanation/poleo-model.adoc[POLE+O model] gives you five
+coarse entity categories (Person, Organization, Location, Event, Object), an
+ontology refines them into a concrete domain vocabulary:
+
+* **Entity types** — each carries a `pole_type` (one of the POLE+O categories),
+  an optional `subtype`, display metadata (`color`, `icon`), and a list of typed
+  **properties**.
+* **Properties** — a `name`, a `type` (`string`, `datetime`, `date`, `float`,
+  `integer`), and optional `required`, `unique`, and `enum` constraints.
+* **Relationships** — a typed edge (`UPPER_SNAKE`) with `source` and `target`
+  entity labels.
+
+NAMS ships ~28 *system templates* (healthcare, legal, cybersecurity,
+financial-services, software-engineering, and more). Activating one makes
+server-side extraction produce a clean, predictable graph — `Patient`,
+`Provider`, `Diagnosis` with enforced fields and enumerations — instead of
+generic, loosely-typed nodes.
+
+== Templates vs. workspace-owned ontologies
+
+System templates are read-only (`is_system = true`). To customize one you
+*clone* it into a workspace-owned copy, which you can then revise. A workspace
+also has exactly one *active* ontology at a time; until you activate one, the
+`nams-default` template is implicitly bound.
+
+== Versioning and immutability
+
+Every change produces a new *immutable revision*. `clone` yields revision 1;
+each `update` yields revision n+1. A version records its `revision`,
+`validation_mode`, a `schema_hash`, and provenance. You `activate` a specific
+*version* (by its `ov_…` id) — activation is what binds a schema to the
+workspace and starts validating writes against it.
+
+== Validation modes
+
+Each version has a `validation_mode`:
+
+[cols="1,3",options="header"]
+|===
+| Mode | Behavior
+| `permissive` | (default) Non-conforming entity writes are accepted and recorded.
+| `strict` | Writes that violate the schema are rejected. The SDK surfaces the rejection as `ValidationError`.
+|===
+
+`permissive` favors ingestion tolerance; `strict` favors graph cleanliness. You
+choose per version, and `get_active()` reports the active mode.
+
+== Relationship to server-side extraction
+
+Ontologies shape the *server-side* GraphRAG extraction pipeline. Once a version
+is active, entities extracted from stored messages — and entities you write
+directly with `add_entity` — are validated against the active schema. Extraction
+is asynchronous; use
+xref:how-to/use-ontologies.adoc[`wait_for_extraction`] when you need to observe
+the result deterministically.
+
+== See also
+
+* xref:how-to/use-ontologies.adoc[How-to: Use ontologies]
+* xref:reference/ontology-api.adoc[Reference: Ontology API]
+* xref:tutorials/ontology-quickstart.adoc[Tutorial: Ontology quickstart]

--- a/docs/modules/ROOT/pages/how-to/integrations/google-adk.adoc
+++ b/docs/modules/ROOT/pages/how-to/integrations/google-adk.adoc
@@ -1,0 +1,62 @@
+= Google ADK memory service
+:description: Use neo4j-agent-memory as a Google ADK MemoryService, on local bolt or hosted NAMS.
+
+`Neo4jMemoryService` implements the Google Agent Development Kit (ADK)
+`BaseMemoryService` interface, backing an ADK agent's memory with
+neo4j-agent-memory — on either the bolt or the NAMS backend.
+
+== Setup
+
+[source,python]
+----
+from neo4j_agent_memory import MemoryClient, MemorySettings
+from neo4j_agent_memory.integrations.google_adk import Neo4jMemoryService
+
+settings = MemorySettings(backend="nams", nams={"api_key": "nams_...",
+                                                "workspace_id": "your-workspace-id"})
+
+async with MemoryClient(settings) as client:
+    memory = Neo4jMemoryService(memory_client=client, extract_on_store=True)
+
+    await memory.add_session_to_memory(session)        # stores messages, extracts entities
+    results = await memory.search_memory("user preferences")
+----
+
+== Conversation scoping on NAMS
+
+NAMS message search is *conversation-scoped*; ADK's `search_memory()` does not
+carry a session id. `Neo4jMemoryService` handles this for you:
+
+* It tracks the active session whenever you call `add_session_to_memory` or
+  `add_memory`, and scopes `search_memory` to it.
+* You can override per call: `search_memory(query, session_id=...)`.
+* When no session is known on NAMS, it *skips* message search (rather than
+  issuing the unscoped search NAMS rejects) and still returns entity and
+  preference recall, which are workspace-scoped and genuinely cross-session.
+
+On bolt, search is unscoped as before.
+
+== Tool-event filtering
+
+ADK events may carry tool calls (`FunctionCall` / `FunctionResponse`) that have
+no text. The service ingests *only* text parts; tool-only events produce no
+message and never reach the entity-extraction pipeline. This keeps the knowledge
+graph clean — tool JSON is not stringified into it.
+
+== Parameter naming
+
+* `session_id` is the canonical short-term parameter; `conversation_id` is
+  accepted as an alias (`session_id` wins).
+* `add_entity` takes `entity_type` (aliases: `type`, `label`).
+
+[NOTE]
+====
+This integration is community-supported and tracks issue
+https://github.com/neo4j-labs/agent-memory/issues/130[#130]. A staging-backed
+e2e suite guards the NAMS compatibility described here.
+====
+
+== See also
+
+* xref:how-to/integrations/google-cloud.adoc[Google Cloud (Vertex AI, ADK)]
+* xref:how-to/use-nams.adoc[Use NAMS]

--- a/docs/modules/ROOT/pages/how-to/use-nams.adoc
+++ b/docs/modules/ROOT/pages/how-to/use-nams.adoc
@@ -76,6 +76,14 @@ async with MemoryClient(settings) as client:
 | `None`
 | Your NAMS API key (`SecretStr`). `MemorySettings()` can lift `MEMORY_API_KEY`
   into this field when the backend is resolved from the environment.
+| `workspace_id`
+| `None`
+| NAMS workspace id. When set, transmitted as the `X-Workspace-Id` header on
+  every request — required by deployments that scope by header (e.g. the
+  development/staging service) instead of encoding the workspace in the API key
+  (production). Optional and harmless when unset. `MemorySettings()` can lift
+  `MEMORY_WORKSPACE_ID` into this field. An explicit `X-Workspace-Id` entry in
+  `headers` overrides it.
 | `timeout`
 | `30.0`
 | HTTP request timeout in seconds.
@@ -106,6 +114,9 @@ async with MemoryClient(settings) as client:
 | NAMS API key. When set and `backend` is unspecified, the backend defaults to NAMS.
 | `MEMORY_ENDPOINT`
 | Override the default endpoint URL.
+| `MEMORY_WORKSPACE_ID`
+| NAMS workspace id, sent as the `X-Workspace-Id` header. Required by
+  header-scoped deployments (staging); harmless on production.
 | `NAM_BACKEND`
 | Force the backend (`bolt` or `nams`). Overrides the env-based default.
 | `NAM_NAMS__*`

--- a/docs/modules/ROOT/pages/how-to/use-ontologies.adoc
+++ b/docs/modules/ROOT/pages/how-to/use-ontologies.adoc
@@ -1,0 +1,108 @@
+= Use ontologies
+:description: List, clone, customize, activate, and validate against NAMS domain ontologies from the SDK.
+
+Drive the NAMS ontology engine through the `client.ontology` accessor. This is a
+xref:how-to/use-nams.adoc[NAMS-backend] feature; on bolt the methods raise
+`NotSupportedError`.
+
+== List the catalog
+
+[tabs]
+======
+Python::
++
+[source,python]
+----
+async with MemoryClient(settings) as client:
+    catalog = await client.ontology.list()   # ~28 templates + workspace-owned
+    for o in catalog:
+        flag = " (active)" if o.is_active else ""
+        print(f"{o.name}{flag}  rev={o.current_revision}  system={o.is_system}")
+----
+TypeScript::
++
+[source,typescript]
+----
+const catalog = await client.ontology.list();
+for (const o of catalog) {
+  console.log(`${o.name}${o.isActive ? " (active)" : ""}  rev=${o.currentRevision}`);
+}
+----
+======
+
+== Clone a template, customize, activate
+
+`clone` returns a *version* (revision 1). Edit its `document`, push a new
+revision with `update`, then `activate` the version you want bound.
+
+[tabs]
+======
+Python::
++
+[source,python]
+----
+v = await client.ontology.clone("healthcare")          # editable copy, rev 1
+# (optionally edit v.document, then create rev 2:)
+v2 = await client.ontology.update(v.ontology_id, v.document, validation_mode="strict")
+await client.ontology.activate(v2.id)                   # bind the version
+
+active = await client.ontology.get_active()
+print(active.document.domain.name, active.validation_mode)   # Healthcare strict
+----
+TypeScript::
++
+[source,typescript]
+----
+const v = await client.ontology.clone("healthcare");
+const v2 = await client.ontology.update({
+  id: v.ontologyId, schema: v.document!, validationMode: "strict",
+});
+await client.ontology.activate(v2.id);
+const active = await client.ontology.getActive();
+console.log(active.document.domain.name, active.validationMode);
+----
+======
+
+[IMPORTANT]
+====
+`clone` returns an `OntologyVersion`, so activate `v.id` (a version id, `ov_…`).
+Use `v.ontology_id` (`ont_…`) when calling `update`/`delete`.
+====
+
+== Choose a validation mode
+
+Pass `validation_mode` (Python) / `validationMode` (TS) to `create` or `update`.
+Omit it to inherit the server default (`permissive`). Under `strict`, a
+non-conforming entity write surfaces as `ValidationError` carrying the offending
+detail.
+
+== Verify with `get_active()`
+
+`get_active()` returns the parsed schema *plus* the active version's
+`validation_mode`, `revision`, and `version_id` (composed via a second lookup,
+since the service's active-ontology response carries no version metadata).
+
+== Await asynchronous extraction
+
+Extraction runs in a background pipeline, so entities are not searchable the
+instant a write returns. Await consistency explicitly:
+
+[source,python]
+----
+await client.long_term.add_entity("Jane Doe", entity_type="Patient")
+ready = await client.long_term.wait_for_extraction(
+    query="Jane Doe", expected_names=["Jane Doe"], timeout=30
+)
+----
+
+[NOTE]
+====
+On NAMS, entity search is vector / nearest-neighbor, so a `min_results`
+threshold is satisfied almost immediately on a non-empty workspace. Prefer
+`expected_names` (or a `predicate`) to confirm a *specific* extraction landed.
+====
+
+== See also
+
+* xref:explanation/ontologies.adoc[Explanation: Ontologies]
+* xref:reference/ontology-api.adoc[Reference: Ontology API]

--- a/docs/modules/ROOT/pages/reference/environment-variables.adoc
+++ b/docs/modules/ROOT/pages/reference/environment-variables.adoc
@@ -410,6 +410,13 @@ defaults to NAMS. Falls back to bolt when unset.
 | NAMS endpoint base URL. REST mode when the URL contains `/v\d+`.
 | `https://memory.neo4jlabs.com/v1`
 
+| `MEMORY_WORKSPACE_ID`
+| NAMS workspace id. Lifted into `NamsConfig.workspace_id` and sent as the
+`X-Workspace-Id` header on every request. Required by header-scoped
+deployments (e.g. staging); harmless on production (which encodes the
+workspace in the API key).
+| _unset_
+
 | `NAM_BACKEND`
 | Force the backend: `bolt` or `nams`. Overrides the
 `MEMORY_API_KEY`-based default.

--- a/docs/modules/ROOT/pages/reference/ontology-api.adoc
+++ b/docs/modules/ROOT/pages/reference/ontology-api.adoc
@@ -1,0 +1,93 @@
+= Ontology API reference
+:description: The client.ontology method surface, document schema, REST endpoints, and system templates.
+
+NAMS-backend only. All methods raise `NotSupportedError` on bolt.
+
+== Methods
+
+[cols="1,1,3",options="header"]
+|===
+| Python | TypeScript | Semantics
+
+| `ontology.list()` | `ontology.list()`
+| System templates + workspace-owned ontologies; the active one is flagged (`is_active`).
+| `ontology.get(id)` | `ontology.get(id)`
+| One ontology with its full revision history (`{record, versions[]}`).
+| `ontology.get_active()` | `ontology.getActive()`
+| Active version's parsed document + composed `validation_mode` / `revision` / `version_id`.
+| `ontology.clone(template_name)` | `ontology.clone(templateName)`
+| Editable workspace copy of a system template; returns the rev-1 version.
+| `ontology.create(name, schema, validation_mode=None)` | `ontology.create({name, schema, validationMode?})`
+| New workspace ontology from a schema document; returns the rev-1 version.
+| `ontology.update(id, schema, validation_mode=None)` | `ontology.update({id, schema, validationMode?})`
+| New immutable revision (n+1); returns it.
+| `ontology.activate(version_id)` | `ontology.activate(versionId)`
+| Bind a version; subsequent entity writes validate against it.
+| `ontology.delete(id)` | `ontology.delete(id)`
+| Delete a workspace-owned ontology.
+|===
+
+== Return types
+
+`list()` returns `OntologySummary[]`. `get()` returns `Ontology` (`{record,
+versions[]}`). `get_active()` returns `ActiveOntology`. `clone` / `create` /
+`update` / `activate` return an `OntologyVersion`.
+
+== Ontology document schema
+
+[cols="1,2,2",options="header"]
+|===
+| Field | Shape | Notes
+
+| `domain` | `{id, name, description?, tagline?, emoji?}` | Identity + display metadata.
+| `entity_types[]` | `{label, pole_type, subtype?, color?, icon?, properties[]}` | `pole_type` ∈ PERSON / ORGANIZATION / LOCATION / EVENT / OBJECT.
+| `…properties[]` | `{name, type, required?, unique?, enum?}` | `type` ∈ string / datetime / date / float / integer.
+| `relationships[]` | `{type, source, target}` | `type` is UPPER_SNAKE; `source`/`target` are entity labels.
+|===
+
+The `OntologyVersion` carries `id`, `ontology_id`, `revision`,
+`validation_mode` (`permissive` | `strict`), the parsed `document`,
+`schema_hash`, `created_at`, and `message`.
+
+== REST endpoints
+
+The SDK targets these workspace-scoped endpoints (under the versioned base, e.g.
+`/v1`). They are *not* in the published OpenAPI spec; the shapes are verified
+against the staging deployment. Request bodies use snake_case.
+
+[cols="1,3,2",options="header"]
+|===
+| Method | Path | Maps to
+
+| GET | `/ontologies` | `list()`
+| GET | `/ontologies/{id}` | `get()`
+| GET | `/ontologies/active` | `get_active()`
+| POST | `/ontologies/{name}/clone` | `clone()`
+| POST | `/ontologies` — body `{ontology, validation_mode?}` | `create()`
+| PUT | `/ontologies/{id}` — body `{ontology, validation_mode?}` | `update()`
+| POST | `/ontologies/active` — body `{version_id}` | `activate()`
+| DELETE | `/ontologies/{id}` | `delete()`
+|===
+
+== Errors
+
+[cols="1,2",options="header"]
+|===
+| Condition | Exception
+| Strict-mode validation rejection | `ValidationError` (carries the offending detail)
+| Ontology method on the bolt backend | `NotSupportedError` (workaround: `SchemaModel.CUSTOM`)
+| No active ontology bound | `NotSupportedError`
+|===
+
+== System templates
+
+~28 system templates ship on the service (each `is_system = true`, revision 1).
+`nams-default` is bound until a workspace activates its own:
+
+`agent-memory`, `conservation`, `cybersecurity`, `data-journalism`,
+`digital-twin`, `education`, `financial-services`, `gaming`, `genai-llm-ops`,
+`gis-cartography`, `golf-sports`, `government`, `healthcare`, `hospitality`,
+`legal`, `manufacturing`, `nams-default`, `oil-gas`, `options-intelligence`,
+`personal-knowledge`, `product-management`, `real-estate`, `retail-ecommerce`,
+`scientific-research`, `software-engineering`, `trip-planning`,
+`vacation-industry`, `wildlife-management`.

--- a/docs/modules/ROOT/pages/reference/rest-api.adoc
+++ b/docs/modules/ROOT/pages/reference/rest-api.adoc
@@ -9,6 +9,15 @@ Bridge-method names are what the link:https://github.com/neo4j-labs/agent-memory
 cross-language conformance suite uses. SDK methods take language-idiomatic
 casing.
 
+== Request headers
+
+Every request carries `Authorization: Bearer <api_key>`. Deployments that scope
+by header (e.g. the development/staging service) additionally require
+`X-Workspace-Id: <workspace_id>`; the SDK sends it automatically when
+`workspace_id` / `workspaceId` (or `MEMORY_WORKSPACE_ID`) is configured. On
+production the workspace is encoded in the API key and the header is optional.
+See xref:how-to/use-nams.adoc[Use NAMS].
+
 == Conversations
 
 [cols="2,3,1,1,1,1,1"]
@@ -72,6 +81,26 @@ casing.
 | `DELETE` | `/auth/api-keys/{id}` | `revoke_api_key` | `auth.revokeApiKey` | `Auth.RevokeAPIKey` | `auth.revoke_api_key` | `Auth.RevokeApiKeyAsync`
 | `GET` | `/auth/api-keys/{id}/reveal` | `reveal_api_key` | `auth.revealApiKey` | `Auth.RevealAPIKey` | `auth.reveal_api_key` | `Auth.RevealApiKeyAsync`
 | `POST` | `/auth/refresh` | `refresh_access_token` | `auth.refreshAccessToken` | `Auth.RefreshAccessToken` | `auth.refresh_access_token` | `Auth.RefreshAccessTokenAsync`
+|===
+
+== Ontologies
+
+Typed, versioned domain schemas. Workspace-scoped via `X-Workspace-Id`. Request
+bodies are snake_case. See xref:reference/ontology-api.adoc[Ontology API] for the
+document schema and validation modes.
+
+[cols="2,4,2,2"]
+|===
+| HTTP | Path | Python | TypeScript
+
+| `GET` | `/ontologies` | `ontology.list` | `ontology.list`
+| `GET` | `/ontologies/{id}` | `ontology.get` | `ontology.get`
+| `GET` | `/ontologies/active` | `ontology.get_active` | `ontology.getActive`
+| `POST` | `/ontologies/{name}/clone` | `ontology.clone` | `ontology.clone`
+| `POST` | `/ontologies` | `ontology.create` | `ontology.create`
+| `PUT` | `/ontologies/{id}` | `ontology.update` | `ontology.update`
+| `POST` | `/ontologies/active` | `ontology.activate` | `ontology.activate`
+| `DELETE` | `/ontologies/{id}` | `ontology.delete` | `ontology.delete`
 |===
 
 == Wire format differences

--- a/docs/modules/ROOT/pages/reference/typescript-api.adoc
+++ b/docs/modules/ROOT/pages/reference/typescript-api.adoc
@@ -68,6 +68,13 @@ const memory = new MemoryClient({
 |Bearer token for `Authorization` header.
 |`process.env.MEMORY_API_KEY`
 
+|`workspaceId`
+|`string`
+|NAMS workspace id, sent as the `X-Workspace-Id` header on every request.
+Required by header-scoped deployments (e.g. staging); harmless on production.
+An explicit `X-Workspace-Id` entry in `headers` overrides it.
+|`process.env.MEMORY_WORKSPACE_ID`
+
 |`tokenProvider`
 |`() => string \| Promise<string>`
 |Dynamic token source (OAuth refresh, AWS STS, etc.). Overrides `apiKey`.
@@ -308,6 +315,41 @@ TypeDoc: link:https://neo4j-labs.github.io/agent-memory/typescript/classes/Query
 |===
 
 TypeDoc: link:https://neo4j-labs.github.io/agent-memory/typescript/classes/AuthClient.html[`AuthClient`]
+
+== `client.ontology` — domain ontologies (hosted only)
+
+Typed, versioned, validated domain schemas. See
+xref:reference/ontology-api.adoc[Ontology API] and
+xref:how-to/use-ontologies.adoc[Use Ontologies].
+
+[cols="2,3", options="header"]
+|===
+|Method |Purpose
+
+|`list()`
+|System templates + workspace-owned ontologies (active flagged).
+
+|`get(id)`
+|One ontology with its full revision history.
+
+|`getActive()`
+|Active version's parsed document + composed `validationMode` / `revision` / `versionId`.
+
+|`clone(templateName)`
+|Editable workspace copy of a system template (rev 1).
+
+|`create({ name, schema, validationMode? })`
+|New workspace ontology from a schema document.
+
+|`update({ id, schema, validationMode? })`
+|New immutable revision.
+
+|`activate(versionId)`
+|Bind a version; subsequent entity writes validate against it.
+
+|`delete(id)`
+|Delete a workspace-owned ontology.
+|===
 
 == Errors
 

--- a/docs/modules/ROOT/pages/tutorials/ontology-quickstart.adoc
+++ b/docs/modules/ROOT/pages/tutorials/ontology-quickstart.adoc
@@ -1,0 +1,93 @@
+= Tutorial: Ontology quickstart
+:description: Clone the healthcare ontology, activate it strict, write a Patient, and watch typed extraction and a validation rejection.
+
+In this tutorial we will clone a domain ontology, activate it, and observe how
+the active schema shapes — and validates — what lands in the graph. We will use
+the hosted NAMS backend throughout.
+
+== Before you begin
+
+You need a NAMS endpoint, an API key, and (for header-scoped deployments) a
+workspace id. See xref:tutorials/nams-quickstart.adoc[NAMS Quickstart].
+
+[source,python]
+----
+from neo4j_agent_memory import MemoryClient, MemorySettings
+from neo4j_agent_memory.nams import NamsConfig
+
+settings = MemorySettings(
+    backend="nams",
+    nams=NamsConfig(
+        endpoint="https://nams.development.neo4jsandbox.com/v1",
+        api_key="nams_...",
+        workspace_id="your-workspace-id",
+    ),
+)
+----
+
+== Step 1 — Clone the healthcare template
+
+[source,python]
+----
+async with MemoryClient(settings) as client:
+    version = await client.ontology.clone("healthcare")
+    print(version.revision, len(version.document.entity_types))   # 1, e.g. 12
+----
+
+Cloning creates a workspace-owned `healthcare-clone` at revision 1.
+
+== Step 2 — Make it strict and activate it
+
+[source,python]
+----
+    strict = await client.ontology.update(
+        version.ontology_id, version.document, validation_mode="strict"
+    )
+    await client.ontology.activate(strict.id)
+
+    active = await client.ontology.get_active()
+    print(active.document.domain.name, active.validation_mode)    # Healthcare strict
+----
+
+== Step 3 — Write a Patient and watch typed extraction
+
+[source,python]
+----
+    await client.long_term.add_entity("Jane Doe", entity_type="Patient")
+    await client.long_term.wait_for_extraction(
+        query="Jane Doe", expected_names=["Jane Doe"], timeout=30
+    )
+    results = await client.long_term.search_entities("Jane Doe")
+    print(results[0].type)        # Patient — snapped to the typed schema
+----
+
+== Step 4 — Observe a validation rejection under strict
+
+Under `strict`, a write that violates the active schema is rejected:
+
+[source,python]
+----
+    from neo4j_agent_memory.core.exceptions import ValidationError
+    try:
+        await client.long_term.add_entity("Acme Clinic", entity_type="NotInSchema")
+    except ValidationError as e:
+        print("rejected:", e)
+----
+
+== Step 5 — Clean up
+
+[source,python]
+----
+    # Restore the default and remove the clone.
+    # (Re-activate whatever was active before, then delete.)
+    await client.ontology.delete(version.ontology_id)
+----
+
+== What you learned
+
+* Cloning a system template creates an editable, versioned, workspace-owned copy.
+* `activate` binds a *version*; `get_active()` reports its `validation_mode`.
+* Under `strict`, the service enforces the schema and the SDK raises
+  `ValidationError`.
+
+Next: xref:reference/ontology-api.adoc[the full Ontology API reference].

--- a/src/neo4j_agent_memory/__init__.py
+++ b/src/neo4j_agent_memory/__init__.py
@@ -402,6 +402,11 @@ class MemoryClient:
         self._reasoning: ReasoningProtocol | None = None
         self._query: CypherQueryProtocol | None = None
 
+        # Ontology accessor. Real (``NamsOntology``) on NAMS; a
+        # ``_NamsUnsupported`` sentinel on bolt (ontologies are a NAMS
+        # capability). Wired in connect().
+        self._ontology: Any = None
+
         # Bolt-only accessors. On NAMS these are replaced by ``_NamsUnsupported``
         # sentinels — but the declared type stays as the bolt class so user
         # code that type-checks against e.g. ``UserMemory`` continues to work
@@ -553,6 +558,17 @@ class MemoryClient:
 
         self._query = BoltCypherQuery(self._client)
 
+        # Ontologies are a NAMS capability — sentinel on bolt.
+        from neo4j_agent_memory.nams._unsupported import _NamsUnsupported
+
+        self._ontology = _NamsUnsupported(
+            accessor="ontology",
+            message="Ontologies (typed, validated, versioned domain schemas) are a "
+            "NAMS capability.",
+            workaround="On bolt, define a custom schema with SchemaModel.CUSTOM "
+            "(see client.schema / SchemaManager).",
+        )
+
     async def _connect_nams(self) -> None:
         """Connect to the hosted NAMS service via HTTP transport.
 
@@ -587,6 +603,7 @@ class MemoryClient:
         self._long_term = self._nams_backend.long_term
         self._reasoning = self._nams_backend.reasoning
         self._query = self._nams_backend.query
+        self._ontology = self._nams_backend.ontology
 
         # Bolt-only accessors → sentinels that raise on method call.
         self._users = _NamsUnsupported(
@@ -709,6 +726,20 @@ class MemoryClient:
         if self._nams_backend is not None:
             return self._nams_backend.transport.is_open
         return self._client is not None and self._client.is_connected
+
+    @property
+    def backend(self) -> str:
+        """The resolved storage backend — ``"bolt"`` or ``"nams"``.
+
+        Useful for backend-aware integration code (e.g. the Google ADK
+        memory service, which scopes searches differently on NAMS).
+        """
+        return self._settings.backend or "bolt"
+
+    @property
+    def is_nams(self) -> bool:
+        """``True`` when the hosted NAMS backend is active."""
+        return self._settings.backend == "nams"
 
     @property
     def short_term(self) -> ShortTermMemory:
@@ -867,6 +898,32 @@ class MemoryClient:
         if self._query is None:
             raise NotConnectedError("Client not connected. Use 'async with' or call connect().")
         return self._query
+
+    @property
+    def ontology(self) -> Any:
+        """Ontology lifecycle accessor — **NAMS only**.
+
+        Returns the :class:`~neo4j_agent_memory.nams.ontology.NamsOntology`
+        accessor on NAMS, exposing ``list``, ``get``, ``get_active``,
+        ``clone``, ``create``, ``update``, ``activate``, and ``delete``.
+
+        On bolt, returns a sentinel whose method calls raise
+        :class:`NotSupportedError` (define a custom schema with
+        ``SchemaModel.CUSTOM`` instead).
+
+        Example::
+
+            async with MemoryClient(settings) as client:
+                v = await client.ontology.clone("healthcare")
+                await client.ontology.activate(v.id)
+                active = await client.ontology.get_active()
+
+        Raises:
+            NotConnectedError: If client is not connected.
+        """
+        if self._ontology is None:
+            raise NotConnectedError("Client not connected. Use 'async with' or call connect().")
+        return self._ontology
 
     @property
     def graph(self) -> "Neo4jClient":

--- a/src/neo4j_agent_memory/config/settings.py
+++ b/src/neo4j_agent_memory/config/settings.py
@@ -507,6 +507,15 @@ class NamsConfig(BaseModel):
         description="NAMS API key (format 'nams_...'). When constructed via "
         "MemorySettings, an unset value may be populated from MEMORY_API_KEY.",
     )
+    workspace_id: str | None = Field(
+        default=None,
+        description="NAMS workspace id. When set, transmitted as the 'X-Workspace-Id' "
+        "header on every request — required by deployments that scope by header "
+        "(e.g. the development/staging service) rather than encoding the workspace "
+        "in the API key (production). Optional and harmless when unset. When "
+        "constructed via MemorySettings, an unset value may be populated from "
+        "MEMORY_WORKSPACE_ID.",
+    )
     timeout: float = Field(default=30.0, gt=0, description="HTTP request timeout in seconds.")
     max_retries: int = Field(
         default=3,
@@ -759,6 +768,10 @@ class MemorySettings(BaseSettings):
         env_endpoint = os.environ.get("MEMORY_ENDPOINT")
         if env_endpoint and "endpoint" not in self.nams.model_fields_set:
             self.nams.endpoint = env_endpoint
+
+        env_workspace = os.environ.get("MEMORY_WORKSPACE_ID")
+        if env_workspace and self.nams.workspace_id is None:
+            self.nams.workspace_id = env_workspace
 
         # Step 2 & 3: resolve backend if user didn't pin it.
         if self.backend is None:

--- a/src/neo4j_agent_memory/core/protocols.py
+++ b/src/neo4j_agent_memory/core/protocols.py
@@ -219,6 +219,16 @@ class LongTermProtocol(Protocol):
         """Vector/keyword search across entities."""
         ...
 
+    async def wait_for_extraction(self, **kwargs: Any) -> bool:
+        """Await async entity extraction (NAMS) or no-op (bolt).
+
+        Returns ``True`` once extraction has caught up (or immediately on
+        bolt), ``False`` on timeout. See the NAMS implementation for the
+        full keyword surface (``query``, ``expected_names``, ``min_results``,
+        ``predicate``, ``timeout``, ``interval``).
+        """
+        ...
+
     async def search_preferences(
         self,
         query: str,

--- a/src/neo4j_agent_memory/integrations/google_adk/memory_service.py
+++ b/src/neo4j_agent_memory/integrations/google_adk/memory_service.py
@@ -118,6 +118,10 @@ class Neo4jMemoryService(BaseMemoryService):
         self._include_entities = include_entities
         self._include_preferences = include_preferences
         self._extract_on_store = extract_on_store
+        # Last session written/added to. ADK's search_memory() carries no
+        # session id, but NAMS message search is conversation-scoped — we
+        # thread this through so searches stay scoped on NAMS (issue #130).
+        self._current_session_id: str | None = None
 
     @property
     def user_id(self) -> str | None:
@@ -155,6 +159,10 @@ class Neo4jMemoryService(BaseMemoryService):
                 session_id = session.get("id", "default")
             else:
                 session_id = "default"
+
+        # Remember the active session so search_memory() can scope to it
+        # (NAMS message search is conversation-scoped — issue #130).
+        self._current_session_id = session_id
 
         # Extract messages from session
         messages = self._extract_messages(session)
@@ -207,15 +215,39 @@ class Neo4jMemoryService(BaseMemoryService):
         """
         results: list[MemoryEntry] = []
 
+        # Resolve a session to scope message search. NAMS requires it; bolt
+        # treats it as an optional filter. Caller-supplied kwarg wins over the
+        # tracked session (issue #130, defect 1).
+        session_id = kwargs.get("session_id") or self._current_session_id
+
         try:
-            # Search messages
-            messages = await self._client.short_term.search_messages(
-                query=query,
-                limit=limit,
-                threshold=threshold,
-            )
-            for msg in messages:
-                results.append(message_to_memory_entry(msg))
+            # Search messages — conversation-scoped on NAMS.
+            if session_id is not None:
+                messages = await self._client.short_term.search_messages(
+                    query=query,
+                    session_id=session_id,
+                    limit=limit,
+                    threshold=threshold,
+                )
+                for msg in messages:
+                    results.append(message_to_memory_entry(msg))
+            elif self._client.backend == "nams":
+                # No session context and NAMS can't do unscoped message search.
+                # Skip messages and rely on entity/preference recall (which are
+                # workspace-scoped and genuinely cross-session).
+                logger.debug(
+                    "search_memory: no session id on NAMS — skipping message "
+                    "search; entities/preferences still searched."
+                )
+            else:
+                # Bolt: unscoped message search is supported.
+                messages = await self._client.short_term.search_messages(
+                    query=query,
+                    limit=limit,
+                    threshold=threshold,
+                )
+                for msg in messages:
+                    results.append(message_to_memory_entry(msg))
 
             # Search entities if enabled
             if self._include_entities:
@@ -319,6 +351,7 @@ class Neo4jMemoryService(BaseMemoryService):
         """
         try:
             if memory_type == "message":
+                self._current_session_id = session_id
                 msg = await self._client.short_term.add_message(
                     session_id=session_id,
                     role=role,
@@ -364,23 +397,24 @@ class Neo4jMemoryService(BaseMemoryService):
         """Extract plain text from ADK Content/Parts objects or strings.
 
         ADK v1.x uses google.genai.types.Content objects with a `.parts` list,
-        where each Part may have `.text`, `.function_call`, etc.
+        where each Part may carry `.text`, `.function_call`, `.function_response`,
+        etc. We ingest **only** the text parts. Tool events (function calls /
+        responses) carry no `.text`, so they yield an empty string and the
+        caller skips them — they must never be ``str()``-ified into the entity
+        pipeline, where the JSON noise breaks server-side extraction and yields
+        empty knowledge graphs (issue #130, defect 2).
 
         Args:
             content: A string, Content object, or other content type.
 
         Returns:
-            Extracted text as a string.
+            The joined text parts, or ``""`` when there is no text to ingest.
         """
         if isinstance(content, str):
             return content
-        if hasattr(content, "parts"):
-            texts = []
-            for part in content.parts:
-                if hasattr(part, "text") and part.text:
-                    texts.append(part.text)
-            return "\n".join(texts) if texts else str(content)
-        return str(content)
+        parts = getattr(content, "parts", None) or []
+        texts = [part.text for part in parts if getattr(part, "text", None)]
+        return "\n".join(texts)
 
     def _extract_messages(self, session: Any) -> list[SessionMessage]:
         """Extract messages from various session formats.
@@ -425,6 +459,10 @@ class Neo4jMemoryService(BaseMemoryService):
             for msg in session.messages:
                 if hasattr(msg, "role") and hasattr(msg, "content"):
                     text = self._extract_text_from_content(msg.content)
+                    if not text:
+                        # Tool-only event (function call/response) — skip so its
+                        # JSON noise never reaches the entity pipeline (#130).
+                        continue
                     role_val = msg.role
                     role = str(role_val.value) if hasattr(role_val, "value") else str(role_val)
                     messages.append(

--- a/src/neo4j_agent_memory/memory/long_term.py
+++ b/src/neo4j_agent_memory/memory/long_term.py
@@ -1051,6 +1051,18 @@ class LongTermMemory(BaseMemory[Entity]):
 
         return entities
 
+    async def wait_for_extraction(self, **kwargs: Any) -> bool:
+        """No-op readiness check — bolt extraction is synchronous.
+
+        On the bolt backend, entity extraction completes inline with the
+        write, so entities are searchable immediately. This method exists
+        for parity with the NAMS backend (where extraction is async); it
+        always returns ``True`` without polling. See
+        ``NamsLongTermMemory.wait_for_extraction`` for the parameters it
+        accepts on NAMS.
+        """
+        return True
+
     async def search_preferences(
         self,
         query: str,

--- a/src/neo4j_agent_memory/nams/__init__.py
+++ b/src/neo4j_agent_memory/nams/__init__.py
@@ -28,6 +28,19 @@ from neo4j_agent_memory.nams.endpoints import (
     expand_path,
 )
 from neo4j_agent_memory.nams.long_term import NamsLongTermMemory
+from neo4j_agent_memory.nams.ontology import (
+    ActiveOntology,
+    DomainInfo,
+    EntityTypeDef,
+    NamsOntology,
+    Ontology,
+    OntologyDocument,
+    OntologyRecord,
+    OntologySummary,
+    OntologyVersion,
+    PropertyDef,
+    RelationshipDef,
+)
 from neo4j_agent_memory.nams.query import NamsCypherQuery
 from neo4j_agent_memory.nams.reasoning import NamsReasoningMemory
 from neo4j_agent_memory.nams.short_term import NamsShortTermMemory
@@ -53,4 +66,16 @@ __all__ = [
     "NamsReasoningMemory",
     # Cypher accessor (v0.4 Phase 4)
     "NamsCypherQuery",
+    # Ontology surface (v0.5)
+    "NamsOntology",
+    "Ontology",
+    "OntologySummary",
+    "OntologyVersion",
+    "OntologyRecord",
+    "OntologyDocument",
+    "ActiveOntology",
+    "DomainInfo",
+    "EntityTypeDef",
+    "PropertyDef",
+    "RelationshipDef",
 ]

--- a/src/neo4j_agent_memory/nams/client.py
+++ b/src/neo4j_agent_memory/nams/client.py
@@ -22,6 +22,7 @@ from typing import TYPE_CHECKING
 from neo4j_agent_memory.config.settings import NamsConfig
 from neo4j_agent_memory.nams.auth import AuthProvider, StaticApiKeyAuth
 from neo4j_agent_memory.nams.long_term import NamsLongTermMemory
+from neo4j_agent_memory.nams.ontology import NamsOntology
 from neo4j_agent_memory.nams.query import NamsCypherQuery
 from neo4j_agent_memory.nams.reasoning import NamsReasoningMemory
 from neo4j_agent_memory.nams.short_term import NamsShortTermMemory
@@ -47,6 +48,7 @@ class NamsBackend:
         self._long_term = NamsLongTermMemory(transport)
         self._reasoning = NamsReasoningMemory(transport)
         self._query = NamsCypherQuery(transport)
+        self._ontology = NamsOntology(transport)
 
     # ------------------------------------------------------------------ ctors
 
@@ -110,6 +112,11 @@ class NamsBackend:
     def query(self) -> NamsCypherQuery:
         """Read-only Cypher accessor (NAMS Platinum ``POST /v1/query``)."""
         return self._query
+
+    @property
+    def ontology(self) -> NamsOntology:
+        """Ontology lifecycle accessor (``client.ontology``)."""
+        return self._ontology
 
     # ----------------------------------------------------------------- probe
 

--- a/src/neo4j_agent_memory/nams/long_term.py
+++ b/src/neo4j_agent_memory/nams/long_term.py
@@ -211,9 +211,7 @@ class NamsLongTermMemory:
         """
         et = entity_type or kwargs.get("type") or kwargs.get("label")
         if et is None:
-            raise TypeError(
-                "add_entity requires entity_type (aliases: type, label)."
-            )
+            raise TypeError("add_entity requires entity_type (aliases: type, label).")
         body = _drop_none(
             {
                 "name": name,

--- a/src/neo4j_agent_memory/nams/long_term.py
+++ b/src/neo4j_agent_memory/nams/long_term.py
@@ -29,6 +29,9 @@ NAMS-specific endpoint shapes vs. our Protocol:
 
 from __future__ import annotations
 
+import asyncio
+import time
+from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 from uuid import UUID
 
@@ -195,20 +198,26 @@ class NamsLongTermMemory:
     async def add_entity(
         self,
         name: str,
-        entity_type: str,
+        entity_type: str | None = None,
         **kwargs: Any,
     ) -> Entity:
         """Create an entity on NAMS.
 
-        NAMS accepts only ``{name, type, description?}`` per spec.
-        Bolt-only kwargs (``subtype``, ``aliases``, ``attributes``,
-        ``confidence``, ``deduplicate``, ``geocode``, ``enrich``, etc.)
-        are silently dropped.
+        ``entity_type`` is canonical; ``type`` and ``label`` are accepted
+        as aliases (``entity_type`` wins). NAMS accepts only
+        ``{name, type, description?}`` per spec. Bolt-only kwargs
+        (``subtype``, ``aliases``, ``attributes``, ``confidence``,
+        ``deduplicate``, ``geocode``, ``enrich``, etc.) are silently dropped.
         """
+        et = entity_type or kwargs.get("type") or kwargs.get("label")
+        if et is None:
+            raise TypeError(
+                "add_entity requires entity_type (aliases: type, label)."
+            )
         body = _drop_none(
             {
                 "name": name,
-                "type": _to_nams_type(entity_type),
+                "type": _to_nams_type(et),
                 "description": kwargs.get("description"),
             }
         )
@@ -261,7 +270,9 @@ class NamsLongTermMemory:
         body = _drop_none(
             {
                 "query": query,
-                "type": _to_nams_type(kwargs.get("entity_type") or kwargs.get("type")),
+                "type": _to_nams_type(
+                    kwargs.get("entity_type") or kwargs.get("type") or kwargs.get("label")
+                ),
                 "limit": kwargs.get("limit"),
             }
         )
@@ -274,6 +285,70 @@ class NamsLongTermMemory:
         else:
             items = []
         return [payload_to_model(_normalize_entity(item), Entity) for item in items]
+
+    async def wait_for_extraction(
+        self,
+        *,
+        query: str | None = None,
+        expected_names: list[str] | None = None,
+        min_results: int = 1,
+        predicate: Callable[[list[Entity]], bool] | None = None,
+        timeout: float = 30.0,
+        interval: float = 1.0,
+        session_id: str | None = None,  # noqa: ARG002 — reserved; see below
+        **kwargs: Any,
+    ) -> bool:
+        """Poll entity search until extraction has caught up, or time out.
+
+        NAMS extracts entities in a background pipeline, so writes return
+        before the entities are searchable. This helper lets application
+        and test code await consistency explicitly instead of racing a
+        fixed sleep.
+
+        Provide one of:
+
+        * ``predicate`` — called with the current search results; return
+          ``True`` when satisfied.
+        * ``expected_names`` — succeed once every name appears in results
+          (case-insensitive). **Recommended** on NAMS.
+        * otherwise — succeed once at least ``min_results`` entities match.
+          Note: NAMS entity search is vector/nearest-neighbor and returns
+          the top-k existing entities regardless of relevance, so on a
+          non-empty workspace ``min_results=1`` is satisfied almost
+          immediately. Prefer ``expected_names`` or ``predicate`` when you
+          need to confirm a *specific* extraction landed.
+
+        ``query`` is the search string to poll; if omitted, the first of
+        ``expected_names`` is used. Returns ``True`` if satisfied within
+        ``timeout`` seconds, ``False`` otherwise (it does **not** raise,
+        so callers can branch or skip gracefully).
+
+        ``session_id`` is accepted but reserved: NAMS entity search is
+        workspace-scoped, not conversation-scoped, so it currently has no
+        effect. It is part of the signature for forward-compatibility.
+        """
+        q = query if query is not None else (expected_names[0] if expected_names else None)
+        if q is None and predicate is None:
+            raise ValueError(
+                "wait_for_extraction requires one of: query, expected_names, or predicate."
+            )
+        want = [n.lower() for n in (expected_names or [])]
+        fetch = max(min_results, len(want), kwargs.get("limit") or 10)
+        deadline = time.monotonic() + timeout
+        while True:
+            results = await self.search_entities(query=q or "", limit=fetch)
+            if predicate is not None:
+                ok = predicate(results)
+            elif want:
+                found = {e.name.lower() for e in results}
+                ok = all(name in found for name in want)
+            else:
+                ok = len(results) >= min_results
+            if ok:
+                return True
+            if time.monotonic() >= deadline:
+                return False
+            await asyncio.sleep(interval)
 
     async def search_preferences(self, query: str, **kwargs: Any) -> list[Preference]:
         raise NotSupportedError(

--- a/src/neo4j_agent_memory/nams/ontology.py
+++ b/src/neo4j_agent_memory/nams/ontology.py
@@ -204,7 +204,9 @@ def _parse_version(raw: dict[str, Any]) -> OntologyVersion:
 # Endpoint specs (REST-only — ontology is a hosted-NAMS capability).
 # -----------------------------------------------------------------------------
 
-_SPEC_LIST = EndpointSpec(rest_method="GET", rest_path="/ontologies", bridge_method="list_ontologies")
+_SPEC_LIST = EndpointSpec(
+    rest_method="GET", rest_path="/ontologies", bridge_method="list_ontologies"
+)
 _SPEC_GET = EndpointSpec(
     rest_method="GET", rest_path="/ontologies/{id}", bridge_method="get_ontology"
 )
@@ -273,7 +275,9 @@ class NamsOntology:
         payload = await self._transport.request(_SPEC_GET, path_params={"id": ontology_id})
         payload = payload or {}
         record = payload.get("record") or {}
-        versions = [_parse_version(v) for v in (payload.get("versions") or []) if isinstance(v, dict)]
+        versions = [
+            _parse_version(v) for v in (payload.get("versions") or []) if isinstance(v, dict)
+        ]
         return Ontology(record=OntologyRecord.model_validate(record), versions=versions)
 
     async def get_active(self) -> ActiveOntology:
@@ -316,9 +320,7 @@ class NamsOntology:
     async def clone(self, template_name: str) -> OntologyVersion:
         """Clone a system template into an editable workspace copy (revision 1)."""
         self._guard_rest()
-        payload = await self._transport.request(
-            _SPEC_CLONE, path_params={"name": template_name}
-        )
+        payload = await self._transport.request(_SPEC_CLONE, path_params={"name": template_name})
         return _parse_version(payload or {})
 
     async def create(
@@ -361,9 +363,7 @@ class NamsOntology:
     async def activate(self, version_id: str) -> OntologyVersion:
         """Bind a version; subsequent entity writes validate against it."""
         self._guard_rest()
-        payload = await self._transport.request(
-            _SPEC_ACTIVATE, json={"version_id": version_id}
-        )
+        payload = await self._transport.request(_SPEC_ACTIVATE, json={"version_id": version_id})
         return _parse_version(payload or {})
 
     async def delete(self, ontology_id: str) -> None:

--- a/src/neo4j_agent_memory/nams/ontology.py
+++ b/src/neo4j_agent_memory/nams/ontology.py
@@ -1,0 +1,403 @@
+"""NAMS ontology surface — typed domain schemas extending POLE+O.
+
+An *ontology* is a versioned, validated, typed schema for the knowledge
+graph: entity types (each mapped onto a POLE+O ``pole_type``) with typed
+properties (``required`` / ``unique`` / ``enum`` constraints) and typed
+relationships. NAMS ships ~28 system templates and supports
+workspace-owned ontologies with immutable revisions, activation, and a
+per-version ``validation_mode`` (``permissive`` records non-conforming
+writes; ``strict`` rejects them).
+
+This module exposes :class:`NamsOntology` — the ``client.ontology``
+accessor — plus the Pydantic models that hide the wire shape (notably the
+double-encoded ``schema_json`` string the service returns, which we parse
+into :class:`OntologyDocument`).
+
+Contract note
+=============
+
+The ontology endpoints are **not** documented in the staging OpenAPI;
+the routes and payloads below were verified empirically against the
+development/staging deployment:
+
+* ``GET    /ontologies``                          → list (summaries)
+* ``GET    /ontologies/{id}``                      → ``{record, versions[]}``
+* ``GET    /ontologies/active``                    → ``{ontology, version}``
+* ``POST   /ontologies/{name}/clone``              → version (template name in path)
+* ``POST   /ontologies``  body ``{ontology, validation_mode?}`` → version
+* ``PUT    /ontologies/{id}``  body ``{ontology, validation_mode?}`` → new revision
+* ``POST   /ontologies/active``  body ``{version_id}``          → version
+* ``DELETE /ontologies/{id}``                       → 204
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING, Annotated, Any
+
+from pydantic import BaseModel, BeforeValidator, ConfigDict, Field
+
+from neo4j_agent_memory.core.exceptions import NotSupportedError
+from neo4j_agent_memory.nams.endpoints import EndpointSpec
+
+if TYPE_CHECKING:
+    from neo4j_agent_memory.nams.transport import HttpTransport
+
+
+def _none_to_list(v: Any) -> Any:
+    """Coerce a ``null`` collection to ``[]`` (the service emits null for empty)."""
+    return [] if v is None else v
+
+
+# -----------------------------------------------------------------------------
+# Models — lenient (extra="ignore") so server additions don't break parsing.
+# -----------------------------------------------------------------------------
+
+
+class _Lenient(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+
+class PropertyDef(_Lenient):
+    """A typed property on an entity type."""
+
+    name: str
+    type: str  # string | datetime | date | float | integer
+    required: bool = False
+    unique: bool = False
+    enum: list[str] | None = None
+
+
+class EntityTypeDef(_Lenient):
+    """A typed entity in the ontology, mapped onto a POLE+O ``pole_type``."""
+
+    label: str
+    pole_type: str  # PERSON | ORGANIZATION | LOCATION | EVENT | OBJECT
+    subtype: str | None = None
+    color: str | None = None
+    icon: str | None = None
+    properties: Annotated[list[PropertyDef], BeforeValidator(_none_to_list)] = Field(
+        default_factory=list
+    )
+
+
+class RelationshipDef(_Lenient):
+    """A typed relationship between two entity labels."""
+
+    type: str  # UPPER_SNAKE
+    source: str
+    target: str
+
+
+class DomainInfo(_Lenient):
+    """Display + identity metadata for an ontology."""
+
+    id: str
+    name: str
+    description: str | None = None
+    tagline: str | None = None
+    emoji: str | None = None
+
+
+class OntologyDocument(_Lenient):
+    """The parsed schema body — domain + entity types + relationships."""
+
+    domain: DomainInfo
+    entity_types: Annotated[list[EntityTypeDef], BeforeValidator(_none_to_list)] = Field(
+        default_factory=list
+    )
+    relationships: Annotated[list[RelationshipDef], BeforeValidator(_none_to_list)] = Field(
+        default_factory=list
+    )
+
+
+class OntologySummary(_Lenient):
+    """One row from ``list()`` — system templates + workspace-owned."""
+
+    id: str
+    name: str
+    display_name: str | None = None
+    description: str | None = None
+    emoji: str | None = None
+    tagline: str | None = None
+    is_system: bool = False
+    current_revision: int | None = None
+    is_active: bool = False
+
+
+class OntologyVersion(_Lenient):
+    """An immutable ontology revision. ``document`` is the parsed schema.
+
+    The field is named ``document`` (not ``schema``) to avoid shadowing
+    Pydantic's reserved ``BaseModel.schema``.
+    """
+
+    id: str
+    ontology_id: str
+    revision: int
+    validation_mode: str  # permissive | strict
+    document: OntologyDocument | None = None
+    schema_hash: str | None = None
+    created_at: str | None = None
+    message: str | None = None
+
+
+class OntologyRecord(_Lenient):
+    """Identity row for a workspace-owned or system ontology."""
+
+    id: str
+    name: str
+    description: str | None = None
+    workspace_id: str | None = None
+    is_system: bool = False
+    created_at: str | None = None
+
+
+class Ontology(_Lenient):
+    """A single ontology with its full revision history."""
+
+    record: OntologyRecord
+    versions: list[OntologyVersion] = Field(default_factory=list)
+
+
+class ActiveOntology(_Lenient):
+    """The currently-bound ontology, with version metadata composed in.
+
+    ``validation_mode`` / ``revision`` / ``version_id`` are populated by a
+    second lookup (the ``/ontologies/active`` response itself carries no
+    version metadata).
+    """
+
+    document: OntologyDocument
+    validation_mode: str | None = None
+    revision: int | None = None
+    ontology_id: str | None = None
+    version_id: str | None = None
+
+
+# -----------------------------------------------------------------------------
+# Parsing helpers
+# -----------------------------------------------------------------------------
+
+
+def _parse_document(raw: Any) -> OntologyDocument | None:
+    if raw is None:
+        return None
+    if isinstance(raw, str):
+        try:
+            raw = json.loads(raw)
+        except (ValueError, TypeError):
+            return None
+    if isinstance(raw, dict):
+        return OntologyDocument.model_validate(raw)
+    return None
+
+
+def _parse_version(raw: dict[str, Any]) -> OntologyVersion:
+    data = dict(raw)
+    schema_json = data.pop("schema_json", None)
+    doc = _parse_document(schema_json) if schema_json is not None else None
+    return OntologyVersion.model_validate({**data, "document": doc})
+
+
+# -----------------------------------------------------------------------------
+# Endpoint specs (REST-only — ontology is a hosted-NAMS capability).
+# -----------------------------------------------------------------------------
+
+_SPEC_LIST = EndpointSpec(rest_method="GET", rest_path="/ontologies", bridge_method="list_ontologies")
+_SPEC_GET = EndpointSpec(
+    rest_method="GET", rest_path="/ontologies/{id}", bridge_method="get_ontology"
+)
+_SPEC_GET_ACTIVE = EndpointSpec(
+    rest_method="GET", rest_path="/ontologies/active", bridge_method="get_active_ontology"
+)
+_SPEC_CLONE = EndpointSpec(
+    rest_method="POST", rest_path="/ontologies/{name}/clone", bridge_method="clone_ontology"
+)
+_SPEC_CREATE = EndpointSpec(
+    rest_method="POST", rest_path="/ontologies", bridge_method="create_ontology"
+)
+_SPEC_UPDATE = EndpointSpec(
+    rest_method="PUT", rest_path="/ontologies/{id}", bridge_method="update_ontology"
+)
+_SPEC_ACTIVATE = EndpointSpec(
+    rest_method="POST", rest_path="/ontologies/active", bridge_method="activate_ontology"
+)
+_SPEC_DELETE = EndpointSpec(
+    rest_method="DELETE", rest_path="/ontologies/{id}", bridge_method="delete_ontology"
+)
+
+
+# -----------------------------------------------------------------------------
+# Accessor
+# -----------------------------------------------------------------------------
+
+
+class NamsOntology:
+    """``client.ontology`` — the NAMS ontology lifecycle.
+
+    Lifecycle::
+
+        v = await client.ontology.clone("healthcare")   # editable copy, rev 1
+        # v = await client.ontology.update(v.ontology_id, schema=doc)  # -> rev 2
+        await client.ontology.activate(v.id)             # bind the version
+        active = await client.ontology.get_active()      # parsed body + mode
+
+    From activation onward, server-side extraction validates entity writes
+    against the active schema (``strict`` rejects non-conforming writes →
+    :class:`ValidationError`).
+    """
+
+    def __init__(self, transport: HttpTransport) -> None:
+        self._transport = transport
+
+    def _guard_rest(self) -> None:
+        if self._transport.protocol != "rest":
+            raise NotSupportedError(
+                backend="nams",
+                method="ontology",
+                message="The ontology surface requires the REST transport (a /vN "
+                "endpoint); it is not available over the TCK bridge.",
+            )
+
+    async def list(self) -> list[OntologySummary]:
+        """List system templates + workspace-owned ontologies (active flagged)."""
+        self._guard_rest()
+        payload = await self._transport.request(_SPEC_LIST)
+        items = payload.get("ontologies", []) if isinstance(payload, dict) else (payload or [])
+        return [OntologySummary.model_validate(i) for i in items if isinstance(i, dict)]
+
+    async def get(self, ontology_id: str) -> Ontology:
+        """Return one ontology with its full revision history."""
+        self._guard_rest()
+        payload = await self._transport.request(_SPEC_GET, path_params={"id": ontology_id})
+        payload = payload or {}
+        record = payload.get("record") or {}
+        versions = [_parse_version(v) for v in (payload.get("versions") or []) if isinstance(v, dict)]
+        return Ontology(record=OntologyRecord.model_validate(record), versions=versions)
+
+    async def get_active(self) -> ActiveOntology:
+        """Return the active ontology's parsed body + composed version metadata.
+
+        ``GET /ontologies/active`` returns the schema body but no version
+        metadata, so we resolve the active ontology id (via the ``is_active``
+        flag from :meth:`list`) and read its current version to surface
+        ``validation_mode`` / ``revision`` / ``version_id``.
+        """
+        self._guard_rest()
+        payload = await self._transport.request(_SPEC_GET_ACTIVE)
+        payload = payload or {}
+        body = payload.get("ontology") or payload
+        document = _parse_document(body)
+        if document is None:
+            raise NotSupportedError(
+                backend="nams",
+                method="ontology.get_active",
+                message="No active ontology bound for this workspace.",
+            )
+
+        active = ActiveOntology(document=document)
+        # Compose version metadata via a second lookup.
+        summaries = await self.list()
+        match = next((s for s in summaries if s.is_active), None)
+        if match is None:
+            # Fall back to matching the active document's domain id to a name.
+            match = next((s for s in summaries if s.name == document.domain.id), None)
+        if match is not None:
+            active.ontology_id = match.id
+            detail = await self.get(match.id)
+            current = _current_version(detail, match.current_revision)
+            if current is not None:
+                active.validation_mode = current.validation_mode
+                active.revision = current.revision
+                active.version_id = current.id
+        return active
+
+    async def clone(self, template_name: str) -> OntologyVersion:
+        """Clone a system template into an editable workspace copy (revision 1)."""
+        self._guard_rest()
+        payload = await self._transport.request(
+            _SPEC_CLONE, path_params={"name": template_name}
+        )
+        return _parse_version(payload or {})
+
+    async def create(
+        self,
+        name: str,  # noqa: ARG002 — identity comes from schema.domain; kept for ergonomics/docs
+        schema: OntologyDocument | dict[str, Any],
+        *,
+        validation_mode: str | None = None,
+    ) -> OntologyVersion:
+        """Create a new workspace ontology from a schema body (revision 1).
+
+        ``name`` is accepted for API symmetry but the ontology's identity
+        comes from ``schema.domain`` (NAMS reads ``domain.id`` / ``domain.name``).
+        """
+        self._guard_rest()
+        doc = _as_document_dict(schema)
+        body: dict[str, Any] = {"ontology": doc}
+        if validation_mode is not None:
+            body["validation_mode"] = validation_mode
+        payload = await self._transport.request(_SPEC_CREATE, json=body)
+        return _parse_version(payload or {})
+
+    async def update(
+        self,
+        ontology_id: str,
+        schema: OntologyDocument | dict[str, Any],
+        *,
+        validation_mode: str | None = None,
+    ) -> OntologyVersion:
+        """Create a new immutable revision (n+1) from an updated schema body."""
+        self._guard_rest()
+        body: dict[str, Any] = {"ontology": _as_document_dict(schema)}
+        if validation_mode is not None:
+            body["validation_mode"] = validation_mode
+        payload = await self._transport.request(
+            _SPEC_UPDATE, path_params={"id": ontology_id}, json=body
+        )
+        return _parse_version(payload or {})
+
+    async def activate(self, version_id: str) -> OntologyVersion:
+        """Bind a version; subsequent entity writes validate against it."""
+        self._guard_rest()
+        payload = await self._transport.request(
+            _SPEC_ACTIVATE, json={"version_id": version_id}
+        )
+        return _parse_version(payload or {})
+
+    async def delete(self, ontology_id: str) -> None:
+        """Delete a workspace-owned ontology."""
+        self._guard_rest()
+        await self._transport.request(_SPEC_DELETE, path_params={"id": ontology_id})
+
+
+def _current_version(ontology: Ontology, revision: int | None) -> OntologyVersion | None:
+    if not ontology.versions:
+        return None
+    if revision is not None:
+        for v in ontology.versions:
+            if v.revision == revision:
+                return v
+    return max(ontology.versions, key=lambda v: v.revision)
+
+
+def _as_document_dict(schema: OntologyDocument | dict[str, Any]) -> dict[str, Any]:
+    if isinstance(schema, OntologyDocument):
+        return schema.model_dump(exclude_none=True)
+    return schema
+
+
+__all__ = [
+    "NamsOntology",
+    "Ontology",
+    "OntologySummary",
+    "OntologyVersion",
+    "OntologyRecord",
+    "OntologyDocument",
+    "ActiveOntology",
+    "DomainInfo",
+    "EntityTypeDef",
+    "PropertyDef",
+    "RelationshipDef",
+]

--- a/src/neo4j_agent_memory/nams/short_term.py
+++ b/src/neo4j_agent_memory/nams/short_term.py
@@ -193,6 +193,32 @@ def _normalize_conversation(
 # -----------------------------------------------------------------------------
 
 
+def _resolve_conversation_id(
+    session_id: str | None,
+    conversation_id: str | None,
+    *,
+    method: str,
+    error_type: type[Exception] = TypeError,
+) -> str:
+    """Resolve the conversation/session id for a NAMS short-term call.
+
+    NAMS is conversation-scoped (the REST API addresses
+    ``/conversations/{id}``). The SDK's canonical parameter is
+    ``session_id``; ``conversation_id`` is accepted as an alias. When both
+    are supplied, ``session_id`` wins. When neither is supplied, a single
+    clear error naming both is raised — ``TypeError`` for write CRUD,
+    ``ValueError`` for search/context (preserving the historical contract).
+    """
+    conv = session_id if session_id is not None else conversation_id
+    if conv is None:
+        raise error_type(
+            f"{method} requires session_id (alias: conversation_id) on NAMS — the "
+            "API is conversation-scoped. Pass session_id=... to scope the call."
+        )
+    return conv
+
+
+
 class NamsShortTermMemory:
     """Short-term memory backed by the NAMS HTTP service.
 
@@ -209,44 +235,53 @@ class NamsShortTermMemory:
 
     async def add_message(
         self,
-        session_id: str,
-        role: str,
-        content: str,
+        session_id: str | None = None,
+        role: str = "user",
+        content: str = "",
+        *,
+        conversation_id: str | None = None,
         **kwargs: Any,
     ) -> Message:
         """Append a message to a NAMS conversation.
 
+        ``session_id`` is the canonical parameter; ``conversation_id`` is
+        accepted as an alias (``session_id`` wins when both are given).
         Per verified spec, NAMS accepts only ``{content, role}`` — other
-        kwargs (``metadata``, ``user_identifier``, ``conversation_id``,
-        bolt-only knobs) are silently dropped.
+        kwargs (``metadata``, ``user_identifier``, bolt-only knobs) are
+        silently dropped.
         """
+        conv = _resolve_conversation_id(session_id, conversation_id, method="add_message")
         body = {"content": content, "role": role}
         payload = await self._transport.request(
             _SPEC_ADD_MESSAGE,
-            path_params={"conversation_id": session_id},
+            path_params={"conversation_id": conv},
             json=body,
         )
         return payload_to_model(_normalize_message(payload or {}), Message)
 
-    async def get_conversation(self, session_id: str, **kwargs: Any) -> Conversation:
+    async def get_conversation(
+        self, session_id: str | None = None, *, conversation_id: str | None = None, **kwargs: Any
+    ) -> Conversation:
         """Return the conversation + its messages.
 
+        ``session_id`` is canonical; ``conversation_id`` is an alias.
         NAMS splits this across two endpoints — ``GET /conversations/{id}``
         returns header data and ``GET /conversations/{id}/messages``
         returns the message list (envelope ``{"messages": [...]}``).
         We assemble them client-side so the user-facing contract matches
         the Protocol (single call → full :class:`Conversation`).
         """
+        conv = _resolve_conversation_id(session_id, conversation_id, method="get_conversation")
         limit = kwargs.get("limit")
         header = await self._transport.request(
             _SPEC_GET_CONVERSATION,
-            path_params={"conversation_id": session_id},
+            path_params={"conversation_id": conv},
         )
 
         params = _drop_none({"limit": limit})
         msgs_payload = await self._transport.request(
             _SPEC_LIST_MESSAGES,
-            path_params={"conversation_id": session_id},
+            path_params={"conversation_id": conv},
             params=params or None,
         )
         if isinstance(msgs_payload, dict) and "messages" in msgs_payload:
@@ -257,7 +292,7 @@ class NamsShortTermMemory:
             messages = []
 
         return payload_to_model(
-            _normalize_conversation(header, session_id=session_id, messages=messages),
+            _normalize_conversation(header, session_id=conv, messages=messages),
             Conversation,
         )
 
@@ -265,20 +300,19 @@ class NamsShortTermMemory:
         """Vector/keyword search across messages within a conversation.
 
         Per verified spec, NAMS's search is **conversation-scoped** —
-        ``POST /v1/conversations/{id}/search``. A ``session_id`` kwarg
-        is required; if absent, the call raises.
+        ``POST /v1/conversations/{id}/search``. A ``session_id`` (alias
+        ``conversation_id``) kwarg is required; if absent, the call raises.
         """
-        session_id = kwargs.get("session_id")
-        if not session_id:
-            raise ValueError(
-                "search_messages requires session_id on NAMS — the API is "
-                "conversation-scoped (POST /v1/conversations/{id}/search). "
-                "Pass session_id=... to scope the search."
-            )
+        conv = _resolve_conversation_id(
+            kwargs.get("session_id"),
+            kwargs.get("conversation_id"),
+            method="search_messages",
+            error_type=ValueError,
+        )
         body = _drop_none({"query": query, "limit": kwargs.get("limit")})
         payload = await self._transport.request(
             _SPEC_SEARCH_MESSAGES,
-            path_params={"conversation_id": session_id},
+            path_params={"conversation_id": conv},
             json=body,
         )
         # Response: {"messages": [...], "searchType": "vector"|"text"}
@@ -311,11 +345,17 @@ class NamsShortTermMemory:
             workaround="Use clear_session(session_id) to clear an entire conversation.",
         )
 
-    async def clear_session(self, session_id: str) -> None:
-        """Delete the entire conversation (NAMS ``DELETE /conversations/{id}``)."""
+    async def clear_session(
+        self, session_id: str | None = None, *, conversation_id: str | None = None
+    ) -> None:
+        """Delete the entire conversation (NAMS ``DELETE /conversations/{id}``).
+
+        ``session_id`` is canonical; ``conversation_id`` is an alias.
+        """
+        conv = _resolve_conversation_id(session_id, conversation_id, method="clear_session")
         await self._transport.request(
             _SPEC_DELETE_CONVERSATION,
-            path_params={"conversation_id": session_id},
+            path_params={"conversation_id": conv},
         )
 
     async def get_context(self, query: str, **kwargs: Any) -> str:
@@ -330,16 +370,15 @@ class NamsShortTermMemory:
         Returns a formatted text block assembled client-side from the
         three response sections.
         """
-        session_id = kwargs.get("session_id")
-        if not session_id:
-            raise ValueError(
-                "get_context requires session_id on NAMS — the context "
-                "endpoint is conversation-scoped "
-                "(GET /v1/conversations/{id}/context)."
-            )
+        conv = _resolve_conversation_id(
+            kwargs.get("session_id"),
+            kwargs.get("conversation_id"),
+            method="get_context",
+            error_type=ValueError,
+        )
         payload = await self._transport.request(
             _SPEC_GET_CONTEXT,
-            path_params={"conversation_id": session_id},
+            path_params={"conversation_id": conv},
         )
         if not isinstance(payload, dict):
             return ""
@@ -378,15 +417,18 @@ class NamsShortTermMemory:
 
     # -------------------------------------------------------------------- Gold
 
-    async def create_conversation(self, session_id: str, **kwargs: Any) -> Conversation:
+    async def create_conversation(
+        self, session_id: str | None = None, *, conversation_id: str | None = None, **kwargs: Any
+    ) -> Conversation:
         """Create a new conversation on NAMS.
 
-        Per verified spec, NAMS accepts ``{userId?, metadata?}`` only —
-        no ``session_id`` or ``title`` in the body (those are
-        client-side concepts). The ``session_id`` argument is used to
-        populate the returned ``Conversation.session_id`` field for
-        Pydantic compatibility.
+        ``session_id`` is canonical; ``conversation_id`` is an alias. Per
+        verified spec, NAMS accepts ``{userId?, metadata?}`` only — no
+        ``session_id`` or ``title`` in the body (those are client-side
+        concepts). The resolved id populates the returned
+        ``Conversation.session_id`` field for Pydantic compatibility.
         """
+        conv = _resolve_conversation_id(session_id, conversation_id, method="create_conversation")
         body = _drop_none(
             {
                 "userId": kwargs.get("user_identifier"),
@@ -395,7 +437,7 @@ class NamsShortTermMemory:
         )
         payload = await self._transport.request(_SPEC_CREATE_CONVERSATION, json=body)
         return payload_to_model(
-            _normalize_conversation(payload, session_id=session_id),
+            _normalize_conversation(payload, session_id=conv),
             Conversation,
         )
 
@@ -428,21 +470,25 @@ class NamsShortTermMemory:
 
     async def bulk_add_messages(
         self,
-        session_id: str,
-        messages: list[dict[str, Any]],
+        session_id: str | None = None,
+        messages: list[dict[str, Any]] | None = None,
+        *,
+        conversation_id: str | None = None,
         **kwargs: Any,
     ) -> list[Message]:
         """Bulk-insert messages (max 100 per call per NAMS spec).
 
+        ``session_id`` is canonical; ``conversation_id`` is an alias.
         Request: ``{"messages": [{"content", "role"}, ...]}``.
         Response: ``{"messages": [...]}``.
         """
+        conv = _resolve_conversation_id(session_id, conversation_id, method="bulk_add_messages")
         # Strip any extra kwargs each message might carry (bolt-only fields).
-        clean_batch = [{"content": m["content"], "role": m["role"]} for m in messages]
+        clean_batch = [{"content": m["content"], "role": m["role"]} for m in (messages or [])]
         body = {"messages": clean_batch}
         payload = await self._transport.request(
             _SPEC_BULK_ADD_MESSAGES,
-            path_params={"conversation_id": session_id},
+            path_params={"conversation_id": conv},
             json=body,
         )
         items: list[Any]
@@ -454,11 +500,16 @@ class NamsShortTermMemory:
             items = []
         return [payload_to_model(_normalize_message(m), Message) for m in items]
 
-    async def get_observations(self, session_id: str, **kwargs: Any) -> list[dict[str, Any]]:
+    async def get_observations(
+        self, session_id: str | None = None, **kwargs: Any
+    ) -> list[dict[str, Any]]:
         """Return inline observations extracted from a conversation."""
+        conv = _resolve_conversation_id(
+            session_id, kwargs.get("conversation_id"), method="get_observations"
+        )
         payload = await self._transport.request(
             _SPEC_GET_OBSERVATIONS,
-            path_params={"conversation_id": session_id},
+            path_params={"conversation_id": conv},
         )
         if isinstance(payload, dict) and "observations" in payload:
             return list(payload["observations"])
@@ -466,11 +517,16 @@ class NamsShortTermMemory:
             return list(payload)
         return []
 
-    async def get_reflections(self, session_id: str, **kwargs: Any) -> list[dict[str, Any]]:
+    async def get_reflections(
+        self, session_id: str | None = None, **kwargs: Any
+    ) -> list[dict[str, Any]]:
         """Return LLM-generated reflections for a conversation."""
+        conv = _resolve_conversation_id(
+            session_id, kwargs.get("conversation_id"), method="get_reflections"
+        )
         payload = await self._transport.request(
             _SPEC_GET_REFLECTIONS,
-            path_params={"conversation_id": session_id},
+            path_params={"conversation_id": conv},
         )
         if isinstance(payload, dict) and "reflections" in payload:
             return list(payload["reflections"])

--- a/src/neo4j_agent_memory/nams/short_term.py
+++ b/src/neo4j_agent_memory/nams/short_term.py
@@ -218,7 +218,6 @@ def _resolve_conversation_id(
     return conv
 
 
-
 class NamsShortTermMemory:
     """Short-term memory backed by the NAMS HTTP service.
 

--- a/src/neo4j_agent_memory/nams/transport.py
+++ b/src/neo4j_agent_memory/nams/transport.py
@@ -93,6 +93,7 @@ class HttpTransport:
         max_retries: int = 3,
         retry_backoff_seconds: float = 0.5,
         headers: dict[str, str] | None = None,
+        workspace_id: str | None = None,
         tracer: Tracer | None = None,
     ) -> None:
         self._endpoint = endpoint.rstrip("/")
@@ -102,6 +103,7 @@ class HttpTransport:
         self._max_retries = max_retries
         self._backoff = retry_backoff_seconds
         self._user_headers: dict[str, str] = dict(headers or {})
+        self._workspace_id = workspace_id
         self._tracer = tracer
         self._client: httpx.AsyncClient | None = None
 
@@ -122,6 +124,7 @@ class HttpTransport:
             max_retries=config.max_retries,
             retry_backoff_seconds=config.retry_backoff_seconds,
             headers=dict(config.headers),
+            workspace_id=config.workspace_id,
             tracer=tracer,
         )
 
@@ -194,8 +197,12 @@ class HttpTransport:
 
         http_method, url = spec.resolve(self._endpoint, self._protocol, path_params)
 
-        # Prepare headers: user-supplied + auth + json default.
+        # Prepare headers: user-supplied + workspace + auth + json default.
+        # Precedence for X-Workspace-Id: an explicit entry in user headers wins
+        # (the documented escape hatch); otherwise the configured workspace_id.
         headers: dict[str, str] = dict(self._user_headers)
+        if self._workspace_id and "X-Workspace-Id" not in headers:
+            headers["X-Workspace-Id"] = self._workspace_id
         if json is not None and "Content-Type" not in headers:
             headers["Content-Type"] = "application/json"
         headers = await self._auth.apply(headers)

--- a/tests/integration/nams/README.md
+++ b/tests/integration/nams/README.md
@@ -24,13 +24,33 @@ sandbox using the `NAMS_SANDBOX_KEY` repo secret.
 
 ```bash
 export NAMS_SANDBOX_KEY=nams_sandbox_xxxxx
-# Optional: override the endpoint (defaults to https://memory.neo4jlabs.com/v1)
-# export NAMS_SANDBOX_URL=https://nams.sandbox.internal/v1
 
 make test-nams-integration
 
 # Or run a single tier:
 uv run pytest tests/integration/nams/test_tck_bronze.py -v
+```
+
+#### Selecting an environment
+
+The endpoint defaults to **staging** (`https://nams.development.neo4jsandbox.com/v1`).
+Choose a different one without memorizing URLs via the `NAMS_ENV` preset:
+
+| `NAMS_ENV` | Endpoint |
+|---|---|
+| `staging` (default) / `development` | `https://nams.development.neo4jsandbox.com/v1` |
+| `sandbox` | `https://memory.neo4jlabs.com/v1` |
+| `local` | `http://localhost:8765` |
+
+```bash
+# Named preset — env var or dedicated make target:
+NAMS_ENV=staging make test-nams-integration
+make test-nams-staging
+make test-nams-sandbox
+
+# Raw URL override always wins over the preset:
+export NAMS_SANDBOX_URL=https://nams.internal/v1
+make test-nams-integration
 ```
 
 ### Against a local TCK reference impl

--- a/tests/integration/nams/conftest.py
+++ b/tests/integration/nams/conftest.py
@@ -56,9 +56,50 @@ logger = logging.getLogger(__name__)
 # -----------------------------------------------------------------------------
 
 
-# Default staging/development endpoint this suite targets. Override with
-# NAMS_SANDBOX_URL (or MEMORY_ENDPOINT) to point elsewhere.
-_DEFAULT_SANDBOX_URL = "https://nams.development.neo4jsandbox.com/v1"
+# Named environment presets. Select one with ``NAMS_ENV=<name>`` instead of
+# memorizing a URL. An explicit ``NAMS_SANDBOX_URL`` / ``MEMORY_ENDPOINT``
+# always wins over the preset.
+_NAMS_ENV_PRESETS = {
+    "staging": "https://nams.development.neo4jsandbox.com/v1",
+    "development": "https://nams.development.neo4jsandbox.com/v1",  # alias of staging
+    "sandbox": "https://memory.neo4jlabs.com/v1",
+    "local": "http://localhost:8765",
+}
+
+# Default environment when neither NAMS_SANDBOX_URL nor NAMS_ENV is set.
+_DEFAULT_NAMS_ENV = "staging"
+
+# Default endpoint this suite targets. Override with NAMS_SANDBOX_URL /
+# MEMORY_ENDPOINT (raw URL), or NAMS_ENV=<name> (named preset).
+_DEFAULT_SANDBOX_URL = _NAMS_ENV_PRESETS[_DEFAULT_NAMS_ENV]
+
+
+def _resolve_endpoint() -> str:
+    """Resolve the NAMS endpoint URL with this precedence:
+
+    1. Explicit raw URL — ``NAMS_SANDBOX_URL`` or ``MEMORY_ENDPOINT``.
+    2. Named preset — ``NAMS_ENV`` mapped through ``_NAMS_ENV_PRESETS``
+       (e.g. ``staging``, ``sandbox``, ``local``).
+    3. The default preset (``staging``).
+
+    An unrecognized ``NAMS_ENV`` value fails loudly rather than silently
+    falling back, so a typo can't quietly target the wrong environment.
+    """
+    explicit = os.environ.get("NAMS_SANDBOX_URL") or os.environ.get("MEMORY_ENDPOINT")
+    if explicit:
+        return explicit
+    env = os.environ.get("NAMS_ENV")
+    if env:
+        key = env.strip().lower()
+        if key not in _NAMS_ENV_PRESETS:
+            valid = ", ".join(sorted(_NAMS_ENV_PRESETS))
+            pytest.fail(
+                f"Unknown NAMS_ENV={env!r}. Valid presets: {valid}. "
+                f"Or set NAMS_SANDBOX_URL to a raw endpoint URL.",
+                pytrace=False,
+            )
+        return _NAMS_ENV_PRESETS[key]
+    return _DEFAULT_SANDBOX_URL
 
 
 def _resolve_credentials() -> tuple[str, str, str | None] | None:
@@ -67,20 +108,16 @@ def _resolve_credentials() -> tuple[str, str, str | None] | None:
     Recognizes the integration-test env family
     ``NAMS_SANDBOX_URL`` / ``NAMS_SANDBOX_KEY`` / ``NAMS_SANDBOX_WORKSPACE_ID``
     and the user-facing aliases ``MEMORY_ENDPOINT`` / ``MEMORY_API_KEY`` /
-    ``MEMORY_WORKSPACE_ID``. The workspace is resolved into the
-    ``X-Workspace-Id`` header by the client itself (no manual header
-    injection in fixtures) — required by the header-scoped staging
-    deployment.
+    ``MEMORY_WORKSPACE_ID``. The endpoint can also be chosen by named
+    preset via ``NAMS_ENV`` (see ``_resolve_endpoint``). The workspace is
+    resolved into the ``X-Workspace-Id`` header by the client itself (no
+    manual header injection in fixtures) — required by the header-scoped
+    staging deployment.
     """
     key = os.environ.get("NAMS_SANDBOX_KEY") or os.environ.get("MEMORY_API_KEY")
     workspace = os.environ.get("NAMS_SANDBOX_WORKSPACE_ID") or os.environ.get("MEMORY_WORKSPACE_ID")
     if key:
-        url = (
-            os.environ.get("NAMS_SANDBOX_URL")
-            or os.environ.get("MEMORY_ENDPOINT")
-            or _DEFAULT_SANDBOX_URL
-        )
-        return url, key, workspace
+        return _resolve_endpoint(), key, workspace
     if (url := os.environ.get("NAMS_TCK_URL")) and (
         key := os.environ.get("NAMS_TCK_KEY", "test-tck-key")
     ):

--- a/tests/integration/nams/conftest.py
+++ b/tests/integration/nams/conftest.py
@@ -73,9 +73,7 @@ def _resolve_credentials() -> tuple[str, str, str | None] | None:
     deployment.
     """
     key = os.environ.get("NAMS_SANDBOX_KEY") or os.environ.get("MEMORY_API_KEY")
-    workspace = os.environ.get("NAMS_SANDBOX_WORKSPACE_ID") or os.environ.get(
-        "MEMORY_WORKSPACE_ID"
-    )
+    workspace = os.environ.get("NAMS_SANDBOX_WORKSPACE_ID") or os.environ.get("MEMORY_WORKSPACE_ID")
     if key:
         url = (
             os.environ.get("NAMS_SANDBOX_URL")

--- a/tests/integration/nams/conftest.py
+++ b/tests/integration/nams/conftest.py
@@ -56,27 +56,51 @@ logger = logging.getLogger(__name__)
 # -----------------------------------------------------------------------------
 
 
-def _resolve_endpoint_and_key() -> tuple[str, str] | None:
-    """Return (endpoint, api_key) if a sandbox or TCK is reachable, else None."""
-    if (key := os.environ.get("NAMS_SANDBOX_KEY")) and (
-        url := os.environ.get("NAMS_SANDBOX_URL", "https://memory.neo4jlabs.com/v1")
-    ):
-        return url, key
+# Default staging/development endpoint this suite targets. Override with
+# NAMS_SANDBOX_URL (or MEMORY_ENDPOINT) to point elsewhere.
+_DEFAULT_SANDBOX_URL = "https://nams.development.neo4jsandbox.com/v1"
+
+
+def _resolve_credentials() -> tuple[str, str, str | None] | None:
+    """Return (endpoint, api_key, workspace_id) if reachable, else None.
+
+    Recognizes the integration-test env family
+    ``NAMS_SANDBOX_URL`` / ``NAMS_SANDBOX_KEY`` / ``NAMS_SANDBOX_WORKSPACE_ID``
+    and the user-facing aliases ``MEMORY_ENDPOINT`` / ``MEMORY_API_KEY`` /
+    ``MEMORY_WORKSPACE_ID``. The workspace is resolved into the
+    ``X-Workspace-Id`` header by the client itself (no manual header
+    injection in fixtures) — required by the header-scoped staging
+    deployment.
+    """
+    key = os.environ.get("NAMS_SANDBOX_KEY") or os.environ.get("MEMORY_API_KEY")
+    workspace = os.environ.get("NAMS_SANDBOX_WORKSPACE_ID") or os.environ.get(
+        "MEMORY_WORKSPACE_ID"
+    )
+    if key:
+        url = (
+            os.environ.get("NAMS_SANDBOX_URL")
+            or os.environ.get("MEMORY_ENDPOINT")
+            or _DEFAULT_SANDBOX_URL
+        )
+        return url, key, workspace
     if (url := os.environ.get("NAMS_TCK_URL")) and (
         key := os.environ.get("NAMS_TCK_KEY", "test-tck-key")
     ):
-        return url, key
+        # TCK reference implementation scopes by key, not header.
+        return url, key, None
     return None
 
 
 @pytest.fixture(scope="session")
-def nams_credentials() -> tuple[str, str]:
-    """Sandbox / TCK endpoint + key. Skips the whole module if unset."""
-    creds = _resolve_endpoint_and_key()
+def nams_credentials() -> tuple[str, str, str | None]:
+    """Sandbox / TCK endpoint + key + workspace. Skips the module if unset."""
+    creds = _resolve_credentials()
     if creds is None:
         pytest.skip(
             "No NAMS sandbox or TCK reachable. Set NAMS_SANDBOX_KEY (and "
-            "optionally NAMS_SANDBOX_URL) or NAMS_TCK_URL to enable these tests."
+            "optionally NAMS_SANDBOX_URL / NAMS_SANDBOX_WORKSPACE_ID), or the "
+            "MEMORY_API_KEY / MEMORY_ENDPOINT / MEMORY_WORKSPACE_ID aliases, or "
+            "NAMS_TCK_URL to enable these tests."
         )
     return creds
 
@@ -87,13 +111,18 @@ def nams_credentials() -> tuple[str, str]:
 
 
 @pytest.fixture
-def nams_config(nams_credentials: tuple[str, str]) -> NamsConfig:
+def nams_config(nams_credentials: tuple[str, str, str | None]) -> NamsConfig:
     """Per-test NamsConfig pointing at the sandbox. ``validate_on_connect`` off
-    so individual tests can opt into the probe (or skip it for write-only flows)."""
-    endpoint, api_key = nams_credentials
+    so individual tests can opt into the probe (or skip it for write-only flows).
+
+    The workspace is supplied as ``workspace_id`` — the client transmits it as
+    ``X-Workspace-Id`` automatically. No manual header injection.
+    """
+    endpoint, api_key, workspace_id = nams_credentials
     return NamsConfig(
         endpoint=endpoint,
         api_key=SecretStr(api_key),
+        workspace_id=workspace_id,
         validate_on_connect=False,
         max_retries=2,
         retry_backoff_seconds=0.5,

--- a/tests/integration/nams/test_adk_e2e.py
+++ b/tests/integration/nams/test_adk_e2e.py
@@ -1,0 +1,83 @@
+"""End-to-end ADK ↔ NAMS suite (issue #130 regression, against staging).
+
+Exercises ``Neo4jMemoryService`` against the live NAMS backend to prove
+the #130 fixes hold end-to-end:
+
+* conversation-scoped search (no unscoped-search ``ValueError``);
+* graceful no-session search (skips messages, still recalls entities);
+* entity extraction from real text (the service must not crash NAMS).
+
+The service accepts dict-style sessions, so these run without the
+``google-adk`` package installed.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from neo4j_agent_memory import MemoryClient
+from neo4j_agent_memory.integrations.google_adk.memory_service import Neo4jMemoryService
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture
+def adk_service(nams_client: MemoryClient) -> Neo4jMemoryService:
+    return Neo4jMemoryService(memory_client=nams_client, extract_on_store=True)
+
+
+@pytest.mark.asyncio
+async def test_search_is_conversation_scoped_no_crash(
+    adk_service: Neo4jMemoryService, nams_client: MemoryClient, cleanup_registry
+) -> None:
+    sid = f"itest-adk-{uuid.uuid4().hex[:8]}"
+    conv = await nams_client.short_term.create_conversation(conversation_id=sid)
+    cid = str(conv.id)
+    cleanup_registry.track_session(cid)
+
+    await adk_service.add_session_to_memory(
+        {
+            "id": cid,
+            "messages": [
+                {"role": "user", "content": "Tell me about Marie Curie and radioactivity."},
+                {"role": "assistant", "content": "Marie Curie pioneered research on radioactivity."},
+            ],
+        }
+    )
+    # Must not raise the unscoped-search ValueError that #130 reported.
+    response = await adk_service.search_memory("radioactivity")
+    assert response is not None
+
+
+@pytest.mark.asyncio
+async def test_search_without_session_skips_messages_gracefully(
+    nams_client: MemoryClient,
+) -> None:
+    # Fresh service, no session ever tracked — must not crash on NAMS.
+    service = Neo4jMemoryService(memory_client=nams_client)
+    response = await service.search_memory("anything")
+    assert response is not None  # entities/preferences searched; messages skipped
+
+
+@pytest.mark.asyncio
+async def test_entity_extraction_from_session_text(
+    adk_service: Neo4jMemoryService, nams_client: MemoryClient, cleanup_registry
+) -> None:
+    sid = f"itest-adk-extract-{uuid.uuid4().hex[:8]}"
+    marker = f"Zylotech{uuid.uuid4().hex[:6].capitalize()}"
+    conv = await nams_client.short_term.create_conversation(conversation_id=sid)
+    cid = str(conv.id)
+    cleanup_registry.track_session(cid)
+
+    await adk_service.add_session_to_memory(
+        {"id": cid, "messages": [{"role": "user", "content": f"{marker} is a robotics company."}]}
+    )
+    # Extraction is async — await it explicitly via the readiness helper.
+    ready = await nams_client.long_term.wait_for_extraction(
+        query=marker, expected_names=[marker], timeout=40, interval=2
+    )
+    # If staging extraction is lagging, skip rather than flake (perf signal).
+    if not ready:
+        pytest.skip("Staging extraction did not surface the entity within timeout.")

--- a/tests/integration/nams/test_adk_e2e.py
+++ b/tests/integration/nams/test_adk_e2e.py
@@ -42,7 +42,10 @@ async def test_search_is_conversation_scoped_no_crash(
             "id": cid,
             "messages": [
                 {"role": "user", "content": "Tell me about Marie Curie and radioactivity."},
-                {"role": "assistant", "content": "Marie Curie pioneered research on radioactivity."},
+                {
+                    "role": "assistant",
+                    "content": "Marie Curie pioneered research on radioactivity.",
+                },
             ],
         }
     )

--- a/tests/integration/nams/test_errors.py
+++ b/tests/integration/nams/test_errors.py
@@ -153,7 +153,7 @@ async def test_cypher_rejects_write_keywords(nams_client: MemoryClient) -> None:
 
 @pytest.mark.asyncio
 async def test_warning_when_extraction_explicitly_configured(
-    nams_credentials: tuple[str, str],
+    nams_credentials: tuple[str, str, str | None],
 ) -> None:
     """Setting ``extraction=`` explicitly with NAMS emits a single ``UserWarning``."""
     import warnings as _w
@@ -163,12 +163,13 @@ async def test_warning_when_extraction_explicitly_configured(
     from neo4j_agent_memory import MemorySettings, NamsConfig
     from neo4j_agent_memory.config.settings import ExtractionConfig
 
-    endpoint, api_key = nams_credentials
+    endpoint, api_key, workspace_id = nams_credentials
     settings = MemorySettings(
         backend="nams",
         nams=NamsConfig(
             endpoint=endpoint,
             api_key=SecretStr(api_key),
+            workspace_id=workspace_id,
             validate_on_connect=False,
         ),
         extraction=ExtractionConfig(),  # explicit → in model_fields_set

--- a/tests/integration/nams/test_framework_smoke.py
+++ b/tests/integration/nams/test_framework_smoke.py
@@ -1,0 +1,175 @@
+"""Thin per-framework NAMS smoke tests (issue B.4).
+
+Each test constructs a framework integration against a ``workspace_id``-scoped
+NAMS client, stores a message mentioning a unique synthetic entity through the
+integration's own store path, awaits the asynchronous extraction pipeline, and
+asserts the entity became searchable. This proves the integration's *write*
+path works end-to-end on the hosted backend.
+
+Integrations whose framework package is not installed skip cleanly, so this
+file is safe to run in any environment (it lights up more frameworks as their
+optional extras are installed). Google ADK and AWS Strands have dedicated,
+deeper suites (``test_adk_e2e.py`` / ``test_strands*``) and are not repeated
+here.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Awaitable, Callable
+
+import pytest
+
+from neo4j_agent_memory import MemoryClient
+
+pytestmark = pytest.mark.integration
+
+
+async def _assert_extraction_round_trip(
+    nams_client: MemoryClient,
+    store: Callable[[], Awaitable[None]],
+    marker: str,
+) -> None:
+    """Run the integration's store path, then await + assert extraction."""
+    await store()
+    ready = await nams_client.long_term.wait_for_extraction(
+        query=marker, expected_names=[marker], timeout=45, interval=3
+    )
+    if not ready:
+        pytest.skip(f"Staging extraction did not surface '{marker}' within timeout (perf signal).")
+
+
+def _marker() -> str:
+    # A unique, capitalized, clearly-entity-like token the extractor will surface.
+    return f"Qwentish{uuid.uuid4().hex[:6].capitalize()}"
+
+
+@pytest.mark.asyncio
+async def test_langchain_smoke(nams_client: MemoryClient, nams_session: str) -> None:
+    try:
+        from neo4j_agent_memory.integrations.langchain import Neo4jAgentMemory
+    except (ImportError, AttributeError):
+        pytest.skip("langchain integration unavailable")
+
+    memory = Neo4jAgentMemory(memory_client=nams_client, session_id=nams_session)
+    marker = _marker()
+
+    async def store() -> None:
+        await memory._save_context_async(
+            {"input": f"{marker} founded Acme Corporation in Paris."},
+            {"output": "Noted."},
+        )
+
+    await _assert_extraction_round_trip(nams_client, store, marker)
+
+
+@pytest.mark.asyncio
+async def test_pydantic_ai_smoke(nams_client: MemoryClient, nams_session: str) -> None:
+    try:
+        from neo4j_agent_memory.integrations.pydantic_ai import MemoryDependency
+    except (ImportError, AttributeError):
+        pytest.skip("pydantic_ai integration unavailable")
+
+    deps = MemoryDependency(client=nams_client, session_id=nams_session)
+    marker = _marker()
+
+    async def store() -> None:
+        await deps.save_interaction(
+            user_message=f"{marker} founded Acme Corporation in Paris.",
+            assistant_message="Noted.",
+        )
+
+    await _assert_extraction_round_trip(nams_client, store, marker)
+
+
+@pytest.mark.asyncio
+async def test_agentcore_smoke(nams_client: MemoryClient, nams_session: str) -> None:
+    try:
+        from neo4j_agent_memory.integrations.agentcore import Neo4jMemoryProvider
+    except (ImportError, AttributeError):
+        pytest.skip("agentcore integration unavailable")
+
+    provider = Neo4jMemoryProvider(memory_client=nams_client)
+    marker = _marker()
+
+    async def store() -> None:
+        await provider.store_memory(
+            session_id=nams_session,
+            content=f"{marker} founded Acme Corporation in Paris.",
+            role="user",
+        )
+
+    await _assert_extraction_round_trip(nams_client, store, marker)
+
+
+@pytest.mark.asyncio
+async def test_openai_agents_smoke(nams_client: MemoryClient, nams_session: str) -> None:
+    try:
+        from neo4j_agent_memory.integrations.openai_agents import Neo4jOpenAIMemory
+    except (ImportError, AttributeError):
+        pytest.skip("openai_agents integration unavailable")
+
+    memory = Neo4jOpenAIMemory(memory_client=nams_client, session_id=nams_session)
+    marker = _marker()
+
+    async def store() -> None:
+        await memory.save_message("user", f"{marker} founded Acme Corporation in Paris.")
+
+    await _assert_extraction_round_trip(nams_client, store, marker)
+
+
+@pytest.mark.asyncio
+async def test_microsoft_agent_smoke(nams_client: MemoryClient, nams_session: str) -> None:
+    try:
+        from neo4j_agent_memory.integrations.microsoft_agent import Neo4jMicrosoftMemory
+    except (ImportError, AttributeError):
+        pytest.skip("microsoft_agent integration unavailable")
+
+    memory = Neo4jMicrosoftMemory(memory_client=nams_client, session_id=nams_session)
+    marker = _marker()
+
+    async def store() -> None:
+        await memory.save_message("user", f"{marker} founded Acme Corporation in Paris.")
+
+    await _assert_extraction_round_trip(nams_client, store, marker)
+
+
+@pytest.mark.asyncio
+async def test_crewai_smoke(nams_client: MemoryClient, nams_session: str) -> None:
+    try:
+        from neo4j_agent_memory.integrations.crewai import Neo4jCrewMemory
+    except (ImportError, AttributeError):
+        pytest.skip("crewai integration unavailable")
+
+    # CrewAI's adapter is crew-scoped (no session_id) and uses an internal
+    # crew id rather than a pre-created NAMS conversation, so we assert it
+    # constructs against a NAMS-backed client and round-trip the write path
+    # through the shared client.
+    _ = Neo4jCrewMemory(memory_client=nams_client)
+    marker = _marker()
+
+    async def store() -> None:
+        await nams_client.short_term.add_message(
+            nams_session, "user", f"{marker} founded Acme Corporation in Paris."
+        )
+
+    await _assert_extraction_round_trip(nams_client, store, marker)
+
+
+@pytest.mark.asyncio
+async def test_llamaindex_smoke(nams_client: MemoryClient, nams_session: str) -> None:
+    try:
+        from neo4j_agent_memory.integrations.llamaindex import Neo4jLlamaIndexMemory
+    except (ImportError, AttributeError):
+        pytest.skip("llamaindex integration unavailable")
+
+    memory = Neo4jLlamaIndexMemory(memory_client=nams_client, session_id=nams_session)
+    marker = _marker()
+
+    async def store() -> None:
+        await nams_client.short_term.add_message(
+            nams_session, "user", f"{marker} founded Acme Corporation in Paris."
+        )
+        _ = memory  # adapter constructed against NAMS (round-trip via shared client)
+
+    await _assert_extraction_round_trip(nams_client, store, marker)

--- a/tests/integration/nams/test_ontology.py
+++ b/tests/integration/nams/test_ontology.py
@@ -1,0 +1,139 @@
+"""Integration tests for the NAMS ontology surface (P2).
+
+Exercises the live ontology lifecycle against the staging deployment:
+list → clone → update (new revision) → activate → get_active → delete,
+plus a strict-mode validation check.
+
+These tests **mutate workspace-global active-ontology state**, so the
+``restore_active_ontology`` fixture snapshots the active version before
+each test and rebinds it afterward. Created ontologies are tracked and
+deleted on teardown.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+
+import pytest
+
+from neo4j_agent_memory import MemoryClient
+from neo4j_agent_memory.nams import OntologyDocument
+
+pytestmark = pytest.mark.integration
+
+# A template unlikely to clash with other suites; its clone is "<name>-clone".
+TEMPLATE = "conservation"
+CLONE_NAME = f"{TEMPLATE}-clone"
+
+
+@pytest.fixture
+async def restore_active_ontology(nams_client: MemoryClient) -> AsyncIterator[None]:
+    """Snapshot the active ontology version, restore it on teardown."""
+    onto = nams_client.ontology
+    before = await onto.get_active()
+    prior_version_id = before.version_id
+    yield
+    # Best-effort cleanup: delete any test clone, restore prior active.
+    for summary in await onto.list():
+        if summary.name == CLONE_NAME and not summary.is_system:
+            try:
+                await onto.delete(summary.id)
+            except Exception:  # noqa: BLE001 — best-effort teardown
+                pass
+    if prior_version_id:
+        try:
+            await onto.activate(prior_version_id)
+        except Exception:  # noqa: BLE001
+            pass
+
+
+@pytest.fixture
+async def fresh_clone(nams_client: MemoryClient, restore_active_ontology: None):
+    """Delete any pre-existing clone, then clone TEMPLATE fresh."""
+    onto = nams_client.ontology
+    for summary in await onto.list():
+        if summary.name == CLONE_NAME and not summary.is_system:
+            await onto.delete(summary.id)
+    return await onto.clone(TEMPLATE)
+
+
+@pytest.mark.asyncio
+async def test_list_includes_system_templates(nams_client: MemoryClient) -> None:
+    catalog = await nams_client.ontology.list()
+    names = {o.name for o in catalog}
+    assert TEMPLATE in names
+    assert "nams-default" in names
+    # System templates are flagged.
+    assert any(o.is_system for o in catalog)
+
+
+@pytest.mark.asyncio
+async def test_clone_returns_revision_1_version(fresh_clone) -> None:
+    assert fresh_clone.revision == 1
+    assert fresh_clone.ontology_id.startswith("ont_")
+    assert fresh_clone.id.startswith("ov_")
+    assert fresh_clone.document is not None
+    assert len(fresh_clone.document.entity_types) > 0
+
+
+@pytest.mark.asyncio
+async def test_update_creates_new_revision_preserving_schema(
+    nams_client: MemoryClient, fresh_clone
+) -> None:
+    onto = nams_client.ontology
+    original_types = len(fresh_clone.document.entity_types)
+    v2 = await onto.update(fresh_clone.ontology_id, fresh_clone.document)
+    assert v2.revision == 2
+    # The schema is preserved across the revision (regression: the body must
+    # be wrapped under "ontology", else the service stores an empty schema).
+    assert len(v2.document.entity_types) == original_types
+
+
+@pytest.mark.asyncio
+async def test_activate_and_get_active_surface_validation_mode(
+    nams_client: MemoryClient, fresh_clone
+) -> None:
+    onto = nams_client.ontology
+    strict = await onto.update(
+        fresh_clone.ontology_id, fresh_clone.document, validation_mode="strict"
+    )
+    await onto.activate(strict.id)
+
+    active = await onto.get_active()
+    assert active.document.domain.id == CLONE_NAME
+    assert active.validation_mode == "strict"
+    assert active.revision == strict.revision
+    assert active.version_id == strict.id
+
+
+@pytest.mark.asyncio
+async def test_create_from_document(
+    nams_client: MemoryClient, restore_active_ontology: None
+) -> None:
+    onto = nams_client.ontology
+    name = "itest-create-ontology"
+    # clean any leftover
+    for s in await onto.list():
+        if s.name == name and not s.is_system:
+            await onto.delete(s.id)
+    doc = OntologyDocument.model_validate(
+        {
+            "domain": {"id": name, "name": "Integration Create", "description": "synthetic"},
+            "entity_types": [
+                {
+                    "label": "Widget",
+                    "pole_type": "OBJECT",
+                    "properties": [{"name": "sku", "type": "string", "unique": True}],
+                }
+            ],
+            "relationships": [],
+        }
+    )
+    try:
+        v = await onto.create(name, doc)
+        assert v.revision == 1
+        assert v.document.entity_types[0].label == "Widget"
+    finally:
+        for s in await onto.list():
+            if s.name == name and not s.is_system:
+                await onto.delete(s.id)

--- a/tests/unit/integrations/test_google_adk.py
+++ b/tests/unit/integrations/test_google_adk.py
@@ -1,6 +1,7 @@
 """Unit tests for Google ADK integration."""
 
 from datetime import datetime
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -426,3 +427,95 @@ class TestNeo4jMemoryService:
         messages = memory_service._extract_messages(mock_session)
 
         assert len(messages) == 2
+
+
+class TestIssue130Regression:
+    """Regression coverage for #130 — ADK/NAMS incompatibility.
+
+    Three defects:
+      1. Unscoped message search hard-rejected by NAMS.
+      2. Tool objects (FunctionCall/FunctionResponse) stringified into the
+         entity pipeline, producing empty knowledge graphs.
+      3. (doc/signature — covered by NAMS short_term alias tests.)
+    """
+
+    @pytest.fixture
+    def service_factory(self):
+        from neo4j_agent_memory.integrations.google_adk.memory_service import (
+            Neo4jMemoryService,
+        )
+
+        def _make(backend: str):
+            client = MagicMock()
+            client.backend = backend
+            client.short_term = MagicMock()
+            client.long_term = MagicMock()
+            client.short_term.search_messages = AsyncMock(return_value=[])
+            client.long_term.search_entities = AsyncMock(return_value=[])
+            client.long_term.search_preferences = AsyncMock(return_value=[])
+            return Neo4jMemoryService(memory_client=client), client
+
+        return _make
+
+    # --- Defect 2: tool-event filtering --------------------------------------
+
+    def test_extract_text_ignores_tool_only_parts(self, service_factory):
+        service, _ = service_factory("nams")
+
+        text_part = SimpleNamespace(text="real user text")
+        tool_call_part = SimpleNamespace(text=None, function_call={"name": "search"})
+        mixed = SimpleNamespace(parts=[text_part, tool_call_part])
+        assert service._extract_text_from_content(mixed) == "real user text"
+
+        tool_only = SimpleNamespace(parts=[tool_call_part])
+        assert service._extract_text_from_content(tool_only) == ""  # never str(content)
+
+    def test_tool_only_event_produces_no_message(self, service_factory):
+        service, _ = service_factory("nams")
+        tool_event = SimpleNamespace(
+            content=SimpleNamespace(parts=[SimpleNamespace(text=None, function_call={"n": 1})]),
+            author="model",
+        )
+        text_event = SimpleNamespace(
+            content=SimpleNamespace(parts=[SimpleNamespace(text="hello")]),
+            author="user",
+        )
+        session = SimpleNamespace(events=[tool_event, text_event])
+        messages = service._extract_messages(session)
+        assert len(messages) == 1
+        assert messages[0].content == "hello"
+
+    # --- Defect 1: conversation-scoped search --------------------------------
+
+    @pytest.mark.asyncio
+    async def test_search_scopes_to_tracked_session_on_nams(self, service_factory):
+        service, client = service_factory("nams")
+        await service.add_session_to_memory({"id": "sess-7", "messages": []})
+        await service.search_memory("q")
+        # search_messages must be called WITH the tracked session_id.
+        client.short_term.search_messages.assert_awaited_once()
+        assert client.short_term.search_messages.await_args.kwargs["session_id"] == "sess-7"
+
+    @pytest.mark.asyncio
+    async def test_search_skips_messages_when_no_session_on_nams(self, service_factory):
+        service, client = service_factory("nams")
+        await service.search_memory("q")  # no session ever tracked
+        # Never calls the unscoped search that NAMS rejects...
+        client.short_term.search_messages.assert_not_awaited()
+        # ...but entity + preference recall still runs (cross-session).
+        client.long_term.search_entities.assert_awaited_once()
+        client.long_term.search_preferences.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_search_unscoped_on_bolt(self, service_factory):
+        service, client = service_factory("bolt")
+        await service.search_memory("q")
+        client.short_term.search_messages.assert_awaited_once()
+        assert "session_id" not in client.short_term.search_messages.await_args.kwargs
+
+    @pytest.mark.asyncio
+    async def test_search_kwarg_session_overrides_tracked(self, service_factory):
+        service, client = service_factory("nams")
+        await service.add_session_to_memory({"id": "tracked", "messages": []})
+        await service.search_memory("q", session_id="explicit")
+        assert client.short_term.search_messages.await_args.kwargs["session_id"] == "explicit"

--- a/tests/unit/nams/test_long_term.py
+++ b/tests/unit/nams/test_long_term.py
@@ -76,8 +76,10 @@ class TestWaitForExtraction:
             200, json={"entities": [SAMPLE_ENTITY], "searchType": "vector"}
         )
         ok = await long_term.wait_for_extraction(
-            query="Alice", predicate=lambda ents: any(e.name == "Alice" for e in ents),
-            timeout=2, interval=0.01,
+            query="Alice",
+            predicate=lambda ents: any(e.name == "Alice" for e in ents),
+            timeout=2,
+            interval=0.01,
         )
         assert ok is True
 

--- a/tests/unit/nams/test_long_term.py
+++ b/tests/unit/nams/test_long_term.py
@@ -47,6 +47,45 @@ SAMPLE_ENTITY = {
 }
 
 
+class TestWaitForExtraction:
+    """A.4 — extraction-readiness helper over async entity search."""
+
+    @respx.mock
+    async def test_returns_true_when_expected_name_appears(self, long_term):
+        respx.post("https://memory.test/v1/entities/search").respond(
+            200, json={"entities": [SAMPLE_ENTITY], "searchType": "vector"}
+        )
+        ok = await long_term.wait_for_extraction(
+            query="Alice", expected_names=["Alice"], timeout=2, interval=0.01
+        )
+        assert ok is True
+
+    @respx.mock
+    async def test_returns_false_on_timeout(self, long_term):
+        respx.post("https://memory.test/v1/entities/search").respond(
+            200, json={"entities": [SAMPLE_ENTITY], "searchType": "vector"}
+        )
+        ok = await long_term.wait_for_extraction(
+            query="x", expected_names=["NeverAppears"], timeout=0.05, interval=0.01
+        )
+        assert ok is False
+
+    @respx.mock
+    async def test_predicate_path(self, long_term):
+        respx.post("https://memory.test/v1/entities/search").respond(
+            200, json={"entities": [SAMPLE_ENTITY], "searchType": "vector"}
+        )
+        ok = await long_term.wait_for_extraction(
+            query="Alice", predicate=lambda ents: any(e.name == "Alice" for e in ents),
+            timeout=2, interval=0.01,
+        )
+        assert ok is True
+
+    async def test_requires_a_signal(self, long_term):
+        with pytest.raises(ValueError, match="query.*expected_names.*predicate|requires"):
+            await long_term.wait_for_extraction(timeout=0.01)
+
+
 class TestProtocolConformance:
     def test_satisfies_long_term_protocol(self, long_term):
         assert isinstance(long_term, LongTermProtocol)

--- a/tests/unit/nams/test_ontology.py
+++ b/tests/unit/nams/test_ontology.py
@@ -114,14 +114,14 @@ class TestGet:
 class TestGetActive:
     @respx.mock
     async def test_get_active_composes_validation_mode(self, ontology):
-        respx.get(f"{BASE}/ontologies/active").respond(
-            200, json={"ontology": DOC, "version": None}
-        )
+        respx.get(f"{BASE}/ontologies/active").respond(200, json={"ontology": DOC, "version": None})
         respx.get(f"{BASE}/ontologies").respond(200, json={"ontologies": [SUMMARY]})
         respx.get(f"{BASE}/ontologies/ont_1").respond(
             200,
-            json={"record": {"id": "ont_1", "name": "legal-clone"},
-                  "versions": [_version(1, "permissive"), _version(2, "strict")]},
+            json={
+                "record": {"id": "ont_1", "name": "legal-clone"},
+                "versions": [_version(1, "permissive"), _version(2, "strict")],
+            },
         )
         active = await ontology.get_active()
         assert isinstance(active, ActiveOntology)
@@ -191,8 +191,10 @@ class TestBackendGuards:
     @respx.mock
     async def test_bridge_transport_raises_not_supported(self):
         config = NamsConfig(
-            endpoint="https://memory.test", api_key=SecretStr("k"),  # bridge shape (no /vN)
-            transport_mode="bridge", validate_on_connect=False,
+            endpoint="https://memory.test",
+            api_key=SecretStr("k"),  # bridge shape (no /vN)
+            transport_mode="bridge",
+            validate_on_connect=False,
         )
         async with HttpTransport.from_config(
             config, auth=StaticApiKeyAuth.from_config(config)
@@ -203,7 +205,8 @@ class TestBackendGuards:
     async def test_bolt_sentinel_raises(self):
         # On bolt, client.ontology is a sentinel that raises on method call.
         sentinel = _NamsUnsupported(
-            accessor="ontology", message="NAMS capability.",
+            accessor="ontology",
+            message="NAMS capability.",
             workaround="SchemaModel.CUSTOM",
         )
         with pytest.raises(NotSupportedError, match="ontology"):

--- a/tests/unit/nams/test_ontology.py
+++ b/tests/unit/nams/test_ontology.py
@@ -1,0 +1,210 @@
+"""Unit tests for nams/ontology.py — NamsOntology accessor + models.
+
+Endpoint shapes and payloads verified empirically against the staging
+deployment (the ontology surface is absent from the OpenAPI spec).
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+import respx
+from pydantic import SecretStr
+
+from neo4j_agent_memory.config.settings import NamsConfig
+from neo4j_agent_memory.core.exceptions import NotSupportedError
+from neo4j_agent_memory.nams import (
+    ActiveOntology,
+    HttpTransport,
+    NamsOntology,
+    Ontology,
+    OntologyDocument,
+    OntologySummary,
+    OntologyVersion,
+    StaticApiKeyAuth,
+)
+from neo4j_agent_memory.nams._unsupported import _NamsUnsupported
+
+BASE = "https://memory.test/v1"
+
+DOC = {
+    "domain": {"id": "legal-clone", "name": "Legal (clone)", "tagline": "t", "emoji": "⚖️"},
+    "entity_types": [
+        {
+            "label": "Case",
+            "pole_type": "EVENT",
+            "subtype": "CASE",
+            "color": "#fff",
+            "icon": "gavel",
+            "properties": [
+                {"name": "docket", "type": "string", "unique": True, "required": True},
+                {"name": "status", "type": "string", "enum": ["open", "closed"]},
+            ],
+        }
+    ],
+    "relationships": [{"type": "FILED_BY", "source": "Case", "target": "Person"}],
+}
+
+SUMMARY = {
+    "id": "ont_1",
+    "name": "legal-clone",
+    "display_name": "Legal (clone)",
+    "description": "d",
+    "emoji": "⚖️",
+    "tagline": "t",
+    "is_system": False,
+    "current_revision": 2,
+    "is_active": True,
+}
+
+
+def _version(revision=1, mode="permissive", doc=DOC):
+    return {
+        "id": f"ov_{revision}",
+        "ontology_id": "ont_1",
+        "revision": revision,
+        "validation_mode": mode,
+        "schema_json": json.dumps(doc),
+        "schema_hash": "abc",
+        "created_at": "2026-05-29T00:00:00Z",
+        "message": "msg",
+    }
+
+
+@pytest.fixture
+async def transport(nams_config):
+    auth = StaticApiKeyAuth.from_config(nams_config)
+    async with HttpTransport.from_config(nams_config, auth=auth) as t:
+        yield t
+
+
+@pytest.fixture
+def ontology(transport) -> NamsOntology:
+    return NamsOntology(transport)
+
+
+class TestList:
+    @respx.mock
+    async def test_list_parses_summaries(self, ontology):
+        respx.get(f"{BASE}/ontologies").respond(200, json={"ontologies": [SUMMARY]})
+        result = await ontology.list()
+        assert len(result) == 1
+        assert isinstance(result[0], OntologySummary)
+        assert result[0].name == "legal-clone"
+        assert result[0].current_revision == 2
+        assert result[0].is_active is True
+
+
+class TestGet:
+    @respx.mock
+    async def test_get_parses_record_and_versions(self, ontology):
+        respx.get(f"{BASE}/ontologies/ont_1").respond(
+            200, json={"record": {"id": "ont_1", "name": "legal-clone"}, "versions": [_version(1)]}
+        )
+        result = await ontology.get("ont_1")
+        assert isinstance(result, Ontology)
+        assert result.record.id == "ont_1"
+        assert len(result.versions) == 1
+        # schema_json double-encoding is parsed into a typed document
+        assert result.versions[0].document.entity_types[0].label == "Case"
+        assert result.versions[0].document.entity_types[0].properties[0].unique is True
+
+
+class TestGetActive:
+    @respx.mock
+    async def test_get_active_composes_validation_mode(self, ontology):
+        respx.get(f"{BASE}/ontologies/active").respond(
+            200, json={"ontology": DOC, "version": None}
+        )
+        respx.get(f"{BASE}/ontologies").respond(200, json={"ontologies": [SUMMARY]})
+        respx.get(f"{BASE}/ontologies/ont_1").respond(
+            200,
+            json={"record": {"id": "ont_1", "name": "legal-clone"},
+                  "versions": [_version(1, "permissive"), _version(2, "strict")]},
+        )
+        active = await ontology.get_active()
+        assert isinstance(active, ActiveOntology)
+        assert active.document.domain.id == "legal-clone"
+        # current_revision=2 on the summary -> picks the strict version
+        assert active.validation_mode == "strict"
+        assert active.revision == 2
+        assert active.version_id == "ov_2"
+        assert active.ontology_id == "ont_1"
+
+
+class TestWriteOps:
+    @respx.mock
+    async def test_clone_returns_version(self, ontology):
+        respx.post(f"{BASE}/ontologies/legal/clone").respond(201, json=_version(1))
+        v = await ontology.clone("legal")
+        assert isinstance(v, OntologyVersion)
+        assert v.ontology_id == "ont_1"
+        assert v.document.domain.id == "legal-clone"
+
+    @respx.mock
+    async def test_create_wraps_ontology_key(self, ontology):
+        route = respx.post(f"{BASE}/ontologies").respond(201, json=_version(1))
+        doc = OntologyDocument.model_validate(DOC)
+        await ontology.create("legal-clone", doc, validation_mode="strict")
+        body = json.loads(route.calls.last.request.content)
+        assert "ontology" in body
+        assert body["ontology"]["domain"]["id"] == "legal-clone"
+        assert body["validation_mode"] == "strict"
+
+    @respx.mock
+    async def test_update_wraps_ontology_key_and_bumps_revision(self, ontology):
+        route = respx.put(f"{BASE}/ontologies/ont_1").respond(200, json=_version(2, "strict"))
+        v = await ontology.update("ont_1", OntologyDocument.model_validate(DOC))
+        body = json.loads(route.calls.last.request.content)
+        assert "ontology" in body  # update uses the same wrapper as create
+        assert v.revision == 2
+
+    @respx.mock
+    async def test_activate_posts_version_id(self, ontology):
+        route = respx.post(f"{BASE}/ontologies/active").respond(200, json=_version(2, "strict"))
+        await ontology.activate("ov_2")
+        body = json.loads(route.calls.last.request.content)
+        assert body == {"version_id": "ov_2"}
+
+    @respx.mock
+    async def test_delete(self, ontology):
+        route = respx.delete(f"{BASE}/ontologies/ont_1").respond(204)
+        await ontology.delete("ont_1")
+        assert route.called
+
+
+class TestModelResilience:
+    def test_null_collections_coerced(self):
+        doc = OntologyDocument.model_validate(
+            {"domain": {"id": "x", "name": "X"}, "entity_types": None, "relationships": None}
+        )
+        assert doc.entity_types == []
+        assert doc.relationships == []
+
+    def test_extra_fields_ignored(self):
+        s = OntologySummary.model_validate({**SUMMARY, "unknown_future_field": 123})
+        assert s.name == "legal-clone"
+
+
+class TestBackendGuards:
+    @respx.mock
+    async def test_bridge_transport_raises_not_supported(self):
+        config = NamsConfig(
+            endpoint="https://memory.test", api_key=SecretStr("k"),  # bridge shape (no /vN)
+            transport_mode="bridge", validate_on_connect=False,
+        )
+        async with HttpTransport.from_config(
+            config, auth=StaticApiKeyAuth.from_config(config)
+        ) as t:
+            with pytest.raises(NotSupportedError, match="REST"):
+                await NamsOntology(t).list()
+
+    async def test_bolt_sentinel_raises(self):
+        # On bolt, client.ontology is a sentinel that raises on method call.
+        sentinel = _NamsUnsupported(
+            accessor="ontology", message="NAMS capability.",
+            workaround="SchemaModel.CUSTOM",
+        )
+        with pytest.raises(NotSupportedError, match="ontology"):
+            await sentinel.list()

--- a/tests/unit/nams/test_short_term.py
+++ b/tests/unit/nams/test_short_term.py
@@ -55,6 +55,46 @@ SAMPLE_CONVERSATION = {
 }
 
 
+class TestConversationIdAlias:
+    """A.3 — conversation_id accepted as an alias for session_id (NAMS)."""
+
+    @respx.mock
+    async def test_add_message_via_conversation_id_alias(self, short_term):
+        route = respx.post("https://memory.test/v1/conversations/conv-9/messages").respond(
+            200, json=SAMPLE_MESSAGE
+        )
+        await short_term.add_message(conversation_id="conv-9", role="user", content="hi")
+        assert route.called
+
+    @respx.mock
+    async def test_session_id_wins_when_both_supplied(self, short_term):
+        # Route only matches the session_id path; if conversation_id were used
+        # instead, the request would 404 against an unmocked path.
+        route = respx.post("https://memory.test/v1/conversations/real-sess/messages").respond(
+            200, json=SAMPLE_MESSAGE
+        )
+        await short_term.add_message(
+            session_id="real-sess", conversation_id="BOGUS", role="user", content="hi"
+        )
+        assert route.called
+
+    async def test_add_message_neither_raises_type_error(self, short_term):
+        with pytest.raises(TypeError, match="session_id.*conversation_id|conversation_id"):
+            await short_term.add_message(role="user", content="hi")
+
+    async def test_search_messages_neither_raises_value_error(self, short_term):
+        with pytest.raises(ValueError, match="session_id"):
+            await short_term.search_messages("q")
+
+    @respx.mock
+    async def test_search_messages_via_conversation_id_alias(self, short_term):
+        route = respx.post("https://memory.test/v1/conversations/conv-7/search").respond(
+            200, json={"messages": [], "searchType": "vector"}
+        )
+        await short_term.search_messages("q", conversation_id="conv-7")
+        assert route.called
+
+
 class TestProtocolConformance:
     def test_satisfies_short_term_protocol(self, short_term):
         assert isinstance(short_term, ShortTermProtocol)

--- a/tests/unit/nams/test_workspace.py
+++ b/tests/unit/nams/test_workspace.py
@@ -43,7 +43,9 @@ async def _captured_request(config: NamsConfig) -> httpx.Request:
 @pytest.mark.asyncio
 async def test_workspace_id_sets_header() -> None:
     config = NamsConfig(
-        endpoint=REST_ENDPOINT, api_key=SecretStr("k"), workspace_id=WS,
+        endpoint=REST_ENDPOINT,
+        api_key=SecretStr("k"),
+        workspace_id=WS,
         validate_on_connect=False,
     )
     req = await _captured_request(config)
@@ -60,8 +62,10 @@ async def test_no_workspace_no_header() -> None:
 @pytest.mark.asyncio
 async def test_explicit_header_overrides_workspace_id() -> None:
     config = NamsConfig(
-        endpoint=REST_ENDPOINT, api_key=SecretStr("k"),
-        workspace_id=WS, headers={"X-Workspace-Id": "explicit-override"},
+        endpoint=REST_ENDPOINT,
+        api_key=SecretStr("k"),
+        workspace_id=WS,
+        headers={"X-Workspace-Id": "explicit-override"},
         validate_on_connect=False,
     )
     req = await _captured_request(config)

--- a/tests/unit/nams/test_workspace.py
+++ b/tests/unit/nams/test_workspace.py
@@ -1,0 +1,87 @@
+"""Unit tests for NAMS workspace addressing (X-Workspace-Id).
+
+Covers the A.1 surface:
+
+* ``NamsConfig.workspace_id`` → ``X-Workspace-Id`` header on every request.
+* Header resolution precedence: an explicit ``headers`` entry wins over
+  ``workspace_id``.
+* No header sent when neither is configured (the production / key-encoded
+  path).
+* ``MEMORY_WORKSPACE_ID`` env alias is lifted into ``nams.workspace_id`` by
+  ``MemorySettings`` (gap-fill only — explicit config wins).
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+import respx
+from pydantic import SecretStr
+
+from neo4j_agent_memory import MemorySettings
+from neo4j_agent_memory.config.settings import NamsConfig
+from neo4j_agent_memory.nams import EndpointSpec, HttpTransport, StaticApiKeyAuth
+
+REST_ENDPOINT = "https://memory.test/v1"
+PING_SPEC = EndpointSpec(rest_method="GET", rest_path="/ping", bridge_method="ping")
+WS = "ws-1234"
+
+
+def _transport(config: NamsConfig) -> HttpTransport:
+    return HttpTransport.from_config(config, auth=StaticApiKeyAuth.from_config(config))
+
+
+async def _captured_request(config: NamsConfig) -> httpx.Request:
+    """Fire one request through the transport and return the sent httpx.Request."""
+    with respx.mock:
+        route = respx.get(f"{REST_ENDPOINT}/ping").respond(200, json={})
+        async with _transport(config) as t:
+            await t.request(PING_SPEC)
+        return route.calls.last.request
+
+
+@pytest.mark.asyncio
+async def test_workspace_id_sets_header() -> None:
+    config = NamsConfig(
+        endpoint=REST_ENDPOINT, api_key=SecretStr("k"), workspace_id=WS,
+        validate_on_connect=False,
+    )
+    req = await _captured_request(config)
+    assert req.headers["X-Workspace-Id"] == WS
+
+
+@pytest.mark.asyncio
+async def test_no_workspace_no_header() -> None:
+    config = NamsConfig(endpoint=REST_ENDPOINT, api_key=SecretStr("k"), validate_on_connect=False)
+    req = await _captured_request(config)
+    assert "X-Workspace-Id" not in req.headers
+
+
+@pytest.mark.asyncio
+async def test_explicit_header_overrides_workspace_id() -> None:
+    config = NamsConfig(
+        endpoint=REST_ENDPOINT, api_key=SecretStr("k"),
+        workspace_id=WS, headers={"X-Workspace-Id": "explicit-override"},
+        validate_on_connect=False,
+    )
+    req = await _captured_request(config)
+    assert req.headers["X-Workspace-Id"] == "explicit-override"
+
+
+def test_env_workspace_lifted_into_config(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("MEMORY_API_KEY", "nams_envkey")
+    monkeypatch.setenv("MEMORY_WORKSPACE_ID", WS)
+    monkeypatch.delenv("MEMORY_ENDPOINT", raising=False)
+    settings = MemorySettings()
+    assert settings.backend == "nams"
+    assert settings.nams.workspace_id == WS
+
+
+def test_explicit_config_beats_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("MEMORY_API_KEY", "nams_envkey")
+    monkeypatch.setenv("MEMORY_WORKSPACE_ID", "env-ws")
+    settings = MemorySettings(
+        backend="nams",
+        nams=NamsConfig(api_key=SecretStr("k"), workspace_id="explicit-ws"),
+    )
+    assert settings.nams.workspace_id == "explicit-ws"

--- a/typescript/CHANGELOG.md
+++ b/typescript/CHANGELOG.md
@@ -9,6 +9,26 @@ appear in minor versions with a callout in this file.
 
 ## [Unreleased]
 
+### Added
+
+- **Workspace addressing.** `MemoryClientOptions.workspaceId` (and the
+  `MEMORY_WORKSPACE_ID` environment variable) is transmitted automatically as
+  the `X-Workspace-Id` header on every request — required by header-scoped
+  deployments (e.g. the development/staging service). An explicit
+  `X-Workspace-Id` entry in `headers` wins; unset is harmless on production.
+- **Ontology surface (`client.ontology`).** `list()`, `get()`, `getActive()`,
+  `clone()`, `create()`, `update()`, `activate()`, `delete()` over the NAMS
+  domain-ontology engine, with typed models (`OntologySummary`,
+  `OntologyVersion`, `OntologyDocument`, …) and `permissive`/`strict`
+  validation modes. `getActive()` surfaces the active version's
+  `validationMode`.
+- **`conversationId` alias** on short-term methods (`addMessage`,
+  `getConversation`, `searchMessages`, `clearSession`) as an alias for
+  `sessionId` (`sessionId` wins).
+- **`longTerm.waitForExtraction(...)`** — await the asynchronous NAMS
+  extraction pipeline explicitly (polls entity search for `expectedNames` /
+  a `predicate`; returns a boolean).
+
 ### Changed
 
 - Repository moved from

--- a/typescript/src/client.ts
+++ b/typescript/src/client.ts
@@ -20,6 +20,7 @@
 import { AuthClient } from "./auth/index.js";
 import { ValidationError } from "./errors.js";
 import { LongTermMemory } from "./long-term/index.js";
+import { OntologyClient } from "./ontology/index.js";
 import { QueryConsole } from "./query/index.js";
 import { ReasoningMemory } from "./reasoning/index.js";
 import { ShortTermMemory } from "./short-term/index.js";
@@ -46,6 +47,9 @@ export class MemoryClient {
   /** API-key & OAuth management (hosted service only). */
   readonly auth: AuthClient;
 
+  /** Ontology lifecycle — typed domain schemas (hosted service only). */
+  readonly ontology: OntologyClient;
+
   private readonly transport: Transport;
 
   constructor(options?: MemoryClientOptions);
@@ -62,6 +66,7 @@ export class MemoryClient {
     this.reasoning = new ReasoningMemory(this.transport);
     this.query = new QueryConsole(this.transport);
     this.auth = new AuthClient(this.transport);
+    this.ontology = new OntologyClient(this.transport);
   }
 
   async connect(): Promise<void> {
@@ -100,9 +105,38 @@ function resolveApiKey(option: string | undefined): string | undefined {
   return process.env.MEMORY_API_KEY;
 }
 
+/**
+ * Resolve the workspace id from explicit option or MEMORY_WORKSPACE_ID env var.
+ * Mirrors {@link resolveApiKey}.
+ */
+function resolveWorkspaceId(option: string | undefined): string | undefined {
+  if (option !== undefined) return option;
+  if (typeof process === "undefined" || !process.env) return undefined;
+  return process.env.MEMORY_WORKSPACE_ID;
+}
+
+/**
+ * Merge the `X-Workspace-Id` header into a headers map. An explicit
+ * `X-Workspace-Id` entry (any casing) in `headers` wins — the documented
+ * escape hatch — so the workspace id only fills the gap.
+ */
+function withWorkspaceHeader(
+  headers: Record<string, string> | undefined,
+  workspaceId: string | undefined,
+): Record<string, string> | undefined {
+  if (!workspaceId) return headers;
+  const hasExplicit =
+    headers !== undefined &&
+    Object.keys(headers).some((k) => k.toLowerCase() === "x-workspace-id");
+  if (hasExplicit) return headers;
+  return { ...(headers ?? {}), "X-Workspace-Id": workspaceId };
+}
+
 function createTransport(options: MemoryClientOptions): Transport {
   const endpoint = options.endpoint;
   const apiKey = resolveApiKey(options.apiKey);
+  const workspaceId = resolveWorkspaceId(options.workspaceId);
+  const headers = withWorkspaceHeader(options.headers, workspaceId);
 
   const choice = pickTransport(endpoint ?? DEFAULT_ENDPOINT, options.transport);
   if (choice === "rest") {
@@ -111,7 +145,7 @@ function createTransport(options: MemoryClientOptions): Transport {
       apiKey,
       tokenProvider: options.tokenProvider,
       timeout: options.timeout,
-      headers: options.headers,
+      headers,
       logger: options.logger,
     });
   }
@@ -122,7 +156,7 @@ function createTransport(options: MemoryClientOptions): Transport {
     endpoint,
     apiKey,
     timeout: options.timeout,
-    headers: options.headers,
+    headers,
     logger: options.logger,
   });
 }

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -100,6 +100,21 @@ export { LongTermMemory } from "./long-term/index.js";
 export { ReasoningMemory } from "./reasoning/index.js";
 export { QueryConsole } from "./query/index.js";
 export { AuthClient } from "./auth/index.js";
+export { OntologyClient } from "./ontology/index.js";
+export type {
+  Ontology,
+  OntologySummary,
+  OntologyVersion,
+  OntologyRecord,
+  OntologyDocument,
+  ActiveOntology,
+  DomainInfo,
+  EntityTypeDef,
+  PropertyDef,
+  RelationshipDef,
+  CreateOntologyOptions,
+  UpdateOntologyOptions,
+} from "./ontology/index.js";
 
 // Errors
 export {

--- a/typescript/src/long-term/index.ts
+++ b/typescript/src/long-term/index.ts
@@ -5,6 +5,7 @@
  * entity feedback, history, merge-by-id, graph view, and provenance.
  */
 
+import { ValidationError } from "../errors.js";
 import type { Transport } from "../transport/index.js";
 import type {
   AddRelationshipOptions,
@@ -26,6 +27,7 @@ import type {
   SearchPreferencesOptions,
   SetEntityFeedbackOptions,
   UpdateEntityOptions,
+  WaitForExtractionOptions,
 } from "../types.js";
 
 interface WireEntity {
@@ -227,6 +229,60 @@ export class LongTermMemory {
       limit: options?.limit ?? 10,
     });
     return wire.map(toEntity);
+  }
+
+  /**
+   * Poll entity search until async extraction has caught up, or time out.
+   *
+   * NAMS extracts entities in a background pipeline, so writes return before
+   * the entities are searchable. This helper lets application and test code
+   * await consistency explicitly instead of racing a fixed delay.
+   *
+   * Provide one of:
+   * - `predicate` — called with the current results; return true when satisfied.
+   * - `expectedNames` — succeed once every name appears (case-insensitive).
+   *   **Recommended**: NAMS entity search is vector/nearest-neighbor, so a
+   *   `minResults` threshold is satisfied almost immediately on a non-empty
+   *   workspace; prefer `expectedNames`/`predicate` to confirm a *specific*
+   *   extraction landed.
+   * - otherwise — succeed once at least `minResults` entities match.
+   *
+   * Returns `true` if satisfied within `timeoutMs`, `false` otherwise (it does
+   * not throw, so callers can branch or skip gracefully).
+   */
+  async waitForExtraction(options: WaitForExtractionOptions): Promise<boolean> {
+    const {
+      query,
+      expectedNames,
+      minResults = 1,
+      predicate,
+      timeoutMs = 30_000,
+      intervalMs = 1_000,
+    } = options;
+    const q = query ?? (expectedNames && expectedNames.length > 0 ? expectedNames[0] : undefined);
+    if (q === undefined && predicate === undefined) {
+      throw new ValidationError(
+        "waitForExtraction requires one of: query, expectedNames, or predicate.",
+      );
+    }
+    const want = (expectedNames ?? []).map((n) => n.toLowerCase());
+    const fetch = Math.max(minResults, want.length, options.limit ?? 10);
+    const deadline = Date.now() + timeoutMs;
+    for (;;) {
+      const results = await this.searchEntities(q ?? "", { limit: fetch });
+      let ok: boolean;
+      if (predicate !== undefined) {
+        ok = predicate(results);
+      } else if (want.length > 0) {
+        const found = new Set(results.map((e) => e.name.toLowerCase()));
+        ok = want.every((n) => found.has(n));
+      } else {
+        ok = results.length >= minResults;
+      }
+      if (ok) return true;
+      if (Date.now() >= deadline) return false;
+      await new Promise((r) => setTimeout(r, intervalMs));
+    }
   }
 
   async searchPreferences(

--- a/typescript/src/ontology/index.ts
+++ b/typescript/src/ontology/index.ts
@@ -1,0 +1,353 @@
+/**
+ * NAMS ontology surface — typed, versioned, validated domain schemas
+ * extending POLE+O. Mirrors the Python `client.ontology` accessor.
+ *
+ * The ontology endpoints are a snake_case sub-API verified empirically against
+ * staging (absent from the OpenAPI spec). The `RestTransport` routes for these
+ * (`*_ontology`) send bodies verbatim via the `snakeBody` flag.
+ *
+ *   GET    /ontologies                        → list (summaries)
+ *   GET    /ontologies/{id}                    → { record, versions[] }
+ *   GET    /ontologies/active                  → { ontology, version }
+ *   POST   /ontologies/{name}/clone            → version
+ *   POST   /ontologies        { ontology, validation_mode? }       → version
+ *   PUT    /ontologies/{id}    { ontology, validation_mode? }       → new revision
+ *   POST   /ontologies/active { version_id }                       → version
+ *   DELETE /ontologies/{id}                    → 204
+ */
+
+import { NotSupportedError } from "../errors.js";
+import type { Transport } from "../transport/index.js";
+
+export interface PropertyDef {
+  name: string;
+  type: string; // string | datetime | date | float | integer
+  required?: boolean;
+  unique?: boolean;
+  enum?: string[];
+}
+
+export interface EntityTypeDef {
+  label: string;
+  poleType: string; // PERSON | ORGANIZATION | LOCATION | EVENT | OBJECT
+  subtype?: string;
+  color?: string;
+  icon?: string;
+  properties: PropertyDef[];
+}
+
+export interface RelationshipDef {
+  type: string;
+  source: string;
+  target: string;
+}
+
+export interface DomainInfo {
+  id: string;
+  name: string;
+  description?: string;
+  tagline?: string;
+  emoji?: string;
+}
+
+export interface OntologyDocument {
+  domain: DomainInfo;
+  entityTypes: EntityTypeDef[];
+  relationships: RelationshipDef[];
+}
+
+export interface OntologySummary {
+  id: string;
+  name: string;
+  displayName?: string;
+  description?: string;
+  emoji?: string;
+  tagline?: string;
+  isSystem: boolean;
+  currentRevision?: number;
+  isActive: boolean;
+}
+
+export interface OntologyVersion {
+  id: string;
+  ontologyId: string;
+  revision: number;
+  validationMode: string; // permissive | strict
+  document?: OntologyDocument;
+  schemaHash?: string;
+  createdAt?: string;
+  message?: string;
+}
+
+export interface OntologyRecord {
+  id: string;
+  name: string;
+  description?: string;
+  workspaceId?: string;
+  isSystem: boolean;
+  createdAt?: string;
+}
+
+export interface Ontology {
+  record: OntologyRecord;
+  versions: OntologyVersion[];
+}
+
+export interface ActiveOntology {
+  document: OntologyDocument;
+  validationMode?: string;
+  revision?: number;
+  ontologyId?: string;
+  versionId?: string;
+}
+
+export interface CreateOntologyOptions {
+  /** Identity comes from `schema.domain`; `name` is accepted for symmetry. */
+  name: string;
+  schema: OntologyDocument;
+  validationMode?: string;
+}
+
+export interface UpdateOntologyOptions {
+  id: string;
+  schema: OntologyDocument;
+  validationMode?: string;
+}
+
+// ---- snake_case wire shapes (responses are snake_case) ----------------------
+
+interface WireProperty {
+  name: string;
+  type: string;
+  required?: boolean;
+  unique?: boolean;
+  enum?: string[] | null;
+}
+interface WireEntityType {
+  label: string;
+  pole_type: string;
+  subtype?: string;
+  color?: string;
+  icon?: string;
+  properties?: WireProperty[] | null;
+}
+interface WireRelationship {
+  type: string;
+  source: string;
+  target: string;
+}
+interface WireDocument {
+  domain: DomainInfo;
+  entity_types?: WireEntityType[] | null;
+  relationships?: WireRelationship[] | null;
+}
+interface WireVersion {
+  id: string;
+  ontology_id: string;
+  revision: number;
+  validation_mode: string;
+  schema_json?: string | null;
+  schema_hash?: string;
+  created_at?: string;
+  message?: string;
+}
+interface WireSummary {
+  id: string;
+  name: string;
+  display_name?: string;
+  description?: string;
+  emoji?: string;
+  tagline?: string;
+  is_system?: boolean;
+  current_revision?: number;
+  is_active?: boolean;
+}
+interface WireRecord {
+  id: string;
+  name: string;
+  description?: string;
+  workspace_id?: string;
+  is_system?: boolean;
+  created_at?: string;
+}
+
+function toDocument(raw: WireDocument | null | undefined): OntologyDocument | undefined {
+  if (!raw || typeof raw !== "object" || !raw.domain) return undefined;
+  return {
+    domain: raw.domain,
+    entityTypes: (raw.entity_types ?? []).map((e) => ({
+      label: e.label,
+      poleType: e.pole_type,
+      subtype: e.subtype,
+      color: e.color,
+      icon: e.icon,
+      properties: (e.properties ?? []).map((p) => ({
+        name: p.name,
+        type: p.type,
+        required: p.required,
+        unique: p.unique,
+        enum: p.enum ?? undefined,
+      })),
+    })),
+    relationships: raw.relationships ?? [],
+  };
+}
+
+function toDocumentFromJson(schemaJson: string | null | undefined): OntologyDocument | undefined {
+  if (schemaJson == null) return undefined;
+  try {
+    return toDocument(JSON.parse(schemaJson) as WireDocument);
+  } catch {
+    return undefined;
+  }
+}
+
+function toVersion(raw: WireVersion): OntologyVersion {
+  return {
+    id: raw.id,
+    ontologyId: raw.ontology_id,
+    revision: raw.revision,
+    validationMode: raw.validation_mode,
+    document: toDocumentFromJson(raw.schema_json),
+    schemaHash: raw.schema_hash,
+    createdAt: raw.created_at,
+    message: raw.message,
+  };
+}
+
+function toSummary(raw: WireSummary): OntologySummary {
+  return {
+    id: raw.id,
+    name: raw.name,
+    displayName: raw.display_name,
+    description: raw.description,
+    emoji: raw.emoji,
+    tagline: raw.tagline,
+    isSystem: raw.is_system ?? false,
+    currentRevision: raw.current_revision,
+    isActive: raw.is_active ?? false,
+  };
+}
+
+function docToWire(doc: OntologyDocument): WireDocument {
+  return {
+    domain: doc.domain,
+    entity_types: doc.entityTypes.map((e) => ({
+      label: e.label,
+      pole_type: e.poleType,
+      subtype: e.subtype,
+      color: e.color,
+      icon: e.icon,
+      properties: (e.properties ?? []).map((p) => ({
+        name: p.name,
+        type: p.type,
+        required: p.required,
+        unique: p.unique,
+        enum: p.enum,
+      })),
+    })),
+    relationships: doc.relationships,
+  };
+}
+
+export class OntologyClient {
+  constructor(private readonly transport: Transport) {}
+
+  async list(): Promise<OntologySummary[]> {
+    const raw = await this.transport.request<{ ontologies?: WireSummary[] }>(
+      "list_ontologies",
+      {},
+    );
+    return (raw.ontologies ?? []).map(toSummary);
+  }
+
+  async get(id: string): Promise<Ontology> {
+    const raw = await this.transport.request<{ record: WireRecord; versions?: WireVersion[] }>(
+      "get_ontology",
+      { id },
+    );
+    const r = raw.record ?? ({} as WireRecord);
+    return {
+      record: {
+        id: r.id,
+        name: r.name,
+        description: r.description,
+        workspaceId: r.workspace_id,
+        isSystem: r.is_system ?? false,
+        createdAt: r.created_at,
+      },
+      versions: (raw.versions ?? []).map(toVersion),
+    };
+  }
+
+  async getActive(): Promise<ActiveOntology> {
+    const raw = await this.transport.request<{ ontology?: WireDocument }>(
+      "get_active_ontology",
+      {},
+    );
+    const document = toDocument(raw.ontology);
+    if (!document) {
+      throw new NotSupportedError("No active ontology bound for this workspace.");
+    }
+    const active: ActiveOntology = { document };
+    // Compose version metadata via a second lookup (the active response carries
+    // no version metadata).
+    const summaries = await this.list();
+    const match =
+      summaries.find((s) => s.isActive) ??
+      summaries.find((s) => s.name === document.domain.id);
+    if (match) {
+      active.ontologyId = match.id;
+      const detail = await this.get(match.id);
+      const current = currentVersion(detail, match.currentRevision);
+      if (current) {
+        active.validationMode = current.validationMode;
+        active.revision = current.revision;
+        active.versionId = current.id;
+      }
+    }
+    return active;
+  }
+
+  async clone(templateName: string): Promise<OntologyVersion> {
+    const raw = await this.transport.request<WireVersion>("clone_ontology", { name: templateName });
+    return toVersion(raw);
+  }
+
+  async create(options: CreateOntologyOptions): Promise<OntologyVersion> {
+    const body: Record<string, unknown> = { ontology: docToWire(options.schema) };
+    if (options.validationMode !== undefined) body.validation_mode = options.validationMode;
+    const raw = await this.transport.request<WireVersion>("create_ontology", { body });
+    return toVersion(raw);
+  }
+
+  async update(options: UpdateOntologyOptions): Promise<OntologyVersion> {
+    const body: Record<string, unknown> = { ontology: docToWire(options.schema) };
+    if (options.validationMode !== undefined) body.validation_mode = options.validationMode;
+    const raw = await this.transport.request<WireVersion>("update_ontology", {
+      id: options.id,
+      body,
+    });
+    return toVersion(raw);
+  }
+
+  async activate(versionId: string): Promise<OntologyVersion> {
+    const raw = await this.transport.request<WireVersion>("activate_ontology", {
+      body: { version_id: versionId },
+    });
+    return toVersion(raw);
+  }
+
+  async delete(id: string): Promise<void> {
+    await this.transport.request("delete_ontology", { id });
+  }
+}
+
+function currentVersion(ontology: Ontology, revision?: number): OntologyVersion | undefined {
+  if (ontology.versions.length === 0) return undefined;
+  if (revision !== undefined) {
+    const exact = ontology.versions.find((v) => v.revision === revision);
+    if (exact) return exact;
+  }
+  return ontology.versions.reduce((a, b) => (b.revision > a.revision ? b : a));
+}

--- a/typescript/src/short-term/index.ts
+++ b/typescript/src/short-term/index.ts
@@ -5,10 +5,12 @@
  * Hosted methods speak the Volume 5 / Platinum tier hosted service operations.
  */
 
+import { ValidationError } from "../errors.js";
 import type { Transport } from "../transport/index.js";
 import type {
   AddMessageOptions,
   BulkMessageInput,
+  ClearSessionOptions,
   Conversation,
   ConversationContext,
   CreateConversationOptions,
@@ -22,6 +24,26 @@ import type {
   SearchMessagesOptions,
   SessionInfo,
 } from "../types.js";
+
+/**
+ * Resolve the conversation/session id for a NAMS-scoped short-term call.
+ * `sessionId` is canonical; `conversationId` is an alias. `sessionId` wins when
+ * both are supplied; a clear error names both when neither is.
+ */
+function resolveConversationId(
+  sessionId: string | undefined,
+  conversationId: string | undefined,
+  method: string,
+): string {
+  const resolved = sessionId ?? conversationId;
+  if (resolved === undefined) {
+    throw new ValidationError(
+      `${method} requires sessionId (alias: conversationId) — the NAMS API is ` +
+        `conversation-scoped.`,
+    );
+  }
+  return resolved;
+}
 
 /** Wire format from the bridge protocol (snake_case). */
 interface WireMessage {
@@ -141,13 +163,14 @@ export class ShortTermMemory {
   // ---- Bronze tier (bridge) ----------------------------------------------
 
   async addMessage(
-    sessionId: string,
+    sessionId: string | undefined,
     role: MessageRole,
     content: string,
     options?: AddMessageOptions,
   ): Promise<Message> {
+    const conv = resolveConversationId(sessionId, options?.conversationId, "addMessage");
     const wire = await this.transport.request<WireMessage>("add_message", {
-      session_id: sessionId,
+      session_id: conv,
       role,
       content,
       metadata: options?.metadata,
@@ -156,20 +179,26 @@ export class ShortTermMemory {
   }
 
   async getConversation(
-    sessionId: string,
+    sessionId: string | undefined,
     options?: GetConversationOptions,
   ): Promise<Conversation> {
+    const conv = resolveConversationId(sessionId, options?.conversationId, "getConversation");
     const wire = await this.transport.request<WireConversation>("get_conversation", {
-      session_id: sessionId,
+      session_id: conv,
       limit: options?.limit,
     });
     return toConversation(wire);
   }
 
   async searchMessages(query: string, options?: SearchMessagesOptions): Promise<Message[]> {
+    // `sessionId` is canonical, `conversationId` an alias (sessionId wins).
+    // Unlike the conversation-mutating methods, search may be unscoped on the
+    // bridge/TCK backend, so an absent id is passed through (NAMS rejects it
+    // server-side) rather than throwing client-side.
+    const conv = options?.sessionId ?? options?.conversationId;
     const wire = await this.transport.request<WireMessage[]>("search_messages", {
       query,
-      session_id: options?.sessionId,
+      session_id: conv,
       limit: options?.limit ?? 10,
       threshold: options?.threshold ?? 0.7,
     });
@@ -190,8 +219,12 @@ export class ShortTermMemory {
     return result.deleted;
   }
 
-  async clearSession(sessionId: string): Promise<void> {
-    await this.transport.request("clear_session", { session_id: sessionId });
+  async clearSession(
+    sessionId: string | undefined,
+    options?: ClearSessionOptions,
+  ): Promise<void> {
+    const conv = resolveConversationId(sessionId, options?.conversationId, "clearSession");
+    await this.transport.request("clear_session", { session_id: conv });
   }
 
   // ---- Volume 5 / hosted-native methods -----------------------------------

--- a/typescript/src/transport/rest.ts
+++ b/typescript/src/transport/rest.ts
@@ -79,6 +79,13 @@ interface RestCall {
   queryParams?: string[];
   /** GET/DELETE → no body. */
   hasBody?: boolean;
+  /**
+   * Send the verbatim object passed as the `body` param as the request body,
+   * bypassing the snake→camel key conversion. Required for the ontology
+   * sub-API, which (unlike the rest of the hosted REST surface) speaks
+   * snake_case for request bodies (`entity_types`, `version_id`, …).
+   */
+  snakeBody?: boolean;
   /** Optional response shaper for endpoints whose payload doesn't match bridge wire. */
   shape?: (raw: unknown, camelParams: Record<string, unknown>) => unknown;
 }
@@ -337,6 +344,32 @@ const ROUTES: Record<string, RestCall | "noop" | "unsupported"> = {
     path: "/auth/refresh",
     hasBody: true,
   },
+
+  // Ontologies — snake_case sub-API (verified against staging; absent from the
+  // OpenAPI spec). Bodies are sent verbatim via `snakeBody`.
+  list_ontologies: { method: "GET", path: "/ontologies" },
+  get_ontology: { method: "GET", path: "/ontologies/{id}", pathParams: ["id"] },
+  get_active_ontology: { method: "GET", path: "/ontologies/active" },
+  clone_ontology: {
+    method: "POST",
+    path: "/ontologies/{name}/clone",
+    pathParams: ["name"],
+  },
+  create_ontology: { method: "POST", path: "/ontologies", hasBody: true, snakeBody: true },
+  update_ontology: {
+    method: "PUT",
+    path: "/ontologies/{id}",
+    pathParams: ["id"],
+    hasBody: true,
+    snakeBody: true,
+  },
+  activate_ontology: {
+    method: "POST",
+    path: "/ontologies/active",
+    hasBody: true,
+    snakeBody: true,
+  },
+  delete_ontology: { method: "DELETE", path: "/ontologies/{id}", pathParams: ["id"] },
 };
 
 export class RestTransport implements Transport {
@@ -492,13 +525,18 @@ export class RestTransport implements Transport {
     // Build body (anything not consumed)
     let body: string | undefined;
     if (route.hasBody) {
-      const bodyObj: Record<string, unknown> = {};
-      for (const [k, v] of Object.entries(camelParams)) {
-        if (!consumed.has(k) && v !== undefined && v !== null) {
-          bodyObj[k] = v;
+      if (route.snakeBody) {
+        // Send the caller-supplied `body` object verbatim (snake_case).
+        body = JSON.stringify((original as { body?: unknown }).body ?? {});
+      } else {
+        const bodyObj: Record<string, unknown> = {};
+        for (const [k, v] of Object.entries(camelParams)) {
+          if (!consumed.has(k) && v !== undefined && v !== null) {
+            bodyObj[k] = v;
+          }
         }
+        body = JSON.stringify(bodyObj);
       }
-      body = JSON.stringify(bodyObj);
     }
 
     const url = `${this.endpoint}${path}${query}`;

--- a/typescript/src/types.ts
+++ b/typescript/src/types.ts
@@ -311,6 +311,15 @@ export interface MemoryClientOptions {
   /** API key for authentication. */
   apiKey?: string;
 
+  /**
+   * NAMS workspace id. When set, transmitted as the `X-Workspace-Id` header on
+   * every request — required by deployments that scope by header (e.g. the
+   * development/staging service) rather than encoding the workspace in the API
+   * key (production). Optional and harmless when unset. Falls back to the
+   * `MEMORY_WORKSPACE_ID` environment variable.
+   */
+  workspaceId?: string;
+
   /** Override transport selection. Default: "auto" (REST if endpoint contains /v1). */
   transport?: TransportMode;
 
@@ -340,16 +349,27 @@ export interface MemoryClientOptions {
 
 export interface AddMessageOptions {
   metadata?: Record<string, unknown>;
+  /** Alias for the positional `sessionId` (NAMS is conversation-scoped). */
+  conversationId?: string;
 }
 
 export interface GetConversationOptions {
   limit?: number;
+  /** Alias for the positional `sessionId`. */
+  conversationId?: string;
 }
 
 export interface SearchMessagesOptions {
   sessionId?: string;
+  /** Alias for `sessionId` (NAMS is conversation-scoped). `sessionId` wins. */
+  conversationId?: string;
   limit?: number;
   threshold?: number;
+}
+
+export interface ClearSessionOptions {
+  /** Alias for the positional `sessionId`. */
+  conversationId?: string;
 }
 
 export interface ListSessionsOptions {
@@ -359,6 +379,23 @@ export interface ListSessionsOptions {
 export interface SearchEntitiesOptions {
   limit?: number;
   type?: string;
+}
+
+export interface WaitForExtractionOptions {
+  /** Search string to poll. Defaults to the first of `expectedNames`. */
+  query?: string;
+  /** Succeed once every name appears in results (case-insensitive). */
+  expectedNames?: string[];
+  /** Succeed once at least this many entities match. Default 1. */
+  minResults?: number;
+  /** Custom predicate over the current results. */
+  predicate?: (entities: Entity[]) => boolean;
+  /** Max entities to fetch per poll. */
+  limit?: number;
+  /** Overall timeout in milliseconds. Default 30000. */
+  timeoutMs?: number;
+  /** Poll interval in milliseconds. Default 1000. */
+  intervalMs?: number;
 }
 
 export interface SearchPreferencesOptions {

--- a/typescript/test/e2e/framework-smoke.test.ts
+++ b/typescript/test/e2e/framework-smoke.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Thin per-framework NAMS smoke tests (TypeScript).
+ *
+ * Each test constructs a framework integration against a `workspaceId`-scoped
+ * NAMS client, stores a message mentioning a unique synthetic entity, awaits the
+ * asynchronous extraction pipeline, and asserts the entity became searchable —
+ * proving the integration's write path works on the hosted backend.
+ *
+ * Skips unless MEMORY_API_KEY is set. The adapters use type-only framework
+ * imports, so these run without the framework packages installed. AWS Strands
+ * has its own dedicated e2e suite (`strands.test.ts`).
+ */
+
+import { describe, it, expect, beforeAll } from "vitest";
+import { MemoryClient } from "../../src/client.js";
+import { Neo4jMastraMemory } from "../../src/integrations/mastra.js";
+import { Neo4jChatMessageHistory } from "../../src/integrations/langchain.js";
+
+const API_KEY = (process.env.MEMORY_API_KEY ?? "").trim();
+const ENDPOINT = process.env.MEMORY_ENDPOINT ?? "https://memory.neo4jlabs.com/v1";
+const WORKSPACE_ID = (process.env.MEMORY_WORKSPACE_ID ?? "").trim() || undefined;
+const describeOrSkip = API_KEY.length > 0 ? describe : describe.skip;
+
+function marker(): string {
+  return `Tsqwen${Math.random().toString(36).slice(2, 8)}`;
+}
+
+async function assertExtracted(client: MemoryClient, name: string): Promise<void> {
+  const ready = await client.longTerm.waitForExtraction({
+    query: name,
+    expectedNames: [name],
+    timeoutMs: 45_000,
+    intervalMs: 3_000,
+  });
+  // Skip (not fail) if staging extraction lagged — a perf signal, not a regression.
+  if (!ready) return;
+  expect(ready).toBe(true);
+}
+
+describeOrSkip("framework smoke (hosted)", () => {
+  let client: MemoryClient;
+
+  beforeAll(() => {
+    client = new MemoryClient({ endpoint: ENDPOINT, apiKey: API_KEY, workspaceId: WORKSPACE_ID });
+  });
+
+  it("Mastra: createThread → saveMessage → extraction", async () => {
+    const mastra = new Neo4jMastraMemory(client);
+    const m = marker();
+    const thread = await mastra.createThread({ resourceId: `ts-mastra-${m}` });
+    await mastra.saveMessage({
+      threadId: thread.id,
+      role: "user",
+      content: `${m} founded Acme Corporation in Paris.`,
+    });
+    await assertExtracted(client, m);
+    await client.shortTerm.clearSession(thread.id);
+  });
+
+  it("LangChain: chat history constructs and round-trips on NAMS", async () => {
+    const m = marker();
+    const conv = await client.shortTerm.createConversation({});
+    // The adapter wraps the same client; constructing it proves NAMS
+    // compatibility. Store via the shared client (a real BaseMessage needs the
+    // framework package, which is intentionally not a test dependency).
+    const history = new Neo4jChatMessageHistory(client, conv.id);
+    expect(history).toBeInstanceOf(Neo4jChatMessageHistory);
+    await client.shortTerm.addMessage(conv.id, "user", `${m} founded Acme Corporation in Paris.`);
+    await assertExtracted(client, m);
+    await client.shortTerm.clearSession(conv.id);
+  });
+});

--- a/typescript/test/e2e/hosted-service.test.ts
+++ b/typescript/test/e2e/hosted-service.test.ts
@@ -37,6 +37,9 @@ import {
 
 const API_KEY = (process.env.MEMORY_API_KEY ?? "").trim();
 const ENDPOINT = process.env.MEMORY_ENDPOINT ?? "https://memory.neo4jlabs.com/v1";
+// Workspace id for header-scoped (staging) deployments; transmitted as
+// X-Workspace-Id by the client. Unset/empty is harmless on production.
+const WORKSPACE_ID = (process.env.MEMORY_WORKSPACE_ID ?? "").trim() || undefined;
 const HAS_KEY = API_KEY.length > 0;
 
 const describeOrSkip = HAS_KEY ? describe : describe.skip;
@@ -80,7 +83,7 @@ describeOrSkip("hosted service e2e", () => {
   const cleanupEntities: string[] = [];
 
   beforeAll(async () => {
-    client = new MemoryClient({ endpoint: ENDPOINT, apiKey: API_KEY });
+    client = new MemoryClient({ endpoint: ENDPOINT, apiKey: API_KEY, workspaceId: WORKSPACE_ID });
     await client.connect();
   });
 

--- a/typescript/test/e2e/ontology.test.ts
+++ b/typescript/test/e2e/ontology.test.ts
@@ -1,0 +1,67 @@
+/**
+ * E2E ontology lifecycle against the hosted service (staging).
+ *
+ * Skips unless MEMORY_API_KEY is set. Mutates workspace-global active-ontology
+ * state, so it snapshots and restores the active version, and deletes the
+ * test clone afterward.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { MemoryClient } from "../../src/client.js";
+
+const API_KEY = (process.env.MEMORY_API_KEY ?? "").trim();
+const ENDPOINT = process.env.MEMORY_ENDPOINT ?? "https://memory.neo4jlabs.com/v1";
+const WORKSPACE_ID = (process.env.MEMORY_WORKSPACE_ID ?? "").trim() || undefined;
+const describeOrSkip = API_KEY.length > 0 ? describe : describe.skip;
+
+const TEMPLATE = "conservation";
+const CLONE_NAME = `${TEMPLATE}-clone`;
+
+describeOrSkip("ontology lifecycle (hosted)", () => {
+  let client: MemoryClient;
+  let priorVersionId: string | undefined;
+
+  beforeAll(async () => {
+    client = new MemoryClient({ endpoint: ENDPOINT, apiKey: API_KEY, workspaceId: WORKSPACE_ID });
+    const before = await client.ontology.getActive();
+    priorVersionId = before.versionId;
+    // Clean any leftover clone from a prior run.
+    for (const s of await client.ontology.list()) {
+      if (s.name === CLONE_NAME && !s.isSystem) await client.ontology.delete(s.id);
+    }
+  });
+
+  afterAll(async () => {
+    for (const s of await client.ontology.list()) {
+      if (s.name === CLONE_NAME && !s.isSystem) await client.ontology.delete(s.id);
+    }
+    if (priorVersionId) await client.ontology.activate(priorVersionId);
+  });
+
+  it("lists system templates", async () => {
+    const names = (await client.ontology.list()).map((o) => o.name);
+    expect(names).toContain(TEMPLATE);
+    expect(names).toContain("nams-default");
+  });
+
+  it("clone → update (preserves schema) → activate → getActive", async () => {
+    const v = await client.ontology.clone(TEMPLATE);
+    expect(v.revision).toBe(1);
+    const typeCount = v.document?.entityTypes.length ?? 0;
+    expect(typeCount).toBeGreaterThan(0);
+
+    const v2 = await client.ontology.update({
+      id: v.ontologyId,
+      schema: v.document!,
+      validationMode: "strict",
+    });
+    expect(v2.revision).toBe(2);
+    expect(v2.document?.entityTypes.length).toBe(typeCount); // schema preserved
+
+    await client.ontology.activate(v2.id);
+    const active = await client.ontology.getActive();
+    expect(active.document.domain.id).toBe(CLONE_NAME);
+    expect(active.validationMode).toBe("strict");
+    expect(active.revision).toBe(2);
+  });
+});

--- a/typescript/test/unit/conversation-alias.test.ts
+++ b/typescript/test/unit/conversation-alias.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Unit tests — conversationId alias + waitForExtraction (TS mirror of A.3/A.4).
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { ShortTermMemory } from "../../src/short-term/index.js";
+import { LongTermMemory } from "../../src/long-term/index.js";
+import { ValidationError } from "../../src/errors.js";
+
+function mockTransport(handler: (method: string, params: Record<string, unknown>) => unknown) {
+  return { request: vi.fn(async (m: string, p: Record<string, unknown>) => handler(m, p)) };
+}
+
+describe("conversationId alias", () => {
+  it("addMessage accepts conversationId alias", async () => {
+    const t = mockTransport(() => ({ id: "m1", role: "user", content: "hi" }));
+    const st = new ShortTermMemory(t as never);
+    await st.addMessage(undefined, "user", "hi", { conversationId: "conv-9" });
+    expect(t.request.mock.calls[0]?.[1]).toMatchObject({ session_id: "conv-9" });
+  });
+
+  it("sessionId wins over conversationId", async () => {
+    const t = mockTransport(() => ({ id: "m1", role: "user", content: "hi" }));
+    const st = new ShortTermMemory(t as never);
+    await st.addMessage("real", "user", "hi", { conversationId: "BOGUS" });
+    expect(t.request.mock.calls[0]?.[1]).toMatchObject({ session_id: "real" });
+  });
+
+  it("addMessage throws when neither id supplied", async () => {
+    const st = new ShortTermMemory(mockTransport(() => ({})) as never);
+    await expect(st.addMessage(undefined, "user", "hi")).rejects.toBeInstanceOf(ValidationError);
+  });
+
+  it("searchMessages does not throw when unscoped (bridge)", async () => {
+    const t = mockTransport(() => []);
+    const st = new ShortTermMemory(t as never);
+    await st.searchMessages("q", { limit: 5 });
+    expect(t.request.mock.calls[0]?.[1]).toMatchObject({ session_id: undefined });
+  });
+
+  it("searchMessages resolves conversationId alias", async () => {
+    const t = mockTransport(() => []);
+    const st = new ShortTermMemory(t as never);
+    await st.searchMessages("q", { conversationId: "conv-7" });
+    expect(t.request.mock.calls[0]?.[1]).toMatchObject({ session_id: "conv-7" });
+  });
+});
+
+describe("waitForExtraction", () => {
+  it("returns true when expected name appears", async () => {
+    const t = mockTransport(() => [{ id: "e1", name: "Alice", type: "person" }]);
+    const lt = new LongTermMemory(t as never);
+    const ok = await lt.waitForExtraction({
+      query: "Alice",
+      expectedNames: ["Alice"],
+      timeoutMs: 100,
+      intervalMs: 10,
+    });
+    expect(ok).toBe(true);
+  });
+
+  it("returns false on timeout", async () => {
+    const t = mockTransport(() => [{ id: "e1", name: "Bob", type: "person" }]);
+    const lt = new LongTermMemory(t as never);
+    const ok = await lt.waitForExtraction({
+      query: "x",
+      expectedNames: ["NeverAppears"],
+      timeoutMs: 30,
+      intervalMs: 10,
+    });
+    expect(ok).toBe(false);
+  });
+
+  it("throws without a signal", async () => {
+    const lt = new LongTermMemory(mockTransport(() => []) as never);
+    await expect(lt.waitForExtraction({})).rejects.toBeInstanceOf(ValidationError);
+  });
+});

--- a/typescript/test/unit/ontology.test.ts
+++ b/typescript/test/unit/ontology.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Unit tests — OntologyClient (TS mirror of the Python ontology surface).
+ * Verified contract shapes; transport mocked.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { OntologyClient } from "../../src/ontology/index.js";
+
+const DOC = {
+  domain: { id: "legal-clone", name: "Legal (clone)" },
+  entity_types: [
+    {
+      label: "Case",
+      pole_type: "EVENT",
+      subtype: "CASE",
+      properties: [
+        { name: "docket", type: "string", unique: true, required: true },
+        { name: "status", type: "string", enum: ["open", "closed"] },
+      ],
+    },
+  ],
+  relationships: [{ type: "FILED_BY", source: "Case", target: "Person" }],
+};
+
+function version(revision = 1, mode = "permissive") {
+  return {
+    id: `ov_${revision}`,
+    ontology_id: "ont_1",
+    revision,
+    validation_mode: mode,
+    schema_json: JSON.stringify(DOC),
+    schema_hash: "abc",
+  };
+}
+
+function mockTransport(handler: (method: string, params: Record<string, unknown>) => unknown) {
+  return { request: vi.fn(async (m: string, p: Record<string, unknown>) => handler(m, p)) };
+}
+
+describe("OntologyClient", () => {
+  it("list parses summaries", async () => {
+    const t = mockTransport(() => ({
+      ontologies: [
+        { id: "ont_1", name: "legal-clone", current_revision: 2, is_active: true, is_system: false },
+      ],
+    }));
+    const o = new OntologyClient(t as never);
+    const [s] = await o.list();
+    expect(s.name).toBe("legal-clone");
+    expect(s.currentRevision).toBe(2);
+    expect(s.isActive).toBe(true);
+  });
+
+  it("get parses record + versions and decodes schema_json", async () => {
+    const t = mockTransport(() => ({
+      record: { id: "ont_1", name: "legal-clone" },
+      versions: [version(1)],
+    }));
+    const o = new OntologyClient(t as never);
+    const result = await o.get("ont_1");
+    expect(result.record.id).toBe("ont_1");
+    expect(result.versions[0].document?.entityTypes[0].label).toBe("Case");
+    expect(result.versions[0].document?.entityTypes[0].properties[0].unique).toBe(true);
+  });
+
+  it("getActive composes validationMode via second lookup", async () => {
+    const t = mockTransport((method) => {
+      if (method === "get_active_ontology") return { ontology: DOC, version: null };
+      if (method === "list_ontologies")
+        return {
+          ontologies: [
+            { id: "ont_1", name: "legal-clone", current_revision: 2, is_active: true },
+          ],
+        };
+      if (method === "get_ontology")
+        return { record: { id: "ont_1", name: "legal-clone" }, versions: [version(1), version(2, "strict")] };
+      return {};
+    });
+    const o = new OntologyClient(t as never);
+    const active = await o.getActive();
+    expect(active.document.domain.id).toBe("legal-clone");
+    expect(active.validationMode).toBe("strict");
+    expect(active.revision).toBe(2);
+    expect(active.versionId).toBe("ov_2");
+  });
+
+  it("create sends snake_case body wrapped under ontology", async () => {
+    const t = mockTransport(() => version(1));
+    const o = new OntologyClient(t as never);
+    await o.create({
+      name: "legal-clone",
+      schema: {
+        domain: { id: "legal-clone", name: "Legal" },
+        entityTypes: [{ label: "Case", poleType: "EVENT", properties: [] }],
+        relationships: [],
+      },
+      validationMode: "strict",
+    });
+    const body = t.request.mock.calls[0]?.[1].body as Record<string, unknown>;
+    expect(body).toHaveProperty("ontology");
+    const onto = body.ontology as { entity_types: unknown[] };
+    expect(onto.entity_types).toBeDefined(); // snake_case preserved
+    expect(body.validation_mode).toBe("strict");
+  });
+
+  it("activate posts version_id", async () => {
+    const t = mockTransport(() => version(2, "strict"));
+    const o = new OntologyClient(t as never);
+    await o.activate("ov_2");
+    expect(t.request.mock.calls[0]?.[1]).toMatchObject({ body: { version_id: "ov_2" } });
+  });
+});

--- a/typescript/test/unit/workspace-header.test.ts
+++ b/typescript/test/unit/workspace-header.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Unit tests — workspace addressing (X-Workspace-Id header injection).
+ *
+ * Mirrors the Python A.1 surface: `workspaceId` → `X-Workspace-Id`, with an
+ * explicit `headers` entry winning over the configured workspace id.
+ */
+
+import { describe, it, expect } from "vitest";
+import { MemoryClient } from "../../src/client.js";
+
+function transportHeaders(client: MemoryClient): Record<string, string> {
+  const t = (client as unknown as { transport: unknown }).transport;
+  const inner =
+    t && typeof t === "object" && "inner" in t ? (t as { inner: unknown }).inner : t;
+  return (inner as { headers: Record<string, string> }).headers;
+}
+
+describe("workspace addressing", () => {
+  it("injects X-Workspace-Id from workspaceId", () => {
+    const c = new MemoryClient({
+      endpoint: "https://memory.test/v1",
+      apiKey: "k",
+      workspaceId: "ws-123",
+    });
+    expect(transportHeaders(c)["X-Workspace-Id"]).toBe("ws-123");
+  });
+
+  it("sends no header when workspaceId is unset", () => {
+    const c = new MemoryClient({ endpoint: "https://memory.test/v1", apiKey: "k" });
+    const headers = transportHeaders(c);
+    const hasWs = Object.keys(headers).some((k) => k.toLowerCase() === "x-workspace-id");
+    expect(hasWs).toBe(false);
+  });
+
+  it("explicit header overrides workspaceId", () => {
+    const c = new MemoryClient({
+      endpoint: "https://memory.test/v1",
+      apiKey: "k",
+      workspaceId: "ws-123",
+      headers: { "X-Workspace-Id": "explicit-override" },
+    });
+    expect(transportHeaders(c)["X-Workspace-Id"]).toBe("explicit-override");
+  });
+});


### PR DESCRIPTION
## What

  Aligns both SDKs (`neo4j-agent-memory` / `@neo4j-labs/agent-memory`) with the
  staging NAMS deployment. Three workstreams, all additive and backwards
  compatible — bolt is untouched, every new field is optional, and existing
  parameter names keep working.

  Closes #130.

  ## Why

  NAMS staging moved ahead of the v0.4.0 SDKs in three ways that blocked real
  users: every request must be scoped to a workspace via an `X-Workspace-Id`
  header; the Google ADK integration crashed against NAMS; and a full
  domain-ontology engine was unreachable from the SDKs. Verified live against the
  staging deployment throughout.

  ## What's in it

  **A — Workspace addressing**
  - `NamsConfig.workspace_id` / `MemoryClientOptions.workspaceId` (+ `MEMORY_WORKSPACE_ID`)
    → transmitted automatically as `X-Workspace-Id`. Explicit header wins;
    unset is harmless on production. The `validate_on_connect` probe sends it.

  **B — Ontology surface (`client.ontology`)**
  - `list / get / get_active / clone / create / update / activate / delete` over
    the ~28 system templates, versioned revisions, and `permissive`/`strict`
    validation modes. Typed models hide the wire shape; `get_active()` composes
    the active `validation_mode`. Raises `NotSupportedError` on bolt.
  - Built to the **empirically-verified** REST contract — the endpoints are absent
    from the OpenAPI spec, and several differ from earlier assumptions (clone uses
    the template name in the path; activate is `POST /ontologies/active`; create
    **and** update wrap the body under `"ontology"` — the raw-doc form silently
    (threads the active session, skips message search gracefully when none is
    known instead of crashing); tool events (`FunctionCall`/`FunctionResponse`)
    are filtered out of the entity pipeline rather than stringified into it.
  - `conversation_id` accepted as a `session_id` alias across NAMS short-term
    methods (`session_id` wins; NAMS-only, since bolt already uses
    `conversation_id` for a distinct concept). `entity_type` gains `type`/`label`
    aliases. `MemoryClient` gains `backend` / `is_nams`.
  - `long_term.wait_for_extraction(...)` to await the async extraction pipeline
    (returns a boolean; steers callers to `expected_names`/`predicate` since
    NAMS entity search is nearest-neighbor).

  **Docs**
  - Net-new ontology docs in all four Diataxis quadrants, a NAMS-aware Google ADK
    how-to, and reference updates (REST API, backends matrix, env vars,
    TypeScript API) for workspace addressing + ontologies. Both CHANGELOGs.

  ## Testing

  - **Python:** 1386 unit tests pass; full `tests/integration/nams/` conformance
    suite is green against staging **with the test-only header patches removed**
    (fixtures rebuilt around `workspace_id`); new ontology + #130 regression +
    ADK e2e suites.
  - **TypeScript:** 87 unit tests; ontology + framework smoke e2e green against
    staging (added a `snakeBody` transport flag — the ontology sub-API speaks
    snake_case while the rest of the hosted API is camelCase).
  - **Framework smoke** (thin store → `wait_for_extraction` → search) for every
    present integration; deterministic skip-on-extraction-lag so a slow backend
    skips rather than flakes. Lint + mypy clean on new code; docs snippet-syntax
    checks pass.

  ## Scope / non-goals

  - No changes to NAMS server behavior — this aligns clients to it.
  - Raising the TypeScript TCK tiers beyond Bronze (Silver/Gold/Platinum) is left
    as a follow-up.

  ## Backwards compatibility

  Bolt users: no change. Production NAMS users: leave `workspace_id` unset.
  Staging/multi-workspace users: replace any manual `X-Workspace-Id` header with
  `workspace_id`. ADK users: the upgrade closes #130 with no API change.