### PR TITLE
fix: type EntityTypeDef.poleType as PoleType literal union (#141)

### DIFF
--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -111,6 +111,7 @@ export type {
   ActiveOntology,
   DomainInfo,
   EntityTypeDef,
+  PoleType,
   PropertyDef,
   RelationshipDef,
   CreateOntologyOptions,

--- a/typescript/src/ontology/index.ts
+++ b/typescript/src/ontology/index.ts
@@ -27,9 +27,22 @@ export interface PropertyDef {
   enum?: string[];
 }
 
+/**
+ * The semantic category of an entity type, as recognized by the hosted
+ * ontology service. Must be an exact SCREAMING_CASE match — lowercase or
+ * unrecognized values are rejected at runtime with a 422.
+ */
+export type PoleType =
+  | "PERSON"
+  | "ORGANIZATION"
+  | "LOCATION"
+  | "EVENT"
+  | "OBJECT"
+  | "CUSTOM";
+
 export interface EntityTypeDef {
   label: string;
-  poleType: string; // PERSON | ORGANIZATION | LOCATION | EVENT | OBJECT
+  poleType: PoleType;
   subtype?: string;
   color?: string;
   icon?: string;
@@ -38,7 +51,17 @@ export interface EntityTypeDef {
 
 export interface RelationshipDef {
   type: string;
+  /**
+   * Must exactly match the `label` of an `EntityTypeDef` defined in the same
+   * ontology schema. There is no wildcard ("*" is not accepted) — every
+   * relationship endpoint must reference a concrete entity label.
+   */
   source: string;
+  /**
+   * Must exactly match the `label` of an `EntityTypeDef` defined in the same
+   * ontology schema. There is no wildcard ("*" is not accepted) — every
+   * relationship endpoint must reference a concrete entity label.
+   */
   target: string;
 }
 
@@ -243,7 +266,7 @@ function toDocument(raw: WireDocument | null | undefined): OntologyDocument | un
     domain: raw.domain,
     entityTypes: (raw.entity_types ?? []).map((e) => ({
       label: e.label,
-      poleType: e.pole_type,
+      poleType: e.pole_type as PoleType,
       subtype: e.subtype,
       color: e.color,
       icon: e.icon,


### PR DESCRIPTION
## Summary

Fixes #141 — `EntityTypeDef.poleType` was typed as bare `string`, letting invalid/lowercase values pass TypeScript compilation only to fail at runtime with an opaque `422 schema validation failed` from the server.

## Changes

- Added exported `PoleType` literal union: `"PERSON" | "ORGANIZATION" | "LOCATION" | "EVENT" | "OBJECT" | "CUSTOM"`
- `EntityTypeDef.poleType` now uses `PoleType` instead of `string`
- Documented `RelationshipDef.source`/`target` with JSDoc: they require an exact entity label from the same ontology schema — no wildcard (`"*"`) support server-side, per the issue's findings
- `PoleType` exported from the package root alongside the other ontology types
- Wire-format deserialization (`toDocument`) uses an explicit `as PoleType` assertion since the raw server response is still typed as `string` (trusted boundary)

Closes #141