### PR TITLE
Add POST /v1/relationships and GET /v1/entities/by-name (REST/SDK parity)

### DIFF
--- a/docs/modules/ROOT/pages/explanation/backends.adoc
+++ b/docs/modules/ROOT/pages/explanation/backends.adoc
@@ -94,14 +94,20 @@ This is the canonical capability reference. Backend-sensitive how-to pages link 
 | No | Yes
 | `client.long_term.add_entity` / `search_entities`
 | Yes (with dedup) | Yes (server-side dedup)
+| `client.long_term.get_entity_by_name`
+| Yes (exact match) | Yes (resolver-normalized: case/punctuation/suffix-insensitive + aliases)
+| `client.long_term.add_relationship` / `get_related_entities`
+| Yes | Yes (types outside the workspace vocabulary collapse to `RELATED_TO`; reads are 1-hop — `depth > 1` raises)
 | `client.long_term.set_entity_feedback` / `get_entity_history`
 | No | Yes
 | `client.long_term.get_entity_provenance`
 | Yes | Yes
 | `client.long_term.geocode_locations` / `search_locations_near`
 | Yes | No
-| `client.long_term.find_potential_duplicates` / `merge_duplicate_entities`
+| `client.long_term.find_potential_duplicates`
 | Yes | (handled server-side)
+| `client.long_term.merge_duplicate_entities`
+| Yes | Yes (returns the surviving entity, not a tuple)
 | `client.reasoning.start_trace` / `add_step` / `record_tool_call`
 | Yes | Yes
 | `client.reasoning.get_tool_stats`

--- a/docs/modules/ROOT/pages/explanation/resolution-deduplication.adoc
+++ b/docs/modules/ROOT/pages/explanation/resolution-deduplication.adoc
@@ -8,7 +8,7 @@
 
 Understanding how agent memory systems handle duplicate and variant entity references to maintain data quality.
 
-NOTE: The resolution and deduplication strategies here are *client-side*, configurable on the *bolt* backend. On *NAMS*, resolution and dedup run server-side automatically: `add_entity` runs the full resolution cascade synchronously and reports a `resolution` outcome (`created` / `merged` / `review_pending`), with ambiguous matches landing in a `SAME_AS` review queue. The manual review APIs (`find_potential_duplicates`, `merge_duplicate_entities`) are bolt-only. See xref:explanation/backends.adoc#capability-matrix[Bolt vs NAMS].
+NOTE: The resolution and deduplication strategies here are *client-side*, configurable on the *bolt* backend. On *NAMS*, resolution and dedup run server-side automatically: `add_entity` runs the full resolution cascade synchronously and reports a `resolution` outcome (`created` / `merged` / `review_pending`), with ambiguous matches landing in a `SAME_AS` review queue. The manual review API (`find_potential_duplicates`) is bolt-only; `merge_duplicate_entities` works on both backends (on NAMS it composes `POST /v1/entities/{id}/merge` and returns the surviving entity). See xref:explanation/backends.adoc#capability-matrix[Bolt vs NAMS].
 
 == The Entity Resolution Problem
 

--- a/docs/modules/ROOT/pages/how-to/migrate-to-nams.adoc
+++ b/docs/modules/ROOT/pages/how-to/migrate-to-nams.adoc
@@ -83,8 +83,8 @@ Search your codebase for any of these patterns — they need replacement or guar
 | Cannot port; consider keeping that pipeline on bolt.
 | `client.long_term.geocode_locations()`, `search_locations_near()`, etc.
 | Not available on NAMS; keep on bolt or pre-geocode at ingest.
-| `client.long_term.find_potential_duplicates()`, `merge_duplicate_entities()`, `review_duplicate()`
-| Removed by NAMS (server handles dedup automatically).
+| `client.long_term.find_potential_duplicates()`, `review_duplicate()`
+| Removed by NAMS (server handles dedup automatically). `merge_duplicate_entities()` still works — on NAMS it composes the hosted merge endpoint and returns the surviving `Entity` (not a `(source, target)` tuple).
 | `await client.get_stats()` / `get_graph()` / `get_locations()`
 | Use `client.query.cypher` with a counting / traversal query, or skip.
 |===
@@ -157,9 +157,12 @@ What raises on each backend, with workarounds:
 | `client.long_term.search_locations_near()`, `search_locations_in_bounding_box()`, `get_location_coordinates()`
 | Method call raises
 | Same — no NAMS analog.
-| `client.long_term.find_potential_duplicates()`, `merge_duplicate_entities()`, `review_duplicate()`, `get_same_as_cluster()`, `get_deduplication_stats()`
+| `client.long_term.find_potential_duplicates()`, `review_duplicate()`, `get_same_as_cluster()`, `get_deduplication_stats()`
 | Method call raises
-| NAMS handles dedup server-side; the surface isn't exposed.
+| NAMS handles dedup server-side; the review surface isn't exposed. `merge_duplicate_entities(source_id, target_id, canonical_name=...)` IS supported — it merges via `POST /v1/entities/{id}/merge` and returns the surviving `Entity`.
+| `client.long_term.get_related_entities(..., depth=2)`
+| Raises for `depth > 1` only
+| The NAMS REST API inlines 1-hop relationships on `GET /v1/entities/{id}`. Chain 1-hop calls or use bolt for deeper traversal.
 | `client.long_term.register_extractor()`, `link_entity_to_message()`, `link_entity_to_extractor()`, `list_extractors()`
 | Method call raises
 | Provenance is server-managed; query via `get_entity_provenance(entity_id)`.

--- a/docs/modules/ROOT/pages/how-to/use-nams.adoc
+++ b/docs/modules/ROOT/pages/how-to/use-nams.adoc
@@ -230,7 +230,7 @@ These accessors / methods raise `NotSupportedError` because NAMS handles them se
 * `client.consolidation` (dedupe / archival).
 * `client.schema.adopt_existing_graph()`.
 * `client.long_term.geocode_locations()`, `search_locations_near()`, `search_locations_in_bounding_box()`.
-* `client.long_term.find_potential_duplicates()`, `merge_duplicate_entities()`, `review_duplicate()`.
+* `client.long_term.find_potential_duplicates()`, `review_duplicate()`. (`merge_duplicate_entities()` IS supported — it composes `POST /v1/entities/{id}/merge` + an optional canonical-name rename.)
 * `client.get_stats()`, `client.get_graph()`, `client.get_locations()`.
 
 If you configure client-side `embedding`, `extraction`, `resolution`, `geocoding`, or `enrichment` alongside `backend="nams"`, you'll see a single `UserWarning` at `connect()` time naming the inactive layers — the configs are otherwise ignored (NAMS manages these server-side).

--- a/docs/modules/ROOT/pages/reference/typescript-api.adoc
+++ b/docs/modules/ROOT/pages/reference/typescript-api.adoc
@@ -196,16 +196,16 @@ Entities (POLE+O), preferences, facts, relationships.
 |Semantic search over preferences, with optional category filter.
 
 |`getEntityByName(name)`
-|Look up an entity by exact name (returns `null` if not found).
+|Look up an entity by name (resolver-normalized: case/punctuation/corporate-suffix-insensitive, aliases count; returns `null` if not found).
 
 |`getRelatedEntities(entityId, options?)`
-|Walk relationships outward from a given entity.
+|Walk relationships outward from a given entity. On the hosted REST API this is 1-hop; `depth > 1` throws `NotSupportedError`.
 
 |`addRelationship(sourceId, targetId, relationshipType, options?)`
