### PR TITLE
fix: map 404 responses to NotFoundError in REST and Bridge transports

### DIFF
--- a/typescript/src/transport/bridge.ts
+++ b/typescript/src/transport/bridge.ts
@@ -6,7 +6,7 @@
  * fetch-capable runtime (Node 20+, Bun, Deno, Workers, Edge).
  */
 
-import { AuthenticationError, ConnectionError, TransportError } from "../errors.js";
+import { AuthenticationError, ConnectionError, NotFoundError, TransportError } from "../errors.js";
 import {
   defaultUserAgent,
   extractRequestId,
@@ -193,6 +193,21 @@ export class BridgeTransport implements Transport {
         typeof errorBody === "object" && errorBody !== null && "error" in errorBody
           ? String((errorBody as Record<string, unknown>)["error"])
           : `HTTP ${response.status}`;
+
+      if (response.status === 404) {
+        const notFoundErr = new NotFoundError(errorMessage, { requestId });
+        this.emit({
+          kind: "error",
+          method,
+          url,
+          status: response.status,
+          requestId,
+          durationMs,
+          message: notFoundErr.message,
+        });
+        throw notFoundErr;
+      }
+
       const err = new TransportError(
         `${method} failed: ${errorMessage}`,
         response.status,

--- a/typescript/src/transport/rest.ts
+++ b/typescript/src/transport/rest.ts
@@ -13,6 +13,7 @@
 import {
   AuthenticationError,
   ConnectionError,
+  NotFoundError,
   NotSupportedError,
   TransportError,
 } from "../errors.js";
@@ -630,6 +631,21 @@ export class RestTransport implements Transport {
         typeof errorBody === "object" && errorBody !== null && "error" in errorBody
           ? String((errorBody as Record<string, unknown>)["error"])
           : `HTTP ${response.status}`;
+
+      if (response.status === 404) {
+        const notFoundErr = new NotFoundError(errMsg, { requestId });
+        this.emit({
+          kind: "error",
+          method,
+          url,
+          status: response.status,
+          requestId,
+          durationMs,
+          message: notFoundErr.message,
+        });
+        throw notFoundErr;
+      }
+
       const err = new TransportError(
         `${method} failed: ${errMsg}`,
         response.status,

--- a/typescript/test/integration/rest-transport.test.ts
+++ b/typescript/test/integration/rest-transport.test.ts
@@ -211,6 +211,20 @@ describe("RestTransport — error handling", () => {
     await client.close();
   });
 
+  it("returns NotFoundError on 404", async () => {
+    server.use(
+      http.get(`${ENDPOINT}/entities/:id`, () =>
+        HttpResponse.json({ error: "entity not found" }, { status: 404 }),
+      ),
+    );
+
+    const client = newClient();
+    await expect(
+      client.longTerm.getEntity("ent-00000000-0000-0000-0000-000000000000"),
+    ).rejects.toBeInstanceOf(NotFoundError);
+    await client.close();
+  });
+
   it("legacy bridge-only methods throw NotSupportedError", async () => {
     const client = newClient();
     await expect(


### PR DESCRIPTION
## Problem

`getEntity()` throws `TransportError` instead of `NotFoundError` when an entity does not exist. This breaks typed catch blocks:

```typescript
try {
  await memory.longTerm.getEntity("ent-00000000-0000-0000-0000-000000000000");
} catch (e) {
  console.log(e instanceof NotFoundError);  // false — wrong
  console.log(e instanceof TransportError); // true  — wrong
}
```

## Root cause

Both `RestTransport` and `BridgeTransport` map all non-OK HTTP responses to `TransportError`, including 404s.

## Fix

Add a `response.status === 404` check before the generic error path in both transports and throw `NotFoundError` with the same message. Added `NotFoundError` import to both files.

Closes #125