### PR TITLE
Ontology-aware LLM extraction: thread entity-type descriptions & examples into the prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`long_term.expand_graph(node_id, loaded_ids=...)`** — 1-hop entity-neighborhood
   expansion (`POST /v1/graph/expand`) for graph visualization; mirrored in the
   TypeScript SDK as `longTerm.expandGraph(nodeId, loadedIds)`.
+- **Ontology-aware LLM extraction — entity-type descriptions and examples now reach
+  the prompt.** Custom (domain-specific) entity types defined with rich
+  `EntityTypeConfig` descriptions now extract reliably on the LLM path, bringing it to
+  parity with the GLiNER path. New surface:
+  - `EntityTypeConfig.examples: list[str]` — few-shot surface examples that anchor a
+    type during extraction (rendered alongside the description).
+  - `ExtractionConfig.entity_type_specs` — rich `list[EntityTypeConfig]` that supersedes
+    `entity_types` (names) for LLM-extractor construction so descriptions reach the
+    prompt; `entity_types` is retained for non-LLM stages and back-compat.
+  - `SchemaConfig.entity_schema` — attach a full `EntitySchemaConfig` programmatically;
+    its type descriptions, examples, subtypes and relationship types drive extraction.
+  - `SchemaConfig.custom_schema_path` is now honored (previously orphaned): it is loaded
+    eagerly into a rich schema at extractor construction and **fails fast** on a
+    missing/invalid file rather than silently falling back to POLE+O.
+  - Precedence (highest first): `entity_type_specs` → `entity_schema` → `custom_schema_path`
+    → `schema_config.entity_types` (names) → `extraction_config.entity_types` (names).
+  - `ExtractionConfig.max_type_description_chars` / `max_type_examples` /
+    `max_typed_block_chars` — configurable caps bounding the typed-block prompt-token cost.
+  - Relationship-type descriptions (with `Source → Target` hints) now render in the
+    prompt when a schema supplies them.
+  - When `strict_types` is set, the structured-output schema is constrained to the
+    configured entity (and relationship) types, rejecting invented types.
+  - `ExtractionResult.type_coverage: dict[str, int]` — additive per-type
+    requested-vs-extracted counts (zeros included); also emitted to logs and tracer spans.
+  - `LLMEntityExtractor(...)` / `LLMEntityExtractor.for_custom_types(...)` now accept a
+    `list[EntityTypeConfig]` (not just names), plus `relation_types=` and `strict_types=`.
+  Fully backward compatible: name-only configurations and the default POLE+O behaviour
+  are unchanged. See NAMS-PRD-002 for the related hosted-service ontology runtime gap.
 
 ### Changed
 
@@ -43,6 +71,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > `reference/rest-api.adoc`, `reference/ontology-api.adoc`, and
 > `reference/authentication.adoc`, and the Python↔TS parity note in
 > `reference/typescript-api.adoc`, to reflect the new SDK surface.
+
+### Fixed
+
+- **`LLMEntityExtractor` ignored `EntityTypeConfig.description`.** Custom-schema type
+  descriptions were dropped before the extraction prompt was built, so the LLM received
+  only a bare list of type names — domain types such as `DECISION`, `TASK`, and `OUTCOME`
+  were rarely extracted. Descriptions (and examples) are now threaded end-to-end into the
+  prompt on both the structured and plain-completion paths.
+- **Same-name over-classification within a single extraction call.** A single surface form
+  (e.g. `Hume`) could be emitted as several nodes under different types. The LLM extractor
+  now collapses entities sharing a normalized name within one call, keeping the
+  highest-confidence classification. (Cross-call/cross-document resolution remains the job
+  of the deduplication/resolution stage.)
+- **`_map_to_allowed_type` mislabeled off-list types under a custom schema.** A type not in
+  the configured set was coerced to a POLE+O default (or `allowed_types[0]`) even when that
+  default wasn't part of the schema — e.g. an extracted date could become the first custom
+  type. Mapping is now schema-aware: a configured type is never coerced, and under a custom
+  schema an unmappable type is kept (flag-not-drop) instead of being collapsed.
 
 ## [0.5.0] - 2026-05-30
 

--- a/docs/modules/ROOT/pages/configuration.adoc
+++ b/docs/modules/ROOT/pages/configuration.adoc
@@ -236,8 +236,19 @@ extraction_config = ExtractionConfig(
     # LLM settings
     llm_model="gpt-4o-mini",
 
-    # Entity types
+    # Entity types (names only)
     entity_types=["PERSON", "ORGANIZATION", "LOCATION", "EVENT", "OBJECT"],
+
+    # Rich entity-type definitions (name + description + examples). When set,
+    # these supersede `entity_types` for the LLM extractor so the descriptions
+    # reach the extraction prompt. Pass a list[EntityTypeConfig].
+    entity_type_specs=None,
+
+    # Typed-block rendering caps (LLM extractor) — bound the prompt-token cost
+    # of rendering many described types.
+    max_type_description_chars=500,   # per-type description truncation
+    max_type_examples=5,              # examples rendered per type
+    max_typed_block_chars=4000,       # global typed-block cap (0 = uncapped)
 
     # Extraction options
     extract_relations=True,
@@ -349,12 +360,34 @@ from neo4j_agent_memory import SchemaConfig, SchemaModel
 
 schema_config = SchemaConfig(
     model=SchemaModel.POLEO,              # Schema model
-    entity_types=None,                     # Custom types (for CUSTOM model)
+    entity_types=None,                     # Custom type names (for CUSTOM model)
+    entity_schema=None,                    # Rich EntitySchemaConfig (descriptions,
+                                           #   examples, subtypes, relation types)
     enable_subtypes=True,                  # Track entity subtypes
-    strict_types=False,                    # Reject unknown types
-    custom_schema_path=None,               # Path to schema file
+    strict_types=False,                    # Reject unknown types (constrains the
+                                           #   structured output on the LLM path)
+    custom_schema_path=None,               # Path to schema file (.json/.yaml);
+                                           #   loaded eagerly, fails fast on a bad path
 )
 ----
+
+[IMPORTANT]
+====
+When you supply a rich schema, the LLM extractor renders each type's
+`description` and `examples` into the extraction prompt — this is what makes
+custom domain types (e.g. `DECISION`, `TASK`, `OUTCOME`) extract reliably.
+The type source for the LLM extractor is resolved by precedence (highest first):
+
+. `ExtractionConfig.entity_type_specs` (rich, extraction-layer override)
+. `SchemaConfig.entity_schema` (rich, programmatic)
+. `SchemaConfig.custom_schema_path` (rich, loaded from file)
+. `SchemaConfig.entity_types` (names)
+. `ExtractionConfig.entity_types` (names)
+
+A set `custom_schema_path` implies custom types regardless of `model`, and a
+missing or invalid path raises rather than silently falling back to POLE+O. See
+xref:how-to/entity-extraction-schemas.adoc[Domain Schemas] for worked examples.
+====
 
 === Environment Variables
 

--- a/docs/modules/ROOT/pages/explanation/extraction-pipeline.adoc
+++ b/docs/modules/ROOT/pages/explanation/extraction-pipeline.adoc
@@ -216,6 +216,39 @@ GLiNER doesn't just match labels - it uses the semantic meaning of descriptions:
 
 This is why domain schemas significantly improve extraction quality.
 
+=== Descriptions on the LLM path
+
+The same principle holds for the LLM extractor, and as of v0.6 it honors type
+descriptions and examples end-to-end — reaching parity with GLiNER. When a
+custom schema supplies descriptions, the extractor renders a typed block into
+the prompt instead of a bare comma-separated list of names:
+
+[source,text]
+----
+## Entity Types
+Extract entities of these types. Assign exactly one type per distinct entity;
+prefer the most specific type that applies.
+- DECISION: A concrete agreement, resolution, or choice made during a meeting.
+  Signalled by "Decisions:" sections or verbs such as decided, agreed, approved.
+  Examples: "Adopt local transcription tool", "Ship file-drop by Q3".
+- TASK: An action item, follow-up, or to-do assigned to a person or team.
+...
+----
+
+Without the descriptions, the model has no signal for abstract domain types
+such as `DECISION`, `TASK`, or `OUTCOME` and tends to skip them — its priors
+only carry well-known NER types like `PERSON` and `ORGANIZATION`. The
+description is the extraction contract; the examples anchor it.
+
+*POLE+O defaults vs. custom schemas.* With the default POLE+O schema (or any
+name-only configuration), the prompt keeps the built-in POLE+O type guidance
+unchanged — existing behavior is untouched. The typed block is rendered only
+when a type carries a description or examples. A configured POLE+O type left
+undescribed backfills the library's built-in description, so a
+partially-customized schema never regresses its untouched core types. Under
+`strict_types`, the structured-output schema is additionally constrained to the
+configured types, so the model cannot invent types outside the ontology.
+
 == Relationship Extraction with GLiREL
 
 Beyond entities, GLiREL extracts relationships:

--- a/docs/modules/ROOT/pages/faq.adoc
+++ b/docs/modules/ROOT/pages/faq.adoc
@@ -228,7 +228,11 @@ When using multiple extractors, you need to combine their results. Available str
 
 [IMPORTANT]
 ====
-**Yes, domain schemas are specific to GLiNER.** They leverage GLiNER's ability to accept entity type descriptions at inference time, which helps the model understand what to extract.
+**No — as of v0.6 the LLM extractor honors type descriptions and examples too.**
+Both GLiNER and the LLM path use the full schema (descriptions + examples) to
+understand what to extract. Before v0.6 the LLM path saw only type names, so
+abstract domain types were often dropped; see
+xref:how-to/entity-extraction-schemas.adoc#_custom_types_on_the_llm_extraction_path[Custom Types on the LLM Extraction Path].
 ====
 
 [cols="1,3"]
@@ -239,10 +243,10 @@ When using multiple extractors, you need to combine their results. Available str
 |Uses a fixed set of trained entity types (PERSON, ORG, GPE, etc.) -- cannot use domain schemas
 
 |**LLM**
-|Uses a prompt-based approach with entity type names but not the detailed descriptions from schemas
+|Renders the full schema -- type descriptions and examples -- into the extraction prompt (v0.6+). Optionally constrains the structured output to the configured types with `strict_types`.
 
 |**GLiNER**
-|The only extractor that uses the full schema with descriptions
+|Uses the full schema with descriptions at inference time
 |===
 
 [[labels-vs-schemas]]
@@ -282,6 +286,11 @@ extractor = (
     .build()
 )
 ----
+
+To also feed the LLM stage the full schema (descriptions + examples), pass an
+`EntitySchemaConfig` via `.with_schema(...)` instead of relying on names — the
+builder threads its descriptions, examples, relation types, and `strict_types`
+into the LLM extractor (v0.6+).
 
 [[which-schema]]
 === Which schema should I use?

--- a/docs/modules/ROOT/pages/how-to/entity-extraction-schemas.adoc
+++ b/docs/modules/ROOT/pages/how-to/entity-extraction-schemas.adoc
@@ -241,6 +241,150 @@ loaded = await manager.load_schema("insurance")
 extractor = GLiNEREntityExtractor.for_schema(loaded.config)
 ----
 
+== Custom Types on the LLM Extraction Path
+
+The examples above wire a schema directly into a GLiNER extractor. To drive the
+**LLM** extractor — including the multi-stage pipeline used by `MemoryClient` —
+attach the rich schema to your settings. As of v0.6 the type `description` and
+`examples` are threaded into the extraction prompt, so domain types extract
+reliably instead of being silently dropped.
+
+[NOTE]
+====
+Before v0.6, custom-type descriptions were accepted and stored but dropped
+before the LLM prompt was built — the extractor saw only a list of names, so
+abstract types such as `DECISION`, `TASK`, and `OUTCOME` were rarely extracted.
+The change is fully backward compatible: name-only configurations and the
+default POLE+O behaviour are unchanged.
+====
+
+=== Attach a schema to MemoryClient
+
+[source,python]
+----
+from neo4j_agent_memory import MemoryClient, MemorySettings
+from neo4j_agent_memory.config.settings import SchemaConfig, SchemaModel
+from neo4j_agent_memory.schema import EntitySchemaConfig, EntityTypeConfig
+
+meeting_schema = EntitySchemaConfig(
+    name="meeting",
+    entity_types=[
+        EntityTypeConfig(
+            name="DECISION",
+            description=(
+                "A concrete agreement, resolution, or choice made during a "
+                "meeting. Signalled by 'Decisions:' sections or verbs such as "
+                "decided, agreed, approved, ratified, resolved."
+            ),
+            examples=["Adopt local transcription tool", "Ship file-drop by Q3"],
+        ),
+        EntityTypeConfig(
+            name="TASK",
+            description="An action item, follow-up, or to-do assigned to a person or team.",
+        ),
+        EntityTypeConfig(
+            name="OUTCOME",
+            description="A result or stated impact. Distinct from DECISION (a choice).",
+        ),
+        # Undescribed POLE+O types backfill their built-in description.
+        EntityTypeConfig(name="PERSON"),
+        EntityTypeConfig(name="ORGANIZATION"),
+    ],
+)
+
+settings = MemorySettings(
+    neo4j={"uri": "bolt://localhost:7687", "password": "password"},
+    schema_config=SchemaConfig(
+        model=SchemaModel.CUSTOM,
+        entity_schema=meeting_schema,   # descriptions reach the LLM prompt
+    ),
+)
+
+async with MemoryClient(settings) as client:
+    await client.short_term.add_message(
+        "standup-2026-06-08",
+        "user",
+        "Decisions: adopt the local transcription tool; ship the Hume file-drop by Q3.",
+        extract_entities=True,
+    )
+----
+
+=== Load a schema from a file
+
+A `custom_schema_path` is loaded eagerly when the extractor is built and
+**fails fast** on a missing or invalid file — there is no silent fallback to
+POLE+O. A set path implies custom types regardless of `model`.
+
+[source,python]
+----
+settings = MemorySettings(
+    schema_config=SchemaConfig(
+        model=SchemaModel.CUSTOM,
+        custom_schema_path="schemas/meeting.json",   # .json or .yaml
+    ),
+)
+----
+
+=== Override only the LLM extractor
+
+To thread rich types into the LLM extractor without changing the schema used by
+the other stages, set `entity_type_specs` on the extraction config. It takes
+precedence over every other type source for LLM-extractor construction.
+
+[source,python]
+----
+from neo4j_agent_memory.config.settings import ExtractionConfig
+from neo4j_agent_memory.schema import EntityTypeConfig
+
+extraction = ExtractionConfig(
+    entity_type_specs=[
+        EntityTypeConfig(name="DECISION", description="A ratified choice.", examples=["Ship by Q3"]),
+        EntityTypeConfig(name="TASK", description="An assigned action item."),
+    ],
+)
+----
+
+The type source for the LLM extractor is resolved by precedence (highest first):
+`entity_type_specs` → `entity_schema` → `custom_schema_path` →
+`schema_config.entity_types` (names) → `extraction_config.entity_types` (names).
+
+=== Constrain the output with strict_types
+
+By default an off-list type returned by the model is kept as-is (flag, don't
+drop) under a custom schema. Set `strict_types=True` to constrain the
+structured output to exactly the configured types, so the model cannot invent
+types outside your ontology:
+
+[source,python]
+----
+schema_config = SchemaConfig(
+    model=SchemaModel.CUSTOM,
+    entity_schema=meeting_schema,
+    strict_types=True,   # reject types outside the schema
+)
+----
+
+=== Inspect per-type coverage
+
+Each extraction reports how many entities were produced per requested type
+(zeros included), so you can see at a glance which domain types the model is
+missing. The counts are also emitted to logs and tracer spans.
+
+[source,python]
+----
+result = await extractor.extract(meeting_notes)
+print(result.type_coverage)
+# {"DECISION": 4, "TASK": 2, "OUTCOME": 0, "PERSON": 2, "ORGANIZATION": 1}
+----
+
+[TIP]
+====
+A single surface form is collapsed to one node per extraction call (keeping the
+highest-confidence type), so a name like `Hume` won't appear as separate
+`PRODUCT`, `PERSON`, and `ORGANIZATION` nodes. Cross-document resolution remains
+the job of xref:how-to/deduplication.adoc[deduplication].
+====
+
 == Relationship Extraction
 
 === GLiREL (No LLM Required)

--- a/docs/modules/ROOT/pages/reference/schemas.adoc
+++ b/docs/modules/ROOT/pages/reference/schemas.adoc
@@ -296,8 +296,9 @@ drive extraction on both the GLiNER and (as of v0.6) the LLM path:
 
 |`name`
 |`str`
-|Entity type name, e.g. `DECISION`. Stored uppercase in the `type` property and
-converted to a PascalCase Neo4j label (for example, `:Decision`).
+|Entity type name, e.g. `DECISION`. Stored uppercase in the `type` property
+(for example, `DECISION`) and also applied as a PascalCase Neo4j label
+(for example, `:Decision`).
 
 |`description`
 |`str \| None`

--- a/docs/modules/ROOT/pages/reference/schemas.adoc
+++ b/docs/modules/ROOT/pages/reference/schemas.adoc
@@ -285,6 +285,43 @@ real_estate_schema = DomainSchema(
 extractor = GLiNEREntityExtractor(schema=real_estate_schema, threshold=0.5)
 ----
 
+=== EntityTypeConfig fields
+
+`EntitySchemaConfig.entity_types` is a list of `EntityTypeConfig`. These fields
+drive extraction on both the GLiNER and (as of v0.6) the LLM path:
+
+[cols="1,2,3", options="header"]
+|===
+|Field |Type |Description
+
+|`name`
+|`str`
+|Entity type name, e.g. `DECISION`. Uppercased and used as a Neo4j label.
+
+|`description`
+|`str \| None`
+|What the type means. Rendered into the LLM extraction prompt; the model's
+extraction contract for this type. Write it like a prompt, not a label.
+
+|`examples`
+|`list[str]`
+|Few-shot surface examples that anchor the type (e.g. `["Adopt local tool"]`).
+Rendered alongside the description; capped by
+`ExtractionConfig.max_type_examples`. _(Added in v0.6.)_
+
+|`subtypes`
+|`list[str]`
+|Valid subtypes for finer classification (e.g. `VEHICLE` under `OBJECT`).
+
+|`attributes`
+|`list[str]`
+|Common node properties for this type. Not part of the extraction prompt.
+
+|`color`
+|`str \| None`
+|Hex color for visualization.
+|===
+
 === Schema Best Practices
 
 1. **Use descriptive names**: `"A real estate property"` is better than `"property"`

--- a/docs/modules/ROOT/pages/reference/schemas.adoc
+++ b/docs/modules/ROOT/pages/reference/schemas.adoc
@@ -296,7 +296,8 @@ drive extraction on both the GLiNER and (as of v0.6) the LLM path:
 
 |`name`
 |`str`
-|Entity type name, e.g. `DECISION`. Uppercased and used as a Neo4j label.
+|Entity type name, e.g. `DECISION`. Stored uppercase in the `type` property and
+converted to a PascalCase Neo4j label (for example, `:Decision`).
 
 |`description`
 |`str \| None`

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -2001,6 +2001,7 @@
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.4.0"
       }

--- a/src/neo4j_agent_memory/config/settings.py
+++ b/src/neo4j_agent_memory/config/settings.py
@@ -10,6 +10,13 @@ from pydantic import BaseModel, ConfigDict, Field, SecretStr, model_validator
 from pydantic_settings import BaseSettings, PydanticBaseSettingsSource, SettingsConfigDict
 from pydantic_settings.sources import DotEnvSettingsSource
 
+# NOTE: schema.models (EntitySchemaConfig / EntityTypeConfig) is intentionally
+# NOT imported here. Doing so creates an import cycle
+# (config -> schema -> schema.persistence -> graph -> config). The rich-schema
+# fields below are therefore typed ``Any`` at runtime and carry
+# EntitySchemaConfig / list[EntityTypeConfig] objects verbatim; the extraction
+# factory duck-types them.
+
 # Strict config shared by every child config model. Misspelled fields raise
 # at construction time instead of being silently dropped.
 _STRICT_CONFIG = ConfigDict(extra="forbid")
@@ -165,10 +172,26 @@ class SchemaConfig(BaseModel):
     entity_types: list[str] | None = Field(
         default=None, description="Custom entity types (overrides model default when model=custom)"
     )
+    entity_schema: Any = Field(
+        default=None,
+        description=(
+            "Rich entity schema (an EntitySchemaConfig with per-type descriptions, "
+            "examples, subtypes, and relation types). When set, its type descriptions "
+            "reach the LLM extraction prompt. Takes precedence over 'entity_types' "
+            "(names) and over 'custom_schema_path'. Typed Any at runtime to avoid an "
+            "import cycle; pass an EntitySchemaConfig instance."
+        ),
+    )
     enable_subtypes: bool = Field(default=True, description="Whether to track entity subtypes")
     strict_types: bool = Field(default=False, description="Whether to reject unknown entity types")
     custom_schema_path: str | None = Field(
-        default=None, description="Path to custom schema definition file (.json or .yaml)"
+        default=None,
+        description=(
+            "Path to a custom schema definition file (.json or .yaml). When set, it is "
+            "loaded eagerly into a rich EntitySchemaConfig at extractor construction; a "
+            "missing/invalid file raises. A set path implies custom types regardless of "
+            "'model'. 'entity_schema' (if also set) wins over the loaded file."
+        ),
     )
 
 
@@ -236,6 +259,32 @@ class ExtractionConfig(BaseModel):
             "OBJECT",
         ],
         description="Entity types to extract (POLE+O by default)",
