### PR TITLE
Fix GLiREL relation extraction: pass token-index ner, not character offsets

### DIFF
--- a/src/neo4j_agent_memory/extraction/gliner_extractor.py
+++ b/src/neo4j_agent_memory/extraction/gliner_extractor.py
@@ -9,6 +9,7 @@ Reference: https://github.com/urchade/GLiNER
 
 import asyncio
 import logging
+import re
 from collections.abc import Callable
 from typing import Any
 
@@ -867,6 +868,54 @@ class GLiRELConfig(BaseModel):
     device: str = Field(default="cpu", description="Device to run model on (cpu, cuda, mps)")
 
 
+# --- glirel >= 1.x compatibility ---------------------------------------------------------------
+# glirel's ``predict_relations`` consumes the entity ``ner`` argument as TOKEN-index triples
+# ``[start_token, end_token, label]`` aligned to the token list passed as ``text``, and it returns
+# ``head_text``/``tail_text`` as token-list SLICES. Passing GLiNER's CHARACTER offsets in a 4-tuple
+# (and reading head_text/tail_text as strings) produces empty/garbage spans -> zero relations at the
+# default threshold, or a pydantic ValidationError at lower thresholds. The helpers below convert
+# correctly. glirel tokenizes with the regex mirrored here, so the indices line up without spaCy.
+_GLIREL_TOKEN_RE = re.compile(r"\w+(?:[-_]\w+)*|\S")
+
+
+def _glirel_tokenize_with_offsets(text: str) -> tuple[list[str], list[tuple[int, int]]]:
+    """Tokenize ``text`` the way glirel does, returning ``(tokens, char_spans)``."""
+    tokens: list[str] = []
+    spans: list[tuple[int, int]] = []
+    for match in _GLIREL_TOKEN_RE.finditer(text):
+        tokens.append(match.group())
+        spans.append((match.start(), match.end()))
+    return tokens, spans
+
+
+def _apply_glirel_hub_compat_shim() -> bool:
+    """Make ``GLiREL.from_pretrained`` work on newer ``huggingface_hub``.
+
+    glirel (<= 1.2.1) declares ``GLiREL._from_pretrained(..., proxies, resume_download)`` as
+    REQUIRED keyword-only arguments, but newer ``huggingface_hub`` no longer passes them, so
+    ``from_pretrained`` raises ``TypeError: missing 2 required keyword-only arguments``. Inject
+    safe defaults. Idempotent and a no-op if glirel is not importable.
+    """
+    try:
+        import glirel
+
+        cls = glirel.GLiREL
+        if getattr(cls, "_hub_compat_shim", False):
+            return True
+        original = cls.__dict__["_from_pretrained"].__func__
+
+        def _patched(c, *args, **kwargs):
+            kwargs.setdefault("proxies", None)
+            kwargs.setdefault("resume_download", None)
+            return original(c, *args, **kwargs)
+
+        cls._from_pretrained = classmethod(_patched)
+        cls._hub_compat_shim = True
+        return True
+    except Exception:  # noqa: BLE001 - best-effort; load errors surface in the `model` property
+        return False
+
+
 class GLiRELExtractor:
     """Relation extraction using GLiREL (GLiNER for Relations).
 
@@ -931,6 +980,7 @@ class GLiRELExtractor:
             try:
                 from glirel import GLiREL
 
+                _apply_glirel_hub_compat_shim()
                 logger.info(f"Loading GLiREL model: {self._model_name}")
                 self._model = GLiREL.from_pretrained(self._model_name)
                 # GLiREL uses .to() for device placement
@@ -973,25 +1023,30 @@ class GLiRELExtractor:
     def _entities_to_glirel_format(
         self,
         entities: list[ExtractedEntity],
+        token_spans: list[tuple[int, int]],
     ) -> list[list[int | str]]:
-        """Convert ExtractedEntity list to GLiREL NER format.
+        """Convert entities to GLiREL's NER format: ``[[start_token, end_token, label], ...]``.
 
-        GLiREL expects entities as: [[start_token, end_token, type, text], ...]
-        But it also accepts character positions when using predict_relations with text.
+        GLiREL expects TOKEN indices into the token list passed to ``predict_relations`` — not the
+        CHARACTER offsets that GLiNER produces. Each entity's character span (``start_pos``..
+        ``end_pos``) is mapped to the range of tokens it overlaps in ``token_spans``. Entities whose
+        span can't be resolved are skipped (fewer relations, never a crash).
         """
-        glirel_entities = []
+        ner: list[list[int | str]] = []
         for entity in entities:
