### PR TITLE
Vercel nams provider

### DIFF
--- a/.github/workflows/ci-typescript.yml
+++ b/.github/workflows/ci-typescript.yml
@@ -85,3 +85,38 @@ jobs:
       - name: Type-check example
         working-directory: typescript/examples/${{ matrix.example }}
         run: npx tsc --noEmit
+
+  vercel-ai-provider:
+    name: Vercel AI provider package (Node ${{ matrix.node }})
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: typescript/packages/vercel-ai-provider
+    strategy:
+      fail-fast: false
+      matrix:
+        node: ['20', '22']
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node }}
+          cache: 'npm'
+          cache-dependency-path: typescript/packages/vercel-ai-provider/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Type-check
+        run: npm run typecheck
+
+      - name: Tests
+        run: npm test
+
+      - name: Build
+        run: npm run build
+
+      - name: Verify packed artifact
+        run: npm pack --dry-run

--- a/.github/workflows/publish-nams-ai-provider.yml
+++ b/.github/workflows/publish-nams-ai-provider.yml
@@ -1,0 +1,61 @@
+name: Publish NAMS AI provider
+
+on:
+  push:
+    tags:
+      - "nams-ai-provider-v*"
+
+defaults:
+  run:
+    working-directory: typescript/packages/vercel-ai-provider
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment:
+      name: npm
+      url: https://www.npmjs.com/package/@neo4j-labs/nams-ai-provider
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          registry-url: 'https://registry.npmjs.org'
+          cache: 'npm'
+          cache-dependency-path: typescript/packages/vercel-ai-provider/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Type-check
+        run: npm run typecheck
+
+      - name: Test
+        run: npm test
+
+      - name: Build
+        run: npm run build
+
+      - name: Publish to npm with provenance
+        run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  github-release:
+    needs: publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          name: "NAMS AI provider ${{ github.ref_name }}"

--- a/typescript/packages/vercel-ai-provider/.gitignore
+++ b/typescript/packages/vercel-ai-provider/.gitignore
@@ -1,0 +1,35 @@
+# Dependencies
+node_modules/
+
+# Build output
+dist/
+*.tsbuildinfo
+
+# Test coverage
+coverage/
+.nyc_output/
+
+# npm pack output
+*.tgz
+
+# Logs
+logs/
+*.log
+npm-debug.log*
+
+# Caches
+.cache/
+.turbo/
+.vite/
+.vitest/
+
+# Environment / secrets
+.env
+.env.local
+.env.*.local
+
+# Editor & OS
+.idea/
+.vscode/
+*.swp
+.DS_Store