+    )
+    entity_type_specs: Any = Field(
+        default=None,
+        description=(
+            "Rich entity-type definitions (a list[EntityTypeConfig] of name + "
+            "description + examples). When set, supersedes 'entity_types' and any "
+            "schema source for LLM-extractor construction so type descriptions reach "
+            "the extraction prompt. 'entity_types' (names) is retained for non-LLM "
+            "stages and back-compat. Typed Any at runtime to avoid an import cycle."
+        ),
+    )
+    # Typed-block rendering caps (LLM extractor). Bound the prompt-token cost of
+    # rendering many described types; see the typed-block renderer for the
+    # deterministic degrade order when the global cap is exceeded.
+    max_type_description_chars: int = Field(
+        default=500,
+        ge=0,
+        description="Per-type description truncation length (chars) in the typed block",
+    )
+    max_type_examples: int = Field(
+        default=5, ge=0, description="Maximum examples rendered per type in the typed block"
+    )
+    max_typed_block_chars: int = Field(
+        default=4000,
+        ge=0,
+        description="Global cap (chars) for the rendered typed-entity block (0 = uncapped)",
     )
     extract_relations: bool = Field(default=True, description="Whether to extract relations")
     extract_preferences: bool = Field(default=True, description="Whether to extract preferences")

--- a/src/neo4j_agent_memory/extraction/_payloads.py
+++ b/src/neo4j_agent_memory/extraction/_payloads.py
@@ -13,7 +13,9 @@ forcing the LLM to invent values for downstream-only fields like
 
 from __future__ import annotations
 
-from pydantic import BaseModel, Field
+from typing import Literal
+
+from pydantic import BaseModel, Field, create_model
 
 
 class EntityPayload(BaseModel):
@@ -22,8 +24,9 @@ class EntityPayload(BaseModel):
     name: str = Field(description="Entity name, as it appears in the text.")
     type: str = Field(
         description=(
-            "Entity type. One of the allowed types (PERSON, OBJECT, "
-            "LOCATION, EVENT, ORGANIZATION for POLE+O, or as configured)."
+            "Entity type. Use exactly one of the configured entity types "
+            "(the default POLE+O set is PERSON, OBJECT, LOCATION, EVENT, "
+            "ORGANIZATION; a custom schema overrides this set)."
         )
     )
     subtype: str | None = Field(
@@ -73,9 +76,61 @@ class ExtractionPayload(BaseModel):
     preferences: list[PreferencePayload] = Field(default_factory=list)
 
 
+def build_constrained_payload(
+    entity_types: list[str],
+    relation_types: list[str] | None = None,
+) -> type[ExtractionPayload]:
+    """Build a per-call payload model that constrains the extracted types.
+
+    Used by the LLM extractor when ``strict_types`` is enabled: the
+    ``type`` field on entities (and optionally ``relation_type`` on
+    relations) becomes a :data:`typing.Literal` over the configured names,
+    so the structured-output schema rejects invented types at the provider
+    layer (OpenAI strict mode / Anthropic tool schema) or, failing that, at
+    Pydantic-validation time on the schema-aligned fallback path.
+
+    Falls back to the unconstrained :class:`ExtractionPayload` when no
+    entity types are supplied (nothing to constrain to).
+    """
+    if not entity_types:
+        return ExtractionPayload
+
+    # ``Literal[tuple(...)]`` expands the tuple into the Literal's args at
+    # runtime — the supported idiom for building a Literal dynamically.
+    entity_type_literal = Literal[tuple(entity_types)]  # type: ignore[valid-type]
+    constrained_entity = create_model(
+        "ConstrainedEntityPayload",
+        __base__=EntityPayload,
+        type=(
+            entity_type_literal,
+            Field(description="Entity type. Must be one of the configured types."),
+        ),
+    )
+
+    relation_model: type[BaseModel] = RelationPayload
+    if relation_types:
+        relation_type_literal = Literal[tuple(relation_types)]  # type: ignore[valid-type]
+        relation_model = create_model(
+            "ConstrainedRelationPayload",
+            __base__=RelationPayload,
+            relation_type=(
+                relation_type_literal,
+                Field(description="Relationship type. Must be one of the configured types."),
+            ),
+        )
+
+    return create_model(
+        "ConstrainedExtractionPayload",
+        __base__=ExtractionPayload,
+        entities=(list[constrained_entity], Field(default_factory=list)),  # type: ignore[valid-type]
+        relations=(list[relation_model], Field(default_factory=list)),  # type: ignore[valid-type]
+    )
+
+
 __all__ = [
     "EntityPayload",
     "RelationPayload",
     "PreferencePayload",
     "ExtractionPayload",
+    "build_constrained_payload",
 ]

--- a/src/neo4j_agent_memory/extraction/base.py
+++ b/src/neo4j_agent_memory/extraction/base.py
@@ -330,6 +330,14 @@ class ExtractionResult(BaseModel):
     relations: list[ExtractedRelation] = Field(default_factory=list)
     preferences: list[ExtractedPreference] = Field(default_factory=list)
     source_text: str | None = Field(default=None, description="Original source text")
+    type_coverage: dict[str, int] = Field(
+        default_factory=dict,
+        description=(
+            "Per-type extracted-entity counts keyed by requested type name, including "
+            "requested types that produced zero entities. Empty unless the extractor "
+            "populates it (currently the LLM extractor). Additive/observational only."
+        ),
+    )
 
     @property
     def entity_count(self) -> int:
@@ -392,6 +400,7 @@ class ExtractionResult(BaseModel):
             relations=valid_relations,
             preferences=self.preferences,  # Preferences don't need filtering
             source_text=self.source_text,
+            type_coverage=self.type_coverage,
         )
 
 

--- a/src/neo4j_agent_memory/extraction/factory.py
+++ b/src/neo4j_agent_memory/extraction/factory.py
@@ -39,6 +39,12 @@ def _get_entity_labels_for_schema(schema_config: SchemaConfig) -> list[str]:
         # Use custom entity types as labels (lowercase for GLiNER)
         return [t.lower() for t in schema_config.entity_types]
 