-            # GLiREL format: [start, end, type, text]
-            # Using character positions
-            glirel_entities.append(
-                [
-                    entity.start_pos or 0,
-                    entity.end_pos or len(entity.name),
-                    entity.type,
-                    entity.name,
-                ]
-            )
-        return glirel_entities
+            char_start = entity.start_pos
+            char_end = entity.end_pos
+            if char_start is None or char_end is None:
+                continue
+            start_tok = end_tok = None
+            for index, (tok_start, tok_end) in enumerate(token_spans):
+                if tok_end > char_start and tok_start < char_end:  # token overlaps the entity span
+                    if start_tok is None:
+                        start_tok = index
+                    end_tok = index
+            if start_tok is not None:
+                ner.append([start_tok, end_tok, str(entity.type or "ENTITY")])
+        return ner
 
     def _extract_relations_sync(
         self,
@@ -1012,35 +1067,54 @@ class GLiRELExtractor:
         else:
             labels = list(self.relation_types.keys())
 
-        # Tokenize text
-        tokens = self._tokenize(text)
+        # Tokenize the way GLiREL does and map entity character spans to token indices.
+        tokens, token_spans = _glirel_tokenize_with_offsets(text)
 
-        # Convert entities to GLiREL format
-        ner_entities = self._entities_to_glirel_format(entities)
+        # Convert entities to GLiREL's token-index NER format.
+        ner_entities = self._entities_to_glirel_format(entities, token_spans)
+        if len(ner_entities) < 2:
+            # Fewer than 2 locatable entities -> no pairs to relate.
+            return []
 
-        # Run GLiREL prediction
+        # Run GLiREL prediction. ``top_k=1`` keeps the best-scoring label per entity pair.
         predictions = self.model.predict_relations(
             tokens,
             labels,
             threshold=self.threshold,
             ner=ner_entities,
+            top_k=1,
         )
 
         relations = []
-        for pred in predictions:
+        seen: set[tuple[str, str, str]] = set()
+        for pred in predictions or []:
             head_text = pred.get("head_text", "")
             tail_text = pred.get("tail_text", "")
-            label = pred.get("label", "RELATED_TO")
-            score = pred.get("score", 0.0)
+            # GLiREL returns head_text/tail_text as token-list slices; join them into strings.
+            if isinstance(head_text, (list, tuple)):
+                head_text = " ".join(head_text)
+            if isinstance(tail_text, (list, tuple)):
+                tail_text = " ".join(tail_text)
+            head_text = (head_text or "").strip()
+            tail_text = (tail_text or "").strip()
+            if not head_text or not tail_text or head_text == tail_text:
+                continue
 
-            # Create relation
-            relation = ExtractedRelation(
-                source=head_text,
-                target=tail_text,
-                relation_type=label.upper().replace(" ", "_"),
-                confidence=score,
+            label = pred.get("label", "RELATED_TO")
+            relation_type = str(label).upper().replace(" ", "_")
+            key = (head_text, relation_type, tail_text)
+            if key in seen:
+                continue
+            seen.add(key)
+
+            relations.append(
+                ExtractedRelation(
+                    source=head_text,
+                    target=tail_text,
+                    relation_type=relation_type,
+                    confidence=float(pred.get("score", 0.0) or 0.0),
+                )
             )
-            relations.append(relation)
 
         return relations
 


### PR DESCRIPTION
# Fix GLiREL relation extraction: pass token-index `ner`, not character offsets (silent 0 relations on glirel ≥ 1.x)

Fixes #151.

## Summary
`GLiRELExtractor` (and therefore `GLiNERWithRelationsExtractor`) produces **zero relations** when used
exactly as documented, and **raises a `pydantic.ValidationError`** at non-default thresholds. The cause
is the entity→GLiREL format conversion: it passes GLiNER **character offsets** in a 4-tuple where GLiREL
expects **token indices** in a 3-tuple, and it reads GLiREL's token-list `head_text`/`tail_text` as if
they were strings. As a side effect, any pipeline that falls back to an LLM when local relation
extraction yields nothing silently routes **all** relation extraction to the LLM.

This PR makes the conversion correct, joins the token-slice output, and adds a small
`huggingface_hub` compatibility shim so `GLiREL.from_pretrained` loads on current `glirel`/`hub`
versions. Verified end-to-end (see **Verification**).

## Environment where this reproduces
```
neo4j-agent-memory 0.4.0
glirel              1.2.1
gliner              0.2.26
transformers        5.1.0
huggingface_hub     1.18.0
pydantic            2.13.4
torch               2.12.0+cpu
```
`neo4j-agent-memory` advertises the GLiREL feature but declares **no `glirel` version pin** (only
`gliner`), so there is no "supported `glirel` version" that avoids this — current resolutions get 1.2.1.

## Symptoms
- `GLiNERWithRelationsExtractor.for_poleo().extract(text)` → entities found, **`relations == []`** at the
  default `threshold=0.5`. No error is raised — it just looks like "no relations in this text."
- At lower thresholds the same call **crashes**: GLiREL returns `head_text`/`tail_text` as token-list
  *slices* (lists), which are passed straight into `ExtractedRelation(source=..., target=...)` whose
  fields are typed `str` → `pydantic.ValidationError`.
- On `glirel` ≤ 1.2.1 + recent `huggingface_hub`, the model won't even load:
  `TypeError: GLiREL._from_pretrained() missing 2 required keyword-only arguments: 'proxies' and 'resume_download'`.

## Root cause
`GLiRELExtractor._entities_to_glirel_format` builds entries as:
```python
[entity.start_pos or 0, entity.end_pos or len(entity.name), entity.type, entity.name]   # CHAR offsets, 4-tuple
```
but `glirel.GLiREL.predict_relations(text, labels, ..., ner=...)` (signature
`(self, text, labels, flat_ner=True, threshold=0.5, ner=None, ground_truth_relations=None, top_k=-1)`)
expects `ner` as **`[[start_token, end_token, label], ...]` — TOKEN indices** aligned to the token list
passed as `text`. Character offsets interpreted as token indices land out of range / span the whole
sentence, so predictions are empty (silently dropped at `0.5`) or degenerate. And the returned
`head_text`/`tail_text` are **token-list slices**, not strings, so building `ExtractedRelation` from them
either validates oddly or raises.

## The fix
`src/neo4j_agent_memory/extraction/gliner_extractor.py`:
1. **`_entities_to_glirel_format(entities, token_spans)`** now maps each entity's character span to the
   range of **tokens it overlaps** and emits the correct **3-tuple `[start_token, end_token, label]`**.
   Entities whose span can't be resolved are skipped (fewer relations, never a crash).
2. **`_extract_relations_sync`** tokenizes with the same regex GLiREL uses
   (`\w+(?:[-_]\w+)*|\S`) so token indices line up, passes `top_k=1` (best label per pair), and
   **joins the token-slice `head_text`/`tail_text` into strings** before constructing
   `ExtractedRelation`. Empty/self-pair predictions are dropped and duplicates de-duplicated.
   *Bonus:* this removes the hard dependency on a loaded spaCy model (`en_core_web_sm`) for GLiREL
   tokenization — a common silent failure point. (`_tokenize`/`nlp` are retained, just unused here.)
3. **`_apply_glirel_hub_compat_shim()`** is called in the lazy `model` property: it injects safe
   defaults for the `proxies`/`resume_download` kwargs that newer `huggingface_hub` no longer passes,
   so `from_pretrained` works on `glirel` ≤ 1.2.1. Idempotent; no-op if `glirel` isn't importable.

The only signature change is to the **private** `_entities_to_glirel_format` (now takes `token_spans`).

## Reproduction
The runnable repro is in #151. On the **unpatched** package it prints `relations: 0` for every
sentence; with this PR applied it prints real relations. Run:
```bash
pip install "neo4j-agent-memory==0.4.0" "glirel==1.2.1" gliner spacy
python repro_glirel_bug.py
```

## Verification (controlled, with an independent oracle)
A controlled before/after harness loads the model **once** and compares the shipped vs patched
`GLiRELExtractor.extract_relations` on the same GLiNER entities at the same thresholds, against an
**independent reference implementation** of the correct GLiREL contract. Results
(`jackboyla/glirel-large-v0`, CPU):

| | relations @ 0.5 | @ 0.3 |
|---|---|---|
| **Shipped (before)** | **0** across all 5 test sentences | **0 / crash** |
| **Patched (after)** | **12**, e.g. `John Smith —WORKS_AT→ Acme Corporation`, `Questar —LOCATED_IN→ Salt Lake City`, `Sarah Lee —CEO_OF→ Enron` | no crash |

The patched output matches the independent reference implementation **set-for-set on every sentence**,
and the model loads via the in-property shim with no external patching. Same model, same entities, same
thresholds — the only variable was the conversion code.

## Notes
- The relations GLiREL returns zero-shot are still noisy/symmetric (it scores both directions and can
  mislabel); that's a model-quality matter, separate from this correctness fix. This PR is strictly
  about "the pipeline now returns relations at all" rather than "always to the LLM."
- Affected: 0.4.0 (current). The conversion bug predates the `huggingface_hub` kwarg change; the load
  shim is needed only on newer `huggingface_hub` + `glirel` ≤ 1.2.1.