--- a/typescript/packages/vercel-ai-provider/LICENSE
+++ b/typescript/packages/vercel-ai-provider/LICENSE
@@ -1,0 +1,190 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to the Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by the Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding any notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright 2026 Neo4j Labs
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/typescript/packages/vercel-ai-provider/README.md
+++ b/typescript/packages/vercel-ai-provider/README.md
@@ -157,6 +157,9 @@ There are three ways to integrate NAMS depending on how much control you want:
 
 Switching modes is purely a code-level choice — all three use the same API key
 and environment variables (see [Environment variables](#environment-variables)).
+Middleware and tools modes can also be
+[combined on one agent](#combining-tools-mode-with-middleware-hybrid) —
+injected baseline context plus explicit memory tools.
 
 > **How does this relate to `@neo4j-labs/agent-memory/middleware/vercel-ai`?**
 > The core SDK ships a minimal middleware for the AI SDK v4-era
@@ -261,7 +264,7 @@ return createUIMessageStreamResponse({ stream });
 Expose `query_memory` and `store_memory` as explicit AI SDK tools. The model decides when to call them, and the calls are visible in your UI — useful for debugging or when you want the user to see memory activity:
 
 ```ts
-import { createNams } from '@neo4j-labs/nams-ai-provider';
+import { createNams, enforceQueryMemory } from '@neo4j-labs/nams-ai-provider';
 import { openai } from '@ai-sdk/openai';
 import {
   ToolLoopAgent,
@@ -275,8 +278,12 @@ const tools = nams.tools({ userId: session.userId });
 
 const agent = new ToolLoopAgent({
   model:        openai('gpt-5.4-mini'),
-  instructions: 'Always call query_memory first. Call store_memory after responding.',
+  instructions:
+    'Before answering, consult memory with query_memory. When the conversation ' +
+    'contains facts or preferences worth remembering, call store_memory before ' +
+    'giving your final answer.',
   tools,
+  prepareStep:  enforceQueryMemory(),
   stopWhen:     stepCountIs(10),
 });
 
@@ -290,6 +297,21 @@ const stream = createUIMessageStream({
 return createUIMessageStreamResponse({ stream });
 ```
 
+Tool descriptions and instructions are advisory — models routinely skip
+"bookkeeping" tool calls. `enforceQueryMemory()` makes retrieval mechanical
+instead: it checks the executed tool calls each step and, until `query_memory`
+has run, holds the model at `toolChoice: 'required'` — it can still call other
+tools in any order, but cannot finish with a text-only answer before querying
+memory. After `graceSteps` steps (default: 3) without a query, the next step
+forces `query_memory` directly, so the loop can never exhaust its budget
+without the query having run; `{ graceSteps: 0 }` forces it as the literal
+first step. Keep `graceSteps` at least two below your `stopWhen` budget so the
+forced query and the final answer both fit. There is no equivalent forcing
+hook for `store_memory` (the loop ends when the model emits final text) — if
+persistence must be guaranteed, check `steps` in `onFinish` and call
+`store_memory.execute()` yourself, or use provider / middleware mode where
+both directions happen unconditionally in code.
+
 ### Tools Mode with MCP (optional)
 
 Still tools mode — not a separate mode. `toolsWithMcp()` connects to an MCP
@@ -299,7 +321,7 @@ remember *and* use external tooling. Requires the optional peer `@ai-sdk/mcp`
 passed.
 
 ```ts
-import { createNams } from '@neo4j-labs/nams-ai-provider';
+import { createNams, enforceQueryMemory } from '@neo4j-labs/nams-ai-provider';
 import { openai } from '@ai-sdk/openai';
 import { ToolLoopAgent, stepCountIs } from 'ai';
 
@@ -307,13 +329,18 @@ const nams = createNams({ apiKey: process.env.MEMORY_API_KEY! });
 
 const { tools, close } = await nams.toolsWithMcp(
   { userId: session.userId },
-  { url: 'https://mcp.example.com/mcp', headers: { Authorization: `Bearer ${token}` } },
+  {
+    url:        'https://mcp.example.com/mcp',
+    headers:    { Authorization: `Bearer ${token}` },
+    toolPrefix: 'mcp_',
+  },
 );
 
 const agent = new ToolLoopAgent({
-  model: openai('gpt-5.4-mini'),
-  tools, // query_memory + store_memory + all MCP server tools
-  stopWhen: stepCountIs(10),
+  model:       openai('gpt-5.4-mini'),
+  tools,       // query_memory + store_memory + mcp_* server tools
+  prepareStep: enforceQueryMemory(),  // memory queried before answering, MCP tools in any order
+  stopWhen:    stepCountIs(10),
 });
 
 try {
@@ -327,13 +354,30 @@ try {
 When the MCP config is omitted, `toolsWithMcp(scope)` behaves exactly like
 `tools(scope)` with a no-op `close`.
 
-> **Merging is for complementary tools, not overlapping ones.** This is meant
-> to pair NAMS memory with *unrelated* tooling from an MCP server (search,
-> filesystem, domain APIs, etc.) — not another memory implementation. If the
-> MCP server happens to expose a tool named `query_memory` or `store_memory`,
-> its tool silently takes precedence (`{ ...namsTools, ...mcpTools }`), and a
-> warning is logged via the configured `logger` so the collision doesn't go
-> unnoticed.
+### Combining tools mode with middleware (hybrid)
+
+Middleware and tools modes are not mutually exclusive — one `createNams`
+instance can serve both. The middleware-wrapped model injects baseline memory
+context on every call, while the tools let the model run targeted searches and
+explicit writes on top. This mirrors the "core memory injected each turn +
+memory tool for on-demand search" pattern from the
+[AI SDK custom memory tool guide](https://ai-sdk.dev/cookbook/guides/custom-memory-tool):
+
+```ts
+const nams  = createNams({ apiKey: process.env.MEMORY_API_KEY! });
+const scope = { userId: session.userId };
+
+const agent = new ToolLoopAgent({
+  model:    nams.wrap(openai('gpt-5.4-mini'), scope), // baseline context injected every call
+  tools:    nams.tools(scope),                        // targeted search + explicit writes
+  stopWhen: stepCountIs(10),
+});
+```
+
+In this setup, skip `enforceQueryMemory()` — the middleware already guarantees
+retrieval unconditionally in code, so forcing `query_memory` as well would
+just spend an extra step re-fetching similar context. The enforcement hook is
+for pure tools mode, where the tool call is the *only* retrieval path.
 
 ---
 

--- a/typescript/packages/vercel-ai-provider/README.md
+++ b/typescript/packages/vercel-ai-provider/README.md
@@ -90,7 +90,7 @@ import {
 } from 'ai';
 
 const agent = new ToolLoopAgent({
-  model:        openai('gpt-4o-mini'),
+  model:        openai('gpt-5.4-mini'),
   instructions: 'You are a helpful assistant.',
   stopWhen:     stepCountIs(10),
 });
@@ -123,7 +123,7 @@ const nams = createNamsProvider({
 });
 
 const agent = new ToolLoopAgent({
-  model:        nams.languageModel('gpt-4o-mini'),  // ← only change
+  model:        nams.languageModel('gpt-5.4-mini'),  // ← only change
   instructions: 'You are a helpful assistant.',
   stopWhen:     stepCountIs(10),
 });
@@ -189,7 +189,7 @@ const nams = createNamsProvider({
 });
 
 const agent = new ToolLoopAgent({
-  model:        nams.languageModel('gpt-4o-mini'),
+  model:        nams.languageModel('gpt-5.4-mini'),
   instructions: 'You are a helpful assistant.',
   stopWhen:     stepCountIs(1),       // no tools needed in provider mode
 });
@@ -218,7 +218,7 @@ const registry = createRegistry({
 });
 
 const agent = new ToolLoopAgent({
-  model:    registry.languageModel('nams:gpt-4o-mini'),
+  model:    registry.languageModel('nams:gpt-5.4-mini'),
   stopWhen: stepCountIs(1),
 });
 ```
@@ -240,7 +240,7 @@ import {
 } from 'ai';
 
 const nams  = createNams({ apiKey: process.env.MEMORY_API_KEY! });
-const model = nams.wrap(openai('gpt-4o-mini'), { userId: session.userId });
+const model = nams.wrap(openai('gpt-5.4-mini'), { userId: session.userId });
 
 const agent = new ToolLoopAgent({ model, stopWhen: stepCountIs(1) });
 
@@ -274,7 +274,7 @@ const nams  = createNams({ apiKey: process.env.MEMORY_API_KEY! });
 const tools = nams.tools({ userId: session.userId });
 
 const agent = new ToolLoopAgent({
-  model:        openai('gpt-4o-mini'),
+  model:        openai('gpt-5.4-mini'),
   instructions: 'Always call query_memory first. Call store_memory after responding.',
   tools,
   stopWhen:     stepCountIs(10),
@@ -311,7 +311,7 @@ const { tools, close } = await nams.toolsWithMcp(
 );
 
 const agent = new ToolLoopAgent({
-  model: openai('gpt-4o-mini'),
+  model: openai('gpt-5.4-mini'),
   tools, // query_memory + store_memory + all MCP server tools
   stopWhen: stepCountIs(10),
 });
@@ -326,6 +326,14 @@ try {
 
 When the MCP config is omitted, `toolsWithMcp(scope)` behaves exactly like
 `tools(scope)` with a no-op `close`.
+
+> **Merging is for complementary tools, not overlapping ones.** This is meant
+> to pair NAMS memory with *unrelated* tooling from an MCP server (search,
+> filesystem, domain APIs, etc.) — not another memory implementation. If the
+> MCP server happens to expose a tool named `query_memory` or `store_memory`,
+> its tool silently takes precedence (`{ ...namsTools, ...mcpTools }`), and a
+> warning is logged via the configured `logger` so the collision doesn't go
+> unnoticed.
 
 ---
 
@@ -342,7 +350,7 @@ createNamsProvider({
   endpoint?:            string,   // Default: https://memory.neo4jlabs.com/v1
   workspaceId?:         string,
   logger?:              NamsLogger, // warn/error sink for non-fatal errors. Default: console
-  injectLimit?:         number,   // Max memories injected per turn (capped at 12). Default: 6
+  maxMemories?:         number,   // Max memories retrieved and injected into the prompt per turn (capped at 12). Default: 6
   persistInteractions?: boolean,  // Save each turn. Default: true
   extractionModel?:     LanguageModel, // Enables graph entity extraction
 });
@@ -359,6 +367,7 @@ variables:
 | `MEMORY_API_KEY` | yes | NAMS API key — pass it as `apiKey` (the examples and snippets read it from the environment) |
 | `OPENAI_API_KEY` | yes* | Read by `@ai-sdk/openai`; *swap for whichever `@ai-sdk/*` provider key your base model needs |
 | `NAMS_DEMO_USER` | no | Overrides the demo `userId` in the [runnable examples](./examples) |
+| `NAMS_DEMO_MODEL` | no | Overrides the demo model id (default: `gpt-5.4-mini`) in the [runnable examples](./examples) |
 
 ---
 
@@ -371,7 +380,7 @@ const nams = createNamsProvider({
   apiKey:          process.env.MEMORY_API_KEY!,
   baseProvider:    openai,
   scope:           { userId },
-  extractionModel: openai('gpt-4o-mini'),
+  extractionModel: openai('gpt-5.4-mini'),
 });
 ```
 

--- a/typescript/packages/vercel-ai-provider/README.md
+++ b/typescript/packages/vercel-ai-provider/README.md
@@ -1,0 +1,430 @@
+# @neo4j-labs/nams-ai-provider
+
+![Neo4j Labs](https://img.shields.io/badge/Neo4j-Labs-6366F1?logo=neo4j)
+![Status: Experimental](https://img.shields.io/badge/Status-Experimental-F59E0B)
+![Community Supported](https://img.shields.io/badge/Support-Community-6B7280)
+
+Community provider for the [Vercel AI SDK](https://sdk.vercel.ai) that adds persistent cross-session memory to any language model, backed by the [Neo4j Agent Memory Service (NAMS)](https://memory.neo4jlabs.com).
+
+> ⚠️ **Neo4j Labs Project**
+>
+> This project is part of Neo4j Labs and is actively maintained, but not
+> officially supported. There are no SLAs or guarantees around backwards
+> compatibility and deprecation. For questions and support, please use
+> the [Neo4j Community Forum](https://community.neo4j.com).
+
+On every turn, NAMS automatically retrieves relevant memories from the user's history and injects them into the prompt — then persists the response so future sessions remember it. No Neo4j infrastructure to manage.
+
+## What does it do?
+
+Without this package, every chat session starts fresh — the model has no recollection of who the user is, what they've said before, or what decisions were made in prior conversations.
+
+`@neo4j-labs/nams-ai-provider` wraps your existing AI model and transparently adds memory to every call:
+
+1. **Before the model responds** — NAMS searches its memory store for facts, preferences, and past interactions relevant to the current message, then injects them into the prompt automatically.
+2. **After the model responds** — NAMS persists the exchange (and optionally extracts entities into a Neo4j knowledge graph) so the next session can recall it.
+
+The result: your AI remembers users across sessions without you changing your application logic.
+
+```
+User message
+     │
+     ▼
+┌─────────────────────────────┐
+│  NAMS: fetch relevant       │  ← searches long-term graph,
+│  memories from Neo4j        │    past sessions, reasoning traces
+└────────────┬────────────────┘
+             │  memories injected into prompt
+             ▼
+┌─────────────────────────────┐
+│  Your LLM (GPT, Claude…)    │  ← responds with full context
+└────────────┬────────────────┘
+             │  response
+             ▼
+┌─────────────────────────────┐
+│  NAMS: persist & extract    │  ← stores turn, builds knowledge graph
+└─────────────────────────────┘
+```
+
+## Setup
+
+**1. Install the provider and its peer dependencies**
+
+```bash
+npm install @neo4j-labs/nams-ai-provider ai @ai-sdk/provider @neo4j-labs/agent-memory zod
+```
+
+<details>
+<summary>Working from source (package not yet on npm)</summary>
+
+```bash
+# from the repo root
+cd typescript/packages/vercel-ai-provider
+npm install
+npm run build
+npm pack   # then `npm install ../path/to/neo4j-labs-nams-ai-provider-0.1.0.tgz` in your app
+```
+
+</details>
+
+**2. Get a free API key** at [memory.neo4jlabs.com](https://memory.neo4jlabs.com)
+
+```env
+MEMORY_API_KEY=sk-nams-...
+```
+
+---
+
+## Quick Start
+
+Once installed and your API key is set, adding memory to your Vercel AI SDK app is a one-line model swap:
+
+```ts
+// Before: plain agent, no memory
+import { openai } from '@ai-sdk/openai';
+import {
+  ToolLoopAgent,
+  createUIMessageStream,
+  createUIMessageStreamResponse,
+  stepCountIs,
+} from 'ai';
+
+const agent = new ToolLoopAgent({
+  model:        openai('gpt-4o-mini'),
+  instructions: 'You are a helpful assistant.',
+  stopWhen:     stepCountIs(10),
+});
+
+const stream = createUIMessageStream({
+  execute: async ({ writer }) => {
+    const result = await agent.stream({ messages });
+    writer.merge(result.toUIMessageStream());
+  },
+});
+
+return createUIMessageStreamResponse({ stream });
+```
+
+```ts
+// After: swap model → agent now remembers users across sessions
+import { createNamsProvider } from '@neo4j-labs/nams-ai-provider';
+import { openai } from '@ai-sdk/openai';
+import {
+  ToolLoopAgent,
+  createUIMessageStream,
+  createUIMessageStreamResponse,
+  stepCountIs,
+} from 'ai';
+
+const nams = createNamsProvider({
+  apiKey:       process.env.MEMORY_API_KEY!,
+  baseProvider: openai,
+  scope:        { userId: 'user-123' },  // identify the user
+});
+
+const agent = new ToolLoopAgent({
+  model:        nams.languageModel('gpt-4o-mini'),  // ← only change
+  instructions: 'You are a helpful assistant.',
+  stopWhen:     stepCountIs(10),
+});
+
+const stream = createUIMessageStream({
+  execute: async ({ writer }) => {
+    const result = await agent.stream({ messages });
+    writer.merge(result.toUIMessageStream());
+  },
+});
+
+return createUIMessageStreamResponse({ stream });
+```
+
+**What happens automatically on every call:**
+- Relevant memories for `user-123` are fetched and prepended to the prompt
+- The model's response is saved back to memory for future sessions
+- No other code changes needed
+
+---
+
+## Usage Modes
+
+There are three ways to integrate NAMS depending on how much control you want:
+
+| Mode | How it works | Best for |
+|------|-------------|----------|
+| **Provider** | Swap your model for a NAMS-wrapped one | Simplest integration, fully transparent |
+| **Middleware** | Wrap an existing model instance | When you already have a model configured |
+| **Tools** | Expose memory as explicit AI SDK tools (optionally merged with tools from an MCP server) | When you want the model to decide when to remember |
+
+Switching modes is purely a code-level choice — all three use the same API key
+and environment variables (see [Environment variables](#environment-variables)).
+
+> **How does this relate to `@neo4j-labs/agent-memory/middleware/vercel-ai`?**
+> The core SDK ships a minimal middleware for the AI SDK v4-era
+> `LanguageModelV1Middleware` shape that injects current-conversation context.
+> This package targets AI SDK v6 / `LanguageModelV3` and adds a registrable
+> `ProviderV3`, cross-session retrieval, optional graph extraction, explicit
+> memory tools, and MCP tool merging. New projects should prefer this package.
+
+---
+
+## Provider Mode (ProviderV3)
+
+Drop NAMS into any Vercel AI SDK project as a standard `ProviderV3`. Memory is fully transparent — no tools, no system prompt changes needed.
+
+```ts
+import { createNamsProvider } from '@neo4j-labs/nams-ai-provider';
+import { openai } from '@ai-sdk/openai';
+import {
+  ToolLoopAgent,
+  createUIMessageStream,
+  createUIMessageStreamResponse,
+  stepCountIs,
+} from 'ai';
+
+// One instance per user session
+const nams = createNamsProvider({
+  apiKey:       process.env.MEMORY_API_KEY!,
+  baseProvider: openai,               // any @ai-sdk/* provider
+  scope:        { userId: session.userId },
+});
+
+const agent = new ToolLoopAgent({
+  model:        nams.languageModel('gpt-4o-mini'),
+  instructions: 'You are a helpful assistant.',
+  stopWhen:     stepCountIs(1),       // no tools needed in provider mode
+});
+
+const stream = createUIMessageStream({
+  execute: async ({ writer }) => {
+    const result = await agent.stream({ messages });
+    writer.merge(result.toUIMessageStream());
+  },
+});
+
+return createUIMessageStreamResponse({ stream });
+```
+
+Works with the provider registry:
+
+```ts
+import { createProviderRegistry as createRegistry } from 'ai';
+
+const registry = createRegistry({
+  nams: createNamsProvider({
+    apiKey:       process.env.MEMORY_API_KEY!,
+    baseProvider: openai,
+    scope:        { userId },
+  }),
+});
+
+const agent = new ToolLoopAgent({
+  model:    registry.languageModel('nams:gpt-4o-mini'),
+  stopWhen: stepCountIs(1),
+});
+```
+
+---
+
+## Middleware Mode
+
+Wrap any existing model instance with memory — useful when you already configure your model elsewhere and just want to decorate it:
+
+```ts
+import { createNams } from '@neo4j-labs/nams-ai-provider';
+import { openai } from '@ai-sdk/openai';
+import {
+  ToolLoopAgent,
+  createUIMessageStream,
+  createUIMessageStreamResponse,
+  stepCountIs,
+} from 'ai';
+
+const nams  = createNams({ apiKey: process.env.MEMORY_API_KEY! });
+const model = nams.wrap(openai('gpt-4o-mini'), { userId: session.userId });
+
+const agent = new ToolLoopAgent({ model, stopWhen: stepCountIs(1) });
+
+const stream = createUIMessageStream({
+  execute: async ({ writer }) => {
+    const result = await agent.stream({ messages });
+    writer.merge(result.toUIMessageStream());
+  },
+});
+
+return createUIMessageStreamResponse({ stream });
+```
+
+---
+
+## Tools Mode
+
+Expose `query_memory` and `store_memory` as explicit AI SDK tools. The model decides when to call them, and the calls are visible in your UI — useful for debugging or when you want the user to see memory activity:
+
+```ts
+import { createNams } from '@neo4j-labs/nams-ai-provider';
+import { openai } from '@ai-sdk/openai';
+import {
+  ToolLoopAgent,
+  createUIMessageStream,
+  createUIMessageStreamResponse,
+  stepCountIs,
+} from 'ai';
+
+const nams  = createNams({ apiKey: process.env.MEMORY_API_KEY! });
+const tools = nams.tools({ userId: session.userId });
+
+const agent = new ToolLoopAgent({
+  model:        openai('gpt-4o-mini'),
+  instructions: 'Always call query_memory first. Call store_memory after responding.',
+  tools,
+  stopWhen:     stepCountIs(10),
+});
+
+const stream = createUIMessageStream({
+  execute: async ({ writer }) => {
+    const result = await agent.stream({ messages });
+    writer.merge(result.toUIMessageStream());
+  },
+});
+
+return createUIMessageStreamResponse({ stream });
+```
+
+### Tools Mode with MCP (optional)
+
+Still tools mode — not a separate mode. `toolsWithMcp()` connects to an MCP
+server and merges its tools with the NAMS memory tools, so one agent can
+remember *and* use external tooling. Requires the optional peer `@ai-sdk/mcp`
+(`npm install @ai-sdk/mcp`) — it is loaded lazily, only when an MCP config is
+passed.
+
+```ts
+import { createNams } from '@neo4j-labs/nams-ai-provider';
+import { openai } from '@ai-sdk/openai';
+import { ToolLoopAgent, stepCountIs } from 'ai';
+
+const nams = createNams({ apiKey: process.env.MEMORY_API_KEY! });
+
+const { tools, close } = await nams.toolsWithMcp(
+  { userId: session.userId },
+  { url: 'https://mcp.example.com/mcp', headers: { Authorization: `Bearer ${token}` } },
+);
+
+const agent = new ToolLoopAgent({
+  model: openai('gpt-4o-mini'),
+  tools, // query_memory + store_memory + all MCP server tools
+  stopWhen: stepCountIs(10),
+});
+
+try {
+  const result = await agent.generate({ prompt: 'What did we decide last week?' });
+  console.log(result.text);
+} finally {
+  await close(); // closes the MCP connection (no-op when MCP wasn't configured)
+}
+```
+
+When the MCP config is omitted, `toolsWithMcp(scope)` behaves exactly like
+`tools(scope)` with a no-op `close`.
+
+---
+
+## Configuration
+
+```ts
+createNamsProvider({
+  // Required
+  apiKey:               string,
+  baseProvider:         (modelId: string) => LanguageModelV3,
+  scope:                { userId: string, conversationId?: string },
+
+  // Optional
+  endpoint?:            string,   // Default: https://memory.neo4jlabs.com/v1
+  workspaceId?:         string,
+  logger?:              NamsLogger, // warn/error sink for non-fatal errors. Default: console
+  injectLimit?:         number,   // Max memories injected per turn (capped at 12). Default: 6
+  persistInteractions?: boolean,  // Save each turn. Default: true
+  extractionModel?:     LanguageModel, // Enables graph entity extraction
+});
+```
+
+### Environment variables
+
+No environment variable selects or changes the mode — provider, middleware,
+and tools modes are chosen entirely in code, and all three read the same
+variables:
+
+| Variable | Required | Used for |
+|----------|----------|----------|
+| `MEMORY_API_KEY` | yes | NAMS API key — pass it as `apiKey` (the examples and snippets read it from the environment) |
+| `OPENAI_API_KEY` | yes* | Read by `@ai-sdk/openai`; *swap for whichever `@ai-sdk/*` provider key your base model needs |
+| `NAMS_DEMO_USER` | no | Overrides the demo `userId` in the [runnable examples](./examples) |
+
+---
+
+## Graph Extraction (optional)
+
+Pass `extractionModel` to build a real Neo4j entity graph from memories instead of storing flat text:
+
+```ts
+const nams = createNamsProvider({
+  apiKey:          process.env.MEMORY_API_KEY!,
+  baseProvider:    openai,
+  scope:           { userId },
+  extractionModel: openai('gpt-4o-mini'),
+});
+```
+
+`"User is named Alex, works at TechCorp"` becomes `(Alex)-[:WORKS_AT]->(TechCorp)` in the graph.
+
+> **Note:** relationship persistence depends on backend support. Where the
+> NAMS API does not yet expose a relationship endpoint (the hosted REST API
+> currently doesn't), extracted entities are stored and relationship writes
+> are skipped with a warning — the graph gains edges automatically once the
+> endpoint is available.
+
+---
+
+## Memory Sources
+
+NAMS searches four sources in parallel per turn:
+
+| Source | What it stores |
+|--------|---------------|
+| Long-term graph | Facts, preferences, patterns (Neo4j entities + relationships) |
+| Current conversation | Messages in the active session (vector search) |
+| Cross-session | Messages from past conversations for the same user |
+| Reasoning traces | Prior step-by-step reasoning from agent runs |
+
+---
+
+## Development
+
+```bash
+npm install        # install dev dependencies
+npm test           # run the vitest suite (provider, tools, ProviderV3 surface)
+npm run typecheck  # tsc --noEmit
+npm run build      # tsup → dist/
+```
+
+> **Note on conversation caching:** each provider / tools instance keeps its own
+> conversation-id cache (scoped per `MemoryClient`). Create one instance per user
+> session; instances never share cached conversation ids.
+
+## Links
+
+- [Neo4j Agent Memory Service](https://memory.neo4jlabs.com)
+- [Vercel AI SDK community providers](https://ai-sdk.dev/providers/community-providers/custom-providers)
+- [@neo4j-labs/agent-memory on npm](https://www.npmjs.com/package/@neo4j-labs/agent-memory)
+- [Runnable examples](./examples)
+
+## Support
+
+- [Neo4j Community Forum](https://community.neo4j.com) — questions and
+  discussion (primary)
+- [GitHub Issues](https://github.com/neo4j-labs/agent-memory/issues) —
+  bug reports and feature requests
+
+## License
+
+Apache-2.0 — see [LICENSE](./LICENSE).

--- a/typescript/packages/vercel-ai-provider/examples/README.md
+++ b/typescript/packages/vercel-ai-provider/examples/README.md
@@ -15,7 +15,7 @@ export OPENAI_API_KEY=sk-...
 |---------|------|-----|
 | [`basic-chat.ts`](./basic-chat.ts) | Provider (transparent memory) — teaches a fact in session 1, recalls it in session 2 | `npx tsx examples/basic-chat.ts` |
 | [`middleware-chat.ts`](./middleware-chat.ts) | Middleware — wraps an existing model instance; a fresh model in turn 2 recalls turn 1 | `npx tsx examples/middleware-chat.ts` |
-| [`tools-chat.ts`](./tools-chat.ts) | Tools (model-driven) — `query_memory` / `store_memory` visible as tool calls | `npx tsx examples/tools-chat.ts` |
+| [`tools-chat.ts`](./tools-chat.ts) | Tools (model-driven) — `query_memory` / `store_memory` visible as tool calls; retrieval guaranteed via `enforceQueryMemory()` | `npx tsx examples/tools-chat.ts` |
 | [`nextjs-chat-route.ts`](./nextjs-chat-route.ts) | Provider inside a Next.js App Router endpoint — copy into `app/api/chat/route.ts` | n/a (template) |
 
 Each script's header comment shows the **expected output**, so you can compare

--- a/typescript/packages/vercel-ai-provider/examples/README.md
+++ b/typescript/packages/vercel-ai-provider/examples/README.md
@@ -1,0 +1,26 @@
+# Examples
+
+One runnable example per integration mode — provider, middleware, and tools —
+plus a Next.js route template. All examples need a free NAMS API key from
+[memory.neo4jlabs.com](https://memory.neo4jlabs.com) and an OpenAI key (swap in
+any `@ai-sdk/*` provider if you prefer). No other environment changes are
+needed to switch modes — mode selection is code-level.
+
+```bash
+export MEMORY_API_KEY=sk-nams-...
+export OPENAI_API_KEY=sk-...
+```
+
+| Example | Mode | Run |
+|---------|------|-----|
+| [`basic-chat.ts`](./basic-chat.ts) | Provider (transparent memory) — teaches a fact in session 1, recalls it in session 2 | `npx tsx examples/basic-chat.ts` |
+| [`middleware-chat.ts`](./middleware-chat.ts) | Middleware — wraps an existing model instance; a fresh model in turn 2 recalls turn 1 | `npx tsx examples/middleware-chat.ts` |
+| [`tools-chat.ts`](./tools-chat.ts) | Tools (model-driven) — `query_memory` / `store_memory` visible as tool calls | `npx tsx examples/tools-chat.ts` |
+| [`nextjs-chat-route.ts`](./nextjs-chat-route.ts) | Provider inside a Next.js App Router endpoint — copy into `app/api/chat/route.ts` | n/a (template) |
+
+Each script's header comment shows the **expected output**, so you can compare
+what you see locally — in provider and middleware mode the recall happens
+silently inside the model call, while in tools mode the same memory operations
+appear as visible `query_memory` / `store_memory` tool calls.
+
+The scripts import from `../src` so they run directly against the source tree — no build step needed. In your own app, import from `@neo4j-labs/nams-ai-provider` instead.

--- a/typescript/packages/vercel-ai-provider/examples/basic-chat.ts
+++ b/typescript/packages/vercel-ai-provider/examples/basic-chat.ts
@@ -25,6 +25,7 @@ import { ToolLoopAgent, stepCountIs } from 'ai';
 import { createNamsProvider } from '../src/index';
 
 const userId = process.env.NAMS_DEMO_USER ?? 'demo-user-basic-chat';
+const model = process.env.NAMS_DEMO_MODEL ?? 'gpt-5.4-mini';
 
 async function session(label: string, message: string): Promise<void> {
   // One provider instance per user session — memory is transparent.
@@ -35,7 +36,7 @@ async function session(label: string, message: string): Promise<void> {
   });
 
   const agent = new ToolLoopAgent({
-    model: nams.languageModel('gpt-4o-mini'),
+    model: nams.languageModel(model),
     instructions: 'You are a helpful assistant.',
     stopWhen: stepCountIs(1), // no tools needed in provider mode
   });

--- a/typescript/packages/vercel-ai-provider/examples/basic-chat.ts
+++ b/typescript/packages/vercel-ai-provider/examples/basic-chat.ts
@@ -1,0 +1,61 @@
+/**
+ * Minimal runnable demo — provider mode across two simulated sessions.
+ *
+ * Session 1 tells the agent a fact; session 2 (a fresh agent, same userId)
+ * recalls it from NAMS. Run with:
+ *
+ *   MEMORY_API_KEY=sk-nams-... OPENAI_API_KEY=sk-... npx tsx examples/basic-chat.ts
+ *
+ * Expected output (assistant wording will vary):
+ *
+ *   ─── Session 1 — teach it something
+ *   user:      Hi! My name is Alex and I work at TechCorp on the graph platform team.
+ *   assistant: Nice to meet you, Alex! How can I help you today? …
+ *
+ *   ─── Session 2 — fresh session, same user
+ *   user:      Where do I work, and what team am I on?
+ *   assistant: You work at TechCorp, on the graph platform team.
+ *
+ * Session 2 is a brand-new agent — the answer comes from NAMS memory, not
+ * from the conversation history.
+ */
+
+import { openai } from '@ai-sdk/openai';
+import { ToolLoopAgent, stepCountIs } from 'ai';
+import { createNamsProvider } from '../src/index';
+
+const userId = process.env.NAMS_DEMO_USER ?? 'demo-user-basic-chat';
+
+async function session(label: string, message: string): Promise<void> {
+  // One provider instance per user session — memory is transparent.
+  const nams = createNamsProvider({
+    apiKey: process.env.MEMORY_API_KEY!,
+    baseProvider: openai,
+    scope: { userId },
+  });
+
+  const agent = new ToolLoopAgent({
+    model: nams.languageModel('gpt-4o-mini'),
+    instructions: 'You are a helpful assistant.',
+    stopWhen: stepCountIs(1), // no tools needed in provider mode
+  });
+
+  const { text } = await agent.generate({ prompt: message });
+
+  console.log(`\n─── ${label}`);
+  console.log(`user:      ${message}`);
+  console.log(`assistant: ${text}`);
+}
+
+async function main(): Promise<void> {
+  await session('Session 1 — teach it something', 'Hi! My name is Alex and I work at TechCorp on the graph platform team.');
+
+  // A brand-new agent = a brand-new "session". Without NAMS the model would
+  // have no idea who the user is.
+  await session('Session 2 — fresh session, same user', 'Where do I work, and what team am I on?');
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/typescript/packages/vercel-ai-provider/examples/middleware-chat.ts
+++ b/typescript/packages/vercel-ai-provider/examples/middleware-chat.ts
@@ -3,6 +3,9 @@
  *
  * Unlike provider mode there is no ProviderV3 registration: you keep whatever
  * model you already configured and decorate it with `createNams().wrap()`.
+ * MEMORY_API_KEY authenticates with NAMS; OPENAI_API_KEY authenticates the
+ * base model call made by `@ai-sdk/openai` (swap for another provider's key
+ * if you use a different `baseProvider`). 
  * Run with:
  *
  *   MEMORY_API_KEY=sk-nams-... OPENAI_API_KEY=sk-... npx tsx examples/middleware-chat.ts
@@ -26,14 +29,15 @@ import { ToolLoopAgent, stepCountIs } from 'ai';
 import { createNams } from '../src/index';
 
 const userId = process.env.NAMS_DEMO_USER ?? 'demo-user-middleware-chat';
+const model = process.env.NAMS_DEMO_MODEL ?? 'gpt-5.4-mini';
 
 async function turn(label: string, message: string): Promise<void> {
   // A fresh wrapped model per turn — memory continuity comes from NAMS.
   const nams = createNams({ apiKey: process.env.MEMORY_API_KEY! });
-  const model = nams.wrap(openai('gpt-4o-mini'), { userId });
+  const wrappedModel = nams.wrap(openai(model), { userId });
 
   const agent = new ToolLoopAgent({
-    model,
+    model: wrappedModel,
     instructions: 'You are a helpful assistant.',
     stopWhen: stepCountIs(1), // no tools needed in middleware mode
   });

--- a/typescript/packages/vercel-ai-provider/examples/middleware-chat.ts
+++ b/typescript/packages/vercel-ai-provider/examples/middleware-chat.ts
@@ -1,0 +1,56 @@
+/**
+ * Middleware mode demo — wrap an existing model instance with memory.
+ *
+ * Unlike provider mode there is no ProviderV3 registration: you keep whatever
+ * model you already configured and decorate it with `createNams().wrap()`.
+ * Run with:
+ *
+ *   MEMORY_API_KEY=sk-nams-... OPENAI_API_KEY=sk-... npx tsx examples/middleware-chat.ts
+ *
+ * Expected output (assistant wording will vary):
+ *
+ *   ─── Turn 1 — teach it something
+ *   user:      My favourite programming language is Rust.
+ *   assistant: Great choice! Rust is loved for its safety and performance. …
+ *
+ *   ─── Turn 2 — fresh model instance, same user
+ *   user:      What is my favourite programming language?
+ *   assistant: Your favourite programming language is Rust.
+ *
+ * Turn 2 only answers correctly because the middleware injected the memory
+ * persisted in turn 1 — the model instance itself is brand new.
+ */
+
+import { openai } from '@ai-sdk/openai';
+import { ToolLoopAgent, stepCountIs } from 'ai';
+import { createNams } from '../src/index';
+
+const userId = process.env.NAMS_DEMO_USER ?? 'demo-user-middleware-chat';
+
+async function turn(label: string, message: string): Promise<void> {
+  // A fresh wrapped model per turn — memory continuity comes from NAMS.
+  const nams = createNams({ apiKey: process.env.MEMORY_API_KEY! });
+  const model = nams.wrap(openai('gpt-4o-mini'), { userId });
+
+  const agent = new ToolLoopAgent({
+    model,
+    instructions: 'You are a helpful assistant.',
+    stopWhen: stepCountIs(1), // no tools needed in middleware mode
+  });
+
+  const { text } = await agent.generate({ prompt: message });
+
+  console.log(`\n─── ${label}`);
+  console.log(`user:      ${message}`);
+  console.log(`assistant: ${text}`);
+}
+
+async function main(): Promise<void> {
+  await turn('Turn 1 — teach it something', 'My favourite programming language is Rust.');
+  await turn('Turn 2 — fresh model instance, same user', 'What is my favourite programming language?');
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/typescript/packages/vercel-ai-provider/examples/nextjs-chat-route.ts
+++ b/typescript/packages/vercel-ai-provider/examples/nextjs-chat-route.ts
@@ -1,0 +1,34 @@
+/**
+ * Drop-in Next.js App Router chat endpoint with NAMS memory.
+ *
+ * Copy into your app as `app/api/chat/route.ts`. Pair with `useChat()` from
+ * `@ai-sdk/react` on the client — no other changes needed; memory is
+ * transparent per user.
+ */
+
+import { openai } from '@ai-sdk/openai';
+import { ToolLoopAgent, createAgentUIStreamResponse, stepCountIs, type UIMessage } from 'ai';
+// In your app, import from the published package instead:
+//   import { createNamsProvider } from '@neo4j-labs/nams-ai-provider';
+import { createNamsProvider } from '../src/index';
+
+export const maxDuration = 30;
+
+export async function POST(req: Request): Promise<Response> {
+  const { messages, userId }: { messages: UIMessage[]; userId: string } = await req.json();
+
+  // One provider instance per request, scoped to the authenticated user.
+  const nams = createNamsProvider({
+    apiKey: process.env.MEMORY_API_KEY!,
+    baseProvider: openai,
+    scope: { userId },
+  });
+
+  const agent = new ToolLoopAgent({
+    model: nams.languageModel('gpt-4o-mini'),
+    instructions: 'You are a helpful assistant.',
+    stopWhen: stepCountIs(1), // no tools needed in provider mode
+  });
+
+  return createAgentUIStreamResponse({ agent, uiMessages: messages });
+}

--- a/typescript/packages/vercel-ai-provider/examples/nextjs-chat-route.ts
+++ b/typescript/packages/vercel-ai-provider/examples/nextjs-chat-route.ts
@@ -14,6 +14,8 @@ import { createNamsProvider } from '../src/index';
 
 export const maxDuration = 30;
 
+const model = process.env.NAMS_DEMO_MODEL ?? 'gpt-5.4-mini';
+
 export async function POST(req: Request): Promise<Response> {
   const { messages, userId }: { messages: UIMessage[]; userId: string } = await req.json();
 
@@ -25,7 +27,7 @@ export async function POST(req: Request): Promise<Response> {
   });
 
   const agent = new ToolLoopAgent({
-    model: nams.languageModel('gpt-4o-mini'),
+    model: nams.languageModel(model),
     instructions: 'You are a helpful assistant.',
     stopWhen: stepCountIs(1), // no tools needed in provider mode
   });

--- a/typescript/packages/vercel-ai-provider/examples/tools-chat.ts
+++ b/typescript/packages/vercel-ai-provider/examples/tools-chat.ts
@@ -1,25 +1,34 @@
 /**
  * Tools mode demo — the agent decides when to query/store memory, and every
- * memory operation is visible as a tool call. Run with:
+ * memory operation is visible as a tool call. `enforceQueryMemory()` adds a
+ * mechanical guarantee on top: the model cannot give its final answer until
+ * `query_memory` has actually executed (other tools may still run first, in
+ * any order). Run with:
  *
- *   MEMORY_API_KEY=sk-nams-... OPENAI_API_KEY=sk-... npx tsx examples/tools-chat.ts
+ * MEMORY_API_KEY=sk-nams-... OPENAI_API_KEY=sk-... npx tsx examples/tools-chat.ts
  *
  * Expected output (tool arguments and assistant wording will vary):
  *
- *   tool call: query_memory({"query":"user editor preferences","limit":5})
- *   tool call: store_memory({"content":"User prefers very short answers","type":"user_preference","confidence":0.9,"tags":[…
- *   tool call: store_memory({"content":"User uses Neovim as their editor","type":"fact","confidence":0.9,"tags":["editor"…
+ *   step 0 [enforced: some tool required]
+ *     tool call: query_memory({"query":"user editor preferences","limit":5})
+ *   step 1 [unconstrained]
+ *     tool call: store_memory({"content":"User prefers very short answers","type":"user_preference","confidence":0.9,…
+ *     tool call: store_memory({"content":"User uses Neovim as their editor","type":"fact","confidence":0.9,"tags":["e…
+ *   step 2 [unconstrained]
  *
  *   assistant: Try Telescope for fuzzy finding and Harpoon for quick file
  *   switching.
  *
  * Unlike provider/middleware mode, the memory operations appear here as
- * visible tool calls the model chose to make.
+ * visible tool calls — but retrieval is still guaranteed: if the model spent
+ * its grace window (default: 3 steps) on other tools without querying memory,
+ * the next step would force query_memory directly instead of relying on the
+ * tool description.
  */
 
 import { openai } from '@ai-sdk/openai';
 import { ToolLoopAgent, stepCountIs } from 'ai';
-import { createNams } from '../src/index';
+import { createNams, enforceQueryMemory } from '../src/index';
 
 const userId = process.env.NAMS_DEMO_USER ?? 'demo-user-tools-chat';
 const model = process.env.NAMS_DEMO_MODEL ?? 'gpt-5.4-mini';
@@ -31,9 +40,11 @@ async function main(): Promise<void> {
   const agent = new ToolLoopAgent({
     model: openai(model),
     instructions:
-      'Always call query_memory first to check what you know about the user. ' +
-      'After answering, call store_memory to save anything worth remembering.',
+      'Consult memory with query_memory before answering. When the conversation ' +
+      'contains facts or preferences worth remembering, call store_memory before ' +
+      'giving your final answer.',
     tools,
+    prepareStep: enforceQueryMemory(),
     stopWhen: stepCountIs(6),
   });
 
@@ -41,11 +52,14 @@ async function main(): Promise<void> {
     prompt: 'I prefer very short answers, and I use Neovim. Got any editor tips for me?',
   });
 
-  for (const step of result.steps) {
+  let queried = false;
+  result.steps.forEach((step, i) => {
+    console.log(`step ${i} [${queried ? 'unconstrained' : 'enforced: some tool required'}]`);
     for (const call of step.toolCalls) {
-      console.log(`tool call: ${call.toolName}(${JSON.stringify(call.input).slice(0, 120)})`);
+      queried ||= call.toolName === 'query_memory';
+      console.log(`  tool call: ${call.toolName}(${JSON.stringify(call.input).slice(0, 120)})`);
     }
-  }
+  });
   console.log(`\nassistant: ${result.text}`);
 }
 

--- a/typescript/packages/vercel-ai-provider/examples/tools-chat.ts
+++ b/typescript/packages/vercel-ai-provider/examples/tools-chat.ts
@@ -1,0 +1,54 @@
+/**
+ * Tools mode demo — the agent decides when to query/store memory, and every
+ * memory operation is visible as a tool call. Run with:
+ *
+ *   MEMORY_API_KEY=sk-nams-... OPENAI_API_KEY=sk-... npx tsx examples/tools-chat.ts
+ *
+ * Expected output (tool arguments and assistant wording will vary):
+ *
+ *   tool call: query_memory({"query":"user editor preferences","limit":5})
+ *   tool call: store_memory({"content":"User prefers very short answers","type":"user_preference","confidence":0.9,"tags":[…
+ *   tool call: store_memory({"content":"User uses Neovim as their editor","type":"fact","confidence":0.9,"tags":["editor"…
+ *
+ *   assistant: Try Telescope for fuzzy finding and Harpoon for quick file
+ *   switching.
+ *
+ * Unlike provider/middleware mode, the memory operations appear here as
+ * visible tool calls the model chose to make.
+ */
+
+import { openai } from '@ai-sdk/openai';
+import { ToolLoopAgent, stepCountIs } from 'ai';
+import { createNams } from '../src/index';
+
+const userId = process.env.NAMS_DEMO_USER ?? 'demo-user-tools-chat';
+
+async function main(): Promise<void> {
+  const nams = createNams({ apiKey: process.env.MEMORY_API_KEY! });
+  const tools = nams.tools({ userId });
+
+  const agent = new ToolLoopAgent({
+    model: openai('gpt-4o-mini'),
+    instructions:
+      'Always call query_memory first to check what you know about the user. ' +
+      'After answering, call store_memory to save anything worth remembering.',
+    tools,
+    stopWhen: stepCountIs(6),
+  });
+
+  const result = await agent.generate({
+    prompt: 'I prefer very short answers, and I use Neovim. Got any editor tips for me?',
+  });
+
+  for (const step of result.steps) {
+    for (const call of step.toolCalls) {
+      console.log(`tool call: ${call.toolName}(${JSON.stringify(call.input).slice(0, 120)})`);
+    }
+  }
+  console.log(`\nassistant: ${result.text}`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/typescript/packages/vercel-ai-provider/examples/tools-chat.ts
+++ b/typescript/packages/vercel-ai-provider/examples/tools-chat.ts
@@ -22,13 +22,14 @@ import { ToolLoopAgent, stepCountIs } from 'ai';
 import { createNams } from '../src/index';
 
 const userId = process.env.NAMS_DEMO_USER ?? 'demo-user-tools-chat';
+const model = process.env.NAMS_DEMO_MODEL ?? 'gpt-5.4-mini';
 
 async function main(): Promise<void> {
   const nams = createNams({ apiKey: process.env.MEMORY_API_KEY! });
   const tools = nams.tools({ userId });
 
   const agent = new ToolLoopAgent({
-    model: openai('gpt-4o-mini'),
+    model: openai(model),
     instructions:
       'Always call query_memory first to check what you know about the user. ' +
       'After answering, call store_memory to save anything worth remembering.',

--- a/typescript/packages/vercel-ai-provider/package-lock.json
+++ b/typescript/packages/vercel-ai-provider/package-lock.json
@@ -1,0 +1,2631 @@
+{
+  "name": "@neo4j-labs/nams-ai-provider",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@neo4j-labs/nams-ai-provider",
+      "version": "0.1.0",
+      "license": "Apache-2.0",
+      "devDependencies": {
+        "@ai-sdk/mcp": "^1.0.0",
+        "@ai-sdk/openai": "^3.0.0",
+        "@ai-sdk/provider": "^3.0.0",
+        "@neo4j-labs/agent-memory": "^0.4.0",
+        "@types/node": "^20",
+        "ai": "^6.0.0",
+        "tsup": "^8.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^2.0.0",
+        "zod": "^3.0.0"
+      },
+      "peerDependencies": {
+        "@ai-sdk/mcp": ">=1.0.0",
+        "@ai-sdk/provider": ">=3.0.0",
+        "@neo4j-labs/agent-memory": ">=0.4.0",
+        "ai": ">=6.0.0",
+        "zod": ">=3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@ai-sdk/mcp": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@ai-sdk/gateway": {
+      "version": "3.0.134",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.134.tgz",
+      "integrity": "sha512-PfUkQp01EihEyNM6e+nexXmVANiY5KcHMui/MmaHsC4KVVQYh/MwPeOsD3bTPu63e581BKO+AwaPPNmD4x943A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.10",
+        "@ai-sdk/provider-utils": "4.0.30",
+        "@vercel/oidc": "3.2.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/mcp": {
+      "version": "1.0.52",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/mcp/-/mcp-1.0.52.tgz",
+      "integrity": "sha512-yudE3Mdl8fsbzjMepOPbikA6nIRWOez+5e/IvOv1jK6XMAtsZ4+Xz8vjRQHI77VMv2TdiaMfsKKFoW6dlZRT3g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.10",
+        "@ai-sdk/provider-utils": "4.0.30",
+        "pkce-challenge": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/openai": {
+      "version": "3.0.74",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-3.0.74.tgz",
+      "integrity": "sha512-LPDBWd2WCv0GQs29K2pHcNrGx24hm4D8QEP386HwUAUPr1URho6bNVXHNmIv0FxaW+xDkLpNMTen+mFCUBp2LA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.10",
+        "@ai-sdk/provider-utils": "4.0.30"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/provider": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.10.tgz",
+      "integrity": "sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@ai-sdk/provider-utils": {
+      "version": "4.0.30",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.30.tgz",
+      "integrity": "sha512-VO7I+vPffqI5sMnPoUq5DCSqKIgQIk/naJWRdQVpz2ma2zoprC/lqiJiUEl2s6DfvTD76TbhD3q39ROjlA6rGw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.10",
+        "@standard-schema/spec": "^1.1.0",
+        "eventsource-parser": "^3.0.8"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@neo4j-labs/agent-memory": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@neo4j-labs/agent-memory/-/agent-memory-0.4.0.tgz",
+      "integrity": "sha512-iKUi+STQm0DQqDUDx0cR486RTMCHlPfmmHBqjyN/gaVXSBlaTzYaLp63D5O/qP5tDc4E4iqiMfMITLUabllTaw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.2.tgz",
+      "integrity": "sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.2.tgz",
+      "integrity": "sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.2.tgz",
+      "integrity": "sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.2.tgz",
+      "integrity": "sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.2.tgz",
+      "integrity": "sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.2.tgz",
+      "integrity": "sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.2.tgz",
+      "integrity": "sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.2.tgz",
+      "integrity": "sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.2.tgz",
+      "integrity": "sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.2.tgz",
+      "integrity": "sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.2.tgz",
+      "integrity": "sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.2.tgz",
+      "integrity": "sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.2.tgz",
+      "integrity": "sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.2.tgz",
+      "integrity": "sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.2.tgz",
+      "integrity": "sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.2.tgz",
+      "integrity": "sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.2.tgz",
+      "integrity": "sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.2.tgz",
+      "integrity": "sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.2.tgz",
+      "integrity": "sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.2.tgz",
+      "integrity": "sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.2.tgz",
+      "integrity": "sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.2.tgz",
+      "integrity": "sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.2.tgz",
+      "integrity": "sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@vercel/oidc": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.2.0.tgz",
+      "integrity": "sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner/node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot/node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/ai": {
+      "version": "6.0.209",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.209.tgz",
+      "integrity": "sha512-NE7uErmxOe+i77BPT1+AhW4wr7xzilbQLsKVmvGEyil5AjaF6C/m92hlPI4Xwtnv5n77D/29bizwcR27/S/gSQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/gateway": "3.0.134",
+        "@ai-sdk/provider": "3.0.10",
+        "@ai-sdk/provider-utils": "4.0.30",
+        "@opentelemetry/api": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/bundle-require": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/bundle-require/-/bundle-require-5.1.0.tgz",
+      "integrity": "sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "load-tsconfig": "^0.2.3"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "esbuild": ">=0.18"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/commander": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/confbox": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
+      "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/consola": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/consola/-/consola-3.4.2.tgz",
+      "integrity": "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.18.0 || >=16.10.0"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fix-dts-default-cjs-exports": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fix-dts-default-cjs-exports/-/fix-dts-default-cjs-exports-1.0.1.tgz",
+      "integrity": "sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "magic-string": "^0.30.17",
+        "mlly": "^1.7.4",
+        "rollup": "^4.34.8"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/joycon": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
+      "integrity": "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/json-schema": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
+      "dev": true,
+      "license": "(AFL-2.1 OR BSD-3-Clause)"
+    },
+    "node_modules/lilconfig": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antonk52"
+      }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/load-tsconfig": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/load-tsconfig/-/load-tsconfig-0.2.5.tgz",
+      "integrity": "sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/mlly": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.2.tgz",
+      "integrity": "sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "pathe": "^2.0.3",
+        "pkg-types": "^1.3.1",
+        "ufo": "^1.6.3"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mz": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "thenify-all": "^1.0.0"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.15",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
+      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pirates": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+      "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/pkg-types": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
+      "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "confbox": "^0.1.8",
+        "mlly": "^1.7.4",
+        "pathe": "^2.0.1"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.16",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
+      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postcss-load-config": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-6.0.1.tgz",
+      "integrity": "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "lilconfig": "^3.1.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "jiti": ">=1.21.0",
+        "postcss": ">=8.0.9",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.2.tgz",
+      "integrity": "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.62.2",
+        "@rollup/rollup-android-arm64": "4.62.2",
+        "@rollup/rollup-darwin-arm64": "4.62.2",
+        "@rollup/rollup-darwin-x64": "4.62.2",
+        "@rollup/rollup-freebsd-arm64": "4.62.2",
+        "@rollup/rollup-freebsd-x64": "4.62.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.2",
+        "@rollup/rollup-linux-arm64-musl": "4.62.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.2",
+        "@rollup/rollup-linux-loong64-musl": "4.62.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-musl": "4.62.2",
+        "@rollup/rollup-openbsd-x64": "4.62.2",
+        "@rollup/rollup-openharmony-arm64": "4.62.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.2",
+        "@rollup/rollup-win32-x64-gnu": "4.62.2",
+        "@rollup/rollup-win32-x64-msvc": "4.62.2",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
+      "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/sucrase": {
+      "version": "3.35.1",
+      "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
+      "integrity": "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.2",
+        "commander": "^4.0.0",
+        "lines-and-columns": "^1.1.6",
+        "mz": "^2.7.0",
+        "pirates": "^4.0.1",
+        "tinyglobby": "^0.2.11",
+        "ts-interface-checker": "^0.1.9"
+      },
+      "bin": {
+        "sucrase": "bin/sucrase",
+        "sucrase-node": "bin/sucrase-node"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/thenify": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0"
+      }
+    },
+    "node_modules/thenify-all": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+      "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "thenify": ">= 3.1.0 < 4"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tree-kill": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "tree-kill": "cli.js"
+      }
+    },
+    "node_modules/ts-interface-checker": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
+      "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/tsup": {
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/tsup/-/tsup-8.5.1.tgz",
+      "integrity": "sha512-xtgkqwdhpKWr3tKPmCkvYmS9xnQK3m3XgxZHwSUjvfTjp7YfXe5tT3GgWi0F2N+ZSMsOeWeZFh7ZZFg5iPhing==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bundle-require": "^5.1.0",
+        "cac": "^6.7.14",
+        "chokidar": "^4.0.3",
+        "consola": "^3.4.0",
+        "debug": "^4.4.0",
+        "esbuild": "^0.27.0",
+        "fix-dts-default-cjs-exports": "^1.0.0",
+        "joycon": "^3.1.1",
+        "picocolors": "^1.1.1",
+        "postcss-load-config": "^6.0.1",
+        "resolve-from": "^5.0.0",
+        "rollup": "^4.34.8",
+        "source-map": "^0.7.6",
+        "sucrase": "^3.35.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.11",
+        "tree-kill": "^1.2.2"
+      },
+      "bin": {
+        "tsup": "dist/cli-default.js",
+        "tsup-node": "dist/cli-node.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@microsoft/api-extractor": "^7.36.0",
+        "@swc/core": "^1",
+        "postcss": "^8.4.12",
+        "typescript": ">=4.5.0"
+      },
+      "peerDependenciesMeta": {
+        "@microsoft/api-extractor": {
+          "optional": true
+        },
+        "@swc/core": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/ufo": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.4.tgz",
+      "integrity": "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite-node/node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/typescript/packages/vercel-ai-provider/package-lock.json
+++ b/typescript/packages/vercel-ai-provider/package-lock.json
@@ -20,12 +20,15 @@
         "vitest": "^2.0.0",
         "zod": "^3.0.0"
       },
+      "engines": {
+        "node": ">=20"
+      },
       "peerDependencies": {
-        "@ai-sdk/mcp": ">=1.0.0",
-        "@ai-sdk/provider": ">=3.0.0",
-        "@neo4j-labs/agent-memory": ">=0.4.0",
-        "ai": ">=6.0.0",
-        "zod": ">=3.0.0"
+        "@ai-sdk/mcp": "~1.0.0",
+        "@ai-sdk/provider": "~3.0.0",
+        "@neo4j-labs/agent-memory": "~0.4.0",
+        "ai": "~6.0.0",
+        "zod": "~3.0.0"
       },
       "peerDependenciesMeta": {
         "@ai-sdk/mcp": {

--- a/typescript/packages/vercel-ai-provider/package.json
+++ b/typescript/packages/vercel-ai-provider/package.json
@@ -1,0 +1,77 @@
+{
+  "name": "@neo4j-labs/nams-ai-provider",
+  "version": "0.1.0",
+  "description": "Neo4j Agent Memory (NAMS) provider for the Vercel AI SDK \u2014 persistent cross-session memory backed by Neo4j",
+  "keywords": [
+    "ai",
+    "ai-sdk",
+    "vercel-ai",
+    "provider",
+    "neo4j",
+    "memory",
+    "agent-memory",
+    "nams",
+    "langchain",
+    "llm"
+  ],
+  "homepage": "https://github.com/neo4j-labs/agent-memory/tree/main/typescript/packages/vercel-ai-provider",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/neo4j-labs/agent-memory.git",
+    "directory": "typescript/packages/vercel-ai-provider"
+  },
+  "license": "Apache-2.0",
+  "sideEffects": false,
+  "engines": {
+    "node": ">=20"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "src",
+    "LICENSE"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "dev": "tsup --watch",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "prepublishOnly": "npm run build"
+  },
+  "peerDependencies": {
+    "@ai-sdk/mcp": ">=1.0.0",
+    "@ai-sdk/provider": ">=3.0.0",
+    "@neo4j-labs/agent-memory": ">=0.4.0",
+    "ai": ">=6.0.0",
+    "zod": ">=3.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@ai-sdk/mcp": {
+      "optional": true
+    }
+  },
+  "devDependencies": {
+    "@ai-sdk/mcp": "^1.0.0",
+    "@ai-sdk/openai": "^3.0.0",
+    "@ai-sdk/provider": "^3.0.0",
+    "@neo4j-labs/agent-memory": "^0.4.0",
+    "@types/node": "^20",
+    "ai": "^6.0.0",
+    "tsup": "^8.0.0",
+    "typescript": "^5.0.0",
+    "vitest": "^2.0.0",
+    "zod": "^3.0.0"
+  }
+}

--- a/typescript/packages/vercel-ai-provider/package.json
+++ b/typescript/packages/vercel-ai-provider/package.json
@@ -51,11 +51,11 @@
     "prepublishOnly": "npm run build"
   },
   "peerDependencies": {
-    "@ai-sdk/mcp": ">=1.0.0",
-    "@ai-sdk/provider": ">=3.0.0",
-    "@neo4j-labs/agent-memory": ">=0.4.0",
-    "ai": ">=6.0.0",
-    "zod": ">=3.0.0"
+    "@ai-sdk/mcp": "~1.0.0",
+    "@ai-sdk/provider": "~3.0.0",
+    "@neo4j-labs/agent-memory": "~0.4.0",
+    "ai": "~6.0.0",
+    "zod": "~3.0.0"
   },
   "peerDependenciesMeta": {
     "@ai-sdk/mcp": {

--- a/typescript/packages/vercel-ai-provider/src/index.ts
+++ b/typescript/packages/vercel-ai-provider/src/index.ts
@@ -1,0 +1,113 @@
+/**
+ * Neo4j Agent Memory (NAMS) — unified entry point.
+ *
+ * Three integration modes backed by the same @neo4j-labs/agent-memory client:
+ * - Provider   — `createNamsProvider(...)`: a registrable ProviderV3; memory is
+ *                retrieved + persisted automatically on every call
+ * - Middleware — `createNams(...).wrap(model, scope)`: decorate an existing
+ *                model instance with the same transparent memory
+ * - Tools      — `createNams(...).tools(scope)`: the model calls query_memory /
+ *                store_memory itself; `.toolsWithMcp(scope, mcp)` optionally
+ *                merges tools from an MCP server into the same tool set
+ *
+ * @example
+ * ```ts
+ * const nams  = createNams({ apiKey: process.env.MEMORY_API_KEY! });
+ * const model = nams.wrap(openai('gpt-4o-mini'), { userId });
+ * ```
+ */
+
+export type { NamsConfig, NamsScope, NamsLogger, MemoryHit, StoreInput, GraphExtractor } from './vercel-ai-provider-client';
+export type { NamsMemoryConfig } from './vercel-ai-provider-middleware';
+export type {
+  NamsToolsOptions, NamsToolsWithMcpOptions, NamsToolsResult,
+  McpConfig, QueryInput, StoreInput as ToolStoreInput,
+  QueryOutput, StoreOutput
+} from './vercel-ai-provider-tools';
+export type { NamsProviderOptions } from './vercel-ai-provider';
+
+export { makeClient, getLogger, resolveConversation, findExistingConversation, retrieveMemories, storeMemory } from './vercel-ai-provider-client';
+export { createGraphExtractor } from './vercel-ai-provider-extract';
+export { createNamsMemory } from './vercel-ai-provider-middleware';
+export { createNamsMemoryTools, createNamsTools, NamsMemoryTools } from './vercel-ai-provider-tools';
+export { createNamsProvider } from './vercel-ai-provider';
+
+import type { LanguageModel } from 'ai';
+import type { LanguageModelV3 } from '@ai-sdk/provider';
+import type { NamsConfig, NamsScope } from './vercel-ai-provider-client';
+import type { NamsMemoryConfig } from './vercel-ai-provider-middleware';
+import type { McpConfig } from './vercel-ai-provider-tools';
+import { createNamsMemory } from './vercel-ai-provider-middleware';
+import { createNamsMemoryTools, createNamsTools } from './vercel-ai-provider-tools';
+
+/** The three NAMS integration modes. */
+export type NamsMode = 'provider' | 'middleware' | 'tools';
+
+export interface NamsFactoryConfig extends NamsConfig {
+  extractionModel?: LanguageModel;
+  injectLimit?: number;
+  persistInteractions?: boolean;
+}
+
+/**
+ * Create a unified NAMS instance covering the middleware and tools modes.
+ * (For provider mode — a registrable ProviderV3 — use `createNamsProvider`.)
+ *
+ * - `.wrap(model, scope)`             → middleware mode (transparent memory)
+ * - `.tools(scope)`                   → tools mode (query_memory / store_memory)
+ * - `.toolsWithMcp(scope, mcpConfig)` → tools mode with MCP tools merged in
+ */
+export function createNams(config: NamsFactoryConfig) {
+  const providerConfig: NamsMemoryConfig = {
+    apiKey: config.apiKey,
+    endpoint: config.endpoint,
+    workspaceId: config.workspaceId,
+    logger: config.logger,
+    extractionModel: config.extractionModel,
+    injectLimit: config.injectLimit,
+    persistInteractions: config.persistInteractions,
+  };
+
+  const memory = createNamsMemory(providerConfig);
+
+  return {
+    /**
+     * Middleware mode — wrap an existing model instance.
+     * Memory is retrieved + persisted automatically; no tool calls emitted.
+     * Pass the returned model directly to ToolLoopAgent / generateText.
+     */
+    wrap(model: LanguageModelV3, scope: NamsScope): LanguageModelV3 {
+      return memory.wrap(model, scope);
+    },
+
+    /**
+     * Tools mode — model-driven memory.
+     * Returns { query_memory, store_memory } as AI SDK tool()s.
+     * Pair with a system prompt that instructs: query → answer → store.
+     */
+    tools(scope: NamsScope) {
+      return createNamsMemoryTools({
+        ...config,
+        userId: scope.userId,
+        conversationId: scope.conversationId,
+        extractionModel: config.extractionModel,
+      });
+    },
+
+    /**
+     * Tools mode with MCP (optional extension of tools mode).
+     * Connects to an MCP server and merges its tools with NAMS memory tools.
+     * Returns { tools, close } — call close() in ToolLoopAgent's onFinish.
+     * When mcpConfig is omitted, behaves identically to .tools() with a no-op close.
+     */
+    async toolsWithMcp(scope: NamsScope, mcpConfig?: McpConfig) {
+      return createNamsTools({
+        ...config,
+        userId: scope.userId,
+        conversationId: scope.conversationId,
+        extractionModel: config.extractionModel,
+        mcp: mcpConfig,
+      });
+    },
+  };
+}

--- a/typescript/packages/vercel-ai-provider/src/index.ts
+++ b/typescript/packages/vercel-ai-provider/src/index.ts
@@ -29,7 +29,8 @@ export type { NamsProviderOptions } from './vercel-ai-provider';
 export { makeClient, getLogger, resolveConversation, findExistingConversation, retrieveMemories, storeMemory } from './vercel-ai-provider-client';
 export { createGraphExtractor } from './vercel-ai-provider-extract';
 export { createNamsMemory } from './vercel-ai-provider-middleware';
-export { createNamsMemoryTools, createNamsTools, NamsMemoryTools } from './vercel-ai-provider-tools';
+export { createNamsMemoryTools, createNamsTools, enforceQueryMemory, NamsMemoryTools } from './vercel-ai-provider-tools';
+export type { EnforceQueryMemoryOptions } from './vercel-ai-provider-tools';
 export { createNamsProvider } from './vercel-ai-provider';
 
 import type { LanguageModel } from 'ai';

--- a/typescript/packages/vercel-ai-provider/src/index.ts
+++ b/typescript/packages/vercel-ai-provider/src/index.ts
@@ -13,7 +13,7 @@
  * @example
  * ```ts
  * const nams  = createNams({ apiKey: process.env.MEMORY_API_KEY! });
- * const model = nams.wrap(openai('gpt-4o-mini'), { userId });
+ * const model = nams.wrap(openai('gpt-5.4-mini'), { userId });
  * ```
  */
 
@@ -45,7 +45,7 @@ export type NamsMode = 'provider' | 'middleware' | 'tools';
 
 export interface NamsFactoryConfig extends NamsConfig {
   extractionModel?: LanguageModel;
-  injectLimit?: number;
+  maxMemories?: number;
   persistInteractions?: boolean;
 }
 
@@ -64,7 +64,7 @@ export function createNams(config: NamsFactoryConfig) {
     workspaceId: config.workspaceId,
     logger: config.logger,
     extractionModel: config.extractionModel,
-    injectLimit: config.injectLimit,
+    maxMemories: config.maxMemories,
     persistInteractions: config.persistInteractions,
   };
 

--- a/typescript/packages/vercel-ai-provider/src/vercel-ai-provider-client.ts
+++ b/typescript/packages/vercel-ai-provider/src/vercel-ai-provider-client.ts
@@ -1,5 +1,5 @@
 import { MemoryClient } from '@neo4j-labs/agent-memory';
-import { DEFAULT_ENDPOINT, NamsConfig, NamsScope, NamsLogger, MemoryHit, StoreInput, GraphExtractor } from './vercel-ai-provider-types';
+import { DEFAULT_ENDPOINT, NamsConfig, NamsScope, NamsLogger, MemoryHit, StoreInput, GraphExtractor, ClientState } from './vercel-ai-provider-types';
 
 export type { NamsConfig, NamsScope, NamsLogger, MemoryHit, StoreInput, GraphExtractor };
 
@@ -14,11 +14,6 @@ const defaultLogger: NamsLogger = {
 // createNams / createNamsProvider / tools factory call). Nothing is shared
 // across instances, so warm serverless workers can hold multiple providers
 // for different users without cross-talk.
-
-interface ClientState {
-  convCache: Map<string, string>;
-  logger: NamsLogger;
-}
 
 const stateByClient = new WeakMap<MemoryClient, ClientState>();
 

--- a/typescript/packages/vercel-ai-provider/src/vercel-ai-provider-client.ts
+++ b/typescript/packages/vercel-ai-provider/src/vercel-ai-provider-client.ts
@@ -1,0 +1,274 @@
+import { MemoryClient } from '@neo4j-labs/agent-memory';
+import { DEFAULT_ENDPOINT, NamsConfig, NamsScope, NamsLogger, MemoryHit, StoreInput, GraphExtractor } from './vercel-ai-provider-types';
+
+export type { NamsConfig, NamsScope, NamsLogger, MemoryHit, StoreInput, GraphExtractor };
+
+const defaultLogger: NamsLogger = {
+  warn: (message, error) => console.warn(`[nams] ${message}`, error ?? ''),
+  error: (message, error) => console.error(`[nams] ${message}`, error ?? ''),
+};
+
+// Per-instance state
+//
+// The conversation cache is scoped to each MemoryClient instance (one per
+// createNams / createNamsProvider / tools factory call). Nothing is shared
+// across instances, so warm serverless workers can hold multiple providers
+// for different users without cross-talk.
+
+interface ClientState {
+  convCache: Map<string, string>;
+  logger: NamsLogger;
+}
+
+const stateByClient = new WeakMap<MemoryClient, ClientState>();
+
+function getState(client: MemoryClient): ClientState {
+  let state = stateByClient.get(client);
+  if (!state) {
+    state = { convCache: new Map(), logger: defaultLogger };
+    stateByClient.set(client, state);
+  }
+  return state;
+}
+
+/** The logger bound to a client via makeClient (default: console). */
+export function getLogger(client: MemoryClient): NamsLogger {
+  return getState(client).logger;
+}
+
+export function makeClient(config: NamsConfig): MemoryClient {
+  const client = new MemoryClient({
+    endpoint: config.endpoint ?? DEFAULT_ENDPOINT,
+    apiKey: config.apiKey,
+    workspaceId: config.workspaceId,
+  });
+  stateByClient.set(client, { convCache: new Map(), logger: config.logger ?? defaultLogger });
+  return client;
+}
+
+// Conversation resolution
+
+function cacheKey(config: NamsConfig, userId: string): string {
+  return `${config.workspaceId ?? 'default'}:${userId}`;
+}
+
+/**
+ * Resolve a conversation id. Precedence:
+ *   1. explicit scope.conversationId
+ *   2. this instance's cache
+ *   3. the user's most recent existing conversation in NAMS (GET)
+ *   4. create a new one (CREATE)
+ */
+export async function resolveConversation(
+  client: MemoryClient,
+  config: NamsConfig,
+  scope: NamsScope,
+): Promise<string> {
+  const { convCache } = getState(client);
+  const key = cacheKey(config, scope.userId);
+
+  if (scope.conversationId) {
+    convCache.set(key, scope.conversationId);
+    return scope.conversationId;
+  }
+
+  const cached = convCache.get(key);
+  if (cached) return cached;
+
+  try {
+    const convs = await client.shortTerm.listConversations({ userId: scope.userId, limit: 1 });
+    if (convs.length > 0) {
+      convCache.set(key, convs[0].id);
+      return convs[0].id;
+    }
+  } catch (err) {
+    getLogger(client).warn('listConversations failed, creating new conversation', err);
+  }
+
+  const conv = await client.shortTerm.createConversation({ userId: scope.userId });
+  convCache.set(key, conv.id);
+  return conv.id;
+}
+
+/**
+ * Find an existing conversation without creating one.
+ * Returns null if the user has no conversations yet
+ * (e.g. reasoning trace) that should not side-effect a new conversation.
+ */
+export async function findExistingConversation(
+  client: MemoryClient,
+  config: NamsConfig,
+  scope: NamsScope,
+): Promise<string | null> {
+  if (scope.conversationId) return scope.conversationId;
+
+  const { convCache } = getState(client);
+  const key = cacheKey(config, scope.userId);
+  const cached = convCache.get(key);
+  if (cached) return cached;
+
+  try {
+    const convs = await client.shortTerm.listConversations({ userId: scope.userId, limit: 1 });
+    if (convs.length === 0) return null;
+    convCache.set(key, convs[0].id);
+    return convs[0].id;
+  } catch {
+    return null;
+  }
+}
+
+//Retrieval
+
+const RETRIEVAL = {
+  currentThreshold: 0.4,
+  crossThreshold: 0.4,
+  maxReasoning: 6,
+  maxTotal: 12,
+};
+
+function deduplicatePush(hits: MemoryHit[], seen: Set<string>, hit: MemoryHit): void {
+  const k = hit.content?.trim();
+  if (!k || seen.has(k)) return;
+  seen.add(k);
+  hits.push(hit);
+}
+
+async function searchPastConversations(
+  client: MemoryClient,
+  userId: string,
+  currentConvId: string,
+  query: string,
+): Promise<MemoryHit[]> {
+  const log = getLogger(client);
+  const seen = new Set<string>();
+  const hits: MemoryHit[] = [];
+
+  let convs: Array<{ id: string }>;
+  try {
+    convs = await client.shortTerm.listConversations({ userId, limit: 20 });
+  } catch (err) {
+    log.warn('cross-session listConversations failed', err);
+    return hits;
+  }
+
+  const past = convs.filter(c => c.id !== currentConvId);
+  await Promise.all(
+    past.map(async (conv) => {
+      const [messages, steps] = await Promise.all([
+        client.shortTerm
+          .searchMessages(query, { sessionId: conv.id, limit: 4, threshold: RETRIEVAL.crossThreshold })
+          .catch((e: unknown) => { log.warn('cross-session searchMessages failed', e); return [] as any[]; }),
+        client.reasoning.listSteps(conv.id)
+          .catch((e: unknown) => { log.warn('cross-session listSteps failed', e); return [] as any[]; }),
+      ]);
+
+      for (const m of messages) {
+        deduplicatePush(hits, seen, { content: m.content, source: 'cross-session', type: 'message' });
+      }
+      for (const s of steps) {
+        if (s.actionTaken !== 'direct response' || !s.reasoning) continue;
+        deduplicatePush(hits, seen, { content: s.reasoning, source: 'cross-session', type: 'reasoning' });
+      }
+    }),
+  );
+
+  return hits;
+}
+
+/**
+ * Search all four NAMS sources in parallel, dedupe, rank, and cap.
+ * Priority (when no score): long-term > current conversation > cross-session > reasoning.
+ * When scores are present the results are sorted by score descending.
+ */
+export async function retrieveMemories(
+  client: MemoryClient,
+  scope: NamsScope,
+  convId: string,
+  query: string,
+  limit = 5,
+): Promise<MemoryHit[]> {
+  const log = getLogger(client);
+  const [shortHits, longHits, reasoningSteps, crossHits] = await Promise.all([
+    client.shortTerm
+      .searchMessages(query, { sessionId: convId, limit, threshold: RETRIEVAL.currentThreshold })
+      .catch((e: unknown) => { log.warn('searchMessages failed', e); return [] as any[]; }),
+    client.longTerm.searchEntities(query, { limit: 5 })
+      .catch((e: unknown) => { log.warn('searchEntities failed', e); return [] as any[]; }),
+    client.reasoning.listSteps(convId)
+      .catch((e: unknown) => { log.warn('listSteps failed', e); return [] as any[]; }),
+    searchPastConversations(client, scope.userId, convId, query),
+  ]);
+
+  const seen = new Set<string>();
+  const hits: MemoryHit[] = [];
+
+  for (const e of longHits) {
+    deduplicatePush(hits, seen, {
+      content: e.description ?? e.name,
+      source: 'long-term',
+      type: e.type ?? 'entity',
+      score: e.confidence,
+    });
+  }
+  for (const m of shortHits) {
+    deduplicatePush(hits, seen, { content: m.content, source: 'conversation', type: 'message' });
+  }
+  for (const h of crossHits) deduplicatePush(hits, seen, h);
+
+  const reasoning = (reasoningSteps as any[])
+    .filter(s => s.actionTaken === 'direct response' && s.reasoning)
+    .slice(0, RETRIEVAL.maxReasoning);
+  for (const s of reasoning) {
+    deduplicatePush(hits, seen, { content: s.reasoning, source: 'reasoning', type: 'step' });
+  }
+
+  const hasScores = hits.some(h => typeof h.score === 'number');
+  const ranked = hasScores ? [...hits].sort((a, b) => (b.score ?? 0) - (a.score ?? 0)) : hits;
+  return ranked.slice(0, Math.min(limit, RETRIEVAL.maxTotal));
+}
+
+// Storage
+
+function entityName(content: string, max = 60): string {
+  const s = content.replace(/\s+/g, ' ').trim();
+  return s.length > max ? s.slice(0, max) + '…' : s;
+}
+
+/**
+ * Persist a memory:
+ *   - `interaction`               → short-term conversation thread
+ *   - fact / preference / pattern → long-term graph
+ * If `extractor` is provided, real entities + relationships are extracted
+ * so the graph actually forms. Otherwise falls back to a single entity node.
+ */
+export async function storeMemory(
+  client: MemoryClient,
+  convId: string,
+  input: StoreInput,
+  opts: { extractor?: GraphExtractor } = {},
+): Promise<void> {
+  if (input.type === 'interaction') {
+    await client.shortTerm.addMessage(convId, 'assistant', input.content);
+    return;
+  }
+
+  if (opts.extractor) {
+    try {
+      await opts.extractor(client, input);
+      return;
+    } catch (err) {
+      getLogger(client).warn('graph extraction failed, falling back to flat entity', err);
+    }
+  }
+
+  const name = entityName(input.content);
+  let entity = await client.longTerm.getEntityByName(name).catch(() => null);
+  if (!entity) {
+    entity = await client.longTerm.addEntity(name, input.type, { description: input.content });
+  }
+  if (entity?.id && input.confidence !== undefined) {
+    await client.longTerm
+      .setEntityFeedback(entity.id, { userScore: input.confidence, confirmed: input.confidence >= 0.8 })
+      .catch(() => { });
+  }
+}

--- a/typescript/packages/vercel-ai-provider/src/vercel-ai-provider-client.ts
+++ b/typescript/packages/vercel-ai-provider/src/vercel-ai-provider-client.ts
@@ -264,6 +264,6 @@ export async function storeMemory(
   if (entity?.id && input.confidence !== undefined) {
     await client.longTerm
       .setEntityFeedback(entity.id, { userScore: input.confidence, confirmed: input.confidence >= 0.8 })
-      .catch(() => { });
+      .catch((e: unknown) => getLogger(client).warn('setEntityFeedback failed', e));
   }
 }

--- a/typescript/packages/vercel-ai-provider/src/vercel-ai-provider-client.ts
+++ b/typescript/packages/vercel-ai-provider/src/vercel-ai-provider-client.ts
@@ -31,13 +31,18 @@ export function getLogger(client: MemoryClient): NamsLogger {
   return getState(client).logger;
 }
 
+/** Resolve the configured logger without needing a live client instance. */
+export function resolveLogger(config: NamsConfig): NamsLogger {
+  return config.logger ?? defaultLogger;
+}
+
 export function makeClient(config: NamsConfig): MemoryClient {
   const client = new MemoryClient({
     endpoint: config.endpoint ?? DEFAULT_ENDPOINT,
     apiKey: config.apiKey,
     workspaceId: config.workspaceId,
   });
-  stateByClient.set(client, { convCache: new Map(), logger: config.logger ?? defaultLogger });
+  stateByClient.set(client, { convCache: new Map(), logger: resolveLogger(config) });
   return client;
 }
 
@@ -119,6 +124,7 @@ const RETRIEVAL = {
   crossThreshold: 0.4,
   maxReasoning: 6,
   maxTotal: 12,
+  maxLongterm:5
 };
 
 function deduplicatePush(hits: MemoryHit[], seen: Set<string>, hit: MemoryHit): void {
@@ -187,7 +193,7 @@ export async function retrieveMemories(
     client.shortTerm
       .searchMessages(query, { sessionId: convId, limit, threshold: RETRIEVAL.currentThreshold })
       .catch((e: unknown) => { log.warn('searchMessages failed', e); return [] as any[]; }),
-    client.longTerm.searchEntities(query, { limit: 5 })
+    client.longTerm.searchEntities(query, { limit: RETRIEVAL.maxLongterm })
       .catch((e: unknown) => { log.warn('searchEntities failed', e); return [] as any[]; }),
     client.reasoning.listSteps(convId)
       .catch((e: unknown) => { log.warn('listSteps failed', e); return [] as any[]; }),

--- a/typescript/packages/vercel-ai-provider/src/vercel-ai-provider-client.ts
+++ b/typescript/packages/vercel-ai-provider/src/vercel-ai-provider-client.ts
@@ -134,6 +134,87 @@ function deduplicatePush(hits: MemoryHit[], seen: Set<string>, hit: MemoryHit): 
   hits.push(hit);
 }
 
+// Keyword + case-variant fallback
+//
+// Verified live against the hosted NAMS API: searchEntities/searchMessages do a
+// literal, case-sensitive substring match 
+
+function titleCase(word: string): string {
+  return word.length ? word[0].toUpperCase() + word.slice(1) : word;
+}
+
+/** Significant query words (own case + Title Case), longest-first, capped. */
+function fallbackTerms(query: string, maxWords = 4): string[] {
+  const words = query
+    .split(/\s+/)
+    .filter(w => w.replace(/[^\p{L}\p{N}]/gu, '').length >= 3);
+  const significant = [...new Set(words)]
+    .sort((a, b) => b.length - a.length)
+    .slice(0, maxWords);
+
+  const variants = new Set<string>();
+  for (const w of significant) {
+    variants.add(w);
+    variants.add(titleCase(w));
+  }
+  return [...variants];
+}
+
+function tokenize(text: string): Set<string> {
+  return new Set(
+    text.toLowerCase().replace(/[^\p{L}\p{N}\s]/gu, ' ').split(/\s+/).filter(Boolean),
+  );
+}
+
+/** Rank candidates by case-insensitive word overlap with the original query. */
+function rankByOverlap<T>(candidates: T[], query: string, contentOf: (item: T) => string | undefined): T[] {
+  const queryTokens = tokenize(query);
+  const overlap = (item: T) => {
+    const tokens = tokenize(contentOf(item) ?? '');
+    let n = 0;
+    for (const t of tokens) if (queryTokens.has(t)) n++;
+    return n;
+  };
+  return [...candidates].sort((a, b) => overlap(b) - overlap(a));
+}
+
+/**
+ * Try `query` as-is first; if NAMS's literal substring match finds nothing,
+ * retry with individual query words (own case + Title Case), merge, dedupe,
+ * and rank the result by word overlap with the original query.
+ */
+async function searchWithFallback<T>(
+  query: string,
+  search: (q: string) => Promise<T[]>,
+  contentOf: (item: T) => string | undefined,
+  log: NamsLogger,
+  label: string,
+): Promise<T[]> {
+  const direct = await search(query).catch((e: unknown) => { log.warn(`${label} failed`, e); return [] as T[]; });
+  if (direct.length > 0) return direct;
+
+  const terms = fallbackTerms(query);
+  if (terms.length === 0) return direct;
+
+  const perTerm = await Promise.all(
+    terms.map(t => search(t).catch((e: unknown) => {
+      log.warn(`${label} fallback ("${t}") failed`, e);
+      return [] as T[];
+    })),
+  );
+
+  const seen = new Set<string>();
+  const merged: T[] = [];
+  for (const item of perTerm.flat()) {
+    const key = contentOf(item)?.trim();
+    if (!key || seen.has(key)) continue;
+    seen.add(key);
+    merged.push(item);
+  }
+
+  return rankByOverlap(merged, query, contentOf);
+}
+
 async function searchPastConversations(
   client: MemoryClient,
   userId: string,
@@ -190,11 +271,20 @@ export async function retrieveMemories(
 ): Promise<MemoryHit[]> {
   const log = getLogger(client);
   const [shortHits, longHits, reasoningSteps, crossHits] = await Promise.all([
-    client.shortTerm
-      .searchMessages(query, { sessionId: convId, limit, threshold: RETRIEVAL.currentThreshold })
-      .catch((e: unknown) => { log.warn('searchMessages failed', e); return [] as any[]; }),
-    client.longTerm.searchEntities(query, { limit: RETRIEVAL.maxLongterm })
-      .catch((e: unknown) => { log.warn('searchEntities failed', e); return [] as any[]; }),
+    searchWithFallback(
+      query,
+      (q) => client.shortTerm.searchMessages(q, { sessionId: convId, limit, threshold: RETRIEVAL.currentThreshold }),
+      (m) => m.content,
+      log,
+      'searchMessages',
+    ),
+    searchWithFallback(
+      query,
+      (q) => client.longTerm.searchEntities(q, { limit: RETRIEVAL.maxLongterm }),
+      (e) => e.description ?? e.name,
+      log,
+      'searchEntities',
+    ),
     client.reasoning.listSteps(convId)
       .catch((e: unknown) => { log.warn('listSteps failed', e); return [] as any[]; }),
     searchPastConversations(client, scope.userId, convId, query),

--- a/typescript/packages/vercel-ai-provider/src/vercel-ai-provider-extract.ts
+++ b/typescript/packages/vercel-ai-provider/src/vercel-ai-provider-extract.ts
@@ -51,7 +51,7 @@ export function createGraphExtractor(model: LanguageModel): GraphExtractor {
       if (entity?.id && input.confidence !== undefined) {
         await client.longTerm
           .setEntityFeedback(entity.id, { userScore: input.confidence, confirmed: input.confidence >= 0.8 })
-          .catch(() => { });
+          .catch((e: unknown) => getLogger(client).warn('setEntityFeedback failed', e));
       }
     }
 

--- a/typescript/packages/vercel-ai-provider/src/vercel-ai-provider-extract.ts
+++ b/typescript/packages/vercel-ai-provider/src/vercel-ai-provider-extract.ts
@@ -1,0 +1,69 @@
+import { generateText, Output, zodSchema } from 'ai';
+import type { LanguageModel } from 'ai';
+import { z } from 'zod';
+import type { MemoryClient } from '@neo4j-labs/agent-memory';
+import { GraphExtractor, StoreInput } from './vercel-ai-provider-types';
+import { getLogger } from './vercel-ai-provider-client';
+
+const graphSchema = z.object({
+  entities: z
+    .array(
+      z.object({
+        name: z.string().describe('Canonical entity name, e.g. "Alex", "Neovim", "TechCorp"'),
+        type: z.string().describe('person | organization | tool | place | concept | preference | event'),
+        description: z.string().optional(),
+      }),
+    )
+    .describe('Distinct, real, named entities only. Do not invent.'),
+  relationships: z
+    .array(
+      z.object({
+        from: z.string().describe('Source entity name (must match an entity above)'),
+        to: z.string().describe('Target entity name (must match an entity above)'),
+        type: z.string().describe('Relationship label, e.g. PREFERS, WORKS_AT, USES, LOCATED_IN'),
+      }),
+    )
+    .default([]),
+});
+
+/**
+ * Build a graph extractor backed by an AI SDK model. Extracts entities and
+ * relationships from a stored memory so the graph actually forms, instead of
+ * one sentence-shaped node. Costs one extra model call per stored memory.
+ */
+export function createGraphExtractor(model: LanguageModel): GraphExtractor {
+  return async function extractAndStore(client: MemoryClient, input: StoreInput): Promise<void> {
+    const { output: object } = await generateText({
+      model,
+      output: Output.object({ schema: zodSchema(graphSchema) }),
+      prompt:
+        `Extract entities and the relationships between them from the memory below. ` +
+        `Be conservative: only real, named entities; skip filler.\n\n` +
+        `Memory (${input.type}): ${input.content}`,
+    });
+
+    const nameToId = new Map<string, string>();
+    for (const e of object.entities) {
+      const entity = await client.longTerm.addEntity(e.name, e.type, {
+        description: e.description ?? input.content,
+      });
+      if (entity?.id) nameToId.set(e.name, entity.id);
+      if (entity?.id && input.confidence !== undefined) {
+        await client.longTerm
+          .setEntityFeedback(entity.id, { userScore: input.confidence, confirmed: input.confidence >= 0.8 })
+          .catch(() => { });
+      }
+    }
+
+    const log = getLogger(client);
+    for (const r of object.relationships) {
+      const from = nameToId.get(r.from);
+      const to = nameToId.get(r.to);
+      if (from && to) {
+        await client.longTerm
+          .addRelationship(from, to, r.type)
+          .catch((e: unknown) => log.warn('addRelationship failed', e));
+      }
+    }
+  };
+}

--- a/typescript/packages/vercel-ai-provider/src/vercel-ai-provider-middleware.ts
+++ b/typescript/packages/vercel-ai-provider/src/vercel-ai-provider-middleware.ts
@@ -135,7 +135,14 @@ const buildMiddleware = (
 
       originalUserText.set(params as object, userText);
 
-      const convId = await getConvId();
+      let convId: string;
+      try {
+        convId = await getConvId();
+      } catch (e) {
+        log.warn('resolveConversation failed', e);
+        return params;
+      }
+
       const memories = await retrieveMemories(client, scope, convId, userText, injectLimit)
         .catch(e => { log.warn('retrieve failed', e); return [] as MemoryHit[]; });
 

--- a/typescript/packages/vercel-ai-provider/src/vercel-ai-provider-middleware.ts
+++ b/typescript/packages/vercel-ai-provider/src/vercel-ai-provider-middleware.ts
@@ -18,8 +18,8 @@ import { createGraphExtractor } from './vercel-ai-provider-extract';
 import { GraphExtractor, MemoryHit, NamsConfig, NamsScope } from './vercel-ai-provider-types';
 
 export interface NamsMemoryConfig extends NamsConfig {
-  /** Max memories injected per turn (default: 6). */
-  injectLimit?: number;
+  /** Max memories retrieved and injected into the prompt per turn (default: 6). Does not affect storage. */
+  maxMemories?: number;
   /** Persist each turn to NAMS short-term memory (default: true). */
   persistInteractions?: boolean;
   /** When set, build a real entity graph per stored turn (one extra model call). */
@@ -92,7 +92,7 @@ const buildMiddleware = (
   config: NamsMemoryConfig,
   scope: NamsScope,
   extractor: GraphExtractor | undefined,
-  injectLimit: number,
+  maxMemories: number,
   persist: boolean,
 ): LanguageModelV3Middleware => {
   const client = makeClient(config);
@@ -115,10 +115,10 @@ const buildMiddleware = (
     if (userText && userText !== lastPersistedUserText) {
       lastPersistedUserText = userText;
       await client.shortTerm.addMessage(convId, 'user', userText)
-        .catch(e => log.warn('persist user message failed', e));
+        .catch(e => log.error('persist user message failed', e));
     }
     if (assistantText) await client.shortTerm.addMessage(convId, 'assistant', assistantText)
-      .catch(e => log.warn('persist assistant message failed', e));
+      .catch(e => log.error('persist assistant message failed', e));
     if (extractor && (userText || assistantText)) {
       const combined = `User: ${userText}\nAssistant: ${assistantText}`.trim();
       await extractor(client, { content: combined, type: 'interaction' })
@@ -143,7 +143,7 @@ const buildMiddleware = (
         return params;
       }
 
-      const memories = await retrieveMemories(client, scope, convId, userText, injectLimit)
+      const memories = await retrieveMemories(client, scope, convId, userText, maxMemories)
         .catch(e => { log.warn('retrieve failed', e); return [] as MemoryHit[]; });
 
       if (memories.length === 0) return params;
@@ -203,12 +203,12 @@ const buildMiddleware = (
  */
 export function createNamsMemory(config: NamsMemoryConfig) {
   const extractor = config.extractionModel ? createGraphExtractor(config.extractionModel) : undefined;
-  const injectLimit = config.injectLimit ?? 6;
+  const maxMemories = config.maxMemories ?? 6;
   const persist = config.persistInteractions ?? true;
 
   return {
     wrap(model: LanguageModelV3, scope: NamsScope, providerId?: string): LanguageModelV3 {
-      const middleware = buildMiddleware(config, scope, extractor, injectLimit, persist);
+      const middleware = buildMiddleware(config, scope, extractor, maxMemories, persist);
       return wrapLanguageModel({ model, middleware, ...(providerId && { providerId }) });
     },
   };

--- a/typescript/packages/vercel-ai-provider/src/vercel-ai-provider-middleware.ts
+++ b/typescript/packages/vercel-ai-provider/src/vercel-ai-provider-middleware.ts
@@ -170,7 +170,6 @@ const buildMiddleware = (
             const id = chunk.toolCallId as string;
             pendingToolArgs.set(id, (pendingToolArgs.get(id) ?? '') + (chunk.argsTextDelta ?? ''));
           } else if (chunk?.type === 'tool-call') {
-            // Full tool calls supersede any streamed deltas for the same id.
             pendingToolArgs.set((chunk.toolCallId ?? chunk.id) as string, toolCallInput(chunk));
           }
           controller.enqueue(chunk);

--- a/typescript/packages/vercel-ai-provider/src/vercel-ai-provider-middleware.ts
+++ b/typescript/packages/vercel-ai-provider/src/vercel-ai-provider-middleware.ts
@@ -82,7 +82,7 @@ const lastUserText = (prompt: any[]): string => {
       return msg.content
         .filter((p: any) => p?.type === 'text')
         .map((p: any) => p.text as string)
-        .join(' ')
+        .join('')
         .trim();
   }
   return '';

--- a/typescript/packages/vercel-ai-provider/src/vercel-ai-provider-middleware.ts
+++ b/typescript/packages/vercel-ai-provider/src/vercel-ai-provider-middleware.ts
@@ -114,9 +114,11 @@ const buildMiddleware = (
     const userText = originalUserText.get(params as object) ?? lastUserText(params.prompt);
     if (userText && userText !== lastPersistedUserText) {
       lastPersistedUserText = userText;
-      await client.shortTerm.addMessage(convId, 'user', userText).catch(() => { });
+      await client.shortTerm.addMessage(convId, 'user', userText)
+        .catch(e => log.warn('persist user message failed', e));
     }
-    if (assistantText) await client.shortTerm.addMessage(convId, 'assistant', assistantText).catch(() => { });
+    if (assistantText) await client.shortTerm.addMessage(convId, 'assistant', assistantText)
+      .catch(e => log.warn('persist assistant message failed', e));
     if (extractor && (userText || assistantText)) {
       const combined = `User: ${userText}\nAssistant: ${assistantText}`.trim();
       await extractor(client, { content: combined, type: 'interaction' })

--- a/typescript/packages/vercel-ai-provider/src/vercel-ai-provider-middleware.ts
+++ b/typescript/packages/vercel-ai-provider/src/vercel-ai-provider-middleware.ts
@@ -1,0 +1,207 @@
+/**
+ * Middleware mode — transparent memory, no tool calls.
+ *
+ * createNamsMemory(config).wrap(model, scope) returns a LanguageModel that
+ * injects relevant memories before every call and persists each turn after.
+ * This middleware also underpins provider mode (see vercel-ai-provider.ts).
+ */
+
+import { wrapLanguageModel, type LanguageModel } from 'ai';
+import type { LanguageModelV3, LanguageModelV3Middleware } from '@ai-sdk/provider';
+import {
+  makeClient,
+  getLogger,
+  resolveConversation,
+  retrieveMemories,
+} from './vercel-ai-provider-client';
+import { createGraphExtractor } from './vercel-ai-provider-extract';
+import { GraphExtractor, MemoryHit, NamsConfig, NamsScope } from './vercel-ai-provider-types';
+
+export interface NamsMemoryConfig extends NamsConfig {
+  /** Max memories injected per turn (default: 6). */
+  injectLimit?: number;
+  /** Persist each turn to NAMS short-term memory (default: true). */
+  persistInteractions?: boolean;
+  /** When set, build a real entity graph per stored turn (one extra model call). */
+  extractionModel?: LanguageModel;
+}
+
+
+const injectIntoLastUser = (prompt: any[], block: string): void => {
+  for (let i = prompt.length - 1; i >= 0; i--) {
+    const msg = prompt[i];
+    if (msg?.role !== 'user') continue;
+    if (typeof msg.content === 'string') {
+      msg.content = `${block}\n\n${msg.content}`;
+    } else if (Array.isArray(msg.content)) {
+      msg.content.unshift({ type: 'text', text: `${block}\n\n` });
+    }
+    return;
+  }
+}
+
+const toolCallInput = (part: any): string => {
+  if (typeof part?.input === 'string') return part.input;
+  const args = part?.input ?? part?.args;
+  if (args === undefined) return '';
+  try { return JSON.stringify(args) ?? ''; } catch { return ''; }
+}
+
+// Extract assistant text from a generate result. Falls back to serialized
+// tool-call input so structured responses (e.g. generateObject) still persist.
+const textFromResult = (result: any): string => {
+  if (typeof result?.text === 'string' && result.text) return result.text;
+  if (Array.isArray(result?.content)) {
+    const textParts = (result.content as any[])
+      .filter(p => p?.type === 'text')
+      .map(p => p.text as string)
+      .join('');
+    if (textParts) return textParts;
+    return (result.content as any[])
+      .filter(p => p?.type === 'tool-call')
+      .map(toolCallInput)
+      .join('');
+  }
+  return '';
+}
+
+const formatMemoryBlock = (memories: MemoryHit[]): string => {
+  return (
+    'Relevant long-term memory about this user (use it to personalise your answer):\n' +
+    memories.map((m, i) => `${i + 1}. [${m.source}] ${m.content}`).join('\n')
+  );
+}
+
+// Text of the most recent user message in the prompt.
+const lastUserText = (prompt: any[]): string => {
+  for (let i = prompt.length - 1; i >= 0; i--) {
+    const msg = prompt[i];
+    if (msg?.role !== 'user') continue;
+    if (typeof msg.content === 'string') return msg.content;
+    if (Array.isArray(msg.content))
+      return msg.content
+        .filter((p: any) => p?.type === 'text')
+        .map((p: any) => p.text as string)
+        .join(' ')
+        .trim();
+  }
+  return '';
+}
+
+const buildMiddleware = (
+  config: NamsMemoryConfig,
+  scope: NamsScope,
+  extractor: GraphExtractor | undefined,
+  injectLimit: number,
+  persist: boolean,
+): LanguageModelV3Middleware => {
+  const client = makeClient(config);
+  const log = getLogger(client);
+
+  let convIdPromise: Promise<string> | null = null;
+  const getConvId = (): Promise<string> =>
+    (convIdPromise ??= resolveConversation(client, config, scope));
+
+  const originalUserText = new WeakMap<object, string>();
+
+  // In a multi-step tool loop every step carries the same last user message —
+  // remember what was persisted so it is stored once per turn, not per step.
+  let lastPersistedUserText: string | undefined;
+
+  async function persistTurn(params: any, assistantText: string): Promise<void> {
+    if (!persist) return;
+    const convId = await getConvId();
+    const userText = originalUserText.get(params as object) ?? lastUserText(params.prompt);
+    if (userText && userText !== lastPersistedUserText) {
+      lastPersistedUserText = userText;
+      await client.shortTerm.addMessage(convId, 'user', userText).catch(() => { });
+    }
+    if (assistantText) await client.shortTerm.addMessage(convId, 'assistant', assistantText).catch(() => { });
+    if (extractor && (userText || assistantText)) {
+      const combined = `User: ${userText}\nAssistant: ${assistantText}`.trim();
+      await extractor(client, { content: combined, type: 'interaction' })
+        .catch(e => log.warn('turn extraction failed', e));
+    }
+  }
+
+  return {
+    specificationVersion: 'v3',
+    // Retrieve memories for the user query and inject them into the prompt.
+    transformParams: async ({ params }) => {
+      const userText = lastUserText(params.prompt);
+      if (!userText) return params;
+
+      originalUserText.set(params as object, userText);
+
+      const convId = await getConvId();
+      const memories = await retrieveMemories(client, scope, convId, userText, injectLimit)
+        .catch(e => { log.warn('retrieve failed', e); return [] as MemoryHit[]; });
+
+      if (memories.length === 0) return params;
+
+      injectIntoLastUser(params.prompt, formatMemoryBlock(memories));
+      return params;
+    },
+
+    wrapGenerate: async ({ doGenerate, params }) => {
+      const result = await doGenerate();
+      await persistTurn(params, textFromResult(result))
+        .catch(e => log.warn('persist failed', e));
+      return result;
+    },
+
+    // Tap the stream to accumulate text and tool-call args; persist the full
+    // turn in flush once the stream closes.
+    wrapStream: async ({ doStream, params }) => {
+      const { stream, ...rest } = await doStream();
+      let text = '';
+      const pendingToolArgs = new Map<string, string>();
+
+      const tap = new TransformStream({
+        transform(chunk: any, controller) {
+          if (chunk?.type === 'text-delta')
+            text += (chunk.delta ?? chunk.textDelta ?? chunk.text ?? '') as string;
+          else if (chunk?.type === 'text')
+            text += (chunk.text ?? '') as string;
+          else if (chunk?.type === 'tool-input-delta') {
+            const id = chunk.id as string;
+            pendingToolArgs.set(id, (pendingToolArgs.get(id) ?? '') + (chunk.delta ?? ''));
+          } else if (chunk?.type === 'tool-call-delta') {
+            const id = chunk.toolCallId as string;
+            pendingToolArgs.set(id, (pendingToolArgs.get(id) ?? '') + (chunk.argsTextDelta ?? ''));
+          } else if (chunk?.type === 'tool-call') {
+            // Full tool calls supersede any streamed deltas for the same id.
+            pendingToolArgs.set((chunk.toolCallId ?? chunk.id) as string, toolCallInput(chunk));
+          }
+          controller.enqueue(chunk);
+        },
+        async flush() {
+          for (const args of pendingToolArgs.values()) {
+            if (args) text += args;
+          }
+          await persistTurn(params, text)
+            .catch(e => log.warn('persist failed', e));
+        },
+      });
+
+      return { stream: stream.pipeThrough(tap), ...rest };
+    },
+  };
+}
+
+/**
+ * Create a NAMS memory provider. `wrap(model, scope)` returns a drop-in
+ * LanguageModelV3 with transparent memory retrieval and persistence.
+ */
+export function createNamsMemory(config: NamsMemoryConfig) {
+  const extractor = config.extractionModel ? createGraphExtractor(config.extractionModel) : undefined;
+  const injectLimit = config.injectLimit ?? 6;
+  const persist = config.persistInteractions ?? true;
+
+  return {
+    wrap(model: LanguageModelV3, scope: NamsScope, providerId?: string): LanguageModelV3 {
+      const middleware = buildMiddleware(config, scope, extractor, injectLimit, persist);
+      return wrapLanguageModel({ model, middleware, ...(providerId && { providerId }) });
+    },
+  };
+}

--- a/typescript/packages/vercel-ai-provider/src/vercel-ai-provider-tools.ts
+++ b/typescript/packages/vercel-ai-provider/src/vercel-ai-provider-tools.ts
@@ -20,7 +20,7 @@ import {
 } from './vercel-ai-provider-client';
 import { createGraphExtractor } from './vercel-ai-provider-extract';
 
-// ─── Schemas
+//Schemas
 
 const querySchema = z.object({
   query: z.string().describe('Keywords or phrase to search in memory'),
@@ -44,7 +44,7 @@ export type StoreInput = z.infer<typeof storeSchema>;
 export type QueryOutput = { found: boolean; count?: number; message?: string; memories: MemoryHit[] };
 export type StoreOutput = { stored: boolean; type: string; preview: string; message: string };
 
-// ─── Options
+//Options
 
 export interface NamsToolsOptions extends NamsConfig, NamsScope {
   extractionModel?: LanguageModel;

--- a/typescript/packages/vercel-ai-provider/src/vercel-ai-provider-tools.ts
+++ b/typescript/packages/vercel-ai-provider/src/vercel-ai-provider-tools.ts
@@ -101,8 +101,8 @@ export function createNamsMemoryTools(options: NamsToolsOptions) {
       'Call this AFTER your response to save facts, preferences, and patterns.',
     inputSchema: zodSchema(storeSchema),
     execute: async ({ content, type, confidence, tags }) => {
-      const convId = await getConvId();
       try {
+        const convId = await getConvId();
         await storeMemory(client, convId, { content, type, confidence, tags }, { extractor });
         return {
           stored: true,

--- a/typescript/packages/vercel-ai-provider/src/vercel-ai-provider-tools.ts
+++ b/typescript/packages/vercel-ai-provider/src/vercel-ai-provider-tools.ts
@@ -1,0 +1,158 @@
+/**
+ * Tools mode — model-driven memory.
+ *
+ * createNamsMemoryTools() returns { query_memory, store_memory } AI SDK tools.
+ * createNamsTools() is the async variant that can also merge in MCP tools
+ * (an optional extension of tools mode, not a separate mode).
+ */
+
+import { tool, zodSchema, type LanguageModel, type ToolSet } from 'ai';
+import { z } from 'zod';
+import {
+  makeClient,
+  getLogger,
+  resolveConversation,
+  retrieveMemories,
+  storeMemory,
+  type NamsConfig,
+  type NamsScope,
+  type MemoryHit,
+} from './vercel-ai-provider-client';
+import { createGraphExtractor } from './vercel-ai-provider-extract';
+
+// ─── Schemas
+
+const querySchema = z.object({
+  query: z.string().describe('Keywords or phrase to search in memory'),
+  limit: z.number().int().min(1).max(20).default(5),
+});
+
+const storeSchema = z.object({
+  content: z.string().min(1).max(2000).describe('The information to remember'),
+  type: z.enum(['fact', 'interaction', 'pattern', 'user_preference']).describe(
+    'fact=persistent knowledge | interaction=conversation event | ' +
+    'pattern=recurring behaviour | user_preference=explicit setting',
+  ),
+  confidence: z.number().min(0).max(1).default(0.7).describe(
+    'Confidence 0–1: 0.8–1.0 very high · 0.6–0.8 high · 0.3–0.6 medium · 0–0.3 low',
+  ),
+  tags: z.array(z.string().max(40)).max(10).default([]),
+});
+
+export type QueryInput = z.infer<typeof querySchema>;
+export type StoreInput = z.infer<typeof storeSchema>;
+export type QueryOutput = { found: boolean; count?: number; message?: string; memories: MemoryHit[] };
+export type StoreOutput = { stored: boolean; type: string; preview: string; message: string };
+
+// ─── Options
+
+export interface NamsToolsOptions extends NamsConfig, NamsScope {
+  extractionModel?: LanguageModel;
+}
+
+/** MCP server connection config. Headers are sent on every request (e.g. Authorization). */
+export interface McpConfig {
+  url: string;
+  headers?: Record<string, string>;
+}
+
+export interface NamsToolsWithMcpOptions extends NamsToolsOptions {
+  mcp?: McpConfig;
+}
+
+export interface NamsToolsResult {
+  /** Merged NAMS + MCP tools, ready to pass to ToolLoopAgent `tools:`. */
+  tools: ToolSet;
+  /** Close the MCP connection (no-op when MCP was not configured). Call in `onFinish`. */
+  close: () => Promise<void>;
+}
+
+export function createNamsMemoryTools(options: NamsToolsOptions) {
+  const client = makeClient(options);
+  const scope: NamsScope = { userId: options.userId, conversationId: options.conversationId };
+  const extractor = options.extractionModel ? createGraphExtractor(options.extractionModel) : undefined;
+
+  let convIdPromise: Promise<string> | null = null;
+  const getConvId = (): Promise<string> =>
+    (convIdPromise ??= resolveConversation(client, options, scope));
+
+  const query_memory = tool<QueryInput, QueryOutput>({
+    description:
+      'Search NAMS (Neo4j Agent Memory System) for context relevant to the current message. ' +
+      'Call this FIRST every turn before answering.',
+    inputSchema: zodSchema(querySchema),
+    execute: async ({ query, limit }) => {
+      const convId = await getConvId();
+      const memories = await retrieveMemories(client, scope, convId, query, limit);
+      if (memories.length === 0)
+        return { found: false, message: 'No relevant memories found.', memories: [] };
+      return { found: true, count: memories.length, memories };
+    },
+  });
+
+  const store_memory = tool<StoreInput, StoreOutput>({
+    description:
+      'Persist important information to NAMS (Neo4j graph). ' +
+      'Call this AFTER your response to save facts, preferences, and patterns.',
+    inputSchema: zodSchema(storeSchema),
+    execute: async ({ content, type, confidence, tags }) => {
+      const convId = await getConvId();
+      try {
+        await storeMemory(client, convId, { content, type, confidence, tags }, { extractor });
+        return {
+          stored: true,
+          type,
+          preview: content.slice(0, 80),
+          message: `Memory stored (${type}, confidence=${confidence})`,
+        };
+      } catch (err) {
+        getLogger(client).error('store_memory failed', err);
+        return { stored: false, type, preview: content.slice(0, 80), message: 'Failed to store memory.' };
+      }
+    },
+  });
+
+  return { query_memory, store_memory };
+}
+
+/**
+ * Async variant of createNamsMemoryTools. Optionally connects to an MCP
+ * server and merges its tools with the NAMS memory tools.
+ */
+export async function createNamsTools(options: NamsToolsWithMcpOptions): Promise<NamsToolsResult> {
+  const namsTools = createNamsMemoryTools(options);
+
+  if (!options.mcp) {
+    return { tools: namsTools, close: async () => {} };
+  }
+
+  const { createMCPClient } = await import('@ai-sdk/mcp');
+  const mcpClient = await createMCPClient({
+    transport: { type: 'http', url: options.mcp.url, headers: options.mcp.headers },
+  });
+
+  const mcpTools = await mcpClient.tools();
+
+  return {
+    tools: { ...namsTools, ...mcpTools },
+    close: () => mcpClient.close(),
+  };
+}
+
+export class NamsMemoryTools {
+  constructor(private readonly base: Omit<NamsToolsOptions, 'userId' | 'conversationId'>) { }
+
+  /** Synchronous — returns NAMS memory tools only. */
+  forUser(userId: string, conversationId?: string) {
+    return createNamsMemoryTools({ ...this.base, userId, conversationId });
+  }
+
+  /** Async — returns NAMS + optional MCP tools merged, plus a close() handle. */
+  async forUserWithMcp(
+    userId: string,
+    mcp?: McpConfig,
+    conversationId?: string,
+  ): Promise<NamsToolsResult> {
+    return createNamsTools({ ...this.base, userId, conversationId, mcp });
+  }
+}

--- a/typescript/packages/vercel-ai-provider/src/vercel-ai-provider-tools.ts
+++ b/typescript/packages/vercel-ai-provider/src/vercel-ai-provider-tools.ts
@@ -82,11 +82,16 @@ export function createNamsMemoryTools(options: NamsToolsOptions) {
       'Call this FIRST every turn before answering.',
     inputSchema: zodSchema(querySchema),
     execute: async ({ query, limit }) => {
-      const convId = await getConvId();
-      const memories = await retrieveMemories(client, scope, convId, query, limit);
-      if (memories.length === 0)
-        return { found: false, message: 'No relevant memories found.', memories: [] };
-      return { found: true, count: memories.length, memories };
+      try {
+        const convId = await getConvId();
+        const memories = await retrieveMemories(client, scope, convId, query, limit);
+        if (memories.length === 0)
+          return { found: false, message: 'No relevant memories found.', memories: [] };
+        return { found: true, count: memories.length, memories };
+      } catch (err) {
+        getLogger(client).error('query_memory failed', err);
+        return { found: false, message: 'Memory lookup failed.', memories: [] };
+      }
     },
   });
 

--- a/typescript/packages/vercel-ai-provider/src/vercel-ai-provider-tools.ts
+++ b/typescript/packages/vercel-ai-provider/src/vercel-ai-provider-tools.ts
@@ -11,6 +11,7 @@ import { z } from 'zod';
 import {
   makeClient,
   getLogger,
+  resolveLogger,
   resolveConversation,
   retrieveMemories,
   storeMemory,
@@ -137,6 +138,13 @@ export async function createNamsTools(options: NamsToolsWithMcpOptions): Promise
   });
 
   const mcpTools = await mcpClient.tools();
+
+  const collisions = Object.keys(mcpTools).filter(name => name in namsTools);
+  if (collisions.length > 0) {
+    resolveLogger(options).warn(
+      `MCP tool(s) [${collisions.join(', ')}] share a name with NAMS memory tools and will override them`,
+    );
+  }
 
   return {
     tools: { ...namsTools, ...mcpTools },

--- a/typescript/packages/vercel-ai-provider/src/vercel-ai-provider-tools.ts
+++ b/typescript/packages/vercel-ai-provider/src/vercel-ai-provider-tools.ts
@@ -6,7 +6,14 @@
  * (an optional extension of tools mode, not a separate mode).
  */
 
-import { tool, zodSchema, type LanguageModel, type ToolSet } from 'ai';
+import {
+  tool,
+  zodSchema,
+  type LanguageModel,
+  type PrepareStepFunction,
+  type Tool,
+  type ToolSet,
+} from 'ai';
 import { z } from 'zod';
 import {
   makeClient,
@@ -55,6 +62,8 @@ export interface NamsToolsOptions extends NamsConfig, NamsScope {
 export interface McpConfig {
   url: string;
   headers?: Record<string, string>;
+  /** Prepended to every MCP tool name (e.g. `'mcp_'`), namespacing them away from `query_memory`/`store_memory`. */
+  toolPrefix?: string;
 }
 
 export interface NamsToolsWithMcpOptions extends NamsToolsOptions {
@@ -80,7 +89,7 @@ export function createNamsMemoryTools(options: NamsToolsOptions) {
   const query_memory = tool<QueryInput, QueryOutput>({
     description:
       'Search NAMS (Neo4j Agent Memory System) for context relevant to the current message. ' +
-      'Call this FIRST every turn before answering.',
+      'Call this before answering, every turn.',
     inputSchema: zodSchema(querySchema),
     execute: async ({ query, limit }) => {
       try {
@@ -99,7 +108,8 @@ export function createNamsMemoryTools(options: NamsToolsOptions) {
   const store_memory = tool<StoreInput, StoreOutput>({
     description:
       'Persist important information to NAMS (Neo4j graph). ' +
-      'Call this AFTER your response to save facts, preferences, and patterns.',
+      'Call this BEFORE giving your final answer whenever the conversation ' +
+      'contains facts, preferences, or patterns worth remembering.',
     inputSchema: zodSchema(storeSchema),
     execute: async ({ content, type, confidence, tags }) => {
       try {
@@ -121,6 +131,51 @@ export function createNamsMemoryTools(options: NamsToolsOptions) {
   return { query_memory, store_memory };
 }
 
+export interface EnforceQueryMemoryOptions {
+  /**
+   * How many steps the model may spend on other tools before `query_memory`
+   * is forced directly. During the grace window a text-only answer is blocked
+   * (`toolChoice: 'required'`) but the model picks which tools to call; once
+   * the window is exhausted the next step forces `query_memory` itself, so
+   * the loop can never end without the query having run. `0` forces
+   * `query_memory` as the very first step. Default: 3.
+   *
+   * Keep this at least two below the agent's `stopWhen` step budget so the
+   * forced query and the final answer both still fit.
+   */
+  graceSteps?: number;
+}
+
+/**
+ * prepareStep hook that guarantees `query_memory` runs before the final
+ * answer, without dictating tool order. While `query_memory` is absent from
+ * the executed tool calls, each step requires *some* tool call (the model may
+ * read files, hit MCP tools, etc.), so it cannot finish with a text-only
+ * answer; after `graceSteps` steps it is forced to call `query_memory`
+ * directly. Once `query_memory` has run, all constraints drop.
+ *
+ * ```ts
+ * const agent = new ToolLoopAgent({
+ *   model, tools,
+ *   prepareStep: enforceQueryMemory(),
+ *   stopWhen: stepCountIs(10),
+ * });
+ * ```
+ */
+export function enforceQueryMemory<
+  TOOLS extends ToolSet & { query_memory: Tool },
+>(options: EnforceQueryMemoryOptions = {}): PrepareStepFunction<TOOLS> {
+  const graceSteps = options.graceSteps ?? 3;
+  return ({ stepNumber, steps }) => {
+    const queried = steps.some(step =>
+      step.toolCalls.some(call => call.toolName === 'query_memory'));
+    if (queried) return undefined;
+    return stepNumber < graceSteps
+      ? { toolChoice: 'required' }
+      : { toolChoice: { type: 'tool', toolName: 'query_memory' as Extract<keyof TOOLS, string> } };
+  };
+}
+
 /**
  * Async variant of createNamsMemoryTools. Optionally connects to an MCP
  * server and merges its tools with the NAMS memory tools.
@@ -137,12 +192,17 @@ export async function createNamsTools(options: NamsToolsWithMcpOptions): Promise
     transport: { type: 'http', url: options.mcp.url, headers: options.mcp.headers },
   });
 
-  const mcpTools = await mcpClient.tools();
+  const rawMcpTools = await mcpClient.tools();
+  const prefix = options.mcp.toolPrefix;
+  const mcpTools: ToolSet = prefix
+    ? Object.fromEntries(Object.entries(rawMcpTools).map(([name, t]) => [`${prefix}${name}`, t]))
+    : rawMcpTools;
 
   const collisions = Object.keys(mcpTools).filter(name => name in namsTools);
   if (collisions.length > 0) {
     resolveLogger(options).warn(
-      `MCP tool(s) [${collisions.join(', ')}] share a name with NAMS memory tools and will override them`,
+      `MCP tool(s) [${collisions.join(', ')}] share a name with NAMS memory tools and will override them` +
+      (prefix ? '' : ' — set mcp.toolPrefix to namespace MCP tools and avoid this'),
     );
   }
 

--- a/typescript/packages/vercel-ai-provider/src/vercel-ai-provider-types.ts
+++ b/typescript/packages/vercel-ai-provider/src/vercel-ai-provider-types.ts
@@ -39,3 +39,8 @@ export interface StoreInput {
 }
 
 export type GraphExtractor = (client: MemoryClient, input: StoreInput) => Promise<void>;
+
+export interface ClientState {
+  convCache: Map<string, string>;
+  logger: NamsLogger;
+}

--- a/typescript/packages/vercel-ai-provider/src/vercel-ai-provider-types.ts
+++ b/typescript/packages/vercel-ai-provider/src/vercel-ai-provider-types.ts
@@ -1,0 +1,41 @@
+import { MemoryClient } from "@neo4j-labs/agent-memory";
+
+export const DEFAULT_ENDPOINT = 'https://memory.neo4jlabs.com/v1';
+
+/** Pluggable logger for non-fatal errors (network failures, fallbacks). */
+export interface NamsLogger {
+  warn: (message: string, error?: unknown) => void;
+  error: (message: string, error?: unknown) => void;
+}
+
+export interface NamsConfig {
+  apiKey: string;
+  endpoint?: string;
+  workspaceId?: string;
+  /** Reports non-fatal errors. Defaults to console; pass your own to redirect or silence. */
+  logger?: NamsLogger;
+}
+
+export interface NamsScope {
+  userId: string;
+  conversationId?: string;
+}
+
+export type MemorySource = 'long-term' | 'conversation' | 'cross-session' | 'reasoning';
+export type MemoryType = 'fact' | 'interaction' | 'pattern' | 'user_preference';
+
+export interface MemoryHit {
+  content: string;
+  source: MemorySource;
+  type: string;
+  score?: number;
+}
+
+export interface StoreInput {
+  content: string;
+  type: MemoryType;
+  confidence?: number;
+  tags?: string[];
+}
+
+export type GraphExtractor = (client: MemoryClient, input: StoreInput) => Promise<void>;

--- a/typescript/packages/vercel-ai-provider/src/vercel-ai-provider-types.ts
+++ b/typescript/packages/vercel-ai-provider/src/vercel-ai-provider-types.ts
@@ -1,4 +1,4 @@
-import { MemoryClient } from "@neo4j-labs/agent-memory";
+import type { MemoryClient } from '@neo4j-labs/agent-memory';
 
 export const DEFAULT_ENDPOINT = 'https://memory.neo4jlabs.com/v1';
 

--- a/typescript/packages/vercel-ai-provider/src/vercel-ai-provider.ts
+++ b/typescript/packages/vercel-ai-provider/src/vercel-ai-provider.ts
@@ -1,0 +1,53 @@
+/**
+ * Provider mode — ProviderV3-compatible NAMS provider.
+ *
+ * Wraps any base AI SDK provider (openai, anthropic, etc.) with NAMS memory —
+ * retrieved automatically on every call, persisted after every response.
+ */
+
+import type { ProviderV3, LanguageModelV3, EmbeddingModelV3, ImageModelV3 } from '@ai-sdk/provider';
+import { NoSuchModelError } from '@ai-sdk/provider';
+import type { LanguageModel } from 'ai';
+import { createNamsMemory } from './vercel-ai-provider-middleware';
+import { NamsConfig, NamsScope } from './vercel-ai-provider-types';
+
+export interface NamsProviderOptions extends NamsConfig {
+  baseProvider: (modelId: string) => LanguageModelV3;
+  /**
+   * User/conversation scope for this provider instance.
+   * Create one provider instance per user session.
+   */
+  scope: NamsScope;
+  /** Max memories injected per turn (default: 6). */
+  injectLimit?: number;
+  /** Persist each turn to NAMS short-term memory (default: true). */
+  persistInteractions?: boolean;
+  /** When set, builds a real entity graph per stored turn (one extra model call). */
+  extractionModel?: LanguageModel;
+}
+
+/**
+ * Create a ProviderV3-compatible NAMS provider, registrable with the
+ * Vercel AI SDK via `createProviderRegistry`.
+ */
+export function createNamsProvider(options: NamsProviderOptions): ProviderV3 {
+  const { baseProvider, scope, ...memoryConfig } = options;
+  const memory = createNamsMemory(memoryConfig);
+
+  return {
+    specificationVersion: 'v3',
+
+    languageModel(modelId: string): LanguageModelV3 {
+      const base = baseProvider(modelId);
+      return memory.wrap(base, scope, 'nams');
+    },
+
+    embeddingModel(modelId: string): EmbeddingModelV3 {
+      throw new NoSuchModelError({ modelId, modelType: 'embeddingModel' });
+    },
+
+    imageModel(modelId: string): ImageModelV3 {
+      throw new NoSuchModelError({ modelId, modelType: 'imageModel' });
+    },
+  };
+}

--- a/typescript/packages/vercel-ai-provider/src/vercel-ai-provider.ts
+++ b/typescript/packages/vercel-ai-provider/src/vercel-ai-provider.ts
@@ -18,8 +18,8 @@ export interface NamsProviderOptions extends NamsConfig {
    * Create one provider instance per user session.
    */
   scope: NamsScope;
-  /** Max memories injected per turn (default: 6). */
-  injectLimit?: number;
+  /** Max memories retrieved and injected into the prompt per turn (default: 6). Does not affect storage. */
+  maxMemories?: number;
   /** Persist each turn to NAMS short-term memory (default: true). */
   persistInteractions?: boolean;
   /** When set, builds a real entity graph per stored turn (one extra model call). */

--- a/typescript/packages/vercel-ai-provider/test/vercel-ai-provider-client.test.ts
+++ b/typescript/packages/vercel-ai-provider/test/vercel-ai-provider-client.test.ts
@@ -1,0 +1,89 @@
+/**
+ * retrieveMemories — fallback for NAMS's literal, case-sensitive substring
+ * search (verified live: "Delh"/"elhi" both match "Delhi" as a pure substring,
+ * but a lowercase query never matches capitalized stored text, and a query
+ * broken across word boundaries that aren't contiguous in the source matches
+ * nothing). A natural-language question is almost never a literal substring of
+ * the fact it's asking about.
+ *
+ * Contract points:
+ *  - a direct phrase search that already finds something is used as-is; no
+ *    fallback calls happen
+ *  - a direct phrase search that finds nothing retries with the query's
+ *    significant words, in both their given case and Title Case
+ *  - the merged fallback candidates are ranked by word overlap with the
+ *    original query, so the most relevant hit isn't lost under the result cap
+ *  - fallback failures are swallowed, not thrown
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { makeFakeClient, type FakeClient } from './vercel-ai-provider-helpers';
+import { retrieveMemories } from '../src/vercel-ai-provider-client';
+
+let fake: FakeClient;
+
+beforeEach(() => {
+  fake = makeFakeClient();
+  vi.spyOn(console, 'warn').mockImplementation(() => {});
+});
+
+const scope = { userId: 'u1' };
+
+describe('retrieveMemories — substring-search fallback', () => {
+  it('does not retry when the direct phrase search already finds a match', async () => {
+    fake.longTerm.searchEntities.mockResolvedValue([
+      { name: 'Fact', description: 'User is from Delhi.', type: 'fact' },
+    ]);
+
+    await retrieveMemories(fake as any, scope, 'conv-1', 'User is from Delhi', 5);
+
+    expect(fake.longTerm.searchEntities).toHaveBeenCalledTimes(1);
+    expect(fake.longTerm.searchEntities).toHaveBeenCalledWith('User is from Delhi', expect.anything());
+  });
+
+  it('retries with Title-Case and as-given word variants when the direct search finds nothing', async () => {
+    fake.longTerm.searchEntities.mockImplementation(async (q: string) =>
+      q === 'Delhi' ? [{ name: 'Fact', description: 'User is from Delhi.', type: 'fact' }] : [],
+    );
+
+    const hits = await retrieveMemories(fake as any, scope, 'conv-1', 'where do i live delhi', 5);
+
+    expect(fake.longTerm.searchEntities).toHaveBeenCalledWith('where do i live delhi', expect.anything());
+    // lowercase "delhi" as typed AND its Title-Case variant are both tried.
+    expect(fake.longTerm.searchEntities).toHaveBeenCalledWith('delhi', expect.anything());
+    expect(fake.longTerm.searchEntities).toHaveBeenCalledWith('Delhi', expect.anything());
+    expect(hits).toContainEqual(expect.objectContaining({ content: 'User is from Delhi.' }));
+  });
+
+  it('ranks noisy fallback candidates by word overlap with the original query', async () => {
+    fake.longTerm.searchEntities.mockImplementation(async (q: string) => {
+      if (q !== 'User') return [];
+      // A liberal substring match returns several "User..." entities — the one
+      // that shares the most words with the query should be ranked first.
+      return [
+        { name: 'e1', description: "User's name is Alex.", type: 'fact' },
+        { name: 'e2', description: 'User is from Delhi.', type: 'fact' },
+      ];
+    });
+
+    const hits = await retrieveMemories(fake as any, scope, 'conv-1', 'is the user from Delhi', 5);
+
+    const contents = hits.map(h => h.content);
+    expect(contents.indexOf('User is from Delhi.')).toBeLessThan(contents.indexOf("User's name is Alex."));
+  });
+
+  it('does not throw when both the direct search and a fallback term reject', async () => {
+    fake.longTerm.searchEntities.mockRejectedValue(new Error('boom'));
+
+    const hits = await retrieveMemories(fake as any, scope, 'conv-1', 'where is the user from', 5);
+
+    expect(hits).toEqual([]);
+  });
+
+  it('skips the fallback entirely when the query has no significant words', async () => {
+    const hits = await retrieveMemories(fake as any, scope, 'conv-1', 'hi ok', 5);
+
+    expect(fake.longTerm.searchEntities).toHaveBeenCalledTimes(1);
+    expect(hits).toEqual([]);
+  });
+});

--- a/typescript/packages/vercel-ai-provider/test/vercel-ai-provider-extract.test.ts
+++ b/typescript/packages/vercel-ai-provider/test/vercel-ai-provider-extract.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Graph extraction — entities and relationships extracted from a stored
+ * memory must land in the long-term graph via the real SDK API:
+ * addEntity(name, type, options) and addRelationship(sourceId, targetId, type).
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { makeFakeClient, type FakeClient } from './vercel-ai-provider-helpers';
+
+vi.mock('ai', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('ai')>()),
+  generateText: vi.fn(),
+}));
+
+import { generateText } from 'ai';
+import { createGraphExtractor } from '../src/vercel-ai-provider-extract';
+
+const mockedGenerateText = vi.mocked(generateText);
+
+const graphResult = (entities: any[], relationships: any[] = []) =>
+  ({ output: { entities, relationships } }) as any;
+
+let fake: FakeClient;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  fake = makeFakeClient();
+  vi.spyOn(console, 'warn').mockImplementation(() => {});
+});
+
+describe('createGraphExtractor', () => {
+  it('stores extracted entities and links them with positional addRelationship args', async () => {
+    mockedGenerateText.mockResolvedValue(graphResult(
+      [
+        { name: 'Alex', type: 'person', description: 'A user' },
+        { name: 'TechCorp', type: 'organization' },
+      ],
+      [{ from: 'Alex', to: 'TechCorp', type: 'WORKS_AT' }],
+    ));
+
+    const extract = createGraphExtractor({} as any);
+    await extract(fake as any, { content: 'Alex works at TechCorp', type: 'fact' });
+
+    expect(fake.longTerm.addEntity).toHaveBeenCalledWith('Alex', 'person', { description: 'A user' });
+    expect(fake.longTerm.addEntity).toHaveBeenCalledWith('TechCorp', 'organization', {
+      description: 'Alex works at TechCorp',
+    });
+    // SDK signature: addRelationship(sourceId, targetId, relationshipType)
+    expect(fake.longTerm.addRelationship).toHaveBeenCalledWith('ent-Alex', 'ent-TechCorp', 'WORKS_AT');
+  });
+
+  it('skips relationships whose endpoints were not extracted', async () => {
+    mockedGenerateText.mockResolvedValue(graphResult(
+      [{ name: 'Alex', type: 'person' }],
+      [{ from: 'Alex', to: 'Ghost', type: 'KNOWS' }],
+    ));
+
+    const extract = createGraphExtractor({} as any);
+    await extract(fake as any, { content: 'Alex', type: 'fact' });
+
+    expect(fake.longTerm.addRelationship).not.toHaveBeenCalled();
+  });
+
+  it('treats relationship write failures as non-fatal', async () => {
+    mockedGenerateText.mockResolvedValue(graphResult(
+      [
+        { name: 'A', type: 'concept' },
+        { name: 'B', type: 'concept' },
+      ],
+      [{ from: 'A', to: 'B', type: 'RELATES_TO' }],
+    ));
+    fake.longTerm.addRelationship.mockRejectedValue(new Error('write failed'));
+
+    const extract = createGraphExtractor({} as any);
+    await expect(
+      extract(fake as any, { content: 'A relates to B', type: 'fact' }),
+    ).resolves.toBeUndefined();
+  });
+
+  it('records confidence feedback on stored entities when provided', async () => {
+    mockedGenerateText.mockResolvedValue(graphResult([{ name: 'Alex', type: 'person' }]));
+
+    const extract = createGraphExtractor({} as any);
+    await extract(fake as any, { content: 'Alex', type: 'fact', confidence: 0.9 });
+
+    expect(fake.longTerm.setEntityFeedback).toHaveBeenCalledWith('ent-Alex', {
+      userScore: 0.9,
+      confirmed: true,
+    });
+  });
+});

--- a/typescript/packages/vercel-ai-provider/test/vercel-ai-provider-helpers.ts
+++ b/typescript/packages/vercel-ai-provider/test/vercel-ai-provider-helpers.ts
@@ -1,0 +1,111 @@
+/**
+ * Shared test doubles: a controllable fake MemoryClient and a minimal
+ * LanguageModelV3 stub that records the params it was called with.
+ */
+
+import { vi } from 'vitest';
+import type { LanguageModelV3 } from '@ai-sdk/provider';
+
+export interface FakeClient {
+  shortTerm: {
+    listConversations: ReturnType<typeof vi.fn>;
+    createConversation: ReturnType<typeof vi.fn>;
+    addMessage: ReturnType<typeof vi.fn>;
+    searchMessages: ReturnType<typeof vi.fn>;
+  };
+  longTerm: {
+    searchEntities: ReturnType<typeof vi.fn>;
+    getEntityByName: ReturnType<typeof vi.fn>;
+    addEntity: ReturnType<typeof vi.fn>;
+    setEntityFeedback: ReturnType<typeof vi.fn>;
+    addRelationship: ReturnType<typeof vi.fn>;
+  };
+  reasoning: {
+    listSteps: ReturnType<typeof vi.fn>;
+  };
+}
+
+export function makeFakeClient(): FakeClient {
+  return {
+    shortTerm: {
+      listConversations: vi.fn(async () => []),
+      createConversation: vi.fn(async ({ userId }: { userId: string }) => ({
+        id: `conv-${userId}`,
+      })),
+      addMessage: vi.fn(async () => ({ id: 'msg-1' })),
+      searchMessages: vi.fn(async () => []),
+    },
+    longTerm: {
+      searchEntities: vi.fn(async () => []),
+      getEntityByName: vi.fn(async () => null),
+      addEntity: vi.fn(async (name: string, type: string) => ({ id: `ent-${name}`, name, type })),
+      setEntityFeedback: vi.fn(async () => ({})),
+      addRelationship: vi.fn(async () => ({})),
+    },
+    reasoning: {
+      listSteps: vi.fn(async () => []),
+    },
+  };
+}
+
+export interface FakeModelResult {
+  capturedParams: any[];
+  model: LanguageModelV3;
+}
+
+/** A LanguageModelV3 stub whose doGenerate returns fixed text and records params. */
+export function makeFakeModel(
+  assistantText = 'Hello back',
+  streamChunks?: any[],
+): FakeModelResult {
+  const capturedParams: any[] = [];
+
+  const model = {
+    specificationVersion: 'v3',
+    provider: 'fake',
+    modelId: 'fake-model',
+    supportedUrls: {},
+    doGenerate: vi.fn(async (params: any) => {
+      capturedParams.push(params);
+      return {
+        content: [{ type: 'text', text: assistantText }],
+        finishReason: 'stop',
+        usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+        warnings: [],
+      };
+    }),
+    doStream: vi.fn(async (params: any) => {
+      capturedParams.push(params);
+      // V3 spelling: text-delta chunks carry `delta`.
+      const chunks = streamChunks ?? [
+        { type: 'text-delta', id: '1', delta: assistantText.slice(0, 5) },
+        { type: 'text-delta', id: '1', delta: assistantText.slice(5) },
+        { type: 'finish', finishReason: 'stop', usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 } },
+      ];
+      const stream = new ReadableStream({
+        start(controller) {
+          for (const chunk of chunks) controller.enqueue(chunk);
+          controller.close();
+        },
+      });
+      return { stream };
+    }),
+  } as unknown as LanguageModelV3;
+
+  return { capturedParams, model };
+}
+
+/** Drain a ReadableStream so middleware flush() runs. */
+export async function drainStream(stream: ReadableStream): Promise<any[]> {
+  const reader = stream.getReader();
+  const chunks: any[] = [];
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    chunks.push(value);
+  }
+  return chunks;
+}
+
+/** Wait for fire-and-forget persistence promises scheduled inside flush(). */
+export const settle = () => new Promise((r) => setTimeout(r, 0));

--- a/typescript/packages/vercel-ai-provider/test/vercel-ai-provider-middleware.test.ts
+++ b/typescript/packages/vercel-ai-provider/test/vercel-ai-provider-middleware.test.ts
@@ -1,0 +1,251 @@
+/**
+ * Middleware mode (createNamsMemory().wrap) — the contract points an adopter
+ * depends on when they wrap their model with NAMS memory (this same
+ * middleware also underpins provider mode via createNamsProvider):
+ *
+ *  1. relevant memories are injected into the prompt before the model runs
+ *  2. the prompt is left untouched when there are no memories
+ *  3. the user + assistant turn is persisted after generate
+ *  4. the streamed turn is persisted after the stream closes
+ *  5. retrieval failures are non-fatal — the model still answers
+ *  6. persistInteractions=false disables persistence
+ *  7. an explicit conversationId wins over lazy resolution
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { makeFakeClient, makeFakeModel, drainStream, settle, type FakeClient } from './vercel-ai-provider-helpers';
+
+const holder = vi.hoisted(() => ({ client: undefined as unknown }));
+
+vi.mock('@neo4j-labs/agent-memory', () => ({
+  MemoryClient: vi.fn().mockImplementation(() => holder.client),
+}));
+
+import { createNamsMemory } from '../src/vercel-ai-provider-middleware';
+
+let fake: FakeClient;
+let userCounter = 0;
+
+/** Unique per test — client.ts keeps a module-global conversation cache. */
+const freshUser = () => `user-${Date.now()}-${userCounter++}`;
+
+beforeEach(() => {
+  fake = makeFakeClient();
+  holder.client = fake;
+  vi.spyOn(console, 'log').mockImplementation(() => {});
+  vi.spyOn(console, 'warn').mockImplementation(() => {});
+});
+
+const userPrompt = (text: string) => [
+  { role: 'user', content: [{ type: 'text', text }] },
+];
+
+describe('middleware mode — memory injection', () => {
+  it('injects retrieved memories into the last user message', async () => {
+    fake.longTerm.searchEntities.mockResolvedValue([
+      { name: 'Alex', description: 'User is named Alex and works at TechCorp', type: 'person', score: 0.9 },
+    ]);
+
+    const { model, capturedParams } = makeFakeModel();
+    const wrapped = createNamsMemory({ apiKey: 'k' }).wrap(model, { userId: freshUser() });
+
+    await wrapped.doGenerate({ prompt: userPrompt('Where do I work?') } as any);
+
+    const prompt = capturedParams[0].prompt;
+    const lastUser = prompt[prompt.length - 1];
+    const text = lastUser.content.map((p: any) => p.text).join('');
+    expect(text).toContain('Relevant long-term memory');
+    expect(text).toContain('User is named Alex and works at TechCorp');
+    expect(text).toContain('Where do I work?');
+  });
+
+  it('leaves the prompt unchanged when no memories are found', async () => {
+    const { model, capturedParams } = makeFakeModel();
+    const wrapped = createNamsMemory({ apiKey: 'k' }).wrap(model, { userId: freshUser() });
+
+    await wrapped.doGenerate({ prompt: userPrompt('Hello') } as any);
+
+    const lastUser = capturedParams[0].prompt.at(-1);
+    const text = lastUser.content.map((p: any) => p.text).join('');
+    expect(text).toBe('Hello');
+  });
+
+  it('survives total retrieval failure and still calls the model', async () => {
+    fake.longTerm.searchEntities.mockRejectedValue(new Error('boom'));
+    fake.shortTerm.searchMessages.mockRejectedValue(new Error('boom'));
+    fake.reasoning.listSteps.mockRejectedValue(new Error('boom'));
+
+    const { model } = makeFakeModel();
+    const wrapped = createNamsMemory({ apiKey: 'k' }).wrap(model, { userId: freshUser() });
+
+    const result = await wrapped.doGenerate({ prompt: userPrompt('Hi') } as any);
+    expect((result as any).content[0].text).toBe('Hello back');
+  });
+});
+
+describe('middleware mode — persistence', () => {
+  it('persists the clean user text and the assistant response after generate', async () => {
+    // Memory hit ensures injection happens — persisted text must still be the original.
+    fake.longTerm.searchEntities.mockResolvedValue([
+      { name: 'Fact', description: 'Some stored fact', type: 'fact' },
+    ]);
+
+    const { model } = makeFakeModel('Graphs model relationships.');
+    const conversationId = 'conv-explicit';
+    const wrapped = createNamsMemory({ apiKey: 'k' }).wrap(model, {
+      userId: freshUser(),
+      conversationId,
+    });
+
+    await wrapped.doGenerate({ prompt: userPrompt('Tell me about graphs.') } as any);
+
+    const calls = fake.shortTerm.addMessage.mock.calls;
+    expect(calls).toContainEqual([conversationId, 'user', 'Tell me about graphs.']);
+    expect(calls).toContainEqual([conversationId, 'assistant', 'Graphs model relationships.']);
+    // The injected memory block must NOT leak into the persisted user message.
+    const persistedUser = calls.find((c) => c[1] === 'user')![2];
+    expect(persistedUser).not.toContain('Relevant long-term memory');
+  });
+
+  it('persists the accumulated text after a stream completes', async () => {
+    const { model } = makeFakeModel('Streamed answer');
+    const wrapped = createNamsMemory({ apiKey: 'k' }).wrap(model, {
+      userId: freshUser(),
+      conversationId: 'conv-stream',
+    });
+
+    const { stream } = await wrapped.doStream({ prompt: userPrompt('Stream it') } as any);
+    await drainStream(stream);
+    await settle();
+
+    const calls = fake.shortTerm.addMessage.mock.calls;
+    expect(calls).toContainEqual(['conv-stream', 'user', 'Stream it']);
+    expect(calls).toContainEqual(['conv-stream', 'assistant', 'Streamed answer']);
+  });
+
+  it('reassembles streamed tool-call args (object generation) for persistence', async () => {
+    const { model } = makeFakeModel('', [
+      { type: 'tool-call-delta', toolCallId: 't1', argsTextDelta: '{"city":' },
+      { type: 'tool-call-delta', toolCallId: 't1', argsTextDelta: '"Berlin"}' },
+      { type: 'finish', finishReason: 'tool-calls' },
+    ]);
+    const wrapped = createNamsMemory({ apiKey: 'k' }).wrap(model, {
+      userId: freshUser(),
+      conversationId: 'conv-obj',
+    });
+
+    const { stream } = await wrapped.doStream({ prompt: userPrompt('Weather?') } as any);
+    await drainStream(stream);
+    await settle();
+
+    expect(fake.shortTerm.addMessage.mock.calls).toContainEqual([
+      'conv-obj', 'assistant', '{"city":"Berlin"}',
+    ]);
+  });
+
+  it('handles V3 stream chunks: tool-input-delta and tool-call with input', async () => {
+    const { model } = makeFakeModel('', [
+      { type: 'tool-input-delta', id: 't1', delta: '{"city":' },
+      { type: 'tool-input-delta', id: 't1', delta: '"Berlin"}' },
+      // The full tool-call supersedes the deltas for the same id — no duplication.
+      { type: 'tool-call', toolCallId: 't1', toolName: 'weather', input: '{"city":"Berlin"}' },
+      { type: 'finish', finishReason: 'tool-calls' },
+    ]);
+    const wrapped = createNamsMemory({ apiKey: 'k' }).wrap(model, {
+      userId: freshUser(),
+      conversationId: 'conv-v3',
+    });
+
+    const { stream } = await wrapped.doStream({ prompt: userPrompt('Weather?') } as any);
+    await drainStream(stream);
+    await settle();
+
+    const assistantCall = fake.shortTerm.addMessage.mock.calls.find((c) => c[1] === 'assistant');
+    expect(assistantCall![2]).toBe('{"city":"Berlin"}');
+    // Regression: V3 tool-call chunks have `input`, not `args` — the literal
+    // string "undefined" must never be persisted.
+    expect(assistantCall![2]).not.toContain('undefined');
+  });
+
+  it('persists the same user message only once across multi-step tool loops', async () => {
+    const { model } = makeFakeModel('step answer');
+    const wrapped = createNamsMemory({ apiKey: 'k' }).wrap(model, {
+      userId: freshUser(),
+      conversationId: 'conv-loop',
+    });
+
+    // A tool loop calls doGenerate once per step with the same last user message.
+    await wrapped.doGenerate({ prompt: userPrompt('Run the tools') } as any);
+    await wrapped.doGenerate({ prompt: userPrompt('Run the tools') } as any);
+
+    const userCalls = fake.shortTerm.addMessage.mock.calls.filter((c) => c[1] === 'user');
+    expect(userCalls).toHaveLength(1);
+    const assistantCalls = fake.shortTerm.addMessage.mock.calls.filter((c) => c[1] === 'assistant');
+    expect(assistantCalls).toHaveLength(2);
+  });
+
+  it('does not persist when persistInteractions is false', async () => {
+    const { model } = makeFakeModel();
+    const wrapped = createNamsMemory({ apiKey: 'k', persistInteractions: false }).wrap(model, {
+      userId: freshUser(),
+      conversationId: 'conv-nopersist',
+    });
+
+    await wrapped.doGenerate({ prompt: userPrompt('Hi') } as any);
+
+    expect(fake.shortTerm.addMessage).not.toHaveBeenCalled();
+  });
+
+  it('forwards the generate result unchanged even when persistence fails', async () => {
+    fake.shortTerm.addMessage.mockRejectedValue(new Error('write failed'));
+
+    const { model } = makeFakeModel('Still fine');
+    const wrapped = createNamsMemory({ apiKey: 'k' }).wrap(model, {
+      userId: freshUser(),
+      conversationId: 'conv-failwrite',
+    });
+
+    const result = await wrapped.doGenerate({ prompt: userPrompt('Hi') } as any);
+    expect((result as any).content[0].text).toBe('Still fine');
+  });
+});
+
+describe('middleware mode — conversation resolution', () => {
+  it('uses an explicit conversationId without listing or creating conversations', async () => {
+    const { model } = makeFakeModel();
+    const wrapped = createNamsMemory({ apiKey: 'k' }).wrap(model, {
+      userId: freshUser(),
+      conversationId: 'conv-fixed',
+    });
+
+    await wrapped.doGenerate({ prompt: userPrompt('Hi') } as any);
+
+    expect(fake.shortTerm.createConversation).not.toHaveBeenCalled();
+    expect(fake.shortTerm.addMessage.mock.calls[0][0]).toBe('conv-fixed');
+  });
+
+  it('resumes the most recent conversation when none is supplied', async () => {
+    fake.shortTerm.listConversations.mockImplementation(async ({ limit }: { limit: number }) =>
+      limit === 1 ? [{ id: 'conv-resumed' }] : [],
+    );
+
+    const { model } = makeFakeModel();
+    const wrapped = createNamsMemory({ apiKey: 'k' }).wrap(model, { userId: freshUser() });
+
+    await wrapped.doGenerate({ prompt: userPrompt('Hi') } as any);
+
+    expect(fake.shortTerm.createConversation).not.toHaveBeenCalled();
+    expect(fake.shortTerm.addMessage.mock.calls[0][0]).toBe('conv-resumed');
+  });
+
+  it('creates a conversation when the user has none', async () => {
+    const userId = freshUser();
+    const { model } = makeFakeModel();
+    const wrapped = createNamsMemory({ apiKey: 'k' }).wrap(model, { userId });
+
+    await wrapped.doGenerate({ prompt: userPrompt('Hi') } as any);
+
+    expect(fake.shortTerm.createConversation).toHaveBeenCalledWith({ userId });
+    expect(fake.shortTerm.addMessage.mock.calls[0][0]).toBe(`conv-${userId}`);
+  });
+});

--- a/typescript/packages/vercel-ai-provider/test/vercel-ai-provider-tools.test.ts
+++ b/typescript/packages/vercel-ai-provider/test/vercel-ai-provider-tools.test.ts
@@ -1,0 +1,190 @@
+/**
+ * Tools mode — query_memory / store_memory as model-driven AI SDK tools.
+ *
+ * Contract points:
+ *  - query_memory returns found=true with hits, found=false when empty
+ *  - store_memory(interaction) → short-term message
+ *  - store_memory(fact) → long-term entity + confidence feedback
+ *  - existing entities are reused, not duplicated
+ *  - a storage failure reports stored=false instead of throwing into the loop
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { makeFakeClient, type FakeClient } from './vercel-ai-provider-helpers';
+
+const holder = vi.hoisted(() => ({ client: undefined as unknown }));
+
+vi.mock('@neo4j-labs/agent-memory', () => ({
+  MemoryClient: vi.fn().mockImplementation(() => holder.client),
+}));
+
+import { createNamsMemoryTools } from '../src/vercel-ai-provider-tools';
+import type { QueryOutput, StoreOutput } from '../src/vercel-ai-provider-tools';
+
+let fake: FakeClient;
+let userCounter = 0;
+const freshUser = () => `tools-user-${Date.now()}-${userCounter++}`;
+
+const toolOptions = { toolCallId: 'call-1', messages: [] } as any;
+
+/** Tool execute() is typed T | AsyncIterable<T>; our tools always return T. */
+async function callTool<T>(t: { execute?: unknown }, input: unknown): Promise<T> {
+  return (await (t.execute as (i: unknown, o: unknown) => Promise<unknown>)(input, toolOptions)) as T;
+}
+
+beforeEach(() => {
+  fake = makeFakeClient();
+  holder.client = fake;
+  vi.spyOn(console, 'log').mockImplementation(() => {});
+  vi.spyOn(console, 'warn').mockImplementation(() => {});
+  vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+describe('query_memory', () => {
+  it('returns found=true with ranked memories', async () => {
+    fake.longTerm.searchEntities.mockResolvedValue([
+      { name: 'Alex', description: 'User is named Alex', type: 'person', confidence: 0.92 },
+    ]);
+    fake.shortTerm.searchMessages.mockResolvedValue([
+      { content: 'I love terse answers' },
+    ]);
+
+    const { query_memory } = createNamsMemoryTools({
+      apiKey: 'k',
+      userId: freshUser(),
+      conversationId: 'conv-q',
+    });
+
+    const out = await callTool<QueryOutput>(query_memory, { query: 'who am I', limit: 5 });
+
+    expect(out.found).toBe(true);
+    expect(out.count).toBe(2);
+    // Scores present → sorted descending, long-term hit first.
+    expect(out.memories[0]).toMatchObject({ content: 'User is named Alex', source: 'long-term' });
+    expect(out.memories[1]).toMatchObject({ content: 'I love terse answers', source: 'conversation' });
+  });
+
+  it('returns found=false when nothing matches', async () => {
+    const { query_memory } = createNamsMemoryTools({
+      apiKey: 'k',
+      userId: freshUser(),
+      conversationId: 'conv-q2',
+    });
+
+    const out = await callTool<QueryOutput>(query_memory, { query: 'anything', limit: 5 });
+
+    expect(out.found).toBe(false);
+    expect(out.memories).toEqual([]);
+    expect(out.message).toMatch(/no relevant memories/i);
+  });
+
+  it('deduplicates identical content across sources', async () => {
+    fake.longTerm.searchEntities.mockResolvedValue([
+      { name: 'x', description: 'duplicate fact', type: 'fact' },
+    ]);
+    fake.shortTerm.searchMessages.mockResolvedValue([{ content: 'duplicate fact' }]);
+
+    const { query_memory } = createNamsMemoryTools({
+      apiKey: 'k',
+      userId: freshUser(),
+      conversationId: 'conv-q3',
+    });
+
+    const out = await callTool<QueryOutput>(query_memory, { query: 'dup', limit: 5 });
+    expect(out.memories).toHaveLength(1);
+  });
+
+  it('caps the number of returned memories at the requested limit', async () => {
+    fake.longTerm.searchEntities.mockResolvedValue(
+      Array.from({ length: 5 }, (_, i) => ({ name: `e${i}`, description: `fact ${i}`, type: 'fact' })),
+    );
+    fake.shortTerm.searchMessages.mockResolvedValue(
+      Array.from({ length: 5 }, (_, i) => ({ content: `message ${i}` })),
+    );
+
+    const { query_memory } = createNamsMemoryTools({
+      apiKey: 'k',
+      userId: freshUser(),
+      conversationId: 'conv-q4',
+    });
+
+    const out = await callTool<QueryOutput>(query_memory, { query: 'lots', limit: 3 });
+    expect(out.memories).toHaveLength(3);
+  });
+});
+
+describe('store_memory', () => {
+  it('stores an interaction as a short-term message', async () => {
+    const { store_memory } = createNamsMemoryTools({
+      apiKey: 'k',
+      userId: freshUser(),
+      conversationId: 'conv-s1',
+    });
+
+    const out = await callTool<StoreOutput>(store_memory,
+      { content: 'User asked about pricing', type: 'interaction', confidence: 0.7, tags: [] },
+    );
+
+    expect(out.stored).toBe(true);
+    expect(fake.shortTerm.addMessage).toHaveBeenCalledWith(
+      'conv-s1', 'assistant', 'User asked about pricing',
+    );
+    expect(fake.longTerm.addEntity).not.toHaveBeenCalled();
+  });
+
+  it('stores a fact as a long-term entity with confidence feedback', async () => {
+    const { store_memory } = createNamsMemoryTools({
+      apiKey: 'k',
+      userId: freshUser(),
+      conversationId: 'conv-s2',
+    });
+
+    const out = await callTool<StoreOutput>(store_memory,
+      { content: 'Prefers dark mode', type: 'user_preference', confidence: 0.9, tags: [] },
+    );
+
+    expect(out.stored).toBe(true);
+    expect(fake.longTerm.addEntity).toHaveBeenCalledWith(
+      'Prefers dark mode', 'user_preference', { description: 'Prefers dark mode' },
+    );
+    expect(fake.longTerm.setEntityFeedback).toHaveBeenCalledWith(
+      'ent-Prefers dark mode', { userScore: 0.9, confirmed: true },
+    );
+  });
+
+  it('reuses an existing entity instead of duplicating it', async () => {
+    fake.longTerm.getEntityByName.mockResolvedValue({ id: 'ent-existing', name: 'Prefers dark mode' });
+
+    const { store_memory } = createNamsMemoryTools({
+      apiKey: 'k',
+      userId: freshUser(),
+      conversationId: 'conv-s3',
+    });
+
+    await callTool<StoreOutput>(store_memory,
+      { content: 'Prefers dark mode', type: 'fact', confidence: 0.7, tags: [] },
+    );
+
+    expect(fake.longTerm.addEntity).not.toHaveBeenCalled();
+    expect(fake.longTerm.setEntityFeedback).toHaveBeenCalledWith(
+      'ent-existing', expect.objectContaining({ userScore: 0.7 }),
+    );
+  });
+
+  it('reports stored=false on failure instead of throwing', async () => {
+    fake.shortTerm.addMessage.mockRejectedValue(new Error('write failed'));
+
+    const { store_memory } = createNamsMemoryTools({
+      apiKey: 'k',
+      userId: freshUser(),
+      conversationId: 'conv-s4',
+    });
+
+    const out = await callTool<StoreOutput>(store_memory,
+      { content: 'x', type: 'interaction', confidence: 0.7, tags: [] },
+    );
+
+    expect(out.stored).toBe(false);
+    expect(out.message).toMatch(/failed/i);
+  });
+});

--- a/typescript/packages/vercel-ai-provider/test/vercel-ai-provider-tools.test.ts
+++ b/typescript/packages/vercel-ai-provider/test/vercel-ai-provider-tools.test.ts
@@ -18,7 +18,23 @@ vi.mock('@neo4j-labs/agent-memory', () => ({
   MemoryClient: vi.fn().mockImplementation(() => holder.client),
 }));
 
-import { createNamsMemoryTools } from '../src/vercel-ai-provider-tools';
+const mcpHolder = vi.hoisted(() => ({
+  tools: {} as Record<string, unknown>,
+  close: vi.fn(),
+}));
+
+vi.mock('@ai-sdk/mcp', () => ({
+  createMCPClient: vi.fn().mockResolvedValue({
+    tools: () => Promise.resolve(mcpHolder.tools),
+    close: mcpHolder.close,
+  }),
+}));
+
+import {
+  createNamsMemoryTools,
+  createNamsTools,
+  enforceQueryMemory,
+} from '../src/vercel-ai-provider-tools';
 import type { QueryOutput, StoreOutput } from '../src/vercel-ai-provider-tools';
 
 let fake: FakeClient;
@@ -186,5 +202,79 @@ describe('store_memory', () => {
 
     expect(out.stored).toBe(false);
     expect(out.message).toMatch(/failed/i);
+  });
+});
+
+describe('enforceQueryMemory', () => {
+  const stepOptions = (stepNumber: number, toolNames: string[][] = []) => ({
+    stepNumber,
+    steps: toolNames.map(names => ({ toolCalls: names.map(toolName => ({ toolName })) })) as never,
+    model: {} as never,
+    messages: [],
+    experimental_context: undefined,
+  });
+
+  it('requires a tool call while query_memory has not been executed', async () => {
+    const prepareStep = enforceQueryMemory();
+    expect(await prepareStep(stepOptions(0))).toEqual({ toolChoice: 'required' });
+    // Other tools ran, but query_memory still hasn't → still constrained.
+    expect(await prepareStep(stepOptions(2, [['read_file'], ['mcp_search']])))
+      .toEqual({ toolChoice: 'required' });
+  });
+
+  it('forces query_memory directly once the grace window is exhausted', async () => {
+    const prepareStep = enforceQueryMemory();  // default graceSteps: 3
+    expect(await prepareStep(stepOptions(3, [['read_file'], ['mcp_search'], ['read_file']])))
+      .toEqual({ toolChoice: { type: 'tool', toolName: 'query_memory' } });
+  });
+
+  it('drops all constraints once query_memory has been executed', async () => {
+    const prepareStep = enforceQueryMemory();
+    expect(await prepareStep(stepOptions(2, [['read_file'], ['query_memory']]))).toBeUndefined();
+    // Parallel call in the same step counts too.
+    expect(await prepareStep(stepOptions(1, [['read_file', 'query_memory']]))).toBeUndefined();
+    // Even past the grace window, no constraint once queried.
+    expect(await prepareStep(stepOptions(4, [['read_file'], ['query_memory'], ['read_file']])))
+      .toBeUndefined();
+  });
+
+  it('graceSteps: 0 forces query_memory as the very first step', async () => {
+    const prepareStep = enforceQueryMemory({ graceSteps: 0 });
+    expect(await prepareStep(stepOptions(0)))
+      .toEqual({ toolChoice: { type: 'tool', toolName: 'query_memory' } });
+    expect(await prepareStep(stepOptions(1, [['query_memory']]))).toBeUndefined();
+  });
+});
+
+describe('createNamsTools with MCP', () => {
+  it('prefixes MCP tool names when toolPrefix is set', async () => {
+    mcpHolder.tools = { search: { description: 'mcp search' }, query_memory: { description: 'mcp memory' } };
+
+    const { tools } = await createNamsTools({
+      apiKey: 'k',
+      userId: freshUser(),
+      mcp: { url: 'https://mcp.example.com/mcp', toolPrefix: 'mcp_' },
+    });
+
+    expect(Object.keys(tools).sort()).toEqual(
+      ['mcp_query_memory', 'mcp_search', 'query_memory', 'store_memory'],
+    );
+    // NAMS query_memory is intact, not shadowed by the MCP tool of the same name.
+    expect((tools.query_memory as { description?: string }).description).toMatch(/NAMS/);
+  });
+
+  it('warns on collision when no prefix is set and MCP tool wins', async () => {
+    mcpHolder.tools = { query_memory: { description: 'mcp memory' } };
+    const warn = vi.fn();
+
+    const { tools } = await createNamsTools({
+      apiKey: 'k',
+      userId: freshUser(),
+      logger: { warn, error: vi.fn() },
+      mcp: { url: 'https://mcp.example.com/mcp' },
+    });
+
+    expect((tools.query_memory as { description?: string }).description).toBe('mcp memory');
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('toolPrefix'));
   });
 });

--- a/typescript/packages/vercel-ai-provider/test/vercel-ai-provider.test.ts
+++ b/typescript/packages/vercel-ai-provider/test/vercel-ai-provider.test.ts
@@ -1,0 +1,75 @@
+/**
+ * ProviderV3 surface — what the Vercel AI SDK (and createProviderRegistry)
+ * expects from a community provider:
+ *
+ *  - specificationVersion 'v3'
+ *  - languageModel(id) delegates to the base provider and wraps it with memory
+ *  - embeddingModel / imageModel throw NoSuchModelError (memory-only provider)
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { NoSuchModelError } from '@ai-sdk/provider';
+import { makeFakeClient, makeFakeModel, type FakeClient } from './vercel-ai-provider-helpers';
+
+const holder = vi.hoisted(() => ({ client: undefined as unknown }));
+
+vi.mock('@neo4j-labs/agent-memory', () => ({
+  MemoryClient: vi.fn().mockImplementation(() => holder.client),
+}));
+
+import { createNamsProvider } from '../src/vercel-ai-provider';
+
+let fake: FakeClient;
+let userCounter = 0;
+const freshUser = () => `prov-user-${Date.now()}-${userCounter++}`;
+
+beforeEach(() => {
+  fake = makeFakeClient();
+  holder.client = fake;
+  vi.spyOn(console, 'log').mockImplementation(() => {});
+  vi.spyOn(console, 'warn').mockImplementation(() => {});
+});
+
+describe('createNamsProvider', () => {
+  it('exposes specificationVersion v3', () => {
+    const provider = createNamsProvider({
+      apiKey: 'k',
+      baseProvider: () => makeFakeModel().model,
+      scope: { userId: freshUser() },
+    });
+    expect(provider.specificationVersion).toBe('v3');
+  });
+
+  it('languageModel(id) calls the base provider with the model id and wraps it', async () => {
+    const { model, capturedParams } = makeFakeModel();
+    const baseProvider = vi.fn(() => model);
+
+    const provider = createNamsProvider({
+      apiKey: 'k',
+      baseProvider,
+      scope: { userId: freshUser(), conversationId: 'conv-p' },
+    });
+
+    const wrapped = provider.languageModel('gpt-test');
+    expect(baseProvider).toHaveBeenCalledWith('gpt-test');
+    expect(wrapped.specificationVersion).toBe('v3');
+
+    // The wrapped model still generates and persists through NAMS.
+    await wrapped.doGenerate({
+      prompt: [{ role: 'user', content: [{ type: 'text', text: 'ping' }] }],
+    } as any);
+    expect(capturedParams).toHaveLength(1);
+    expect(fake.shortTerm.addMessage).toHaveBeenCalledWith('conv-p', 'user', 'ping');
+  });
+
+  it('throws NoSuchModelError for embedding and image models', () => {
+    const provider = createNamsProvider({
+      apiKey: 'k',
+      baseProvider: () => makeFakeModel().model,
+      scope: { userId: freshUser() },
+    });
+
+    expect(() => provider.embeddingModel('text-embedding-3-small')).toThrow(NoSuchModelError);
+    expect(() => provider.imageModel('dall-e-3')).toThrow(NoSuchModelError);
+  });
+});

--- a/typescript/packages/vercel-ai-provider/tsconfig.json
+++ b/typescript/packages/vercel-ai-provider/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2020", "dom"],
+    "strict": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "dist",
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "types": ["node"]
+  },
+  "include": ["src", "test", "examples"]
+}

--- a/typescript/packages/vercel-ai-provider/tsup.config.ts
+++ b/typescript/packages/vercel-ai-provider/tsup.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  // ESM-only: the @neo4j-labs/agent-memory peer is ESM-only (no `require`
+  // export condition), so a CJS build of this package cannot work at runtime.
+  format: ['esm'],
+  dts: true,
+  sourcemap: true,
+  clean: true,
+  treeshake: true,
+  // Peer dependencies (including the optional @ai-sdk/mcp) are externalized
+  // automatically by tsup — no explicit list needed.
+});

--- a/typescript/packages/vercel-ai-provider/tsup.config.ts
+++ b/typescript/packages/vercel-ai-provider/tsup.config.ts
@@ -9,6 +9,6 @@ export default defineConfig({
   sourcemap: true,
   clean: true,
   treeshake: true,
-  // Peer dependencies (including the optional @ai-sdk/mcp) are externalized
-  // automatically by tsup — no explicit list needed.
+  // Keep peer deps external to avoid bundling duplicates into dist.
+  external: ['ai', '@ai-sdk/provider', '@neo4j-labs/agent-memory', 'zod', '@ai-sdk/mcp'],
 });

--- a/typescript/packages/vercel-ai-provider/vitest.config.ts
+++ b/typescript/packages/vercel-ai-provider/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['test/**/*.test.ts'],
+    environment: 'node',
+  },
+});


### PR DESCRIPTION
A new TypeScript package located at typescript/packages/vercel-ai-provider that gives Vercel AI SDK applications persistent, cross-session agent memory backed by Neo4j through @neo4j-labs/agent-memory.

The package supports **three** integration modes using a shared client layer:

A) _**Provider Mode**_ – createNamsProvider(...) Registers as a ProviderV3. Memory is automatically retrieved and persisted on every model call.

B) _**Middleware Mode**_ – createNams(...).wrap(model, scope) Wraps an existing model instance. Provides transparent memory retrieval and storage without generating tool calls.

C) _**Tools Mode**_ – createNams(...).tools(scope) Enables model-driven memory through query_memory and store_memory AI SDK tools. toolsWithMcp(scope, mcp) can optionally merge memory tools with tools from an MCP server.

All integration modes share common client components including makeClient, retrieveMemories, storeMemory, and conversation resolution logic. The package also includes an optional LLM-powered graph extraction capability through createGraphExtractor, which performs entity extraction before storing memories.

Package details

- Peer dependencies: ai >=6, @ai-sdk/provider >=3, @neo4j-labs/agent-memory >=0.4, zod >=3; @ai-sdk/mcp is an         optional peer (only needed for toolsWithMcp)
- Build: tsup (ESM + type declarations), Node >= 20
- Tests: four Vitest suites covering the provider, middleware, tools, and extraction paths, plus shared test helpers
- Examples: basic-chat, middleware-chat, tools-chat, and a Next.js chat route handler

CI / release wiring

- ci-typescript.yml: new vercel-ai-provider job (Node 20 + 22 matrix: typecheck → test → build → npm pack --dry-run) and the vercel-ai example added to the example type-check matrix
- New publish-nams-ai-provider.yml: tag-triggered (nams-ai-provider-v*) npm publish with --provenance, followed by an auto-generated GitHub Release — consistent with the repo's existing tag-namespaced release scheme (python-v*, typescript-v*)

Testing

- npm run typecheck, npm test, and npm run build pass in the package (also enforced by the new CI job)
- Example projects type-check against the built SDK in CI