+    # Fall back to a rich entity_schema's type names when only it is set, so
+    # pipeline mode's GLiNER stage stays coherent with the configured types.
+    rich = getattr(schema_config, "entity_schema", None)
+    if rich is not None and getattr(rich, "entity_types", None):
+        return [t.name.lower() for t in rich.entity_types]
+
     # Default POLE+O labels
     return [
         "person",
@@ -144,10 +150,78 @@ def create_gliner_extractor(
     )
 
 
+def resolve_llm_type_source(
+    extraction_config: ExtractionConfig,
+    schema_config: SchemaConfig | None = None,
+) -> tuple[Any, Any, bool]:
+    """Resolve the entity/relation type source for the LLM extractor.
+
+    Applies the precedence chain (highest first):
+
+    1. ``ExtractionConfig.entity_type_specs`` (rich, extraction-layer override)
+    2. ``SchemaConfig.entity_schema`` (rich, programmatic)
+    3. ``SchemaConfig.custom_schema_path`` (rich, loaded from file — **fail-fast**
+       on a missing/invalid path; a set path implies custom types)
+    4. ``SchemaConfig.entity_types`` (names)
+    5. ``ExtractionConfig.entity_types`` (names)
+
+    Returns ``(entity_types, relation_types, strict_types)`` where
+    ``entity_types`` is a name list or a ``list[EntityTypeConfig]``,
+    ``relation_types`` is a ``list[RelationTypeConfig] | None`` (from a rich
+    schema only), and ``strict_types`` comes from the rich schema if present
+    else ``SchemaConfig.strict_types``.
+    """
+    specs = getattr(extraction_config, "entity_type_specs", None)
+
+    rich = None
+    if schema_config is not None:
+        rich = getattr(schema_config, "entity_schema", None)
+        schema_path = getattr(schema_config, "custom_schema_path", None)
+        if rich is None and schema_path:
+            # Eager, fail-fast load. Raises FileNotFoundError/ValueError on a
+            # bad path rather than silently falling back to POLE+O.
+            from neo4j_agent_memory.schema.models import load_schema_from_file
+
+            rich = load_schema_from_file(schema_path)
+
+    # strict_types: a rich schema's flag wins, else the flat schema_config flag.
+    strict_types = False
+    if rich is not None:
+        strict_types = bool(getattr(rich, "strict_types", False))
+    elif schema_config is not None:
+        strict_types = bool(getattr(schema_config, "strict_types", False))
+
+    relation_types = getattr(rich, "relation_types", None) if rich is not None else None
+
+    if specs:
+        entity_types: Any = specs
+        # R5: surface a names-vs-specs desync; specs win.
+        config_names = getattr(schema_config, "entity_types", None) if schema_config else None
+        if config_names:
+            spec_names = {getattr(s, "name", str(s)).upper() for s in specs}
+            extra = {n.upper() for n in config_names} - spec_names
+            if extra:
+                logger.warning(
+                    "schema_config.entity_types %s are absent from "
+                    "extraction.entity_type_specs; specs take precedence.",
+                    sorted(extra),
+                )
+    elif rich is not None:
+        entity_types = rich.entity_types
+    elif schema_config is not None and schema_config.entity_types:
+        entity_types = schema_config.entity_types
+    else:
+        entity_types = extraction_config.entity_types
+
+    return entity_types, relation_types, strict_types
+
+
 def create_llm_extractor(
     extraction_config: ExtractionConfig,
     schema_config: SchemaConfig | None = None,
     llm_config: Any = None,
+    *,
+    resolved_source: tuple[Any, Any, bool] | None = None,
 ) -> "EntityExtractor":
     """Create an LLM entity extractor.
 
@@ -161,6 +235,11 @@ def create_llm_extractor(
             * a fully-constructed :class:`LLMProvider` instance,
             * ``None`` — falls back to the legacy ``extraction_config.llm_model``
               and lets :class:`LLMEntityExtractor` build its own default.
+        resolved_source: Pre-resolved ``(entity_types, relation_types,
+            strict_types)`` tuple from :func:`resolve_llm_type_source`. When
+            ``None`` (direct call) it is resolved here; the pipeline pre-resolves
+            it outside its per-stage error handling so a bad ``custom_schema_path``
+            fails fast instead of being swallowed.
 
     Returns:
         LLMEntityExtractor instance
@@ -168,14 +247,19 @@ def create_llm_extractor(
     from neo4j_agent_memory.config.settings import LLMConfig
     from neo4j_agent_memory.extraction.llm_extractor import LLMEntityExtractor
 
-    entity_types = extraction_config.entity_types
-    if schema_config and schema_config.entity_types:
-        entity_types = schema_config.entity_types
+    if resolved_source is None:
+        resolved_source = resolve_llm_type_source(extraction_config, schema_config)
+    entity_types, relation_types, strict_types = resolved_source
 
     common_kwargs: dict[str, Any] = {
         "entity_types": entity_types,
+        "relation_types": relation_types,
+        "strict_types": strict_types,
         "extract_relations": extraction_config.extract_relations,
         "extract_preferences": extraction_config.extract_preferences,
+        "max_type_description_chars": extraction_config.max_type_description_chars,
+        "max_type_examples": extraction_config.max_type_examples,
+        "max_typed_block_chars": extraction_config.max_typed_block_chars,
     }
 
     # Provider instance: pass through directly.
@@ -257,8 +341,14 @@ def create_extraction_pipeline(
 
     # Stage 3: LLM fallback for complex cases and relations
     if extraction_config.enable_llm_fallback:
+        # Pre-resolve the type source OUTSIDE the per-stage try/except so a bad
+        # custom_schema_path (or other config error) fails fast rather than
+        # being swallowed and silently degrading to POLE+O defaults.
+        llm_source = resolve_llm_type_source(extraction_config, schema_config)
         try:
-            llm_extractor = create_llm_extractor(extraction_config, schema_config, llm_config)
+            llm_extractor = create_llm_extractor(
+                extraction_config, schema_config, llm_config, resolved_source=llm_source
+            )
             stages.append(llm_extractor)
             logger.info("Added LLM extractor to pipeline")
         except Exception as e:
@@ -384,6 +474,11 @@ class ExtractorBuilder:
             "EVENT",
             "OBJECT",
         ]
+        # Rich type/relation configs (set via with_schema) so the LLM stage can
+        # render descriptions/examples; None when only names are configured.
+        self._entity_type_configs: Any = None
+        self._relation_type_configs: Any = None
+        self._strict_types: bool = False
         self._extract_relations = True
         self._extract_preferences = True
         self._confidence_threshold: float | None = None
@@ -491,6 +586,11 @@ class ExtractorBuilder:
         if type_names:
             self._entity_types = type_names
             self._gliner_entity_labels = [t.lower() for t in type_names]
+        # Retain the rich configs so the LLM stage renders descriptions and
+        # examples (and honours strict_types / relation types).
+        self._entity_type_configs = list(schema_config.entity_types)
+        self._relation_type_configs = list(getattr(schema_config, "relation_types", []) or [])
+        self._strict_types = bool(getattr(schema_config, "strict_types", False))
         return self
 
     def merge_by_union(self) -> "ExtractorBuilder":
@@ -562,10 +662,17 @@ class ExtractorBuilder:
         if self._enable_llm:
             from neo4j_agent_memory.extraction.llm_extractor import LLMEntityExtractor
 
+            # Prefer the rich type configs (with descriptions/examples) when a
+            # schema was supplied via with_schema(); else fall back to names.
+            llm_entity_types = (
+                self._entity_type_configs if self._entity_type_configs else self._entity_types
+            )
             stages.append(
                 LLMEntityExtractor(
                     model=self._llm_model,
-                    entity_types=self._entity_types,
+                    entity_types=llm_entity_types,
+                    relation_types=self._relation_type_configs,
+                    strict_types=self._strict_types,
                     extract_relations=self._extract_relations,
                     extract_preferences=self._extract_preferences,
                 )

--- a/src/neo4j_agent_memory/extraction/llm_extractor.py
+++ b/src/neo4j_agent_memory/extraction/llm_extractor.py
@@ -19,10 +19,14 @@ from __future__ import annotations
 
 import json
 import logging
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 from neo4j_agent_memory.core.exceptions import ExtractionError
-from neo4j_agent_memory.extraction._payloads import ExtractionPayload
+from neo4j_agent_memory.extraction._payloads import (
+    ExtractionPayload,
+    build_constrained_payload,
+)
 from neo4j_agent_memory.extraction.base import (
     EntityExtractor,
     ExtractedEntity,
@@ -33,6 +37,7 @@ from neo4j_agent_memory.extraction.base import (
 
 if TYPE_CHECKING:
     from neo4j_agent_memory.llm.protocol import LLMProvider, StructuredExtractor
+    from neo4j_agent_memory.schema.models import EntityTypeConfig, RelationTypeConfig
 
 
 logger = logging.getLogger(__name__)
@@ -56,17 +61,54 @@ POLEO_SUBTYPES: dict[str, list[str]] = {
     "ORGANIZATION": ["COMPANY", "NONPROFIT", "GOVERNMENT", "EDUCATIONAL", "GROUP"],
 }
 
+# Built-in POLE+O type descriptions. Used both to render the default
+# ``{type_guidelines}`` block (names-only path) and to backfill a typed-block
+# line for a configured POLE+O type that the caller left undescribed, so a
+# partially-described POLE+O schema does not regress its untouched core types.
+POLEO_TYPE_DESCRIPTIONS: dict[str, str] = {
+    "PERSON": "Individuals, people mentioned by name or role",
+    "OBJECT": "Physical or digital items (vehicles, phones, documents, devices)",
+    "LOCATION": "Places, addresses, geographic areas, landmarks",
+    "EVENT": "Incidents, meetings, transactions, things that happened",
+    "ORGANIZATION": "Companies, groups, institutions",
+}
+
+# The default POLE+O type-definition block. Rendered into ``{type_guidelines}``
+# only on the names-only path; when a typed block carries descriptions we drop
+# this so the configured descriptions are the single source of type guidance.
+DEFAULT_POLEO_TYPE_GUIDELINES = "\n".join(
+    f"- {name}: {desc}" for name, desc in POLEO_TYPE_DESCRIPTIONS.items()
+)
+
+# Generic relationship guidance, used when no relationship-type specs are
+# configured. When specs ARE configured they replace this block (E9).
+GENERIC_RELATION_GUIDANCE = (
+    "- Identify how entities are connected\n"
+    "- Use clear relationship types (WORKS_AT, LIVES_IN, OWNS, ATTENDED, KNOWS, etc.)"
+)
+
 # Default prompt optimized for POLE+O extraction. The structured-extraction
 # path uses Pydantic schema validation instead, so this is the fallback
 # for plain-LLM-call extraction (when the provider does not implement
 # StructuredExtractor).
+#
+# Template slots:
+#   {entity_types}     -- comma-joined names (back-compat) OR a typed block
+#                         (name + description + examples per type)
+#   {subtype_info}     -- optional subtype hints
+#   {type_guidelines}  -- POLE+O type definitions on the names-only path; empty
+#                         when a typed block already carries descriptions
+#   {relation_guidance}-- generic guidance OR a configured relationship-type block
+#   {text}             -- the document under analysis
+# Relation/preference/confidence guidance is fixed template text and is present
+# on every path so custom-type extraction never loses it.
 DEFAULT_EXTRACTION_PROMPT = """Extract entities, relationships, and preferences from the following text.
 
 ## Entity Types
-Extract entities of these types:
+Extract entities of these types. Assign exactly one type per distinct entity; \
+prefer the most specific type that applies.
 {entity_types}
-
-{subtype_info}
+{subtype_info}{type_guidelines}
 
 ## Output Format
 Return a JSON object with this structure:
@@ -82,19 +124,11 @@ Return a JSON object with this structure:
     ]
 }}
 
-## Guidelines
-- PERSON: Individuals, people mentioned by name or role
-- OBJECT: Physical or digital items (vehicles, phones, documents, devices)
-- LOCATION: Places, addresses, geographic areas, landmarks
-- EVENT: Incidents, meetings, transactions, things that happened
-- ORGANIZATION: Companies, groups, institutions
-
-For relations:
-- Identify how entities are connected
-- Use clear relationship types (WORKS_AT, LIVES_IN, OWNS, ATTENDED, KNOWS, etc.)
+## Relationships
+{relation_guidance}
 - Only include relations between entities in the entities list
 
-For preferences:
+## Preferences
 - User preferences, likes, dislikes, opinions
 - Categories: food, music, communication, style, technology, etc.
 
@@ -109,6 +143,89 @@ SUBTYPE_INFO_TEMPLATE = """
 Subtypes (optional, use when you can determine a more specific type):
 {subtype_list}
 """
+
+
+@dataclass(frozen=True)
+class _TypeSpec:
+    """Normalized internal entity-type spec carried from config to prompt."""
+
+    name: str
+    description: str | None = None
+    examples: tuple[str, ...] = ()
+    subtypes: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class _RelationSpec:
+    """Normalized internal relationship-type spec (E9)."""
+
+    name: str
+    description: str | None = None
+    source_types: tuple[str, ...] = ()
+    target_types: tuple[str, ...] = ()
+
+
+def _normalize_types(
+    types: list[str] | list[EntityTypeConfig] | None,
+) -> list[_TypeSpec]:
+    """Normalize a name list or :class:`EntityTypeConfig` list to ``_TypeSpec``.
+
+    Strings carry no description/examples; :class:`EntityTypeConfig` objects
+    contribute their ``description``, ``examples``, and ``subtypes``. Empty
+    input falls back to the default POLE+O type names.
+    """
+    if not types:
+        return [_TypeSpec(name=n) for n in DEFAULT_ENTITY_TYPES]
+    specs: list[_TypeSpec] = []
+    for ty in types:
+        if isinstance(ty, str):
+            specs.append(_TypeSpec(name=ty.upper()))
+        else:  # EntityTypeConfig (duck-typed to avoid an import cycle)
+            specs.append(
+                _TypeSpec(
+                    name=ty.name.upper(),
+                    description=ty.description,
+                    examples=tuple(getattr(ty, "examples", []) or []),
+                    subtypes=tuple(ty.subtypes or []),
+                )
+            )
+    return specs
+
+
+def _normalize_relations(
+    relations: list[RelationTypeConfig] | None,
+) -> list[_RelationSpec]:
+    """Normalize a :class:`RelationTypeConfig` list to ``_RelationSpec``."""
+    if not relations:
+        return []
+    specs: list[_RelationSpec] = []
+    for rt in relations:
+        specs.append(
+            _RelationSpec(
+                name=rt.name.upper(),
+                description=rt.description,
+                source_types=tuple(t.upper() for t in (rt.source_types or [])),
+                target_types=tuple(t.upper() for t in (rt.target_types or [])),
+            )
+        )
+    return specs
+
+
+def _truncate(text: str, limit: int | None) -> str:
+    """Truncate ``text`` to ``limit`` chars at a word boundary with an ellipsis.
+
+    Reserves one character for the ellipsis and only backs off to the previous
+    word boundary when the cut would split a word (i.e. the character at the cut
+    point is not whitespace), so a clean boundary keeps its final word.
+    """
+    if not limit or len(text) <= limit:
+        return text
+    budget = max(0, limit - 1)
+    cut = text[:budget]
+    if budget < len(text) and not text[budget].isspace() and " " in cut:
+        cut = cut[: cut.rfind(" ")]
+    return f"{cut.rstrip()}…"
+
 
 SYSTEM_MESSAGE = (
     "You are an expert at extracting structured information from text. "
@@ -146,12 +263,17 @@ class LLMEntityExtractor(EntityExtractor):
         model: str | None = None,
         api_key: str | None = None,
         # Configuration shared between provider modes
-        entity_types: list[str] | None = None,
+        entity_types: list[str] | list[EntityTypeConfig] | None = None,
         subtypes: dict[str, list[str]] | None = None,
+        relation_types: list[RelationTypeConfig] | None = None,
+        strict_types: bool = False,
         extraction_prompt: str | None = None,
         temperature: float = 0.0,
         extract_relations: bool = True,
         extract_preferences: bool = True,
+        max_type_description_chars: int = 500,
+        max_type_examples: int = 5,
+        max_typed_block_chars: int = 4000,
     ) -> None:
         # Resolve the provider: explicit > legacy-args > default(gpt-4o-mini)
         if provider is None:
@@ -169,12 +291,49 @@ class LLMEntityExtractor(EntityExtractor):
             provider = from_provider(resolved_model, kind="llm", **kwargs)  # type: ignore[assignment]
         self._provider = provider
         self._model_label = getattr(provider, "model", "unknown")
-        self._entity_types = entity_types or list(DEFAULT_ENTITY_TYPES)
-        self._subtypes = subtypes if subtypes is not None else dict(POLEO_SUBTYPES)
+        self._type_specs = _normalize_types(entity_types)
+        self._entity_types = [s.name for s in self._type_specs]
+        self._relation_specs = _normalize_relations(relation_types)
+        self._strict_types = strict_types
+        # Subtype resolution: an explicit ``subtypes`` map wins; otherwise
+        # derive from each spec's own subtypes, backfilling the built-in
+        # POLE+O subtypes for any configured type that matches a core POLE+O
+        # name and declares none of its own. This keeps the default POLE+O
+        # extractor identical to prior behaviour while letting custom types
+        # carry (only) their declared subtypes.
+        if subtypes is not None:
+            self._subtypes = subtypes
+        else:
+            derived: dict[str, list[str]] = {}
+            for s in self._type_specs:
+                if s.subtypes:
+                    derived[s.name] = list(s.subtypes)
+                elif s.name in POLEO_SUBTYPES:
+                    derived[s.name] = list(POLEO_SUBTYPES[s.name])
+            self._subtypes = derived
         self._prompt = extraction_prompt or DEFAULT_EXTRACTION_PROMPT
         self._temperature = temperature
         self._extract_relations = extract_relations
         self._extract_preferences = extract_preferences
+        self._max_type_description_chars = max_type_description_chars
+        self._max_type_examples = max_type_examples
+        self._max_typed_block_chars = max_typed_block_chars
+        # Tracer is resolved lazily and memoized once per instance so we don't
+        # re-run provider auto-detection (and emit warnings) on every extract.
+        self._tracer: Any = None
+        self._tracer_resolved = False
+
+    def _get_tracer(self) -> Any:
+        """Return a memoized tracer (NoOp by default; zero overhead)."""
+        if not self._tracer_resolved:
+            self._tracer_resolved = True
+            try:
+                from neo4j_agent_memory.observability import get_tracer
+
+                self._tracer = get_tracer()
+            except Exception:  # pragma: no cover - observability is optional
+                self._tracer = None
+        return self._tracer
 
     @property
     def name(self) -> str:
@@ -192,18 +351,102 @@ class LLMEntityExtractor(EntityExtractor):
             return SUBTYPE_INFO_TEMPLATE.format(subtype_list="\n".join(subtype_lines))
         return ""
 