-|Create a typed relationship between two entities.
+|Create a typed relationship between two entities. Types outside the workspace's allowed-relations vocabulary collapse to `RELATED_TO` server-side (the original name is kept as the edge's `predicate`).
 
 |`mergeDuplicateEntities(sourceId, targetId, options?)`
-|Merge `source` into `target`; aliases the source name onto target.
+|Merge `source` into `target` and return the surviving entity; pass `canonicalName` to rename it in the same call.
 
 |`listEntities(options?)` _(hosted)_
 |Enumerate entities, optionally filtered by type, with pagination.

--- a/src/neo4j_agent_memory/nams/long_term.py
+++ b/src/neo4j_agent_memory/nams/long_term.py
@@ -502,16 +502,23 @@ class NamsLongTermMemory:
         raises :class:`NotSupportedError`.
         """
         depth = kwargs.get("depth")
-        if depth is not None and int(depth) > 1:
-            raise NotSupportedError(
-                backend="nams",
-                method="LongTermMemory.get_related_entities",
-                message=(
-                    "depth > 1 is not supported on the NAMS REST API — "
-                    "GET /v1/entities/{id} inlines 1-hop relationships only."
-                ),
-                workaround="Use the bolt backend for multi-hop traversal, or chain 1-hop calls.",
-            )
+        if depth is not None:
+            try:
+                depth_int = int(depth)
+            except (TypeError, ValueError) as exc:
+                raise ValueError(
+                    f"depth must be an integer, got {depth!r}"
+                ) from exc
+            if depth_int > 1:
+                raise NotSupportedError(
+                    backend="nams",
+                    method="LongTermMemory.get_related_entities",
+                    message=(
+                        "depth > 1 is not supported on the NAMS REST API — "
+                        "GET /v1/entities/{id} inlines 1-hop relationships only."
+                    ),
+                    workaround="Use the bolt backend for multi-hop traversal, or chain 1-hop calls.",
+                )
         rel_types = kwargs.get("relationship_types")
         single = kwargs.get("relationship_type")
         if single is not None:

--- a/src/neo4j_agent_memory/nams/long_term.py
+++ b/src/neo4j_agent_memory/nams/long_term.py
@@ -2,9 +2,9 @@
 
 Endpoint mappings verified against the live NAMS OpenAPI spec.
 
-NAMS provides first-class **Entity** endpoints only. Preferences,
-facts, and entity relationships are NOT exposed as dedicated REST
-endpoints — those features must go through the Cypher console
+NAMS provides first-class **Entity** and **relationship** endpoints.
+Preferences and facts are NOT exposed as dedicated REST endpoints —
+those features must go through the Cypher console
 (``client.query.cypher``) or are out of scope on NAMS entirely.
 
 Methods that raise :class:`NotSupportedError`:
@@ -12,8 +12,7 @@ Methods that raise :class:`NotSupportedError`:
 * ``add_preference``, ``search_preferences``, ``get_preferences_for``,
   ``supersede_preference``
 * ``add_fact``, ``search_facts``, ``get_facts_about``
-* ``add_relationship``, ``get_entity_relationships``,
-  ``get_related_entities``
+* ``get_related_entities`` with ``depth > 1`` (the REST API is 1-hop)
 
 NAMS-specific endpoint shapes vs. our Protocol:
 
@@ -21,6 +20,14 @@ NAMS-specific endpoint shapes vs. our Protocol:
   aliases, attributes, confidence (those are bolt-only).
 * Entity search returns ``{"entities": [...], "searchType": ...}``
   envelope.
+* ``POST /v1/relationships`` validates the relationship type against the
+  workspace's allowed-relations vocabulary — unknown types collapse to
+  ``RELATED_TO`` with the caller's name preserved as ``predicate``
+  (ADR-0016; mirrors the MCP ``memory_create_relation`` tool).
+* ``GET /v1/entities/by-name`` is resolver-normalized (case/punctuation/
+  corporate-suffix-insensitive + aliases) and returns an ordered
+  ``{"entities": [...]}`` list, best match first — 200 with an empty
+  list when nothing matches, never 404.
 * Entity feedback is **PUT** not POST, body
   ``{userScore?, confirmed?}`` (no free-form ``feedback`` string).
 * Entity provenance lives under ``/v1/reasoning/provenance/{entityId}``
@@ -95,6 +102,12 @@ _SPEC_EXPAND_GRAPH = EndpointSpec(
 )
 _SPEC_SEARCH_ENTITIES = EndpointSpec(
     rest_method="POST", rest_path="/entities/search", bridge_method="search_entities"
+)
+_SPEC_GET_ENTITY_BY_NAME = EndpointSpec(
+    rest_method="GET", rest_path="/entities/by-name", bridge_method="get_entity_by_name"
+)
+_SPEC_ADD_RELATIONSHIP = EndpointSpec(
+    rest_method="POST", rest_path="/relationships", bridge_method="add_relationship"
 )
 
 # Entity provenance is under the reasoning namespace per verified spec.
@@ -192,9 +205,9 @@ def _normalize_entity(payload: dict[str, Any] | None) -> dict[str, Any]:
 class NamsLongTermMemory:
     """Long-term memory backed by the NAMS HTTP service.
 
-    Provides entity operations only (NAMS exposes no first-class
-    preference / fact / relationship endpoints). Other Protocol methods
-    raise :class:`NotSupportedError`.
+    Provides entity and relationship operations (NAMS exposes no
+    first-class preference / fact endpoints). Preference / fact Protocol
+    methods raise :class:`NotSupportedError`.
     """
 
     def __init__(self, transport: HttpTransport) -> None:
@@ -255,17 +268,50 @@ class NamsLongTermMemory:
         relationship_type: str,
         target_id: UUID | str,
         **kwargs: Any,
-    ) -> None:
-        raise NotSupportedError(
-            backend="nams",
-            method="LongTermMemory.add_relationship",
-            message=(
-                "NAMS does not expose a relationships endpoint. Relationships "
-                "are accessible read-only via get_entity(id) which inlines "
-                "them in the response."
-            ),
-            workaround="For write-side relationship support, use the bolt backend.",
+    ) -> Relationship:
+        """Create a typed relationship between two entities.
+
+        ``POST /v1/relationships``. The type is validated against the
+        workspace's allowed-relations vocabulary server-side: an unknown
+        type **collapses** to ``RELATED_TO`` (the caller's original name is
+        preserved on the edge as ``predicate``), so the returned
+        :class:`Relationship` carries the type that was actually written.
+        Re-asserting an existing ``(source, type, target)`` edge is
+        idempotent (confidence is averaged server-side).
+
+        Supported kwargs: ``confidence`` (0..1] and ``properties`` (alias
+        ``attributes``) — extra edge properties with scalar or scalar-list
+        values; the keys ``id``/``confidence``/``method``/``predicate``/
+        ``firstSeenAt``/``lastSeenAt`` are reserved and rejected with
+        :class:`ValidationError`. Bolt-only kwargs (``description``,
+        ``valid_from``, ``valid_until``) are silently dropped.
+        """
+        properties = kwargs.get("properties")
+        if properties is None:
+            properties = kwargs.get("attributes")
+        body = _drop_none(
+            {
+                "sourceId": _to_str(source_id),
+                "targetId": _to_str(target_id),
+                "relationshipType": relationship_type,
+                "confidence": kwargs.get("confidence"),
+                "properties": properties,
+            }
         )
+        payload = await self._transport.request(_SPEC_ADD_RELATIONSHIP, json=body)
+        data = snakeize_keys(payload) if isinstance(payload, dict) else {}
+        normalized = _drop_none(
+            {
+                "id": data.get("id"),
+                "source_id": data.get("source_id") or _to_str(source_id),
+                "target_id": data.get("target_id") or _to_str(target_id),
+                # The WRITTEN type — RELATED_TO when the server collapsed it.
+                "type": data.get("relationship_type") or relationship_type,
+                "confidence": data.get("confidence"),
+                "attributes": dict(properties or {}),
+            }
+        )
+        return payload_to_model(normalized, Relationship)
 
     async def search_entities(self, query: str, **kwargs: Any) -> list[Entity]:
         """Vector/keyword search across entities.
