### PR TITLE
fix(bolt): embed entities during extraction + add generate_entity_embeddings_batch()

### DIFF
--- a/src/neo4j_agent_memory/memory/long_term.py
+++ b/src/neo4j_agent_memory/memory/long_term.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -17,6 +18,8 @@ from neo4j_agent_memory.core.memory import BaseMemory, MemoryEntry
 from neo4j_agent_memory.core.protocols import LongTermProtocol
 from neo4j_agent_memory.graph import queries
 from neo4j_agent_memory.graph.query_builder import build_create_entity_query
+
+logger = logging.getLogger(__name__)
 
 # =============================================================================
 # DEDUPLICATION CONFIGURATION
@@ -560,6 +563,74 @@ class LongTermMemory(BaseMemory[Entity], LongTermProtocol):
             )
 
         return entity, dedup_result
+
+    async def generate_entity_embeddings_batch(
+        self,
+        *,
+        batch_size: int = 128,
+        on_progress: Callable[[int, int], None] | None = None,
+    ) -> dict[str, int]:
+        """Generate embeddings for entities that don't have them.
+
+        Entity analogue of ShortTermMemory.generate_embeddings_batch(). Useful after bulk
+        extraction with generate_embeddings=False, or to repair graphs created before entity
+        embedding was wired into the extraction path. Idempotent: only touches entities whose
+        embedding IS NULL. Embeds the entity name (matching add_entity).
+
+        Returns:
+            {"embedded": int, "failed": int, "remaining": int}
+        """
+        if self._embedder is None:
+            return {"embedded": 0, "failed": 0, "remaining": 0}
+
+        total_rows = await self._client.execute_read(queries.COUNT_ENTITIES_WITHOUT_EMBEDDINGS, {})
+        total = total_rows[0]["count"] if total_rows else 0
+        embedded = 0
+        failed = 0
+
+        while True:
+            rows = await self._client.execute_read(
+                queries.GET_ENTITIES_WITHOUT_EMBEDDINGS, {"skip": 0, "limit": batch_size}
+            )
+            if not rows:
+                break
+            progressed = False
+            # Batch-embed the names in this page.
+            names = [r["name"] for r in rows if r.get("name")]
+            try:
+                vectors = await self._embedder.embed_batch(names)
+                name_to_vec = dict(zip(names, vectors))
+            except Exception:  # noqa: BLE001 — degrade to per-name below
+                name_to_vec = {}
+            for r in rows:
+                name = r.get("name")
+                vec = name_to_vec.get(name)
+                if vec is None and name:
+                    try:
+                        vec = await self._embedder.embed(name)
+                    except Exception:  # noqa: BLE001
+                        failed += 1
+                        logger.warning("entity embedding failed for id=%s", r.get("id"))
+                        continue
+                if vec is None:
+                    failed += 1
+                    continue
+                await self._client.execute_write(
+                    queries.UPDATE_ENTITY_EMBEDDING, {"id": r["id"], "embedding": vec}
+                )
+                embedded += 1
+                progressed = True
+                if on_progress:
+                    on_progress(embedded, total)
+            if not progressed:
+                # Every row in this page failed — avoid an infinite loop.
+                break
+
+        remaining_rows = await self._client.execute_read(
+            queries.COUNT_ENTITIES_WITHOUT_EMBEDDINGS, {}
+        )
+        remaining = remaining_rows[0]["count"] if remaining_rows else 0
+        return {"embedded": embedded, "failed": failed, "remaining": remaining}
 
     async def add_preference(
         self,

--- a/src/neo4j_agent_memory/memory/short_term.py
+++ b/src/neo4j_agent_memory/memory/short_term.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 from collections.abc import Awaitable, Callable
 from datetime import datetime, timezone
 from enum import Enum
@@ -16,6 +17,8 @@ from neo4j_agent_memory.core.memory import BaseMemory, MemoryEntry
 from neo4j_agent_memory.core.protocols import ShortTermProtocol
 from neo4j_agent_memory.graph import queries
 from neo4j_agent_memory.graph.query_builder import build_create_entity_query
+
+logger = logging.getLogger(__name__)
 
 
 def _llm_summarizer(
@@ -497,7 +500,11 @@ class ShortTermMemory(BaseMemory[Message], ShortTermProtocol):
         # Extract entities if enabled (done separately for performance)
         if extract_entities and self._extractor is not None:
             for msg in all_created:
-                await self._extract_and_link_entities(msg, extract_relations=extract_relations)
+                await self._extract_and_link_entities(
+                    msg,
+                    extract_relations=extract_relations,
+                    generate_embeddings=generate_embeddings,
+                )
 
         return all_created
 
@@ -749,7 +756,11 @@ class ShortTermMemory(BaseMemory[Message], ShortTermProtocol):
         else:
             # 'auto' — preserve historical behavior.
             if extract_entities and self._extractor is not None:
-                await self._extract_and_link_entities(message, extract_relations=extract_relations)
+                await self._extract_and_link_entities(
+                    message,
+                    extract_relations=extract_relations,
+                    generate_embeddings=generate_embedding,
+                )
 
         return message
 
@@ -1115,6 +1126,7 @@ class ShortTermMemory(BaseMemory[Message], ShortTermProtocol):
         batch_size: int = 50,
         skip_existing: bool = True,
         extract_relations: bool = True,
+        generate_embeddings: bool = True,
         on_progress: Callable[[int, int], None] | None = None,
     ) -> dict[str, int]:
         """
@@ -1128,6 +1140,8 @@ class ShortTermMemory(BaseMemory[Message], ShortTermProtocol):
             batch_size: Messages to process per batch
             skip_existing: Skip messages that already have entity links (MENTIONS relationships)
             extract_relations: Whether to also extract and store relations between entities
+            generate_embeddings: Whether to embed entity names (default True for
+                searchable recall; pass False for fast structural-only import).
             on_progress: Progress callback (processed_count, total_count)
 
         Returns:
@@ -1169,6 +1183,13 @@ class ShortTermMemory(BaseMemory[Message], ShortTermProtocol):
                 # Track entity name to ID mapping for relation linking
                 entity_name_to_id: dict[str, str] = {}
 
+                # Embed all extracted names up front in one batch (matches add_entity semantics).
+                name_vectors = (
+                    await self._embed_names([e.name for e in extraction_result.entities])
+                    if generate_embeddings
+                    else {}
+                )
+
                 for entity in extraction_result.entities:
                     # Create or get entity with dynamic labels for type/subtype
                     entity_id = str(uuid4())
@@ -1183,7 +1204,7 @@ class ShortTermMemory(BaseMemory[Message], ShortTermProtocol):
                             "subtype": entity_subtype,
                             "canonical_name": entity.name,
                             "description": None,
-                            "embedding": None,
+                            "embedding": name_vectors.get(entity.name),
                             "confidence": entity.confidence,
                             "metadata": None,
                             "location": None,  # Required for LOCATION entities
@@ -1325,14 +1346,40 @@ class ShortTermMemory(BaseMemory[Message], ShortTermProtocol):
             },
         )
 
+    async def _embed_names(self, names: list[str]) -> dict[str, list[float]]:
+        """Embed a batch of entity names; returns {name: vector}.
+
+        Mirrors the entity embedding done in LongTermMemory.add_entity (embeds the
+        canonical name). Failures for individual names are swallowed (the entity is
+        written with embedding=NULL and can be repaired later via
+        LongTermMemory.generate_entity_embeddings_batch()), so one bad input never
+        aborts extraction of a whole message.
+        """
+        if self._embedder is None or not names:
+            return {}
+        uniq = list(dict.fromkeys(n for n in names if n))
+        try:
+            vectors = await self._embedder.embed_batch(uniq)
+            return dict(zip(uniq, vectors))
+        except Exception:  # noqa: BLE001 — fall back to per-name so one failure isn't fatal
+            out: dict[str, list[float]] = {}
+            for n in uniq:
+                try:
+                    out[n] = await self._embedder.embed(n)
+                except Exception:  # noqa: BLE001
+                    logger.warning("entity-name embedding failed for %r; leaving NULL", n)
+            return out
+
     async def _extract_and_link_entities(
-        self, message: Message, *, extract_relations: bool = True
+        self, message: Message, *, extract_relations: bool = True, generate_embeddings: bool = True
     ) -> None:
         """Extract entities from message and link them.
 
         Args:
             message: The message to extract entities from
             extract_relations: Whether to also extract and store relations between entities
+            generate_embeddings: Whether to embed entity names (default True for
+                searchable recall; pass False for fast structural-only import).
         """
         if self._extractor is None:
             return
@@ -1344,6 +1391,13 @@ class ShortTermMemory(BaseMemory[Message], ShortTermProtocol):
 
         # Track entity name to ID mapping for relation linking
         entity_name_to_id: dict[str, str] = {}
+
+        # Embed all extracted names up front in one batch (matches add_entity semantics).
+        name_vectors = (
+            await self._embed_names([e.name for e in result.entities])
+            if generate_embeddings
+            else {}
+        )
 
         for entity in result.entities:
             # Create or get entity with dynamic labels for type/subtype
@@ -1366,7 +1420,7 @@ class ShortTermMemory(BaseMemory[Message], ShortTermProtocol):
                     "subtype": entity_subtype,
                     "canonical_name": entity.name,
                     "description": None,
-                    "embedding": None,
+                    "embedding": name_vectors.get(entity.name),
                     "confidence": entity.confidence,
                     "metadata": metadata_payload,
                     "location": None,  # Required for LOCATION entities

--- a/src/neo4j_agent_memory/memory/short_term.py
+++ b/src/neo4j_agent_memory/memory/short_term.py
@@ -1357,7 +1357,7 @@ class ShortTermMemory(BaseMemory[Message], ShortTermProtocol):
         """
         if self._embedder is None or not names:
             return {}
-        uniq = list(dict.fromkeys(n for n in names if n))
+        uniq: list[str] = list(dict.fromkeys(n for n in names if n))
         try:
             vectors = await self._embedder.embed_batch(uniq)
             return dict(zip(uniq, vectors))


### PR DESCRIPTION
## What & why
On the Bolt backend, the LLM extraction pipeline wrote every `:Entity` with `embedding = NULL`, while
`search_entities()` is vector-only (`db.index.vector.queryNodes('entity_embedding_idx', …)`). Net
effect: a knowledge graph built via `add_message(extract_entities=True)` /
`extract_entities_from_session()` populates the graph but is **invisible to semantic recall** — every
query returns empty, with no error. The NAMS backend already embeds extracted entities server-side, so
this fixes a Bolt-vs-NAMS asymmetry and aligns Bolt with the documented prerequisite
("embedding model configured" for automatic extraction). Fixes #NNNNN.

## Changes
1. **Embed entities inline during extraction** (`memory/short_term.py`):
   - `_extract_and_link_entities()` and `extract_entities_from_session()` now embed each extracted
     entity's `name` (matching `add_entity()`) when an embedder is configured, via a new
     `_embed_names()` helper that batches with `embedder.embed_batch()` and tolerates individual
     embed failures (leaves NULL for later backfill rather than aborting the message).
   - New `generate_embeddings: bool = True` control flag, threaded from `add_message(...)` and exposed
     on `extract_entities_from_session(...)`. Default `True` = embed (expected behavior); pass `False`
     for fast structural-only import + deferred batch embedding.
2. **New public batch helper** (`memory/long_term.py`):
   - `LongTermMemory.generate_entity_embeddings_batch(batch_size=128, on_progress=None)` — the entity
     analogue of the existing `ShortTermMemory.generate_embeddings_batch()`. Uses the already-defined
     `GET_ENTITIES_WITHOUT_EMBEDDINGS` / `UPDATE_ENTITY_EMBEDDING` / `COUNT_ENTITIES_WITHOUT_EMBEDDINGS`
     queries (previously dead code). Idempotent; repairs existing graphs without re-extraction.

No new dependencies, no new imports, no schema/index changes (the `entity_embedding_idx` vector index
and the three queries already exist).

## Behavior change / compat notes
- **Extraction now embeds by default**, adding embedding round-trips during extraction. This increases
  extraction latency but makes recall actually work. Opt out with `generate_embeddings=False` (then
  call `generate_entity_embeddings_batch()` later) for the previous fast-import behavior. Flagged in
  CHANGELOG.
- Embeds `name` only, identical to `add_entity`, so manually-added and extracted entities share one
  vector space.
- Failures on individual entity-name embeds are logged and skipped (entity persists with NULL
  embedding), so extraction never hard-fails on a single bad embed.

## Testing
- [ ] Unit: extraction with a stub embedder writes non-null `embedding` on every extracted entity;
      with `generate_embeddings=False`, embeddings are NULL.
- [ ] Unit: `generate_entity_embeddings_batch()` embeds only NULL-embedding entities, is idempotent on
      a second run (`embedded=0, remaining=0`), and reports `failed` on embedder errors without raising.
- [ ] Integration (real Neo4j + embedder): `add_message(extract_entities=True)` → `search_entities()`
      returns the extracted entities by semantic query (the issue's repro now passes).
- [ ] Integration: bulk `extract_entities_from_session(generate_embeddings=False)` then
      `generate_entity_embeddings_batch()` → recall works.
- [ ] Regression: NAMS backend unaffected (no code touched there).

## Notes for reviewers
- Diffs in the linked issue/handoff were anchored to v0.5.0 line numbers; I've re-anchored to `main`
  here.
- Open question for maintainers: should `add_message` reuse its existing `generate_embeddings` flag
  (currently message-only) to also gate entity embedding, or get a dedicated
  `generate_entity_embeddings` flag? This PR reuses the existing flag for a single intuitive knob;
  happy to split if you prefer.

## Related Issue
Fixes #NNNNN