-    def _build_prompt(self, text: str, types_to_use: list[str]) -> str:
+    def _build_prompt(self, text: str, specs: list[_TypeSpec] | None = None) -> str:
+        specs = specs if specs is not None else self._type_specs
+        names = [s.name for s in specs]
+        if any(s.description or s.examples for s in specs):
+            entity_block = "\n" + self._render_typed_block(specs)
+            # The typed block carries the type guidance, so drop the built-in
+            # POLE+O definitions rather than double-specifying.
+            type_guidelines = ""
+        else:
+            entity_block = ", ".join(names)
+            type_guidelines = "\n\n" + DEFAULT_POLEO_TYPE_GUIDELINES
         return self._prompt.format(
-            entity_types=", ".join(types_to_use),
-            subtype_info=self._build_subtype_info(types_to_use),
+            entity_types=entity_block,
+            subtype_info=self._build_subtype_info(names),
+            type_guidelines=type_guidelines,
+            relation_guidance=self._render_relation_block(),
             text=text,
         )
+
+    def _render_typed_block(self, specs: list[_TypeSpec]) -> str:
+        """Render one line per type with description and examples.
+
+        Undescribed POLE+O types backfill the built-in description. Applies
+        the configured caps: per-type description truncation, per-type example
+        count, and a global block-length cap. When the global cap is exceeded
+        the renderer degrades deterministically — first dropping examples, then
+        rendering the overflow types as a single name-only line — and logs what
+        it dropped (never silently).
+        """
+
+        def render_entry(s: _TypeSpec, with_examples: bool) -> str:
+            desc = s.description or POLEO_TYPE_DESCRIPTIONS.get(s.name)
+            if desc:
+                desc = _truncate(desc, self._max_type_description_chars)
+            entry = f"- {s.name}" + (f": {desc}" if desc else "")
+            if with_examples and s.examples:
+                shown = list(s.examples)[: self._max_type_examples]
+                entry += "\n  Examples: " + ", ".join(f'"{e}"' for e in shown)
+            return entry
+
+        cap = self._max_typed_block_chars
+
+        entries = [render_entry(s, True) for s in specs]
+        block = "\n".join(entries)
+        if not cap or len(block) <= cap:
+            return block
+
+        logger.info(
+            "Typed-entity block (%d chars) exceeded cap (%d); dropping per-type examples",
+            len(block),
+            cap,
+        )
+        entries = [render_entry(s, False) for s in specs]
+        block = "\n".join(entries)
+        if len(block) <= cap:
+            return block
+
+        kept: list[str] = []
+        dropped: list[str] = []
+        used = 0
+        for s, entry in zip(specs, entries):
+            if used + len(entry) + 1 <= cap:
+                kept.append(entry)
+                used += len(entry) + 1
+            else:
+                dropped.append(s.name)
+        if dropped:
+            logger.warning(
+                "Typed-entity block still over cap (%d); rendering %d type(s) as name-only: %s",
+                cap,
+                len(dropped),
+                ", ".join(dropped),
+            )
+            kept.append("- Other types: " + ", ".join(dropped))
+        return "\n".join(kept)
+
+    def _render_relation_block(self) -> str:
+        """Render configured relationship types, or generic guidance (E9)."""
+        if not self._relation_specs:
+            return GENERIC_RELATION_GUIDANCE
+        lines = ["Use only these relationship types:"]
+        for r in self._relation_specs:
+            arrow = ""
+            if r.source_types and r.target_types:
+                arrow = f" ({'/'.join(r.source_types)} → {'/'.join(r.target_types)})"
+            line = f"- {r.name}{arrow}"
+            if r.description:
+                line += f": {r.description}"
+            lines.append(line)
+        return "\n".join(lines)
 
     async def extract(
         self,
         text: str,
         *,
-        entity_types: list[str] | None = None,
+        entity_types: list[str] | list[EntityTypeConfig] | None = None,
         extract_relations: bool | None = None,
         extract_preferences: bool | None = None,
     ) -> ExtractionResult:
@@ -216,11 +459,15 @@ class LLMEntityExtractor(EntityExtractor):
           schema. This is the high-quality path.
         * Otherwise falls back to prompt-engineered JSON via
           ``complete``, then parses the response loosely.
+
+        A per-call ``entity_types`` override may be a name list or a list of
+        :class:`EntityTypeConfig` (carrying descriptions/examples), matching
+        the construction-time contract.
         """
         if not text or not text.strip():
             return ExtractionResult(source_text=text)
 
-        types_to_use = entity_types or self._entity_types
+        specs = _normalize_types(entity_types) if entity_types is not None else self._type_specs
         include_relations = (
             extract_relations if extract_relations is not None else self._extract_relations
         )
@@ -231,51 +478,80 @@ class LLMEntityExtractor(EntityExtractor):
         # Lazy import to avoid circular dep at module load
         from neo4j_agent_memory.llm.protocol import StructuredExtractor
 
-        if isinstance(self._provider, StructuredExtractor):
+        async def _run() -> ExtractionResult:
+            if isinstance(self._provider, StructuredExtractor):
+                try:
+                    return await self._extract_structured(
+                        text, specs, include_relations, include_preferences
+                    )
+                except Exception as exc:  # pragma: no cover - defensive
+                    logger.warning(
+                        "Structured extraction failed (%s); falling back to plain LLM call",
+                        type(exc).__name__,
+                    )
+            return await self._extract_with_complete(
+                text, specs, include_relations, include_preferences
+            )
+
+        # Best-effort observability: NoOp tracer by default (zero overhead).
+        tracer = self._get_tracer()
+        if tracer is None:
+            return await _run()
+
+        async with tracer.async_span(
+            "llm_extract", {"text_length": len(text), "requested_types": len(specs)}
+        ) as span:
+            result = await _run()
             try:
-                return await self._extract_structured(
-                    text, types_to_use, include_relations, include_preferences
-                )
-            except Exception as exc:  # pragma: no cover - defensive
-                logger.warning(
-                    "Structured extraction failed (%s); falling back to plain LLM call",
-                    type(exc).__name__,
-                )
-        return await self._extract_with_complete(
-            text, types_to_use, include_relations, include_preferences
-        )
+                span.set_attribute("entity_count", result.entity_count)
+                for type_name, count in result.type_coverage.items():
+                    span.set_attribute(f"type_coverage.{type_name}", count)
+            except Exception:  # pragma: no cover - span is best-effort
+                pass
+            return result
 
     async def _extract_structured(
         self,
         text: str,
-        types_to_use: list[str],
+        specs: list[_TypeSpec],
         include_relations: bool,
         include_preferences: bool,
     ) -> ExtractionResult:
         """Run extraction via :meth:`StructuredExtractor.complete_structured`."""
         from neo4j_agent_memory.llm.types import ChatMessage
 
-        prompt = self._build_prompt(text, types_to_use)
+        prompt = self._build_prompt(text, specs)
         messages = [
             ChatMessage(role="system", content=SYSTEM_MESSAGE),
             ChatMessage(role="user", content=prompt),
         ]
-        # The structured-extraction path validates against ExtractionPayload.
+        # When strict_types is enabled, constrain the structured-output schema
+        # to the configured types so the provider (OpenAI strict mode /
+        # Anthropic tool schema) — or, failing that, Pydantic validation on the
+        # schema-aligned fallback — rejects invented types (E6). Otherwise use
+        # the permissive free-string payload and rely on schema-aware mapping.
+        payload_model: type[ExtractionPayload] = ExtractionPayload
+        if self._strict_types:
+            names = [s.name for s in specs]
+            relation_names = (
+                [r.name for r in self._relation_specs]
+                if include_relations and self._relation_specs
+                else None
+            )
+            payload_model = build_constrained_payload(names, relation_names)
         # ``complete_structured`` raises StructuredExtractionError on failure
         # which we let propagate so the pipeline can decide how to handle it.
-        payload: ExtractionPayload = await self._provider.complete_structured(  # type: ignore[attr-defined]
+        payload: ExtractionPayload = await self._provider.complete_structured(  # type: ignore[union-attr]
             messages,
-            ExtractionPayload,
+            payload_model,
             temperature=self._temperature,
         )
-        return self._payload_to_result(
-            payload, text, types_to_use, include_relations, include_preferences
-        )
+        return self._payload_to_result(payload, text, specs, include_relations, include_preferences)
 
     async def _extract_with_complete(
         self,
         text: str,
-        types_to_use: list[str],
+        specs: list[_TypeSpec],
         include_relations: bool,
         include_preferences: bool,
     ) -> ExtractionResult:
@@ -287,7 +563,7 @@ class LLMEntityExtractor(EntityExtractor):
         """
         from neo4j_agent_memory.llm.types import ChatMessage
 
-        prompt = self._build_prompt(text, types_to_use)
+        prompt = self._build_prompt(text, specs)
         messages = [
             ChatMessage(role="system", content=SYSTEM_MESSAGE),
             ChatMessage(role="user", content=prompt),
@@ -325,24 +601,30 @@ class LLMEntityExtractor(EntityExtractor):
                 f"LLM response did not match expected extraction shape: {exc}"
             ) from exc
 
-        return self._payload_to_result(
-            payload, text, types_to_use, include_relations, include_preferences
-        )
+        return self._payload_to_result(payload, text, specs, include_relations, include_preferences)
 
     def _payload_to_result(
         self,
         payload: ExtractionPayload,
         source_text: str,
-        allowed_types: list[str],
+        specs: list[_TypeSpec],
         include_relations: bool,
         include_preferences: bool,
     ) -> ExtractionResult:
         """Convert an :class:`ExtractionPayload` to an :class:`ExtractionResult`."""
+        allowed_types = [s.name for s in specs]
+        allowed_set = set(allowed_types)
+        # A "custom schema is active" when the configured types differ from the
+        # default POLE+O set. Under a custom schema we keep off-list types
+        # (flag-not-drop) rather than collapsing them to a POLE+O default that
+        # the schema may not even contain.
+        is_custom = allowed_set != set(DEFAULT_ENTITY_TYPES)
+
         entities: list[ExtractedEntity] = []
         for ent in payload.entities:
             entity_type = (ent.type or "OBJECT").upper()
-            if entity_type not in allowed_types:
-                entity_type = self._map_to_allowed_type(entity_type, allowed_types)
+            if entity_type not in allowed_set:
+                entity_type = self._map_to_allowed_type(entity_type, allowed_types, is_custom)
             subtype = ent.subtype.upper() if ent.subtype else None
             if subtype:
                 allowed_subtypes = self._subtypes.get(entity_type, [])
@@ -357,6 +639,22 @@ class LLMEntityExtractor(EntityExtractor):
                     extractor="llm",
                 )
             )
+
+        # Intra-call same-name guard (E5): collapse entities that share a
+        # normalized name to a single node, keeping the highest-confidence
+        # classification. First-seen order is preserved. Cross-call / cross-
+        # document resolution remains the job of the deduplication stage.
+        deduped: dict[str, ExtractedEntity] = {}
+        order: list[str] = []
+        for entity in entities:
+            key = entity.name.strip().lower()
+            existing = deduped.get(key)
+            if existing is None:
+                deduped[key] = entity
+                order.append(key)
+            elif entity.confidence > existing.confidence:
+                deduped[key] = entity
+        entities = [deduped[k] for k in order]
 
         relations: list[ExtractedRelation] = []
         if include_relations:
@@ -388,11 +686,22 @@ class LLMEntityExtractor(EntityExtractor):
                     )
                 )
 
+        # Per-type coverage (E10): requested types start at zero so a
+        # requested-but-unextracted type is visible; off-list types kept under
+        # a custom schema also appear.
+        type_coverage: dict[str, int] = dict.fromkeys(allowed_types, 0)
+        for entity in entities:
+            type_coverage[entity.type] = type_coverage.get(entity.type, 0) + 1
+        missing = [t for t in allowed_types if type_coverage.get(t, 0) == 0]
+
         logger.debug(
-            "LLM extracted %d entities, %d relations, %d preferences",
+            "LLM extracted %d entities, %d relations, %d preferences; "
+            "type_coverage=%s; requested-but-empty=%s",
             len(entities),
             len(relations),
             len(preferences),
+            type_coverage,
+            missing,
         )
 
         return ExtractionResult(
@@ -400,10 +709,33 @@ class LLMEntityExtractor(EntityExtractor):
             relations=relations,
             preferences=preferences,
             source_text=source_text,
+            type_coverage=type_coverage,
         )
 
-    def _map_to_allowed_type(self, entity_type: str, allowed_types: list[str]) -> str:
-        """Map an unknown entity type to the closest allowed type."""
+    def _map_to_allowed_type(
+        self, entity_type: str, allowed_types: list[str], is_custom: bool = False
+    ) -> str:
+        """Map an off-list entity type to an allowed type (schema-aware).
+
+        Behaviour:
+
+        * A type already in ``allowed_types`` is returned unchanged (callers
+          only invoke this for off-list types, but this keeps the contract
+          honest — e.g. PRODUCT is no longer coerced to OBJECT when PRODUCT is
+          itself configured).
+        * A POLE+O-style coercion is applied only when its target is in
+          ``allowed_types``.
+        * Under a custom schema, an unmappable type is kept as-is
+          (flag-not-drop) instead of being collapsed to ``allowed_types[0]`` —
+          which previously turned, e.g., an extracted date into the first
+          custom type. Downstream resolution/validation can flag it.
+        * Under the default POLE+O schema, legacy behaviour is preserved:
+          fall back to the closest POLE+O default, else the first allowed type.
+        """
+        allowed_set = set(allowed_types)
+        if entity_type in allowed_set:
+            return entity_type
+
         type_mappings = {
             "CONCEPT": "OBJECT",
             "EMOTION": "OBJECT",
@@ -425,9 +757,18 @@ class LLMEntityExtractor(EntityExtractor):
             "DATE": "EVENT",
             "TIME": "EVENT",
         }
-        mapped = type_mappings.get(entity_type, "OBJECT")
+        mapped = type_mappings.get(entity_type)
+        if mapped and mapped in allowed_set:
+            return mapped
+        if is_custom:
+            # Keep the model's type rather than inventing a POLE+O default that
+            # isn't part of this schema.
+            return entity_type
+        fallback = mapped or "OBJECT"
         return (
-            mapped if mapped in allowed_types else (allowed_types[0] if allowed_types else "OBJECT")
+            fallback
+            if fallback in allowed_set
+            else (allowed_types[0] if allowed_types else "OBJECT")
         )
 
     @classmethod
@@ -450,19 +791,28 @@ class LLMEntityExtractor(EntityExtractor):
     @classmethod
     def for_custom_types(
         cls,
-        entity_types: list[str],
+        entity_types: list[str] | list[EntityTypeConfig],
         provider: LLMProvider | StructuredExtractor | None = None,
         *,
         model: str = "openai/gpt-4o-mini",
         api_key: str | None = None,
+        relation_types: list[RelationTypeConfig] | None = None,
+        strict_types: bool = False,
     ) -> LLMEntityExtractor:
-        """Create extractor for custom entity types."""
+        """Create extractor for custom entity types.
+
+        ``entity_types`` may be plain names or :class:`EntityTypeConfig`
+        objects; when configs carry ``description``/``examples`` those reach
+        the extraction prompt. Subtypes are derived from the configs (or the
+        built-in POLE+O subtypes for any POLE+O-named type), not forced empty.
+        """
         return cls(
             provider=provider,
             model=model,
             api_key=api_key,
             entity_types=entity_types,
-            subtypes={},
+            relation_types=relation_types,
+            strict_types=strict_types,
         )
 
 