@@ -417,38 +463,126 @@ class NamsLongTermMemory:
         )
 
     async def get_entity_by_name(self, name: str) -> Entity | None:
-        """Look up an entity by name.
+        """Look up an entity by name via ``GET /v1/entities/by-name``.
 
-        NAMS doesn't expose a ``GET /entities?name=`` filter — we use
-        ``POST /entities/search`` with the name as the query and return
-        the first hit whose name matches exactly. Returns ``None`` if
-        no match is found.
+        Matching is resolver-normalized — case/punctuation/corporate-suffix
+        insensitive, and aliases count — so this answers "would a create
+        dedupe onto something?" the same way the write path would. The
+        response is a deterministically ordered ``{"entities": [...]}``
+        list with the best match first; returns that first match, or
+        ``None`` when the list is empty (the endpoint returns 200 with an
+        empty list, never 404).
         """
-        results = await self.search_entities(name, limit=20)
-        for e in results:
-            if e.name == name:
-                return e
-        return None
+        payload = await self._transport.request(_SPEC_GET_ENTITY_BY_NAME, params={"name": name})
+        first: Any = None
+        if isinstance(payload, dict) and "entities" in payload:
+            items = payload.get("entities") or []
+            first = items[0] if items else None
+        elif isinstance(payload, list):
+            first = payload[0] if payload else None
+        elif payload:
+            # Bridge servers may return the entity object directly.
+            first = payload
+        if not isinstance(first, dict):
+            return None
+        return payload_to_model(_normalize_entity(first), Entity)
 
     # ------------------------------------------------------------------ Silver
 
-    async def get_related_entities(self, entity_id: UUID | str, **kwargs: Any) -> Any:
-        """Return entities related to ``entity_id``.
+    async def get_related_entities(self, entity_id: UUID | str, **kwargs: Any) -> list[Entity]:
+        """Return entities related to ``entity_id`` (1 hop, both directions).
 
-        NAMS exposes inline relationships on ``GET /entities/{id}`` —
-        we fetch the entity and return the ``relationships`` array.
-        Each relationship has ``{relType, targetId, targetName, targetType}``.
+        NAMS exposes inline relationships on ``GET /entities/{id}`` — we
+        fetch the entity and map each relationship's target
+        (``{relType, targetId, targetName, targetType}``) to an
+        :class:`Entity`. Optionally filter with ``relationship_type=``
+        (single type) or ``relationship_types=`` (list, bolt-style alias).
+
+        ``depth`` beyond 1 is not representable on the NAMS REST API and
+        raises :class:`NotSupportedError`.
         """
+        depth = kwargs.get("depth")
+        if depth is not None and int(depth) > 1:
+            raise NotSupportedError(
+                backend="nams",
+                method="LongTermMemory.get_related_entities",
+                message=(
+                    "depth > 1 is not supported on the NAMS REST API — "
+                    "GET /v1/entities/{id} inlines 1-hop relationships only."
+                ),
+                workaround="Use the bolt backend for multi-hop traversal, or chain 1-hop calls.",
+            )
+        rel_types = kwargs.get("relationship_types")
+        single = kwargs.get("relationship_type")
+        if single is not None:
+            rel_types = [single]
         payload = await self._transport.request(
             _SPEC_GET_ENTITY,
             path_params={"entity_id": _to_str(entity_id)},
         )
         if not isinstance(payload, dict):
             return []
