### PR TITLE
fix(reasoning): attach tool calls to their step in get_trace_with_steps

### DIFF
--- a/src/neo4j_agent_memory/graph/queries.py
+++ b/src/neo4j_agent_memory/graph/queries.py
@@ -603,7 +603,7 @@ OPTIONAL MATCH (rt)-[:HAS_STEP]->(rs:ReasoningStep)
 OPTIONAL MATCH (rs)-[:USES_TOOL]->(tc:ToolCall)
 RETURN rt,
        collect(DISTINCT rs) AS steps,
-       collect(DISTINCT tc) AS tool_calls
+       collect(DISTINCT {step_id: rs.id, tool_call: tc}) AS tool_calls
 """
 
 LIST_TRACES = """

--- a/src/neo4j_agent_memory/memory/reasoning.py
+++ b/src/neo4j_agent_memory/memory/reasoning.py
@@ -1236,25 +1236,29 @@ class ReasoningMemory(BaseMemory[ReasoningStep]):
         steps_data = row.get("steps", [])
         tool_calls_data = row.get("tool_calls", [])
 
-        # Parse tool calls
+        # Parse tool calls. Each entry pairs a step id with a tool-call node,
+        # derived from the (ReasoningStep)-[:USES_TOOL]->(ToolCall) relationship
+        # (the association is not stored as a property on the node).
         tool_calls_by_step: dict[str, list[ToolCall]] = {}
-        for tc_data in tool_calls_data:
+        for entry in tool_calls_data:
+            entry = dict(entry)
+            tc_data = entry.get("tool_call")
+            step_id = entry.get("step_id")
+            if tc_data is None or step_id is None:
+                continue  # step with no tool call, or trace with no steps
             tc = dict(tc_data)
-            step_id = tc.get("step_id")
-            if step_id:
-                if step_id not in tool_calls_by_step:
-                    tool_calls_by_step[step_id] = []
-                tool_calls_by_step[step_id].append(
-                    ToolCall(
-                        id=UUID(tc["id"]),
-                        tool_name=tc["tool_name"],
-                        arguments=json.loads(tc.get("arguments", "{}")),
-                        result=json.loads(tc["result"]) if tc.get("result") else None,
-                        status=ToolCallStatus(tc.get("status", "success")),
-                        duration_ms=tc.get("duration_ms"),
-                        error=tc.get("error"),
-                    )
+            tool_calls_by_step.setdefault(step_id, []).append(
+                ToolCall(
+                    id=UUID(tc["id"]),
+                    step_id=UUID(step_id),
+                    tool_name=tc["tool_name"],
+                    arguments=json.loads(tc.get("arguments", "{}")),
+                    result=json.loads(tc["result"]) if tc.get("result") else None,
+                    status=ToolCallStatus(tc.get("status", "success")),
+                    duration_ms=tc.get("duration_ms"),
+                    error=tc.get("error"),
                 )
+            )
 
         # Parse steps
         steps = []

--- a/tests/integration/test_reasoning_memory.py
+++ b/tests/integration/test_reasoning_memory.py
@@ -334,6 +334,44 @@ class TestReasoningMemoryToolCalls:
 
         assert tool_call.arguments == complex_args
 
+    @pytest.mark.asyncio
+    async def test_get_trace_with_steps_includes_tool_calls(self, memory_client, session_id):
+        """Tool calls are attached to their step when reading a full trace.
+
+        Regression: ``get_trace_with_steps`` grouped tool calls by a
+        ``step_id`` property that ``record_tool_call`` never persisted (it
+        links via the ``USES_TOOL`` relationship), so ``step.tool_calls``
+        always came back empty.
+        """
+        trace = await memory_client.reasoning.start_trace(
+            session_id,
+            task="Screen owner",
+            generate_embedding=False,
+        )
+        step = await memory_client.reasoning.add_step(
+            trace.id,
+            thought="Need to screen the beneficial owner",
+            action="check_sanctions_list",
+            generate_embedding=False,
+        )
+        await memory_client.reasoning.record_tool_call(
+            step.id,
+            tool_name="check_sanctions_list",
+            arguments={"name": "Jane Doe"},
+            result="NO MATCH",
+            status=ToolCallStatus.SUCCESS,
+        )
+
+        full = await memory_client.reasoning.get_trace_with_steps(trace.id)
+
+        assert full is not None
+        assert len(full.steps) == 1
+        recorded = full.steps[0].tool_calls
+        assert len(recorded) == 1
+        assert recorded[0].tool_name == "check_sanctions_list"
+        assert recorded[0].arguments == {"name": "Jane Doe"}
+        assert recorded[0].step_id == step.id
+
 
 @pytest.mark.integration
 class TestReasoningMemorySearch:


### PR DESCRIPTION
## Problem

`ReasoningMemory.get_trace_with_steps()` always returns `step.tool_calls == []`, even when tool calls were recorded. The data is stored correctly — the reader just can't see it.

**Root cause:** `record_tool_call()` links a `ToolCall` to its `ReasoningStep` via the `(:ReasoningStep)-[:USES_TOOL]->(:ToolCall)` relationship, but never sets a `step_id` *property* on the node. `GET_TRACE_WITH_STEPS` flat-collected the tool-call nodes and the parser grouped them by `tc.get("step_id")` — which is always `None` — so no tool call ever attached to a step.

This surfaced while wiring `record_tool_calls=True` on the Strands `Neo4jSessionManager`: the `ToolCall` nodes were present in Neo4j (correct `USES_TOOL` edges), but the high-level reader reported none.

## Fix

Derive the step↔tool-call association from the relationship instead of an absent property:

- `GET_TRACE_WITH_STEPS` now emits `{step_id: rs.id, tool_call: tc}` pairs.
- `get_trace_with_steps()` parses that shape and also populates `ToolCall.step_id` on the returned objects.

Relationship-sourced, so it works for **already-stored data** — no migration required. No change to the write path.

## Test

Adds `test_get_trace_with_steps_includes_tool_calls` (integration). Verified red→green: fails (`assert 0 == 1`) before the fix, passes after. Full `tests/integration/test_reasoning_memory.py` suite (30 tests) and `tests/unit/nams/test_reasoning.py` (22 tests) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)