@@ -470,5 +820,6 @@ __all__ = [
     "LLMEntityExtractor",
     "DEFAULT_ENTITY_TYPES",
     "POLEO_SUBTYPES",
+    "POLEO_TYPE_DESCRIPTIONS",
     "DEFAULT_EXTRACTION_PROMPT",
 ]

--- a/src/neo4j_agent_memory/extraction/llm_extractor.py
+++ b/src/neo4j_agent_memory/extraction/llm_extractor.py
@@ -424,7 +424,16 @@ class LLMEntityExtractor(EntityExtractor):
                 len(dropped),
                 ", ".join(dropped),
             )
-            kept.append("- Other types: " + ", ".join(dropped))
+            other_line = "- Other types: " + ", ".join(dropped)
+            used = len("\n".join(kept))
+            available = cap - used - (1 if kept else 0)
+            if available > 0:
+                if len(other_line) > available:
+                    if available == 1:
+                        other_line = "…"
+                    else:
+                        other_line = f"{other_line[: available - 1].rstrip()}…"
+                kept.append(other_line)
         return "\n".join(kept)
 
     def _render_relation_block(self) -> str:

--- a/src/neo4j_agent_memory/extraction/llm_extractor.py
+++ b/src/neo4j_agent_memory/extraction/llm_extractor.py
@@ -433,7 +433,8 @@ class LLMEntityExtractor(EntityExtractor):
                         other_line = "…"
                     else:
                         other_line = f"{other_line[: available - 1].rstrip()}…"
-                kept.append(other_line)
+                if other_line and len(other_line) <= available:
+                    kept.append(other_line)
         return "\n".join(kept)
 
     def _render_relation_block(self) -> str:

--- a/src/neo4j_agent_memory/schema/models.py
+++ b/src/neo4j_agent_memory/schema/models.py
@@ -73,6 +73,10 @@ class EntityTypeConfig(BaseModel):
 
     name: str = Field(description="Entity type name (e.g., PERSON)")
     description: str | None = Field(default=None, description="Description of the entity type")