-        # camelCase → snake_case for the wrapper, but keep relationships verbatim
-        # for the caller — they're identifying refs, not full Entity objects.
-        rels = payload.get("relationships") or []
-        return list(rels)
+        related: list[Entity] = []
+        for r in payload.get("relationships") or []:
+            if not isinstance(r, dict):
+                continue
+            rel_type = r.get("relType") or r.get("rel_type") or r.get("type")
+            if rel_types and rel_type not in rel_types:
+                continue
+            target_id = r.get("targetId") or r.get("target_id")
+            if not target_id:
+                continue
+            target = {
+                "id": target_id,
+                "name": r.get("targetName") or r.get("target_name") or "",
+                "type": r.get("targetType") or r.get("target_type") or "custom",
+            }
+            related.append(payload_to_model(_normalize_entity(target), Entity))
+        return related
+
+    async def merge_duplicate_entities(
+        self,
+        source_id: UUID | str,
+        target_id: UUID | str,
+        *,
+        canonical_name: str | None = None,
+        **kwargs: Any,
+    ) -> Entity:
+        """Merge ``source_id`` into ``target_id`` and return the merged entity.
+
+        A two/three-call composition over the REST API:
+
+        1. ``POST /v1/entities/{source_id}/merge`` — the response's
+           ``targetId`` is the *canonical-resolved* merge target (the
+           requested target may itself have been merged already); that id
+           is used for the follow-up calls.
+        2. ``PUT /v1/entities/{canonical_id}`` with ``{name}`` — only when
+           ``canonical_name`` is given.
+        3. ``GET /v1/entities/{canonical_id}`` — returned as the merged
+           :class:`Entity`.
+
+        Note: unlike bolt's ``merge_duplicate_entities`` (which returns a
+        ``(source, target)`` tuple), this returns the surviving target
+        entity only — the source no longer exists after the merge.
+        """
+        merge_payload = await self._transport.request(
+            _SPEC_MERGE_ENTITIES,
+            path_params={"entity_id": _to_str(source_id)},
+            json={"targetId": _to_str(target_id)},
+        )
+        merged = snakeize_keys(merge_payload) if isinstance(merge_payload, dict) else {}
+        canonical_id = str(merged.get("target_id") or _to_str(target_id))
+        if canonical_name is not None:
+            await self._transport.request(
+                _SPEC_UPDATE_ENTITY,
+                path_params={"entity_id": canonical_id},
+                json={"name": canonical_name},
+            )
+        payload = await self._transport.request(
+            _SPEC_GET_ENTITY,
+            path_params={"entity_id": canonical_id},
+        )
+        return payload_to_model(_normalize_entity(payload), Entity)
 
     async def get_preferences_for(self, **kwargs: Any) -> list[Preference]:
         raise NotSupportedError(

--- a/tests/integration/nams/test_tck_gold.py
+++ b/tests/integration/nams/test_tck_gold.py
@@ -22,31 +22,48 @@ pytestmark = pytest.mark.integration
 
 
 # =============================================================================
-# Relationships — writes are bolt-only; reads come inline on GET /entities/{id}
+# Relationships — POST /v1/relationships (ADR-0016); reads come inline on
+# GET /entities/{id}
 # =============================================================================
 
 
 @pytest.mark.asyncio
-async def test_add_relationship_not_supported_on_nams(
+async def test_add_relationship_writes_typed_edge(
     nams_client: MemoryClient, unique_name: Any
 ) -> None:
-    """NAMS has no write endpoint for entity relationships. Relationships
-    must be added via the bolt backend. Existing relationships ARE
-    readable on NAMS via the inline ``relationships`` field on
-    ``GET /v1/entities/{id}`` — see ``test_get_entity_relationships_*``.
+    """``add_relationship`` writes via ``POST /v1/relationships``. The type
+    is validated against the workspace's allowed-relations vocabulary —
+    an allowlisted type like WORKS_AT round-trips; an unknown type would
+    collapse to RELATED_TO (with the original name kept as ``predicate``).
     """
     e1 = await nams_client.long_term.add_entity(unique_name("person"), "PERSON")
     e2 = await nams_client.long_term.add_entity(unique_name("org"), "ORGANIZATION")
     e1 = e1[0] if isinstance(e1, tuple) else e1
     e2 = e2[0] if isinstance(e2, tuple) else e2
 
+    rel = await nams_client.long_term.add_relationship(
+        source_id=e1.id,
+        relationship_type="WORKS_AT",
+        target_id=e2.id,
+        properties={"since": "2023"},
+    )
+    assert isinstance(rel, Relationship)
+    assert str(rel.source_id) == str(e1.id)
+    assert str(rel.target_id) == str(e2.id)
+    # WORKS_AT is in the default allowlist, so it must not collapse.
+    assert rel.type == "WORKS_AT"
+
+
+@pytest.mark.asyncio
+async def test_get_related_entities_depth_gt_one_raises(
+    nams_client: MemoryClient, unique_name: Any
+) -> None:
+    """``get_related_entities`` is 1-hop on REST; depth > 1 raises."""
+    e = await nams_client.long_term.add_entity(unique_name("p"), "PERSON")
+    e = e[0] if isinstance(e, tuple) else e
+
     with pytest.raises(NotSupportedError):
-        await nams_client.long_term.add_relationship(
-            source_id=e1.id,
-            relationship_type="WORKS_AT",
-            target_id=e2.id,
-            properties={"since": "2023"},
-        )
+        await nams_client.long_term.get_related_entities(e.id, depth=2)
 
 
 @pytest.mark.asyncio
@@ -72,8 +89,8 @@ async def test_get_related_entities_returns_list(
     nams_client: MemoryClient, unique_name: Any
 ) -> None:
     """``get_related_entities`` reads from the same inline source. With no
-    relationships in place (since ``add_relationship`` is bolt-only), the
-    result is an empty list — but the endpoint is exercised and parses.
+    relationships in place, the result is an empty list — but the endpoint
+    is exercised and parses.
     """
     a = await nams_client.long_term.add_entity(unique_name("a"), "PERSON")
     a = a[0] if isinstance(a, tuple) else a

--- a/tests/integration/nams/test_tck_silver.py
+++ b/tests/integration/nams/test_tck_silver.py
@@ -62,11 +62,10 @@ async def test_search_entities_finds_recent_writes(
 async def test_get_entity_by_name_found(nams_client: MemoryClient, unique_name: Any) -> None:
     """``get_entity_by_name`` returns the exact entity for a known name.
 
-    Implementation note: NAMS has no ``GET /entities?name=`` filter, so our
-    impl calls ``POST /entities/search`` and filters for exact match. That
-    search is vector-backed and indexed asynchronously — a freshly-written
-    entity may not be returned by search for a brief window. We poll a
-    handful of times before giving up to absorb that lag.
+    Implementation note: this hits ``GET /v1/entities/by-name`` —
+    resolver-normalized exact/alias matching, ordered best-match-first.
+    Explicit ``add_entity`` writes are synchronous, but we still poll a
+    handful of times to absorb any deployment-side indexing lag.
     """
     import asyncio
 

--- a/tests/unit/nams/test_long_term.py
+++ b/tests/unit/nams/test_long_term.py
@@ -2,8 +2,9 @@
 
 Endpoint shapes verified against the live NAMS OpenAPI spec.
 
-NAMS provides entity endpoints only. Preferences, facts, and
-relationship writes raise :class:`NotSupportedError`.
+NAMS provides entity and relationship endpoints (``POST
+/v1/relationships`` and ``GET /v1/entities/by-name`` per ADR-0016).
+Preferences and facts raise :class:`NotSupportedError`.
 """
 
 from __future__ import annotations
@@ -188,34 +189,37 @@ class TestSearchEntities:
 
 
 class TestGetEntityByName:
+    """``GET /v1/entities/by-name`` — resolver-normalized lookup, ordered
+    list with the best match first; the SDK returns first-or-None."""
+
     @respx.mock
-    async def test_uses_search_internally(self, long_term):
-        respx.post("https://memory.test/v1/entities/search").respond(
-            200, json={"entities": [SAMPLE_ENTITY], "searchType": "vector"}
+    async def test_returns_first_match(self, long_term):
+        route = respx.get("https://memory.test/v1/entities/by-name").respond(
+            200,
+            json={
+                "entities": [
+                    {**SAMPLE_ENTITY, "matchKind": "name"},
+                    {
+                        **SAMPLE_ENTITY,
+                        "id": "00000000-0000-0000-0000-000000000002",
+                        "matchKind": "alias",
+                        "resolvedFrom": "Ali",
+                    },
+                ]
+            },
         )
-        result = await long_term.get_entity_by_name("Alice")
+        result = await long_term.get_entity_by_name("alice")
         assert result is not None
         assert result.name == "Alice"
+        assert str(result.id) == "00000000-0000-0000-0000-000000000001"
+        assert result.type == "PERSON"  # uppercased for package consumers
+        assert route.calls[0].request.url.params["name"] == "alice"
 
     @respx.mock
     async def test_returns_none_when_no_match(self, long_term):
-        respx.post("https://memory.test/v1/entities/search").respond(
-            200, json={"entities": [], "searchType": "vector"}
-        )
+        # 200 with an empty list — the endpoint never 404s on no-match.
+        respx.get("https://memory.test/v1/entities/by-name").respond(200, json={"entities": []})
         result = await long_term.get_entity_by_name("Missing")
-        assert result is None
-
-    @respx.mock
-    async def test_returns_none_when_only_inexact_matches(self, long_term):
-        """Search returns hits but none with exact name match."""
-        respx.post("https://memory.test/v1/entities/search").respond(
-            200,
-            json={
-                "entities": [{**SAMPLE_ENTITY, "name": "Alice Different"}],
-                "searchType": "vector",
-            },
-        )
-        result = await long_term.get_entity_by_name("Alice")
         assert result is None
 
 
@@ -277,8 +281,8 @@ class TestGetEntityProvenance:
 
 
 class TestNotSupportedMethods:
-    """Preferences, facts, relationships, related-entities, get_facts_about
-    have no NAMS endpoints — all raise NotSupportedError."""
+    """Preferences, facts, and get_facts_about have no NAMS endpoints —
+    all raise NotSupportedError."""
 
     async def test_add_preference(self, long_term):
         with pytest.raises(NotSupportedError):
@@ -308,13 +312,69 @@ class TestNotSupportedMethods:
         with pytest.raises(NotSupportedError):
             await long_term.get_facts_about("Alice")
 
-    async def test_add_relationship(self, long_term):
-        with pytest.raises(NotSupportedError):
-            await long_term.add_relationship(
-                "00000000-0000-0000-0000-0000000000e1",
-                "WORKS_AT",
-                "00000000-0000-0000-0000-0000000000e2",
-            )
+
+class TestAddRelationship:
+    """``POST /v1/relationships`` — ADR-0016 pipeline-mirroring semantics."""
+
+    @respx.mock
+    async def test_happy_path_sends_camel_body_and_returns_relationship(self, long_term):
+        route = respx.post("https://memory.test/v1/relationships").respond(
+            201,
+            json={
+                "id": "00000000-0000-0000-0000-00000000ab01",
+                "sourceId": "00000000-0000-0000-0000-0000000000e1",
+                "targetId": "00000000-0000-0000-0000-0000000000e2",
+                "relationshipType": "WORKS_AT",
+                "confidence": 0.9,
+                "created": True,
+            },
+        )
+        rel = await long_term.add_relationship(
+            "00000000-0000-0000-0000-0000000000e1",
+            "WORKS_AT",
+            "00000000-0000-0000-0000-0000000000e2",
+            confidence=0.9,
+            properties={"since": "2023"},
+        )
+        body = json.loads(route.calls[0].request.content)
+        assert body == {
+            "sourceId": "00000000-0000-0000-0000-0000000000e1",
+            "targetId": "00000000-0000-0000-0000-0000000000e2",
+            "relationshipType": "WORKS_AT",
+            "confidence": 0.9,
+            "properties": {"since": "2023"},
+        }
+        assert isinstance(rel, Relationship)
+        assert str(rel.id) == "00000000-0000-0000-0000-00000000ab01"
+        assert str(rel.source_id) == "00000000-0000-0000-0000-0000000000e1"
+        assert str(rel.target_id) == "00000000-0000-0000-0000-0000000000e2"
+        assert rel.type == "WORKS_AT"
+        assert rel.confidence == 0.9
+        assert rel.attributes == {"since": "2023"}
+
+    @respx.mock
+    async def test_collapsed_type_passes_through(self, long_term):
+        """An unknown type collapses to RELATED_TO server-side; the SDK
+        reports the WRITTEN type, not the requested one."""
+        respx.post("https://memory.test/v1/relationships").respond(
+            200,
+            json={
+                "id": "00000000-0000-0000-0000-00000000ab02",
+                "sourceId": "00000000-0000-0000-0000-0000000000e1",
+                "targetId": "00000000-0000-0000-0000-0000000000e2",
+                "relationshipType": "RELATED_TO",
+                "predicate": "COLLABORATES_WITH",
+                "confidence": 1.0,
+                "created": False,
+            },
+        )
+        rel = await long_term.add_relationship(
+            "00000000-0000-0000-0000-0000000000e1",
+            "COLLABORATES_WITH",
+            "00000000-0000-0000-0000-0000000000e2",
+        )
+        assert rel.type == "RELATED_TO"
+        assert rel.attributes == {}
 
 
 class TestGetEntityRelationships:
@@ -352,7 +412,7 @@ class TestGetEntityRelationships:
 
 class TestGetRelatedEntities:
     @respx.mock
-    async def test_returns_relationships_as_dicts(self, long_term):
+    async def test_maps_inline_relationships_to_entities(self, long_term):
         respx.get("https://memory.test/v1/entities/00000000-0000-0000-0000-0000000000e1").respond(
             200,
             json={
@@ -362,14 +422,123 @@ class TestGetRelatedEntities:
                         "relType": "KNOWS",
                         "targetId": "00000000-0000-0000-0000-0000000000e2",
                         "targetName": "Bob",
-                        "targetType": "PERSON",
+                        "targetType": "person",
+                    },
+                    {
+                        "relType": "WORKS_AT",
+                        "targetId": "00000000-0000-0000-0000-0000000000e3",
+                        "targetName": "Acme",
+                        "targetType": "organization",
                     },
                 ],
             },
         )
         related = await long_term.get_related_entities("00000000-0000-0000-0000-0000000000e1")
         assert isinstance(related, list)
+        assert len(related) == 2
+        assert all(isinstance(e, Entity) for e in related)
+        assert related[0].name == "Bob"
+        assert related[0].type == "PERSON"
+        assert str(related[0].id) == "00000000-0000-0000-0000-0000000000e2"
+        assert related[1].name == "Acme"
+
+    @respx.mock
+    async def test_filters_by_relationship_type(self, long_term):
+        respx.get("https://memory.test/v1/entities/00000000-0000-0000-0000-0000000000e1").respond(
+            200,
+            json={
+                **SAMPLE_ENTITY,
+                "relationships": [
+                    {
+                        "relType": "KNOWS",
+                        "targetId": "00000000-0000-0000-0000-0000000000e2",
+                        "targetName": "Bob",
+                        "targetType": "person",
+                    },
+                    {
+                        "relType": "WORKS_AT",
+                        "targetId": "00000000-0000-0000-0000-0000000000e3",
+                        "targetName": "Acme",
+                        "targetType": "organization",
+                    },
+                ],
+            },
+        )
+        related = await long_term.get_related_entities(
+            "00000000-0000-0000-0000-0000000000e1", relationship_type="WORKS_AT"
+        )
         assert len(related) == 1
+        assert related[0].name == "Acme"
+
+    async def test_depth_beyond_one_raises(self, long_term):
+        # No respx mock — the guard must trip before any HTTP call.
+        with pytest.raises(NotSupportedError):
+            await long_term.get_related_entities("00000000-0000-0000-0000-0000000000e1", depth=2)
+
+    @respx.mock
+    async def test_depth_one_is_fine(self, long_term):
+        respx.get("https://memory.test/v1/entities/00000000-0000-0000-0000-0000000000e1").respond(
+            200, json=SAMPLE_ENTITY
+        )
+        related = await long_term.get_related_entities(
+            "00000000-0000-0000-0000-0000000000e1", depth=1
+        )
+        assert related == []
+
+
+class TestMergeDuplicateEntities:
+    """Two/three-call composition: merge → optional rename → fetch."""
+
+    SRC = "00000000-0000-0000-0000-0000000000a1"
+    TGT = "00000000-0000-0000-0000-0000000000a2"
+    CANON = "00000000-0000-0000-0000-0000000000c1"
+
+    @respx.mock
+    async def test_merge_then_fetch_uses_canonical_target(self, long_term):
+        merge = respx.post(f"https://memory.test/v1/entities/{self.SRC}/merge").respond(
+            200, json={"status": "merged", "sourceId": self.SRC, "targetId": self.CANON}
+        )
+        # The follow-up GET must hit the canonical-resolved target from the
+        # merge response, NOT the requested target id.
+        get = respx.get(f"https://memory.test/v1/entities/{self.CANON}").respond(
+            200, json={**SAMPLE_ENTITY, "id": self.CANON}
+        )
+        entity = await long_term.merge_duplicate_entities(self.SRC, self.TGT)
+        body = json.loads(merge.calls[0].request.content)
+        assert body == {"targetId": self.TGT}
+        assert get.called
+        assert isinstance(entity, Entity)
+        assert str(entity.id) == self.CANON
+
+    @respx.mock
+    async def test_canonical_name_triggers_rename(self, long_term):
+        respx.post(f"https://memory.test/v1/entities/{self.SRC}/merge").respond(
+            200, json={"status": "merged", "sourceId": self.SRC, "targetId": self.CANON}
+        )
+        put = respx.put(f"https://memory.test/v1/entities/{self.CANON}").respond(
+            200, json={"status": "updated"}
+        )
+        respx.get(f"https://memory.test/v1/entities/{self.CANON}").respond(
+            200, json={**SAMPLE_ENTITY, "id": self.CANON, "name": "Alice Smith"}
+        )
+        entity = await long_term.merge_duplicate_entities(
+            self.SRC, self.TGT, canonical_name="Alice Smith"
+        )
+        assert put.called
+        assert json.loads(put.calls[0].request.content) == {"name": "Alice Smith"}
+        assert entity.name == "Alice Smith"
+
+    @respx.mock
+    async def test_no_rename_without_canonical_name(self, long_term):
+        respx.post(f"https://memory.test/v1/entities/{self.SRC}/merge").respond(
+            200, json={"status": "merged", "sourceId": self.SRC, "targetId": self.CANON}
+        )
+        put = respx.put(f"https://memory.test/v1/entities/{self.CANON}")
+        respx.get(f"https://memory.test/v1/entities/{self.CANON}").respond(
+            200, json={**SAMPLE_ENTITY, "id": self.CANON}
+        )
+        await long_term.merge_duplicate_entities(self.SRC, self.TGT)
+        assert not put.called
 
 
 class TestGetContext:

--- a/typescript/src/transport/rest.ts
+++ b/typescript/src/transport/rest.ts
@@ -192,17 +192,7 @@ const ROUTES: Record<string, RestCall | "noop" | "unsupported"> = {
       >[];
       const first = entities[0];
       if (!first) return null;
-      return {
-        id: first["id"],
-        name: first["name"],
-        type: first["type"],
-        description: first["description"],
-        confidence: first["confidence"],
-        source_stage: first["sourceStage"],
-        created_at: first["createdAt"],
-        updated_at: first["updatedAt"],
-        canonical_name: undefined,
-      };
+      return first;
     },
   },
   get_related_entities: {

--- a/typescript/src/transport/rest.ts
+++ b/typescript/src/transport/rest.ts
@@ -86,6 +86,12 @@ interface RestCall {
    * snake_case for request bodies (`entity_types`, `version_id`, …).
    */
   snakeBody?: boolean;
+  /**
+   * Optional pre-dispatch validation hook, run before any HTTP request is
+   * made. Throw to reject parameter combinations the REST endpoint cannot
+   * express (e.g. `get_related_entities` with depth > 1).
+   */
+  preflight?: (camelParams: Record<string, unknown>) => void;
   /** Optional response shaper for endpoints whose payload doesn't match bridge wire. */
   shape?: (raw: unknown, camelParams: Record<string, unknown>) => unknown;
 }
@@ -172,10 +178,80 @@ const ROUTES: Record<string, RestCall | "noop" | "unsupported"> = {
   add_preference: "unsupported",
   add_fact: "unsupported",
   search_preferences: "unsupported",
-  get_entity_by_name: "unsupported",
-  get_related_entities: "unsupported",
-  add_relationship: "unsupported",
-  merge_duplicate_entities: "unsupported",
+  get_entity_by_name: {
+    method: "GET",
+    path: "/entities/by-name",
+    queryParams: ["name"],
+    // Response is `{entities: [...]}` — resolver-normalized matching, ordered
+    // best-match-first, 200 with an empty list when nothing matches. The SDK
+    // method contract is Entity | null, so pluck the first hit.
+    shape: (raw) => {
+      const entities = ((raw as { entities?: unknown[] })?.entities ?? []) as Record<
+        string,
+        unknown
+      >[];
+      const first = entities[0];
+      if (!first) return null;
+      return {
+        id: first["id"],
+        name: first["name"],
+        type: first["type"],
+        description: first["description"],
+        confidence: first["confidence"],
+        source_stage: first["sourceStage"],
+        created_at: first["createdAt"],
+        updated_at: first["updatedAt"],
+        canonical_name: undefined,
+      };
+    },
+  },
+  get_related_entities: {
+    method: "GET",
+    path: "/entities/{entityId}",
+    pathParams: ["entityId"],
+    // GET /v1/entities/{id} inlines both-direction 1-hop relationships; the
+    // REST API cannot traverse deeper.
+    preflight: (camelParams) => {
+      const depth = camelParams["depth"];
+      if (typeof depth === "number" && depth > 1) {
+        throw new NotSupportedError(
+          "get_related_entities with depth > 1 is not supported by the hosted REST API " +
+            "(GET /v1/entities/{id} is 1-hop only). Use BridgeTransport for deeper traversal.",
+        );
+      }
+    },
+    shape: (raw, camelParams) => {
+      const rels = ((raw as { relationships?: unknown[] })?.relationships ?? []) as Record<
+        string,
+        unknown
+      >[];
+      const filter = camelParams["relationshipType"];
+      return rels
+        .filter((r) => filter === undefined || filter === null || r["relType"] === filter)
+        .map((r) => ({ id: r["targetId"], name: r["targetName"], type: r["targetType"] }));
+    },
+  },
+  add_relationship: {
+    method: "POST",
+    path: "/relationships",
+    hasBody: true,
+    // The response's relationshipType is the WRITTEN type — a type outside
+    // the workspace allowlist collapses to RELATED_TO (with the caller's
+    // original name preserved server-side as `predicate`). Pass it through.
+    shape: (raw, camelParams) => {
+      const rel = raw as Record<string, unknown>;
+      return {
+        id: rel["id"],
+        source_id: rel["sourceId"],
+        target_id: rel["targetId"],
+        relationship_type: rel["relationshipType"],
+        properties: (camelParams["properties"] as Record<string, unknown> | undefined) ?? {},
+      };
+    },
+  },
+  // merge_duplicate_entities is a multi-call composition (merge → optional
+  // rename → fetch) that a single ROUTES entry can't express — it is
+  // special-cased in request(). See mergeDuplicateEntitiesComposite().
 
   // Reasoning — legacy not directly representable in REST
   start_trace: "unsupported",
@@ -496,6 +572,15 @@ export class RestTransport implements Transport {
   async close(): Promise<void> {}
 
   async request<T>(method: string, params: Record<string, unknown>): Promise<T> {
+    const original = params ?? {};
+    const camelParams = snakeToCamel<Record<string, unknown>>(original);
+
+    // Composite methods — multi-call REST flows a single ROUTES entry can't
+    // express. Dispatched before the ROUTES lookup.
+    if (method === "merge_duplicate_entities") {
+      return camelToSnake<T>(await this.mergeDuplicateEntitiesComposite(camelParams));
+    }
+
     const route = ROUTES[method];
     if (!route) {
       throw new NotSupportedError(
@@ -511,8 +596,7 @@ export class RestTransport implements Transport {
       );
     }
 
-    const original = params ?? {};
-    const camelParams = snakeToCamel<Record<string, unknown>>(original);
+    route.preflight?.(camelParams);
 
     // Substitute path params (placeholders match camelCase route literals).
     let path = route.path;
@@ -568,14 +652,76 @@ export class RestTransport implements Transport {
       }
     }
 
-    const url = `${this.endpoint}${path}${query}`;
+    const parsed = await this.httpRequest(method, route.method, `${path}${query}`, body);
+    if (parsed === undefined) return undefined as T;
+    const shaped = route.shape ? route.shape(parsed, camelParams) : parsed;
+    return camelToSnake<T>(shaped);
+  }
+
+  /**
+   * merge_duplicate_entities is a two/three-call composition:
+   *
+   *   1. `POST /entities/{sourceId}/merge` with `{targetId}` — the response's
+   *      `targetId` is the canonical-resolved merge target; use IT below.
+   *   2. `PUT /entities/{canonicalId}` with `{name}` — only when a
+   *      `canonical_name` was supplied.
+   *   3. `GET /entities/{canonicalId}` — returned as the merged entity.
+   */
+  private async mergeDuplicateEntitiesComposite(
+    camelParams: Record<string, unknown>,
+  ): Promise<unknown> {
+    const method = "merge_duplicate_entities";
+    for (const name of ["sourceId", "targetId"]) {
+      const v = camelParams[name];
+      if (v === undefined || v === null || v === "") {
+        throw new TransportError(
+          `Missing required parameter '${name}' for method '${method}'`,
+          400,
+          camelParams,
+        );
+      }
+    }
+    const merged = (await this.httpRequest(
+      method,
+      "POST",
+      `/entities/${encodeURIComponent(String(camelParams["sourceId"]))}/merge`,
+      JSON.stringify({ targetId: camelParams["targetId"] }),
+    )) as { targetId?: unknown } | undefined;
+    const canonicalId = encodeURIComponent(String(merged?.targetId ?? camelParams["targetId"]));
+
+    const canonicalName = camelParams["canonicalName"];
+    if (canonicalName !== undefined && canonicalName !== null) {
+      await this.httpRequest(
+        method,
+        "PUT",
+        `/entities/${canonicalId}`,
+        JSON.stringify({ name: canonicalName }),
+      );
+    }
+
+    return this.httpRequest(method, "GET", `/entities/${canonicalId}`);
+  }
+
+  /**
+   * Dispatch one HTTP call and return the parsed JSON body (camelCase, as
+   * the service sent it), or `undefined` for 204/empty responses. Shared by
+   * request() and the composite methods so auth headers, error mapping, and
+   * logging behave identically on every hop.
+   */
+  private async httpRequest(
+    method: string,
+    httpMethod: HttpMethod,
+    pathAndQuery: string,
+    body?: string,
+  ): Promise<unknown> {
+    const url = `${this.endpoint}${pathAndQuery}`;
     const start = nowMs();
-    this.emit({ kind: "request", method, url, httpMethod: route.method });
+    this.emit({ kind: "request", method, url, httpMethod });
     let response: Response;
     try {
       response = await fetch(url, {
-        method: route.method,
-        headers: await this.buildHeaders(route.hasBody),
+        method: httpMethod,
+        headers: await this.buildHeaders(body !== undefined),
         body,
         signal: AbortSignal.timeout(this.timeout),
       });
@@ -614,7 +760,7 @@ export class RestTransport implements Transport {
 
     if (response.status === 204) {
       this.emit({ kind: "response", method, url, status: 204, requestId, durationMs });
-      return undefined as T;
+      return undefined;
     }
 
     const text = await response.text();
@@ -650,10 +796,8 @@ export class RestTransport implements Transport {
 
     this.emit({ kind: "response", method, url, status: response.status, requestId, durationMs });
 
-    if (!text) return undefined as T;
-    let parsed: unknown = JSON.parse(text);
-    if (route.shape) parsed = route.shape(parsed, camelParams);
-    return camelToSnake<T>(parsed);
+    if (!text) return undefined;
+    return JSON.parse(text) as unknown;
   }
 
   private emit(event: Parameters<Logger>[0]): void {

--- a/typescript/test/integration/rest-transport.test.ts
+++ b/typescript/test/integration/rest-transport.test.ts
@@ -159,6 +159,245 @@ describe("RestTransport — long-term", () => {
     expect(result).toEqual({ id: "e1", updated: true });
   });
 
+  it("addRelationship POSTs /relationships and maps the response", async () => {
+    let observedBody: unknown = null;
+    server.use(
+      http.post(`${ENDPOINT}/relationships`, async ({ request }) => {
+        observedBody = await request.json();
+        return HttpResponse.json(
+          {
+            id: "rel-1",
+            sourceId: "e1",
+            targetId: "e2",
+            relationshipType: "WORKS_AT",
+            confidence: 1,
+            created: true,
+          },
+          { status: 201 },
+        );
+      }),
+    );
+
+    const client = newClient();
+    const rel = await client.longTerm.addRelationship("e1", "e2", "WORKS_AT", {
+      properties: { since: "2023" },
+    });
+    await client.close();
+
+    expect(observedBody).toEqual({
+      sourceId: "e1",
+      targetId: "e2",
+      relationshipType: "WORKS_AT",
+      properties: { since: "2023" },
+    });
+    expect(rel.id).toBe("rel-1");
+    expect(rel.sourceId).toBe("e1");
+    expect(rel.targetId).toBe("e2");
+    expect(rel.relationshipType).toBe("WORKS_AT");
+    expect(rel.properties).toEqual({ since: "2023" });
+  });
+
+  it("addRelationship passes through the server's collapsed type", async () => {
+    // A type outside the workspace allowlist collapses to RELATED_TO server-side
+    // (original name kept as `predicate`). The SDK reports the WRITTEN type.
+    server.use(
+      http.post(`${ENDPOINT}/relationships`, () =>
+        HttpResponse.json({
+          id: "rel-2",
+          sourceId: "e1",
+          targetId: "e2",
+          relationshipType: "RELATED_TO",
+          predicate: "COLLABORATES_WITH",
+          confidence: 0.8,
+          created: false,
+        }),
+      ),
+    );
+
+    const client = newClient();
+    const rel = await client.longTerm.addRelationship("e1", "e2", "COLLABORATES_WITH");
+    await client.close();
+
+    expect(rel.relationshipType).toBe("RELATED_TO");
+    expect(rel.properties).toEqual({});
+  });
+
+  it("getEntityByName GETs /entities/by-name and returns the first match", async () => {
+    let observedName: string | null = null;
+    server.use(
+      http.get(`${ENDPOINT}/entities/by-name`, ({ request }) => {
+        observedName = new URL(request.url).searchParams.get("name");
+        return HttpResponse.json({
+          entities: [
+            {
+              id: "e1",
+              name: "Acme Corp",
+              type: "organization",
+              description: "The best match",
+              confidence: 0.9,
+              sourceStage: "extraction",
+              createdAt: "2026-05-07T00:00:00Z",
+              updatedAt: "2026-05-08T00:00:00Z",
+              matchKind: "alias",
+              resolvedFrom: "ACME",
+            },
+            { id: "e2", name: "Acme Corp", type: "person" },
+          ],
+        });
+      }),
+    );
+
+    const client = newClient();
+    const entity = await client.longTerm.getEntityByName("acme");
+    await client.close();
+
+    expect(observedName).toBe("acme");
+    expect(entity).not.toBeNull();
+    expect(entity!.id).toBe("e1");
+    expect(entity!.name).toBe("Acme Corp");
+    expect(entity!.type).toBe("organization");
+    expect(entity!.description).toBe("The best match");
+    expect(entity!.confidence).toBe(0.9);
+    expect(entity!.sourceStage).toBe("extraction");
+    expect(entity!.createdAt).toBe("2026-05-07T00:00:00Z");
+    expect(entity!.updatedAt).toBe("2026-05-08T00:00:00Z");
+  });
+
+  it("getEntityByName returns null when the list is empty", async () => {
+    server.use(
+      http.get(`${ENDPOINT}/entities/by-name`, () => HttpResponse.json({ entities: [] })),
+    );
+
+    const client = newClient();
+    const entity = await client.longTerm.getEntityByName("nobody");
+    await client.close();
+
+    expect(entity).toBeNull();
+  });
+
+  it("getRelatedEntities maps inline relationships to entities", async () => {
+    server.use(
+      http.get(`${ENDPOINT}/entities/e1`, () =>
+        HttpResponse.json({
+          id: "e1",
+          name: "Alice",
+          type: "person",
+          relationships: [
+            { relType: "WORKS_AT", targetId: "e2", targetName: "Acme", targetType: "organization" },
+            { relType: "KNOWS", targetId: "e3", targetName: "Bob", targetType: "person" },
+          ],
+        }),
+      ),
+    );
+
+    const client = newClient();
+    const related = await client.longTerm.getRelatedEntities("e1");
+    await client.close();
+
+    expect(related).toHaveLength(2);
+    expect(related[0]).toMatchObject({ id: "e2", name: "Acme", type: "organization" });
+    expect(related[1]).toMatchObject({ id: "e3", name: "Bob", type: "person" });
+  });
+
+  it("getRelatedEntities filters by relationshipType", async () => {
+    server.use(
+      http.get(`${ENDPOINT}/entities/e1`, () =>
+        HttpResponse.json({
+          id: "e1",
+          name: "Alice",
+          type: "person",
+          relationships: [
+            { relType: "WORKS_AT", targetId: "e2", targetName: "Acme", targetType: "organization" },
+            { relType: "KNOWS", targetId: "e3", targetName: "Bob", targetType: "person" },
+          ],
+        }),
+      ),
+    );
+
+    const client = newClient();
+    const related = await client.longTerm.getRelatedEntities("e1", {
+      relationshipType: "KNOWS",
+    });
+    await client.close();
+
+    expect(related).toHaveLength(1);
+    expect(related[0]).toMatchObject({ id: "e3", name: "Bob", type: "person" });
+  });
+
+  it("getRelatedEntities throws NotSupportedError for depth > 1 without fetching", async () => {
+    // No handler registered — an HTTP call would trip onUnhandledRequest: "error".
+    const client = newClient();
+    await expect(
+      client.longTerm.getRelatedEntities("e1", { depth: 2 }),
+    ).rejects.toBeInstanceOf(NotSupportedError);
+    await client.close();
+  });
+
+  it("mergeDuplicateEntities composes merge + fetch using the canonical target", async () => {
+    const calls: string[] = [];
+    let mergeBody: unknown = null;
+    server.use(
+      http.post(`${ENDPOINT}/entities/e-src/merge`, async ({ request }) => {
+        mergeBody = await request.json();
+        calls.push("merge");
+        // The service resolves the requested target to its canonical entity.
+        return HttpResponse.json({ status: "merged", sourceId: "e-src", targetId: "e-canon" });
+      }),
+      http.get(`${ENDPOINT}/entities/e-canon`, () => {
+        calls.push("get");
+        return HttpResponse.json({
+          id: "e-canon",
+          name: "Acme Corp",
+          type: "organization",
+          createdAt: "2026-05-07T00:00:00Z",
+        });
+      }),
+    );
+
+    const client = newClient();
+    const entity = await client.longTerm.mergeDuplicateEntities("e-src", "e-tgt");
+    await client.close();
+
+    expect(mergeBody).toEqual({ targetId: "e-tgt" });
+    expect(calls).toEqual(["merge", "get"]);
+    expect(entity.id).toBe("e-canon");
+    expect(entity.name).toBe("Acme Corp");
+  });
+
+  it("mergeDuplicateEntities renames the canonical target when canonicalName is given", async () => {
+    const calls: string[] = [];
+    let putBody: unknown = null;
+    server.use(
+      http.post(`${ENDPOINT}/entities/e-src/merge`, () => {
+        calls.push("merge");
+        return HttpResponse.json({ status: "merged", sourceId: "e-src", targetId: "e-canon" });
+      }),
+      http.put(`${ENDPOINT}/entities/e-canon`, async ({ request }) => {
+        putBody = await request.json();
+        calls.push("rename");
+        return HttpResponse.json({ status: "updated" });
+      }),
+      http.get(`${ENDPOINT}/entities/e-canon`, () => {
+        calls.push("get");
+        return HttpResponse.json({
+          id: "e-canon",
+          name: "ACME Corporation",
+          type: "organization",
+        });
+      }),
+    );
+
+    const client = newClient();
+    const entity = await client.longTerm.mergeDuplicateEntities("e-src", "e-tgt", {
+      canonicalName: "ACME Corporation",
+    });
+    await client.close();
+
+    expect(calls).toEqual(["merge", "rename", "get"]);
+    expect(putBody).toEqual({ name: "ACME Corporation" });
+    expect(entity.name).toBe("ACME Corporation");
+  });
+
   it("getEntityGraph returns nodes and edges", async () => {
     server.use(
       http.get(`${ENDPOINT}/entities/graph`, () =>


### PR DESCRIPTION
Four long-term-memory methods that previously threw `NotSupportedError` on the hosted
NAMS REST transport ("It is supported by BridgeTransport only") are now wired to real
endpoints, in both the TypeScript and Python SDKs. Server-side counterpart:
project-gaylord ADR-0016 (adds `POST /v1/relationships` and
`GET /v1/entities/by-name`); requires a NAMS deployment that includes those endpoints.

## Method mappings (identical semantics in both SDKs)

| Method | Wiring |
|---|---|
| `addRelationship` | `POST /v1/relationships`. Returns the **written** type: types outside the workspace allowlist collapse to `RELATED_TO` with the original name in `predicate` (server-designed, reported honestly). Response `id` is a UUID (SPEC-5.2.4). |
| `getEntityByName` | `GET /v1/entities/by-name` — resolver-normalized matching (case/punctuation/suffix-insensitive + aliases); first of the server-ordered list, or `null`/`None` on empty (never an error). |
| `getRelatedEntities` | `GET /v1/entities/{id}` 1-hop relationships mapped to entities; `relationshipType` filtered client-side; `depth > 1` throws `NotSupportedError` **before any HTTP call**. |
| `mergeDuplicateEntities` | Client-side composition: `POST /entities/{src}/merge` → optional `PUT` rename when `canonicalName` given → `GET` the merged entity. Uses the merge response's canonical-resolved `targetId`. |

## Implementation notes

- TS: `RestCall` gains an optional `preflight` hook (pre-request validation, used for
  the depth guard); the merge composition is special-cased in `RestTransport.request()`
  via a shared private `httpRequest()` helper so auth/error-mapping/logging stay
  identical.
- Python: same four mappings in the NAMS transport specs (`nams/long_term.py`);
  returns the surviving `Entity` from merge (not bolt's tuple — documented in
  migrate-to-nams).
- Docs updated: backends capability matrix, both `NotSupportedError` tables in
  migrate-to-nams, use-nams unsupported list, TS API reference.

## Testing

- TypeScript: `npm test` — 23 files / 164 tests green (9 new MSW transport tests);
  `tsc --noEmit` clean.
- Python: `uv run pytest tests/unit` — 1413 passed, 3 skipped (51 in the rewritten
  long-term suite); ruff clean on touched files.
- Live-gated NAMS integration tests updated but only collection/skip-verified — they
  need one run against a deployment with the new endpoints.

## Out of scope (pre-existing, flagged)

- `mcp/_tools.py` `memory_create_relationship` calls `add_relationship` with
  bolt-style kwargs and never matched the NAMS protocol signature — broken before this
  change, untouched here.