### PR TITLE
Fix MENTIONS edge dropped for messages after the first namer

### DIFF
--- a/src/neo4j_agent_memory/memory/short_term.py
+++ b/src/neo4j_agent_memory/memory/short_term.py
@@ -1071,7 +1071,7 @@ class ShortTermMemory(BaseMemory[Message]):
                     entity_id = str(uuid4())
                     entity_subtype = getattr(entity, "subtype", None)
                     create_query = build_create_entity_query(entity.type, entity_subtype)
-                    await self._client.execute_write(
+                    rows = await self._client.execute_write(
                         create_query,
                         {
                             "id": entity_id,
@@ -1086,6 +1086,8 @@ class ShortTermMemory(BaseMemory[Message]):
                             "location": None,  # Required for LOCATION entities
                         },
                     )
+                    # link to the entity's real id, not the pre-generated uuid
+                    entity_id = rows[0]["e"]["id"]
 
                     # Store mapping for relation linking
                     entity_name_to_id[entity.name.lower().strip()] = entity_id
@@ -1254,7 +1256,7 @@ class ShortTermMemory(BaseMemory[Message]):
             metadata_payload = (
                 json.dumps({"extracted_by": extracted_by}) if extracted_by is not None else None
             )
-            await self._client.execute_write(
+            rows = await self._client.execute_write(
                 create_query,
                 {
                     "id": entity_id,
@@ -1269,6 +1271,8 @@ class ShortTermMemory(BaseMemory[Message]):
                     "location": None,  # Required for LOCATION entities
                 },
             )
+            # link to the entity's real id, not the pre-generated uuid
+            entity_id = rows[0]["e"]["id"]
 
             # Store mapping for relation linking
             entity_name_to_id[entity.name.lower().strip()] = entity_id

--- a/tests/unit/test_relation_storage.py
+++ b/tests/unit/test_relation_storage.py
@@ -42,7 +42,15 @@ class TestRelationStorage:
     def mock_client(self):
         """Create a mock Neo4j client."""
         client = MagicMock()
-        client.execute_write = AsyncMock(return_value=[])
+
+        # Faithful mock: the entity-create query (`... RETURN e`) returns the
+        # node so callers can read back its real id; other writes return [].
+        async def _execute_write(query, params=None):
+            if "RETURN e" in query:
+                return [{"e": {"id": (params or {}).get("id")}}]
+            return []
+
+        client.execute_write = AsyncMock(side_effect=_execute_write)
         client.execute_read = AsyncMock(return_value=[])
         return client
 
@@ -264,7 +272,15 @@ class TestExtractEntitiesFromSessionWithRelations:
     def mock_client(self):
         """Create a mock Neo4j client."""
         client = MagicMock()
-        client.execute_write = AsyncMock(return_value=[])
+
+        # Faithful mock: the entity-create query (`... RETURN e`) returns the
+        # node so callers can read back its real id; other writes return [].
+        async def _execute_write(query, params=None):
+            if "RETURN e" in query:
+                return [{"e": {"id": (params or {}).get("id")}}]
+            return []
+
+        client.execute_write = AsyncMock(side_effect=_execute_write)
         client.execute_read = AsyncMock(return_value=[])
         return client
 


### PR DESCRIPTION
## Problem

Only the **first** message to name a given entity received a
`(:Message)-[:MENTIONS]->(:Entity)` edge. Every subsequent message
naming an already-existing entity — whether later in the same session
or in a different one — was linked to no edge at all. As a result, any
traversal that starts from an entity and walks `MENTIONS` back to the
messages referencing it (or aggregates mention counts) sees only the
first occurrence and undercounts the rest.

## Root cause

The two auto-extraction paths in `ShortTermMemory` mint a fresh
`entity_id = str(uuid4())` and pass it to both the create and the link
query. `build_create_entity_query` sets `e.id` only under
`ON CREATE SET`, so for an already-existing entity the fresh uuid is
discarded and the node keeps its original id. `LINK_MESSAGE_TO_ENTITY`
then matches `{id: $entity_id}` with that dropped uuid, matches
nothing, and silently writes no edge.

## Fix

Read the real id back from the create query's existing `RETURN e`
before linking — the pattern `_link_explicit_mentions` already uses.
Applied to `_extract_and_link_entities` and
`extract_entities_from_session`.

This also repairs `RELATED_TO` edges, which were silently dropped for
the same reason: `entity_name_to_id` held the phantom uuid, so
`CREATE_ENTITY_RELATION_BY_ID` matched nothing without falling back to
the name-based lookup.

## Testing

Run locally per CONTRIBUTING.md:

- **Lint** (`ruff check src tests`) — passes.
- **Format** (`ruff format --check`) — passes (289 files).
- **Unit tests** — 1407 passed, 3 skipped. The relation-storage mocks
  now return the created node for `RETURN e` queries (matching the real
  query contract), giving the create-then-link path unit coverage it
  previously lacked.
- **Integration tests** (Neo4j 5) — short-term memory and entity
  resolution suites pass (42 tests). Full integration suite:
  337 passed, 0 failed, 238 skipped (skips are gated on provider SDKs
  and hosted-service keys — OpenAI/Vertex/AWS/CrewAI/LlamaIndex/
  LangChain/NAMS — none of which touch this change; CI exercises them).
- **Build** — wheel + sdist build cleanly.

**Not addressed:** mypy strict reports 286 pre-existing errors on the
repo baseline; this change adds none, and fixing the baseline is out of
scope for this PR.

## Reproduction

With an extractor configured for entity types like
`["PERSON", "ACTIVITY"]`:

1. Add "I'm Amy. I love kayaking." to session A.
2. Add "I'm Bob. I love kayaking." to session B.

Before: one `:Entity {name:"kayaking"}` exists, but only one of the two
messages has a `MENTIONS` edge to it. After: both messages are linked.

## Notes
- PR description generated by Claude Opus 4.8.
- I've never contributed to this repo before, so if I've made a mistake let me know!