+    examples: list[str] = Field(
+        default_factory=list,
+        description="Few-shot surface examples that anchor this type during extraction",
+    )
     subtypes: list[str] = Field(default_factory=list, description="Valid subtypes for this entity")
     attributes: list[str] = Field(
         default_factory=list, description="Common attributes for this entity type"

--- a/tests/integration/test_ontology_aware_extraction.py
+++ b/tests/integration/test_ontology_aware_extraction.py
@@ -1,0 +1,400 @@
+"""Integration & end-to-end tests for ontology-aware LLM extraction (0.6.0).
+
+These exercise the full wiring: ``MemorySettings`` (rich schema + a mock LLM
+provider) → ``MemoryClient._create_extractor`` → factory precedence resolution →
+``LLMEntityExtractor`` → ``add_message`` extraction → persisted ``:Entity`` nodes
+and ``MENTIONS`` / ``RELATED_TO`` edges in Neo4j, then queried back through the
+client API.
+
+A mock ``StructuredExtractor`` stands in for a real LLM so the tests are
+deterministic and need no API key, but every other layer is real (Neo4j via the
+testcontainer, the factory, the extractor, the storage path).
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from neo4j_agent_memory import MemoryClient, MemorySettings
+from neo4j_agent_memory.config.settings import (
+    ExtractionConfig,
+    ExtractorType,
+    SchemaConfig,
+    SchemaModel,
+)
+from neo4j_agent_memory.schema.models import (
+    EntitySchemaConfig,
+    EntityTypeConfig,
+    RelationTypeConfig,
+)
+
+# --------------------------------------------------------------------------- #
+# Mock providers (deterministic stand-ins for a real LLM)
+# --------------------------------------------------------------------------- #
+
+
+class ScriptedStructured:
+    """Returns a fixed entity/relation list regardless of input."""
+
+    model = "scripted"
+
+    def __init__(self, entities, relations=None):
+        self._entities = entities
+        self._relations = relations or []
+
+    async def complete_structured(self, messages, response_model, **kwargs):
+        return response_model(entities=self._entities, relations=self._relations)
+
+    async def complete(self, messages, **kwargs):  # pragma: no cover
+        raise NotImplementedError
+
+
+class TextDrivenStructured:
+    """Emits entities whose surface form appears in the message text.
+
+    Makes the end-to-end flow meaningful: the extractor builds a prompt from the
+    real message content, and this mock 'extracts' the entities it actually
+    contains.
+    """
+
+    model = "text-driven"
+
+    KNOWN = {
+        "adopt the local transcription tool": ("Adopt the local transcription tool", "DECISION"),
+        "ship the hume file-drop": ("Ship the Hume file-drop", "DECISION"),
+        "hume": ("Hume", "PRODUCT"),
+        "sudhir hasbe": ("Sudhir Hasbe", "PERSON"),
+        "gartner": ("Gartner", "ORGANIZATION"),
+    }
+
+    async def complete_structured(self, messages, response_model, **kwargs):
+        text = messages[-1].content.lower()
+        seen = set()
+        entities = []
+        for key, (name, typ) in self.KNOWN.items():
+            if key in text and name not in seen:
+                seen.add(name)
+                entities.append({"name": name, "type": typ, "confidence": 0.9})
+        return response_model(entities=entities)
+
+    async def complete(self, messages, **kwargs):  # pragma: no cover
+        raise NotImplementedError
+
+
+def _meeting_schema(strict: bool = False) -> EntitySchemaConfig:
+    return EntitySchemaConfig(
+        name="meeting",
+        strict_types=strict,
+        entity_types=[
+            EntityTypeConfig(
+                name="DECISION",
+                description="A concrete agreement, resolution, or choice made in a meeting.",
+                examples=["Adopt local transcription tool"],
+            ),
+            EntityTypeConfig(name="TASK", description="An action item."),
+            EntityTypeConfig(name="OUTCOME", description="A result or impact."),
+            EntityTypeConfig(name="PRODUCT", description="A software product or feature."),
+            EntityTypeConfig(name="PERSON"),
+            EntityTypeConfig(name="ORGANIZATION"),
+        ],
+        relation_types=[
+            RelationTypeConfig(
+                name="DECIDED_BY",
+                description="Who made the decision.",
+                source_types=["DECISION"],
+                target_types=["PERSON"],
+            ),
+        ],
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Client factory fixture
+# --------------------------------------------------------------------------- #
+
+
+@pytest.fixture
+async def make_ontology_client(memory_settings, mock_embedder, mock_resolver):
+    """Build connected MemoryClients wired with a rich schema + mock LLM.
+
+    The extractor is built by the factory from settings (not injected), so the
+    full precedence-resolution path is exercised.
+    """
+    created: list[MemoryClient] = []
+
+    async def _make(
+        *,
+        llm,
+        entity_schema=None,
+        custom_schema_path=None,
+        strict_types=False,
+        extract_relations=False,
+    ) -> MemoryClient:
+        schema_kwargs: dict = {"model": SchemaModel.CUSTOM, "strict_types": strict_types}
+        if entity_schema is not None:
+            schema_kwargs["entity_schema"] = entity_schema
+        if custom_schema_path is not None:
+            schema_kwargs["custom_schema_path"] = custom_schema_path
+
+        settings = MemorySettings(
+            neo4j=memory_settings.neo4j,
+            schema_config=SchemaConfig(**schema_kwargs),
+            extraction=ExtractionConfig(
+                extractor_type=ExtractorType.LLM,
+                enable_spacy=False,
+                enable_gliner=False,
+                extract_relations=extract_relations,
+                extract_preferences=False,
+            ),
+            llm=llm,
+        )
+        client = MemoryClient(settings, embedder=mock_embedder, resolver=mock_resolver)
+        try:
+            await client.connect()
+        except Exception as e:  # pragma: no cover - infra
+            pytest.skip(f"Neo4j not available: {e}")
+        # Clean slate per built client.
+        await client._client.execute_write("MATCH (n) DETACH DELETE n")
+        created.append(client)
+        return client
+
+    yield _make
+
+    for client in created:
+        try:
+            await client._client.execute_write("MATCH (n) DETACH DELETE n")
+        except Exception:  # pragma: no cover
+            pass
+        await client.close()
+
+
+async def _mentioned_entities(client: MemoryClient, message_id) -> list[dict]:
+    rows = await client._client.execute_read(
+        """
+        MATCH (m:Message {id: $id})-[:MENTIONS]->(e:Entity)
+        RETURN e.name AS name, e.type AS type
+        ORDER BY name
+        """,
+        {"id": str(message_id)},
+    )
+    return rows
+
+
+# --------------------------------------------------------------------------- #
+# Integration: extraction → storage
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+class TestCustomTypePersistence:
+    async def test_custom_typed_entities_persisted(self, make_ontology_client, session_id):
+        """A described custom type reaches the prompt AND lands in Neo4j."""
+        provider = ScriptedStructured(
+            entities=[
+                {"name": "Adopt local transcription tool", "type": "DECISION", "confidence": 0.9},
+                {"name": "Sudhir Hasbe", "type": "PERSON", "confidence": 0.95},
+            ]
+        )
+        client = await make_ontology_client(llm=provider, entity_schema=_meeting_schema())
+
+        message = await client.short_term.add_message(
+            session_id,
+            "user",
+            "Decisions: adopt the local transcription tool. Owner: Sudhir Hasbe.",
+            extract_entities=True,
+        )
+
+        rows = await _mentioned_entities(client, message.id)
+        types = {r["type"] for r in rows}
+        assert "DECISION" in types
+        assert "PERSON" in types
+
+        # The custom type also became a PascalCase label.
+        label_rows = await client._client.execute_read("MATCH (e:Decision) RETURN count(e) AS cnt")
+        assert label_rows[0]["cnt"] >= 1
+
+    async def test_intra_call_dedup_persists_single_node(self, make_ontology_client, session_id):
+        """Hume emitted under three types collapses to one PRODUCT node on store."""
+        provider = ScriptedStructured(
+            entities=[
+                {"name": "Hume", "type": "ORGANIZATION", "confidence": 0.7},
+                {"name": "Hume", "type": "PERSON", "confidence": 0.8},
+                {"name": "Hume", "type": "PRODUCT", "confidence": 0.95},
+            ]
+        )
+        client = await make_ontology_client(llm=provider, entity_schema=_meeting_schema())
+
+        message = await client.short_term.add_message(
+            session_id, "user", "Hume shipped.", extract_entities=True
+        )
+
+        rows = await _mentioned_entities(client, message.id)
+        humes = [r for r in rows if r["name"] == "Hume"]
+        assert len(humes) == 1
+        assert humes[0]["type"] == "PRODUCT"
+
+    async def test_relations_persisted(self, make_ontology_client, session_id):
+        """Extracted relations are stored as RELATED_TO edges."""
+        provider = ScriptedStructured(
+            entities=[
+                {"name": "Adopt tool", "type": "DECISION", "confidence": 0.9},
+                {"name": "Sudhir Hasbe", "type": "PERSON", "confidence": 0.9},
+            ],
+            relations=[
+                {
+                    "source": "Adopt tool",
+                    "target": "Sudhir Hasbe",
+                    "relation_type": "DECIDED_BY",
+                    "confidence": 0.9,
+                }
+            ],
+        )
+        client = await make_ontology_client(
+            llm=provider, entity_schema=_meeting_schema(), extract_relations=True
+        )
+
+        await client.short_term.add_message(
+            session_id,
+            "user",
+            "Decision Adopt tool decided by Sudhir Hasbe.",
+            extract_entities=True,
+            extract_relations=True,
+        )
+
+        rel_rows = await client._client.execute_read(
+            """
+            MATCH (a:Entity)-[r:RELATED_TO]->(b:Entity)
+            RETURN a.name AS src, b.name AS tgt, r.relation_type AS rel
+            """
+        )
+        assert any(
+            r["src"] == "Adopt tool" and r["tgt"] == "Sudhir Hasbe" and r["rel"] == "DECIDED_BY"
+            for r in rel_rows
+        )
+
+    async def test_custom_schema_path_flow(self, make_ontology_client, session_id):
+        """A schema loaded from custom_schema_path drives extraction end-to-end."""
+        schema_dict = {
+            "name": "meeting-file",
+            "entity_types": [
+                {"name": "DECISION", "description": "A ratified choice."},
+                {"name": "PERSON"},
+            ],
+        }
+        with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False, encoding="utf-8") as f:
+            json.dump(schema_dict, f)
+            path = f.name
+        try:
+            provider = ScriptedStructured(
+                entities=[{"name": "Adopt tool", "type": "DECISION", "confidence": 0.9}]
+            )
+            client = await make_ontology_client(llm=provider, custom_schema_path=path)
+            message = await client.short_term.add_message(
+                session_id, "user", "Decisions: adopt tool.", extract_entities=True
+            )
+            rows = await _mentioned_entities(client, message.id)
+            assert any(r["type"] == "DECISION" for r in rows)
+        finally:
+            Path(path).unlink(missing_ok=True)
+
+    async def test_strict_types_persists_allowed_types(self, make_ontology_client, session_id):
+        """Under strict_types the constrained model accepts in-schema types and stores them."""
+        provider = ScriptedStructured(
+            entities=[{"name": "Adopt tool", "type": "DECISION", "confidence": 0.9}]
+        )
+        client = await make_ontology_client(
+            llm=provider, entity_schema=_meeting_schema(strict=True), strict_types=True
+        )
+        message = await client.short_term.add_message(
+            session_id, "user", "Decisions: adopt tool.", extract_entities=True
+        )
+        rows = await _mentioned_entities(client, message.id)
+        assert any(r["type"] == "DECISION" for r in rows)
+
+
+# --------------------------------------------------------------------------- #
+# End-to-end: multi-message conversation, queried back through the client API
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+class TestEndToEndConversation:
+    async def test_conversation_extracts_and_is_queryable(self, make_ontology_client, session_id):
+        provider = TextDrivenStructured()
+        client = await make_ontology_client(llm=provider, entity_schema=_meeting_schema())
+
+        turns = [
+            "Decisions: adopt the local transcription tool; ship the Hume file-drop by Q3.",
+            "Sudhir Hasbe will own the rollout.",
+            "Gartner was cited for event branding.",
+        ]
+        for content in turns:
+            await client.short_term.add_message(session_id, "user", content, extract_entities=True)
+
+        # All extracted types present in the graph.
+        type_rows = await client._client.execute_read(
+            "MATCH (e:Entity) RETURN DISTINCT e.type AS type"
+        )
+        types = {r["type"] for r in type_rows}
+        assert {"DECISION", "PRODUCT", "PERSON", "ORGANIZATION"} <= types
+
+        # Two DECISION items were ratified across the conversation.
+        decision_rows = await client._client.execute_read(
+            "MATCH (e:Entity {type: 'DECISION'}) RETURN e.name AS name ORDER BY name"
+        )
+        decision_names = {r["name"] for r in decision_rows}
+        assert "Adopt the local transcription tool" in decision_names
+        assert "Ship the Hume file-drop" in decision_names
+
+        # The conversation is retrievable through the public API with all turns.
+        conversation = await client.short_term.get_conversation(session_id)
+        assert len(conversation.messages) == len(turns)
+
+        # Entities are reachable from their originating messages via MENTIONS.
+        mention_rows = await client._client.execute_read(
+            """
+            MATCH (m:Message)-[:MENTIONS]->(e:Entity {type: 'PRODUCT'})
+            RETURN e.name AS name
+            """
+        )
+        assert any(r["name"] == "Hume" for r in mention_rows)
+
+    async def test_default_poleo_path_unaffected(
+        self, memory_settings, mock_embedder, mock_resolver, session_id
+    ):
+        """A default (name-only, POLE+O) client still extracts and stores normally."""
+        provider = ScriptedStructured(
+            entities=[{"name": "Acme Corp", "type": "ORGANIZATION", "confidence": 0.9}]
+        )
+        settings = MemorySettings(
+            neo4j=memory_settings.neo4j,
+            extraction=ExtractionConfig(
+                extractor_type=ExtractorType.LLM,
+                enable_spacy=False,
+                enable_gliner=False,
+                extract_relations=False,
+                extract_preferences=False,
+            ),
+            llm=provider,
+        )
+        client = MemoryClient(settings, embedder=mock_embedder, resolver=mock_resolver)
+        try:
+            await client.connect()
+        except Exception as e:  # pragma: no cover
+            pytest.skip(f"Neo4j not available: {e}")
+        try:
+            await client._client.execute_write("MATCH (n) DETACH DELETE n")
+            message = await client.short_term.add_message(
+                session_id, "user", "Acme Corp announced earnings.", extract_entities=True
+            )
+            rows = await _mentioned_entities(client, message.id)
+            assert any(r["type"] == "ORGANIZATION" and r["name"] == "Acme Corp" for r in rows)
+        finally:
+            await client._client.execute_write("MATCH (n) DETACH DELETE n")
+            await client.close()

--- a/tests/unit/test_ontology_aware_extraction.py
+++ b/tests/unit/test_ontology_aware_extraction.py
@@ -1,0 +1,555 @@
+"""Regression suite for ontology-aware LLM entity extraction (0.6.0).
+
+Covers threading entity-type descriptions/examples end-to-end into the LLM
+extraction prompt, the intra-call same-name guard, schema-aware type mapping,
+strict-mode structured-output constraints, relationship-type rendering, and
+per-type coverage telemetry.
+
+All tests here are deterministic and run in CI with no live API calls. The
+end-to-end paths use mock providers. A live recall check (AC2: domain-type
+recall >= 0.80) is provided separately, gated behind RUN_INTEGRATION_TESTS and
+an API key, and skipped in CI.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+
+import pytest
+
+from neo4j_agent_memory.config.settings import ExtractionConfig, SchemaConfig
+from neo4j_agent_memory.extraction._payloads import (
+    EntityPayload,
+    ExtractionPayload,
+    build_constrained_payload,
+)
+from neo4j_agent_memory.extraction.factory import (
+    ExtractorBuilder,
+    resolve_llm_type_source,
+)
+from neo4j_agent_memory.extraction.llm_extractor import (
+    DEFAULT_POLEO_TYPE_GUIDELINES,
+    LLMEntityExtractor,
+    _normalize_types,
+    _truncate,
+)
+from neo4j_agent_memory.schema.models import (
+    EntitySchemaConfig,
+    EntityTypeConfig,
+    RelationTypeConfig,
+)
+
+# --------------------------------------------------------------------------- #
+# Fixtures
+# --------------------------------------------------------------------------- #
+
+# A small synthetic stand-in for the reproduction "Decisions" meeting summary.
+# We do not have the original document; this exercises the same shape (an
+# explicit Decisions section with ratified items plus well-known NER entities).
+DECISIONS_DOC = """\
+Meeting notes — Platform sync.
+
+Attendees: Sudhir Hasbe, Lauren Sparacin.
+
+Decisions:
+- Adopt the local transcription tool for all hands.
+- Ship the Hume file-drop feature by Q3.
+- Operate the two business units as separate entities.
+- Prioritise ARR-focused acquisition metrics.
+
+Gartner was cited for the event branding guidance.
+"""
+
+
+def _meeting_schema() -> EntitySchemaConfig:
+    """A custom schema with described domain types (DECISION/TASK/OUTCOME)."""
+    return EntitySchemaConfig(
+        name="meeting",
+        entity_types=[
+            EntityTypeConfig(
+                name="DECISION",
+                description=(
+                    "A concrete agreement, resolution, or choice made during a meeting. "
+                    "Signalled by 'Decisions:' sections or verbs such as decided, agreed, "
+                    "approved, ratified, resolved."
+                ),
+                examples=["Adopt local transcription tool", "Ship file-drop by Q3"],
+            ),
+            EntityTypeConfig(
+                name="TASK", description="An action item assigned to a person or team."
+            ),
+            EntityTypeConfig(
+                name="OUTCOME",
+                description="A result or stated impact. Distinct from DECISION (a choice).",
+            ),
+            EntityTypeConfig(
+                name="PRODUCT",
+                description="A software product, feature set, or productised offering.",
+                examples=["Hume", "Aura"],
+            ),
+            # Undescribed POLE+O core type -> should backfill the built-in description.
+            EntityTypeConfig(name="PERSON"),
+            EntityTypeConfig(name="ORGANIZATION"),
+        ],
+        relation_types=[
+            RelationTypeConfig(
+                name="DECIDED_BY",
+                description="Links a decision to the person who made it.",
+                source_types=["DECISION"],
+                target_types=["PERSON"],
+            ),
+        ],
+    )
+
+
+class MockStructured:
+    """A StructuredExtractor that returns a scripted payload."""
+
+    model = "mock-structured"
+
+    def __init__(self, entities: list[dict]):
+        self._entities = entities
+        self.last_response_model: type | None = None
+
+    async def complete_structured(
+        self, messages, response_model, *, temperature=0.0, max_retries=2, timeout=None
+    ):
+        self.last_response_model = response_model
+        # Construct via the (possibly constrained) response_model so strict-mode
+        # constraints are actually enforced by Pydantic validation.
+        return response_model(entities=self._entities)
+
+    async def complete(self, messages, **kwargs):  # pragma: no cover - not used
+        raise NotImplementedError
+
+
+class _Completion:
+    def __init__(self, content: str):
+        self.content = content
+
+
+class MockPlain:
+    """A plain LLMProvider (no complete_structured) returning JSON text."""
+
+    model = "mock-plain"
+
+    def __init__(self, payload: dict):
+        self._payload = payload
+
+    async def complete(self, messages, **kwargs):
+        return _Completion(json.dumps(self._payload))
+
+
+# --------------------------------------------------------------------------- #
+# _normalize_types / _truncate
+# --------------------------------------------------------------------------- #
+
+
+class TestNormalizeTypes:
+    def test_names_to_specs(self):
+        specs = _normalize_types(["person", "Decision"])
+        assert [s.name for s in specs] == ["PERSON", "DECISION"]
+        assert all(s.description is None and s.examples == () for s in specs)
+
+    def test_configs_to_specs(self):
+        cfgs = [
+            EntityTypeConfig(
+                name="decision", description="a choice", examples=["x"], subtypes=["RATIFIED"]
+            )
+        ]
+        specs = _normalize_types(cfgs)
+        assert specs[0].name == "DECISION"
+        assert specs[0].description == "a choice"
+        assert specs[0].examples == ("x",)
+        assert specs[0].subtypes == ("RATIFIED",)
+
+    def test_empty_falls_back_to_poleo(self):
+        specs = _normalize_types(None)
+        assert [s.name for s in specs] == ["PERSON", "ORGANIZATION", "LOCATION", "EVENT", "OBJECT"]
+
+    def test_truncate_word_boundary(self):
+        assert _truncate("hello world foobar", 12) == "hello world…"
+        assert _truncate("short", 100) == "short"
+        assert _truncate("anything", 0) == "anything"  # 0 = uncapped
+
+
+# --------------------------------------------------------------------------- #
+# Prompt rendering (E1) — AC1, AC4, AC5
+# --------------------------------------------------------------------------- #
+
+
+class TestPromptRendering:
+    def _extractor(self, **kw) -> LLMEntityExtractor:
+        # provider=object() — prompt building never calls the provider.
+        return LLMEntityExtractor(provider=object(), **kw)
+
+    def test_typed_block_includes_descriptions_and_examples(self):
+        """AC1 + AC5: descriptions and examples appear in the prompt."""
+        ex = self._extractor(entity_types=_meeting_schema().entity_types)
+        prompt = ex._build_prompt("text")
+        assert "A concrete agreement, resolution, or choice" in prompt
+        assert 'Examples: "Adopt local transcription tool", "Ship file-drop by Q3"' in prompt
+        assert "TASK" in prompt and "OUTCOME" in prompt
+
+    def test_undescribed_poleo_type_backfills_builtin_description(self):
+        """Q9: a configured but undescribed POLE+O type keeps its built-in anchor."""
+        ex = self._extractor(entity_types=_meeting_schema().entity_types)
+        prompt = ex._build_prompt("text")
+        # PERSON had no user description; built-in description backfilled.
+        assert "Individuals, people mentioned by name or role" in prompt
+
+    def test_one_type_instruction_present(self):
+        ex = self._extractor(entity_types=_meeting_schema().entity_types)
+        prompt = ex._build_prompt("text")
+        assert "exactly one type per distinct entity" in prompt
+
+    def test_names_only_keeps_poleo_guidelines(self):
+        """AC4: default POLE+O / names-only path is unchanged."""
+        ex = self._extractor()  # default POLE+O
+        prompt = ex._build_prompt("text")
+        assert "PERSON, ORGANIZATION, LOCATION, EVENT, OBJECT" in prompt
+        assert DEFAULT_POLEO_TYPE_GUIDELINES in prompt
+
+    def test_names_only_custom_types_have_no_typed_block(self):
+        ex = self._extractor(entity_types=["DECISION", "TASK"])
+        prompt = ex._build_prompt("text")
+        # Bare names -> comma list, no per-type description lines.
+        assert "DECISION, TASK" in prompt
+        assert "- DECISION:" not in prompt
+
+    def test_relation_block_renders_source_target_and_description(self):
+        schema = _meeting_schema()
+        ex = self._extractor(entity_types=schema.entity_types, relation_types=schema.relation_types)
+        prompt = ex._build_prompt("text")
+        assert "DECIDED_BY (DECISION → PERSON): Links a decision" in prompt
+
+    def test_relation_block_generic_when_no_specs(self):
+        ex = self._extractor(entity_types=["DECISION"])
+        prompt = ex._build_prompt("text")
+        assert "WORKS_AT, LIVES_IN, OWNS" in prompt
+
+
+# --------------------------------------------------------------------------- #
+# Rendering caps (Q5 / R1)
+# --------------------------------------------------------------------------- #
+
+
+class TestRenderingCaps:
+    def test_description_truncated(self):
+        long_desc = "word " * 200
+        ex = LLMEntityExtractor(
+            provider=object(),
+            entity_types=[EntityTypeConfig(name="X", description=long_desc)],
+            max_type_description_chars=30,
+        )
+        prompt = ex._build_prompt("t")
+        assert "…" in prompt
+
+    def test_examples_capped(self):
+        ex = LLMEntityExtractor(
+            provider=object(),
+            entity_types=[
+                EntityTypeConfig(name="X", description="d", examples=[f"e{i}" for i in range(20)])
+            ],
+            max_type_examples=3,
+        )
+        block = ex._render_typed_block(ex._type_specs)
+        # Only 3 examples rendered.
+        assert block.count('"e') == 3
+
+    def test_global_cap_degrades_to_name_only(self, caplog):
+        specs = [
+            EntityTypeConfig(name=f"TYPE{i}", description="d " * 50, examples=["ex"])
+            for i in range(10)
+        ]
+        ex = LLMEntityExtractor(provider=object(), entity_types=specs, max_typed_block_chars=120)
+        block = ex._render_typed_block(ex._type_specs)
+        assert len(block) <= 200  # bounded
+        assert "Other types:" in block  # overflow rendered as name-only
+
+
+# --------------------------------------------------------------------------- #
+# Same-name guard (E5) — AC3
+# --------------------------------------------------------------------------- #
+
+
+class TestSameNameGuard:
+    def _ex(self):
+        return LLMEntityExtractor(
+            provider=object(), entity_types=["PERSON", "ORGANIZATION", "PRODUCT"]
+        )
+
+    def test_collapses_to_highest_confidence(self):
+        """AC3: Hume becomes a single PRODUCT node."""
+        payload = ExtractionPayload(
+            entities=[
+                EntityPayload(name="Hume", type="ORGANIZATION", confidence=0.9),
+                EntityPayload(name="Hume", type="PERSON", confidence=0.8),
+                EntityPayload(name="Hume", type="PRODUCT", confidence=0.95),
+            ]
+        )
+        specs = _normalize_types(["PERSON", "ORGANIZATION", "PRODUCT"])
+        res = self._ex()._payload_to_result(payload, "t", specs, False, False)
+        assert [(e.name, e.type) for e in res.entities] == [("Hume", "PRODUCT")]
+
+    def test_distinct_names_preserved_in_order(self):
+        payload = ExtractionPayload(
+            entities=[
+                EntityPayload(name="Alice", type="PERSON", confidence=0.9),
+                EntityPayload(name="Acme", type="ORGANIZATION", confidence=0.9),
+            ]
+        )
+        specs = _normalize_types(["PERSON", "ORGANIZATION"])
+        res = self._ex()._payload_to_result(payload, "t", specs, False, False)
+        assert [e.name for e in res.entities] == ["Alice", "Acme"]
+
+
+# --------------------------------------------------------------------------- #
+# Schema-aware mapping (E6)
+# --------------------------------------------------------------------------- #
+
+
+class TestSchemaAwareMapping:
+    def test_configured_type_not_coerced(self):
+        """PRODUCT must not be coerced to OBJECT when PRODUCT is configured."""
+        ex = LLMEntityExtractor(provider=object())
+        assert (
+            ex._map_to_allowed_type("PRODUCT", ["PRODUCT", "PERSON"], is_custom=True) == "PRODUCT"
+        )
+
+    def test_custom_schema_keeps_offlist_type(self):
+        """Off-list type under a custom schema is kept, not collapsed to first type."""
+        ex = LLMEntityExtractor(provider=object())
+        # DATE is off-list; custom schema has no OBJECT/EVENT to coerce into.
+        assert ex._map_to_allowed_type("DATE", ["DECISION", "TASK"], is_custom=True) == "DATE"
+
+    def test_offlist_mapped_when_target_allowed(self):
+        ex = LLMEntityExtractor(provider=object())
+        assert (
+            ex._map_to_allowed_type("COMPANY", ["ORGANIZATION"], is_custom=True) == "ORGANIZATION"
+        )
+
+    def test_default_poleo_legacy_fallback(self):
+        """Under default POLE+O, an unmappable type falls back as before."""
+        ex = LLMEntityExtractor(provider=object())
+        out = ex._map_to_allowed_type(
+            "GIBBERISH", ["PERSON", "ORGANIZATION", "LOCATION", "EVENT", "OBJECT"], is_custom=False
+        )
+        assert out == "OBJECT"
+
+    def test_payload_to_result_keeps_offlist_under_custom(self):
+        ex = LLMEntityExtractor(provider=object(), entity_types=["DECISION", "TASK", "OUTCOME"])
+        specs = _normalize_types(["DECISION", "TASK", "OUTCOME"])
+        payload = ExtractionPayload(
+            entities=[EntityPayload(name="Q3 2026", type="DATE", confidence=0.7)]
+        )
+        res = ex._payload_to_result(payload, "t", specs, False, False)
+        assert res.entities[0].type == "DATE"
+
+
+# --------------------------------------------------------------------------- #
+# Coverage telemetry (E10)
+# --------------------------------------------------------------------------- #
+
+
+class TestTypeCoverage:
+    def test_requested_types_reported_with_zeros(self):
+        ex = LLMEntityExtractor(provider=object(), entity_types=["DECISION", "TASK", "OUTCOME"])
+        specs = _normalize_types(["DECISION", "TASK", "OUTCOME"])
+        payload = ExtractionPayload(
+            entities=[EntityPayload(name="Adopt tool", type="DECISION", confidence=0.9)]
+        )
+        res = ex._payload_to_result(payload, "t", specs, False, False)
+        assert res.type_coverage == {"DECISION": 1, "TASK": 0, "OUTCOME": 0}
+
+    def test_coverage_survives_filter_invalid(self):
+        ex = LLMEntityExtractor(provider=object(), entity_types=["DECISION"])
+        specs = _normalize_types(["DECISION"])
+        payload = ExtractionPayload(
+            entities=[EntityPayload(name="Adopt tool", type="DECISION", confidence=0.9)]
+        )
+        res = ex._payload_to_result(payload, "t", specs, False, False)
+        assert res.filter_invalid_entities().type_coverage == {"DECISION": 1}
+
+
+# --------------------------------------------------------------------------- #
+# Constrained payload model (E6)
+# --------------------------------------------------------------------------- #
+
+
+class TestConstrainedPayload:
+    def test_schema_has_enum(self):
+        model = build_constrained_payload(["DECISION", "TASK"], ["CAUSES"])
+        schema = model.model_json_schema()
+        dumped = json.dumps(schema)
+        assert '"DECISION"' in dumped and '"TASK"' in dumped
+
+    def test_rejects_offlist_type(self):
+        model = build_constrained_payload(["DECISION", "TASK"], None)
+        with pytest.raises(Exception):
+            model(entities=[{"name": "x", "type": "PERSON", "confidence": 0.9}])
+
+    def test_accepts_allowed_type(self):
+        model = build_constrained_payload(["DECISION", "TASK"], None)
+        obj = model(entities=[{"name": "x", "type": "DECISION", "confidence": 0.9}])
+        assert obj.entities[0].type == "DECISION"
+
+    def test_empty_types_returns_unconstrained(self):
+        assert build_constrained_payload([], None) is ExtractionPayload
+
+
+# --------------------------------------------------------------------------- #
+# Factory precedence + custom_schema_path (E4)
+# --------------------------------------------------------------------------- #
+
+
+class TestFactoryResolution:
+    def test_entity_schema_precedence(self):
+        sc = SchemaConfig(model="custom", entity_schema=_meeting_schema())
+        et, rt, strict = resolve_llm_type_source(ExtractionConfig(), sc)
+        assert [t.name for t in et][:3] == ["DECISION", "TASK", "OUTCOME"]
+        assert rt and rt[0].name == "DECIDED_BY"
+        assert strict is False
+
+    def test_specs_win_over_schema_names(self):
+        ec = ExtractionConfig(entity_type_specs=[EntityTypeConfig(name="TASK", description="d")])
+        sc = SchemaConfig(model="custom", entity_types=["PERSON", "GHOST"])
+        et, _, _ = resolve_llm_type_source(ec, sc)
+        assert [t.name for t in et] == ["TASK"]
+
+    def test_strict_from_rich_schema(self):
+        schema = _meeting_schema()
+        schema.strict_types = True
+        sc = SchemaConfig(model="custom", entity_schema=schema)
+        _, _, strict = resolve_llm_type_source(ExtractionConfig(), sc)
+        assert strict is True
+
+    def test_names_only_fallback(self):
+        sc = SchemaConfig(model="custom", entity_types=["DECISION"])
+        et, rt, _ = resolve_llm_type_source(ExtractionConfig(), sc)
+        assert et == ["DECISION"]
+        assert rt is None
+
+    def test_custom_schema_path_fail_fast(self):
+        sc = SchemaConfig(model="custom", custom_schema_path="/no/such/schema.json")
+        with pytest.raises(FileNotFoundError):
+            resolve_llm_type_source(ExtractionConfig(), sc)
+
+    def test_custom_schema_path_loads(self):
+        with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as f:
+            json.dump(
+                {"name": "x", "entity_types": [{"name": "DECISION", "description": "a choice"}]}, f
+            )
+            path = f.name
+        try:
+            sc = SchemaConfig(model="custom", custom_schema_path=path)
+            et, _, _ = resolve_llm_type_source(ExtractionConfig(), sc)
+            assert [t.name for t in et] == ["DECISION"]
+        finally:
+            os.unlink(path)
+
+    def test_builder_with_schema_retains_rich_configs(self):
+        # build() would eagerly construct a real LLM provider (not installed in
+        # the unit env), so assert the builder retained the rich configs that
+        # build() threads into the LLM stage. Prompt threading itself is covered
+        # by TestPromptRendering.
+        builder = ExtractorBuilder().with_llm("gpt-4o-mini").with_schema(_meeting_schema())
+        names = [c.name for c in builder._entity_type_configs]
+        assert "DECISION" in names
+        decision = next(c for c in builder._entity_type_configs if c.name == "DECISION")
+        assert decision.description and "concrete agreement" in decision.description
+        assert builder._relation_type_configs[0].name == "DECIDED_BY"
+
+
+# --------------------------------------------------------------------------- #
+# End-to-end via mock providers — both extraction paths (AC1/AC2/AC3)
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+class TestEndToEnd:
+    async def test_structured_path_extracts_decisions_and_dedupes(self):
+        provider = MockStructured(
+            entities=[
+                {"name": "Adopt local transcription tool", "type": "DECISION", "confidence": 0.9},
+                {"name": "Ship Hume file-drop by Q3", "type": "DECISION", "confidence": 0.9},
+                {"name": "Hume", "type": "PRODUCT", "confidence": 0.95},
+                {"name": "Hume", "type": "ORGANIZATION", "confidence": 0.7},
+            ]
+        )
+        ex = LLMEntityExtractor(
+            provider=provider,
+            entity_types=_meeting_schema().entity_types,
+            extract_relations=False,
+            extract_preferences=False,
+        )
+        res = await ex.extract(DECISIONS_DOC)
+        decisions = [e.name for e in res.entities if e.type == "DECISION"]
+        assert len(decisions) == 2
+        humes = [e for e in res.entities if e.name == "Hume"]
+        assert len(humes) == 1 and humes[0].type == "PRODUCT"
+        # Descriptions reached the prompt on the structured path (AC1).
+        # (Indirectly verified via TestPromptRendering; here we assert behavior.)
+
+    async def test_strict_path_uses_constrained_model(self):
+        provider = MockStructured(
+            entities=[{"name": "Adopt tool", "type": "DECISION", "confidence": 0.9}]
+        )
+        ex = LLMEntityExtractor(
+            provider=provider,
+            entity_types=[EntityTypeConfig(name="DECISION", description="a choice")],
+            strict_types=True,
+            extract_relations=False,
+            extract_preferences=False,
+        )
+        await ex.extract("Decisions: adopt tool.")
+        # The provider was handed a constrained payload model, not the base one.
+        assert provider.last_response_model is not ExtractionPayload
+        assert provider.last_response_model.__name__ == "ConstrainedExtractionPayload"
+
+    async def test_plain_completion_path(self):
+        provider = MockPlain(
+            {
+                "entities": [
+                    {"name": "Adopt tool", "type": "DECISION", "confidence": 0.9},
+                    {"name": "Hume", "type": "PRODUCT", "confidence": 0.9},
+                ],
+                "relations": [],
+                "preferences": [],
+            }
+        )
+        ex = LLMEntityExtractor(
+            provider=provider,
+            entity_types=_meeting_schema().entity_types,
+            extract_relations=False,
+            extract_preferences=False,
+        )
+        res = await ex.extract(DECISIONS_DOC)
+        assert any(e.type == "DECISION" for e in res.entities)
+
+
+# --------------------------------------------------------------------------- #
+# Opt-in live recall test (AC2: domain-type recall >= 0.80). Skipped in CI.
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+@pytest.mark.skipif(
+    not os.getenv("RUN_INTEGRATION_TESTS") or not os.getenv("OPENAI_API_KEY"),
+    reason="Live recall test requires RUN_INTEGRATION_TESTS=1 and OPENAI_API_KEY",
+)
+async def test_live_domain_type_recall():
+    """AC2 (live): the described DECISION type is recovered from the doc."""
+    ex = LLMEntityExtractor(
+        model="openai/gpt-4o-mini",
+        entity_types=_meeting_schema().entity_types,
+        extract_relations=False,
+        extract_preferences=False,
+    )
+    res = await ex.extract(DECISIONS_DOC)
+    decisions = [e for e in res.entities if e.type == "DECISION"]
+    # The document contains four ratified decisions; require >= 80% recall.
+    assert len(decisions) >= 3, [(e.name, e.type) for e in res.entities]

--- a/tests/unit/test_ontology_aware_extraction.py
+++ b/tests/unit/test_ontology_aware_extraction.py
@@ -266,8 +266,8 @@ class TestRenderingCaps:
         ]
         ex = LLMEntityExtractor(provider=object(), entity_types=specs, max_typed_block_chars=120)
         block = ex._render_typed_block(ex._type_specs)
-        assert len(block) <= 200  # bounded
-        assert "Other types:" in block  # overflow rendered as name-only
+        assert len(block) <= 120
+        assert block.splitlines()[-1].startswith("- Other")  # overflow rendered as name-only
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/unit/test_ontology_aware_extraction_edge.py
+++ b/tests/unit/test_ontology_aware_extraction_edge.py
@@ -1,0 +1,450 @@
+"""Edge-case and regression unit tests for ontology-aware LLM extraction (0.6.0).
+
+Complements ``test_ontology_aware_extraction.py`` with deeper coverage of
+subtype derivation, per-call overrides, the plain-completion path, the
+structured→plain fallback, config round-tripping, cap boundaries, the
+desync warning, and pipeline fail-fast — all deterministic, no live API.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from pydantic import ValidationError
+
+from neo4j_agent_memory import MemorySettings
+from neo4j_agent_memory.config.settings import (
+    ExtractionConfig,
+    ExtractorType,
+    SchemaConfig,
+    SchemaModel,
+)
+from neo4j_agent_memory.core.exceptions import ExtractionError
+from neo4j_agent_memory.extraction._payloads import build_constrained_payload
+from neo4j_agent_memory.extraction.factory import (
+    create_extraction_pipeline,
+    resolve_llm_type_source,
+)
+from neo4j_agent_memory.extraction.llm_extractor import (
+    POLEO_SUBTYPES,
+    LLMEntityExtractor,
+)
+from neo4j_agent_memory.schema.models import (
+    EntitySchemaConfig,
+    EntityTypeConfig,
+    RelationTypeConfig,
+)
+
+# --------------------------------------------------------------------------- #
+# Mock providers
+# --------------------------------------------------------------------------- #
+
+
+class _Completion:
+    def __init__(self, content: str):
+        self.content = content
+
+
+class MockPlain:
+    """Plain LLMProvider (no complete_structured) returning JSON text."""
+
+    model = "mock-plain"
+
+    def __init__(self, content: str):
+        self._content = content
+        self.calls = 0
+
+    async def complete(self, messages, **kwargs):
+        self.calls += 1
+        return _Completion(self._content)
+
+
+class MockStructuredEcho:
+    """StructuredExtractor that echoes scripted entities."""
+
+    model = "mock-structured"
+
+    def __init__(self, entities):
+        self._entities = entities
+        self.calls = 0
+
+    async def complete_structured(self, messages, response_model, **kwargs):
+        self.calls += 1
+        return response_model(entities=self._entities)
+
+    async def complete(self, messages, **kwargs):  # pragma: no cover
+        raise NotImplementedError
+
+
+class MockStructuredRaises:
+    """StructuredExtractor whose structured call fails, with a plain fallback."""
+
+    model = "mock-structured-raises"
+
+    def __init__(self, fallback_json: str):
+        self._fallback_json = fallback_json
+        self.structured_calls = 0
+        self.complete_calls = 0
+
+    async def complete_structured(self, messages, response_model, **kwargs):
+        self.structured_calls += 1
+        raise RuntimeError("structured boom")
+
+    async def complete(self, messages, **kwargs):
+        self.complete_calls += 1
+        return _Completion(self._fallback_json)
+
+
+# --------------------------------------------------------------------------- #
+# Subtype derivation
+# --------------------------------------------------------------------------- #
+
+
+class TestSubtypeDerivation:
+    def test_default_poleo_backfills_builtin_subtypes(self):
+        ex = LLMEntityExtractor(provider=object())
+        assert ex._subtypes["PERSON"] == POLEO_SUBTYPES["PERSON"]
+        assert ex._subtypes["OBJECT"] == POLEO_SUBTYPES["OBJECT"]
+
+    def test_custom_names_have_no_subtypes(self):
+        ex = LLMEntityExtractor(provider=object(), entity_types=["DECISION", "TASK"])
+        assert "DECISION" not in ex._subtypes
+        assert ex._subtypes == {}
+
+    def test_config_subtypes_used(self):
+        ex = LLMEntityExtractor(
+            provider=object(),
+            entity_types=[EntityTypeConfig(name="DECISION", subtypes=["RATIFIED", "PROPOSED"])],
+        )
+        assert ex._subtypes["DECISION"] == ["RATIFIED", "PROPOSED"]
+
+    def test_poleo_named_custom_type_backfills_subtypes(self):
+        ex = LLMEntityExtractor(
+            provider=object(),
+            entity_types=[EntityTypeConfig(name="PERSON"), EntityTypeConfig(name="DECISION")],
+        )
+        assert ex._subtypes["PERSON"] == POLEO_SUBTYPES["PERSON"]
+        assert "DECISION" not in ex._subtypes
+
+    def test_explicit_subtypes_arg_wins(self):
+        ex = LLMEntityExtractor(
+            provider=object(),
+            entity_types=[EntityTypeConfig(name="DECISION", subtypes=["X"])],
+            subtypes={"DECISION": ["OVERRIDE"]},
+        )
+        assert ex._subtypes == {"DECISION": ["OVERRIDE"]}
+
+    @pytest.mark.asyncio
+    async def test_invalid_subtype_dropped_for_known_type(self):
+        from neo4j_agent_memory.extraction._payloads import EntityPayload, ExtractionPayload
+        from neo4j_agent_memory.extraction.llm_extractor import _normalize_types
+
+        ex = LLMEntityExtractor(provider=object())
+        payload = ExtractionPayload(
+            entities=[EntityPayload(name="Alice", type="PERSON", subtype="BOGUS", confidence=0.9)]
+        )
+        specs = _normalize_types(None)
+        res = ex._payload_to_result(payload, "t", specs, False, False)
+        assert res.entities[0].subtype is None  # BOGUS not a valid PERSON subtype
+
+    @pytest.mark.asyncio
+    async def test_custom_type_subtype_kept(self):
+        from neo4j_agent_memory.extraction._payloads import EntityPayload, ExtractionPayload
+        from neo4j_agent_memory.extraction.llm_extractor import _normalize_types
+
+        ex = LLMEntityExtractor(provider=object(), entity_types=["DECISION"])
+        payload = ExtractionPayload(
+            entities=[EntityPayload(name="X", type="DECISION", subtype="RATIFIED", confidence=0.9)]
+        )
+        specs = _normalize_types(["DECISION"])
+        res = ex._payload_to_result(payload, "t", specs, False, False)
+        assert res.entities[0].subtype == "RATIFIED"  # no constraint -> kept
+
+
+# --------------------------------------------------------------------------- #
+# Per-call override
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+class TestPerCallOverride:
+    async def test_override_with_names_changes_allowed_types(self):
+        provider = MockStructuredEcho([{"name": "X", "type": "DECISION", "confidence": 0.9}])
+        # Instance configured for POLE+O; per-call override to DECISION.
+        ex = LLMEntityExtractor(
+            provider=provider, extract_relations=False, extract_preferences=False
+        )
+        res = await ex.extract("text", entity_types=["DECISION"])
+        assert res.entities[0].type == "DECISION"
+        assert "DECISION" in res.type_coverage
+
+    async def test_override_with_configs_injects_description(self):
+        captured = {}
+
+        class CaptureProvider(MockStructuredEcho):
+            async def complete_structured(self, messages, response_model, **kwargs):
+                captured["prompt"] = messages[-1].content
+                return await super().complete_structured(messages, response_model, **kwargs)
+
+        provider = CaptureProvider([{"name": "X", "type": "DECISION", "confidence": 0.9}])
+        ex = LLMEntityExtractor(
+            provider=provider, extract_relations=False, extract_preferences=False
+        )
+        await ex.extract(
+            "text",
+            entity_types=[EntityTypeConfig(name="DECISION", description="a ratified choice")],
+        )
+        assert "a ratified choice" in captured["prompt"]
+
+
+# --------------------------------------------------------------------------- #
+# Plain-completion path + structured fallback
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+class TestPlainCompletionPath:
+    async def test_markdown_fenced_json_parsed(self):
+        fenced = (
+            "```json\n"
+            + json.dumps(
+                {"entities": [{"name": "Adopt tool", "type": "DECISION", "confidence": 0.9}]}
+            )
+            + "\n```"
+        )
+        provider = MockPlain(fenced)
+        ex = LLMEntityExtractor(
+            provider=provider,
+            entity_types=["DECISION"],
+            extract_relations=False,
+            extract_preferences=False,
+        )
+        res = await ex.extract("Decisions: adopt tool.")
+        assert res.entities[0].name == "Adopt tool"
+        assert provider.calls == 1
+
+    async def test_invalid_json_raises(self):
+        provider = MockPlain("not json at all")
+        ex = LLMEntityExtractor(provider=provider, entity_types=["DECISION"])
+        with pytest.raises(ExtractionError):
+            await ex.extract("text")
+
+    async def test_structured_failure_falls_back_to_plain(self):
+        fallback = json.dumps(
+            {"entities": [{"name": "Adopt tool", "type": "DECISION", "confidence": 0.9}]}
+        )
+        provider = MockStructuredRaises(fallback)
+        ex = LLMEntityExtractor(
+            provider=provider,
+            entity_types=["DECISION"],
+            extract_relations=False,
+            extract_preferences=False,
+        )
+        res = await ex.extract("text")
+        assert provider.structured_calls == 1
+        assert provider.complete_calls == 1
+        assert res.entities[0].type == "DECISION"
+
+
+# --------------------------------------------------------------------------- #
+# Empty text short-circuit
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+class TestEmptyText:
+    async def test_empty_and_whitespace_return_empty_without_provider_call(self):
+        provider = MockStructuredEcho([{"name": "X", "type": "PERSON", "confidence": 1.0}])
+        ex = LLMEntityExtractor(provider=provider)
+        for text in ["", "   ", "\n\t"]:
+            res = await ex.extract(text)
+            assert res.entities == []
+        assert provider.calls == 0
+
+
+# --------------------------------------------------------------------------- #
+# for_poleo unchanged
+# --------------------------------------------------------------------------- #
+
+
+class TestForPoleoUnchanged:
+    def test_for_poleo_prompt_matches_default(self):
+        default = LLMEntityExtractor(provider=object())
+        poleo = LLMEntityExtractor.for_poleo(provider=object())
+        assert poleo._build_prompt("hello") == default._build_prompt("hello")
+
+    def test_custom_extraction_prompt_back_compat(self):
+        # A pre-0.6 custom prompt using only the old placeholders still works.
+        ex = LLMEntityExtractor(
+            provider=object(),
+            extraction_prompt="Types: {entity_types}\nText: {text}",
+        )
+        prompt = ex._build_prompt("hello world")
+        assert "Types: PERSON, ORGANIZATION, LOCATION, EVENT, OBJECT" in prompt
+        assert "Text: hello world" in prompt
+
+
+# --------------------------------------------------------------------------- #
+# Relation block edges
+# --------------------------------------------------------------------------- #
+
+
+class TestRelationBlockEdges:
+    def test_no_arrow_when_target_missing(self):
+        ex = LLMEntityExtractor(
+            provider=object(),
+            entity_types=[EntityTypeConfig(name="DECISION")],
+            relation_types=[RelationTypeConfig(name="DECIDED", source_types=["DECISION"])],
+        )
+        block = ex._render_relation_block()
+        assert "DECIDED" in block
+        assert "→" not in block
+
+    def test_relation_without_description(self):
+        ex = LLMEntityExtractor(
+            provider=object(),
+            entity_types=[EntityTypeConfig(name="DECISION")],
+            relation_types=[
+                RelationTypeConfig(
+                    name="DECIDED", source_types=["DECISION"], target_types=["PERSON"]
+                )
+            ],
+        )
+        block = ex._render_relation_block()
+        assert "DECIDED (DECISION → PERSON)" in block
+        assert "DECIDED (DECISION → PERSON):" not in block  # no trailing description
+
+
+# --------------------------------------------------------------------------- #
+# Cap boundaries
+# --------------------------------------------------------------------------- #
+
+
+class TestCapBoundaries:
+    def test_zero_global_cap_is_uncapped(self):
+        specs = [
+            EntityTypeConfig(name=f"T{i}", description="d " * 100, examples=["e"])
+            for i in range(10)
+        ]
+        ex = LLMEntityExtractor(provider=object(), entity_types=specs, max_typed_block_chars=0)
+        block = ex._render_typed_block(ex._type_specs)
+        assert "Other types:" not in block  # nothing dropped
+        assert "Examples:" in block  # examples retained
+
+    def test_examples_dropped_before_name_only(self):
+        # A block that fits once examples are dropped should keep all descriptions.
+        specs = [
+            EntityTypeConfig(name=f"T{i}", description="short", examples=["x"]) for i in range(5)
+        ]
+        ex = LLMEntityExtractor(provider=object(), entity_types=specs, max_typed_block_chars=80)
+        block = ex._render_typed_block(ex._type_specs)
+        # All five types still present by name; examples were the thing dropped.
+        for i in range(5):
+            assert f"T{i}" in block
+        assert "Examples:" not in block
+
+
+# --------------------------------------------------------------------------- #
+# Constrained payload — relations
+# --------------------------------------------------------------------------- #
+
+
+class TestConstrainedRelations:
+    def test_rejects_offlist_relation_type(self):
+        model = build_constrained_payload(["DECISION", "PERSON"], ["DECIDED_BY"])
+        with pytest.raises(Exception):
+            model(
+                entities=[{"name": "x", "type": "DECISION", "confidence": 0.9}],
+                relations=[
+                    {"source": "x", "target": "y", "relation_type": "BOGUS", "confidence": 0.9}
+                ],
+            )
+
+    def test_accepts_allowed_relation_type(self):
+        model = build_constrained_payload(["DECISION", "PERSON"], ["DECIDED_BY"])
+        obj = model(
+            entities=[
+                {"name": "x", "type": "DECISION", "confidence": 0.9},
+                {"name": "y", "type": "PERSON", "confidence": 0.9},
+            ],
+            relations=[
+                {"source": "x", "target": "y", "relation_type": "DECIDED_BY", "confidence": 0.9}
+            ],
+        )
+        assert obj.relations[0].relation_type == "DECIDED_BY"
+
+
+# --------------------------------------------------------------------------- #
+# Desync warning (R5)
+# --------------------------------------------------------------------------- #
+
+
+class TestDesyncWarning:
+    def test_warns_when_schema_names_not_in_specs(self, caplog):
+        import logging
+
+        ec = ExtractionConfig(entity_type_specs=[EntityTypeConfig(name="TASK")])
+        sc = SchemaConfig(model=SchemaModel.CUSTOM, entity_types=["PERSON", "GHOST"])
+        with caplog.at_level(logging.WARNING):
+            resolve_llm_type_source(ec, sc)
+        assert any("GHOST" in r.message or "PERSON" in r.message for r in caplog.records)
+
+    def test_no_warning_when_consistent(self, caplog):
+        import logging
+
+        ec = ExtractionConfig(entity_type_specs=[EntityTypeConfig(name="TASK")])
+        sc = SchemaConfig(model=SchemaModel.CUSTOM, entity_types=["TASK"])
+        with caplog.at_level(logging.WARNING):
+            resolve_llm_type_source(ec, sc)
+        assert not any("absent" in r.message for r in caplog.records)
+
+
+# --------------------------------------------------------------------------- #
+# Pipeline fail-fast on bad custom_schema_path
+# --------------------------------------------------------------------------- #
+
+
+class TestPipelineFailFast:
+    def test_pipeline_raises_on_bad_schema_path(self):
+        ec = ExtractionConfig(
+            extractor_type=ExtractorType.PIPELINE,
+            enable_spacy=False,
+            enable_gliner=False,
+            enable_llm_fallback=True,
+        )
+        sc = SchemaConfig(model=SchemaModel.CUSTOM, custom_schema_path="/no/such/schema.json")
+        # The bad path is resolved BEFORE the per-stage try/except, so it must
+        # propagate rather than being swallowed into a NoOp pipeline.
+        with pytest.raises(FileNotFoundError):
+            create_extraction_pipeline(ec, sc, llm_config=None)
+
+
+# --------------------------------------------------------------------------- #
+# Settings round-trip + validation
+# --------------------------------------------------------------------------- #
+
+
+class TestSettingsRoundTrip:
+    def test_rich_fields_round_trip(self):
+        schema = EntitySchemaConfig(
+            name="m", entity_types=[EntityTypeConfig(name="DECISION", description="d")]
+        )
+        settings = MemorySettings(
+            schema_config=SchemaConfig(model=SchemaModel.CUSTOM, entity_schema=schema),
+            extraction=ExtractionConfig(
+                entity_type_specs=[EntityTypeConfig(name="TASK", description="t")],
+                max_type_examples=2,
+                max_type_description_chars=120,
+                max_typed_block_chars=2000,
+            ),
+        )
+        assert settings.schema_config.entity_schema.entity_types[0].name == "DECISION"
+        assert settings.extraction.entity_type_specs[0].name == "TASK"
+        assert settings.extraction.max_type_examples == 2
+
+    def test_negative_cap_rejected(self):
+        with pytest.raises(ValidationError):
+            ExtractionConfig(max_type_description_chars=-1)
+        with pytest.raises(ValidationError):
+            ExtractionConfig(max_type_examples=-5)

--- a/tests/unit/test_ontology_aware_extraction_edge.py
+++ b/tests/unit/test_ontology_aware_extraction_edge.py
@@ -344,6 +344,15 @@ class TestCapBoundaries:
             assert f"T{i}" in block
         assert "Examples:" not in block
 
+    def test_name_only_overflow_line_respects_global_cap(self):
+        specs = [
+            EntityTypeConfig(name=f"VERY_LONG_TYPE_NAME_{i}", description="d " * 50, examples=["x"])
+            for i in range(50)
+        ]
+        ex = LLMEntityExtractor(provider=object(), entity_types=specs, max_typed_block_chars=40)
+        block = ex._render_typed_block(ex._type_specs)
+        assert len(block) <= 40
+
 
 # --------------------------------------------------------------------------- #
 # Constrained payload — relations


### PR DESCRIPTION
## What & why

  Custom entity types defined via `EntityTypeConfig`/`EntitySchemaConfig` were accepted
  and stored with rich descriptions, but those descriptions were **dropped before the LLM
  extraction prompt was built** — the extractor saw only a flat list of type names. So
  domain types like `DECISION`, `TASK`, and `OUTCOME` were rarely extracted, and well-known
  names were sometimes split across several types. This brings the LLM path to parity with
  the GLiNER path, which already honors descriptions.

  Implements NAMS-PRD-002's companion package fix. Target: **0.6.0 — additive, backward
  compatible.** No commit on the default branch; name-only configs and default POLE+O
  behaviour are unchanged.

  ## What changed

  **Threading (the core fix).** The rich schema now actually reaches the extractor. A new
  `resolve_llm_type_source()` in `extraction/factory.py` resolves a single type source by
  precedence (highest first): `ExtractionConfig.entity_type_specs` → `SchemaConfig.entity_schema`
  → `SchemaConfig.custom_schema_path` → `schema_config.entity_types` (names) →
  `extraction_config.entity_types` (names). The previously-orphaned `custom_schema_path` is now
  loaded eagerly and **fails fast** on a bad path (resolved outside the pipeline's per-stage
  `try/except` so it can't silently degrade to POLE+O).

  **Prompt rendering.** Template split so the POLE+O type-definitions live in a `{type_guidelines}`
  slot (dropped when a typed block renders) while relation/preference/confidence guidance stays
  present on every path. The typed block renders `description` + `examples` per type, with built-in
  POLE+O descriptions **backfilled** for configured-but-undescribed core types. Configurable caps
  (`max_type_description_chars` / `max_type_examples` / `max_typed_block_chars`) bound prompt-token
  cost with deterministic degradation (drop examples → name-only) that is logged, never silent.

  **Robustness.**
  - Intra-call same-name guard: collapses entities sharing a normalized name within one call,
    keeping the highest-confidence type (e.g. `Hume` → a single `PRODUCT` node). Cross-document
    resolution remains the deduplication stage's job.
  - Schema-aware `_map_to_allowed_type`: never coerces a type that's already configured (fixes
    `PRODUCT → OBJECT` when `PRODUCT` is in the schema); under a custom schema, keeps off-list
    types (flag-not-drop) instead of collapsing them to `allowed_types[0]`.
  - `strict_types` constrains the structured output to a dynamic `Literal[...]` of configured
    entity (and relationship) types, rejecting invented types.

  **New surface (all additive).**
  - `EntityTypeConfig.examples: list[str]`
  - `ExtractionConfig.entity_type_specs` + the three cap fields
  - `SchemaConfig.entity_schema` (rich schema, typed `Any` to avoid an import cycle)
  - Relationship-type descriptions render as `NAME (Source → Target): description`
  - `ExtractionResult.type_coverage: dict[str, int]` — per-type requested-vs-extracted counts,
    also emitted to logs and tracer spans
  - `LLMEntityExtractor(...)` / `for_custom_types(...)` now accept `list[EntityTypeConfig]`,
    plus `relation_types=` and `strict_types=`

  ## Tests

  New `tests/unit/test_ontology_aware_extraction.py` (37 deterministic tests, no live API):
  prompt-content assertions (AC1/AC5), names-only prompt unchanged (AC4), Hume dedup (AC3),
  schema-aware mapping, constrained payload, factory precedence, `custom_schema_path` fail-fast,
  and both extraction paths via mock providers. A live recall test (AC2 ≥ 0.80) is gated behind
  `RUN_INTEGRATION_TESTS` + an API key and skipped in CI.

  - Full unit suite: **1444 passed, 4 skipped** — no regressions.
  - `ruff check`/`format` clean; mypy net **−9** errors vs. baseline (no new errors introduced).
  - Docs: syntax + link + Antora build tests pass.

  ## Docs

  How-to (custom types on the LLM path + MemoryClient wiring), Explanation (descriptions on the
  LLM path, POLE+O-vs-custom), Reference (`ExtractionConfig`/`SchemaConfig` fields + precedence,
  new `EntityTypeConfig` field table), FAQ (corrected the stale "schemas are GLiNER-only" answer),
  and CHANGELOG (Added + Fixed).