### PR TITLE
Type-safety Phase 3: mypy-strict + ty clean integrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,14 +28,49 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`long_term.expand_graph(node_id, loaded_ids=...)`** — 1-hop entity-neighborhood
   expansion (`POST /v1/graph/expand`) for graph visualization; mirrored in the
   TypeScript SDK as `longTerm.expandGraph(nodeId, loadedIds)`.
+- **`Neo4jClient.session()`** — public accessor returning a new driver session for
+  raw Cypher access (session-level control the `execute_read`/`execute_write`
+  helpers don't offer, e.g. streaming GDS algorithm results). Thin wrapper over the
+  existing private `_get_session()`.
 
 ### Changed
 
+- **Fixed: Microsoft Agent GDS integration never used the GDS library.**
+  `GDSIntegration` called `self._client._client.session()`, but `Neo4jClient` has no
+  `session()` method — so every algorithm query raised `AttributeError`, was swallowed
+  by the surrounding `try/except`, and silently fell back to basic Cypher even when
+  GDS was installed. The unit-test mock had drifted to expose a `.session` attribute
+  the real object lacked, masking the bug. Fixed by adding `Neo4jClient.session()` and
+  routing GDS through it.
+- **Fixed: `context_graph_tools()` (AWS Strands) raised `ValidationError` at runtime.**
+  It built `Neo4jConfig(user=..., password=<str>)`, but the field is `username` and
+  `password` is a `SecretStr`, with `extra="forbid"` — so every client cache-miss
+  raised. Now `username=...` + `password=SecretStr(...)`. Surfaced by `ty`.
+- **Fixed: `Neo4jCrewMemory` (CrewAI) never subclassed the real base class.** The
+  import `from crewai.memory import Memory` raised `ImportError` (the class lives at
+  `crewai.memory.memory.Memory`), so the class silently fell back to the
+  `except ImportError` stub even when CrewAI was installed. Fixed the import.
+- **`transport_mode` narrowed to `Literal["auto", "rest", "bridge"]`** on the Strands
+  `nams_context_graph_tools()` public function (was `str`), matching
+  `NamsConfig.transport_mode` and the documented values. **Public-API typing
+  change** — downstream callers passing an unconstrained `str` variable will see a
+  type-checker error; the runtime contract is unchanged.
+- **`GDSIntegration.find_shortest_path()` return type corrected** from
+  `list[dict[str, Any]] | None` to `dict[str, Any] | None` — the annotation was a lie
+  (the method has always returned a `{"nodes": ..., "relationships": ...}` dict).
+  **Public-API typing change.**
+- **Pydantic AI `record_agent_trace(result=...)` is now typed `AgentRunResult`**
+  (was `RunResult`, which moved to `pydantic_ai.agent`). Annotation-only; the runtime
+  object is unchanged.
+- **All 9 framework integrations are now `mypy --strict` and `ty` clean** (langchain,
+  crewai, agentcore, pydantic_ai, google_adk, openai_agents, strands, llamaindex,
+  microsoft_agent), plus `integrations/base.py` (`run_sync` is now `ParamSpec`-generic).
+  google.adk.* and nest_asyncio are suppressed per-module (`ignore_missing_imports`);
+  they ship no type information and are used at a typed boundary in only one/two files.
 - **Fixed: `neo4j-agent-memory schemas show` crashed with `AttributeError`.** The
   command called `EntitySchemaConfig.to_dict()`, which does not exist on the
   Pydantic v2 model — so every `schemas show` invocation raised before producing
-  JSON or YAML output. Now uses `model_dump()`. Surfaced by the Phase 2 typing
-  pass. (Type-safety effort, spec §6 Phase 2.)
+  JSON or YAML output. Now uses `model_dump()`. Surfaced by the type-safety pass.
 - **`ReasoningMemory.add_step()` / `complete_trace()` accept `trace_id: UUID | str`.**
   Both are `str(trace_id)`-normalized internally for the Cypher match, so the strict
   `UUID`-only parameter was widened to `UUID | str` for parity with the sibling id
@@ -43,36 +78,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `triggered_by_message_id`). This lets the MCP `memory_record_step` /
   `memory_complete_trace` tools forward the caller-supplied id directly instead of
   requiring UUID-formatted ids. Backward compatible (a `UUID` is still accepted).
-  (Type-safety effort, spec §6 Phase 2.)
 - **Fixed: `MemoryIntegration.add_fact()` parses `valid_from` / `valid_until`.**
   These public parameters accept ISO date strings but were forwarded as `str`
   straight into `LongTermMemory.add_fact`, which expects `datetime | None` — a
-  silent type mismatch surfaced by the Phase 2 typing pass. They are now parsed
+  silent type mismatch surfaced by the type-safety pass. They are now parsed
   with `datetime.fromisoformat()` (a malformed string now raises `ValueError` at
-  the call site instead of corrupting the stored value). (Type-safety effort, spec §6 Phase 2.)
+  the call site instead of corrupting the stored value).
 - **Fixed: `LongTermMemory.add()` now returns `Entity`** (per its `BaseMemory[Entity]`
   contract) instead of a `tuple[Entity, DeduplicationResult]`. The tuple return was a
-  latent contract violation surfaced by the Phase 1 typing pass; no in-tree caller
+  latent contract violation surfaced by the type-safety pass; no in-tree caller
   destructured it. Use `add_entity(...)` (unchanged) if you need the
-  `(Entity, DeduplicationResult)` pair. (Type-safety effort, spec §6 Phase 1.)
+  `(Entity, DeduplicationResult)` pair.
 - **Memory timestamps are now timezone-aware (UTC).** Default timestamps in the
   `memory/` layer (`Conversation.created_at`, `ConversationSummary.generated_at`,
   `ReasoningTrace.started_at`, and `_to_python_datetime` fallbacks) switched from
   naive `datetime.utcnow()` to `datetime.now(timezone.utc)`. Reads already produced
-  aware datetimes; this makes the write side consistent. (Type-safety effort, spec §6 Phase 1.)
+  aware datetimes; this makes the write side consistent.
 - **Fixed: GLiNER entity spans with `end_pos == 0`.** In `extraction/gliner_extractor.py`
   the span fallback changed from `entity.end_pos or len(name)` to an explicit
   `is not None` check, so a zero-width span at offset 0 is preserved instead of being
   replaced by the name length. Real extracted entities never have `end_pos == 0`, so
-  this has no observable effect in practice. (Type-safety effort, spec §6 Phase 1.)
+  this has no observable effect in practice.
 - **BREAKING: `InstructorProvider.__init__` no longer accepts `async_client`.**
-  The parameter (default `True`) was removed during the Phase 1 typing pass.
+  The parameter (default `True`) was removed during the type-safety pass.
   `async_client=False` produced a synchronous `instructor.Instructor`, which
   crashed at call time because the provider always `await`s `self._client.create(...)`
   — the sync path never worked. The provider is now unconditionally async. Callers
   that explicitly passed `async_client=True` (the working default) must drop the
-  argument; `async_client=False` was already non-functional. (Type-safety effort,
-  spec §6 Phase 1.)
+  argument; `async_client=False` was already non-functional.
 - **`long_term.wait_for_extraction(...)` now uses the authoritative extraction-status
   endpoint** when a `session_id` / `conversation_id` is supplied (polls until no
   message is pending), instead of only the workspace-scoped entity-search heuristic.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -211,15 +211,26 @@ plugins = ["pydantic.mypy"]
 # ships py.typed and resolves cleanly, so the stale block was removed. yaml is
 # covered by typeshed's types-PyYAML, now a declared dev dependency so clean CI
 # resolves it (it was previously only ambiently present, which made the ratchet
-# count non-reproducible). Confirmed (Phase 1) that gliner 0.2.24 ships no
-# py.typed marker; it is suppressed via the override below. The remaining deps
-# that genuinely ship no type information are glirel, nest_asyncio, and
-# google.adk.*; their import diagnostics are intentionally left in the budget and
-# will be addressed in the relevant package phases (local stubs vs. per-module
+# count non-reproducible). Confirmed that gliner 0.2.24 ships no
+# py.typed marker; it is suppressed via the override below. google.adk.* also
+# ships no type information; since it is used at a typed boundary in only two
+# files (the ADK MemoryService), it is suppressed per-module here rather than
+# shipping local stubs. nest_asyncio (used only by the llamaindex integration)
+# is likewise suppressed per-module below. The remaining dep that genuinely
+# ships no type information is glirel; its import diagnostics are intentionally
+# left in the budget and will be addressed later (local stubs vs. per-module
 # ignore), not suppressed here.
 
 [[tool.mypy.overrides]]
 module = "gliner"
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = "google.adk.*"
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = "nest_asyncio"
 ignore_missing_imports = true
 
 [tool.ruff]

--- a/scripts/typecheck-budget.txt
+++ b/scripts/typecheck-budget.txt
@@ -7,5 +7,5 @@
 # Measured with integration extras installed: `uv sync --all-extras --group dev`.
 # Refresh after improving a count: `make typecheck-ratchet-update`.
 
-mypy=102
-ty=85
+mypy=13
+ty=26

--- a/src/neo4j_agent_memory/graph/client.py
+++ b/src/neo4j_agent_memory/graph/client.py
@@ -101,6 +101,16 @@ class Neo4jClient:
         driver = self._ensure_connected()
         return driver.session(database=self._config.database)
 
+    def session(self) -> AsyncSession:
+        """Return a new driver session for raw Cypher access.
+
+        Public accessor for callers that need session-level control the
+        ``execute_read``/``execute_write`` helpers don't offer (e.g. the
+        GDS integration streaming algorithm results). Prefer the execute_*
+        helpers for ordinary queries.
+        """
+        return self._get_session()
+
     async def execute_read(
         self,
         query: str,

--- a/src/neo4j_agent_memory/integrations/agentcore/memory_provider.py
+++ b/src/neo4j_agent_memory/integrations/agentcore/memory_provider.py
@@ -43,6 +43,7 @@ from neo4j_agent_memory.integrations.agentcore.types import (
 
 if TYPE_CHECKING:
     from neo4j_agent_memory import MemoryClient
+    from neo4j_agent_memory.graph.client import Neo4jClient
 
 logger = logging.getLogger(__name__)
 
@@ -110,6 +111,13 @@ class Neo4jMemoryProvider:
         self._extraction_model = extraction_model
         self._generate_embeddings = generate_embeddings
         self._sessions: dict[str, SessionContext] = {}
+
+    def _neo4j(self) -> Neo4jClient:
+        """Return the underlying connected Neo4jClient, narrowing the None state."""
+        neo4j_client = self._client._client
+        if neo4j_client is None:
+            raise RuntimeError("MemoryClient is not connected; call connect() first.")
+        return neo4j_client
 
     @property
     def namespace(self) -> str:
@@ -386,7 +394,7 @@ class Neo4jMemoryProvider:
             DETACH DELETE m
             RETURN count(m) AS deleted
             """
-            result = await self._client._client.execute_write(
+            result = await self._neo4j().execute_write(
                 query,
                 {"memory_id": memory_id},
             )
@@ -403,7 +411,7 @@ class Neo4jMemoryProvider:
                 DETACH DELETE e
                 RETURN count(e) AS deleted
                 """
-                result = await self._client._client.execute_write(
+                result = await self._neo4j().execute_write(
                     query,
                     {"memory_id": memory_id},
                 )
@@ -420,7 +428,7 @@ class Neo4jMemoryProvider:
                 DETACH DELETE p
                 RETURN count(p) AS deleted
                 """
-                result = await self._client._client.execute_write(
+                result = await self._neo4j().execute_write(
                     query,
                     {"memory_id": memory_id},
                 )
@@ -451,7 +459,7 @@ class Neo4jMemoryProvider:
             DETACH DELETE m
             RETURN count(m) AS deleted
             """
-            result = await self._client._client.execute_write(
+            result = await self._neo4j().execute_write(
                 query,
                 {"session_id": session_id},
             )

--- a/src/neo4j_agent_memory/integrations/agentcore/types.py
+++ b/src/neo4j_agent_memory/integrations/agentcore/types.py
@@ -6,7 +6,7 @@ These types map Neo4j Agent Memory concepts to the AgentCore MemoryProvider inte
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import datetime, timezone
 from enum import Enum
 from typing import Any
 
@@ -46,7 +46,7 @@ class Memory:
     memory_type: MemoryType = MemoryType.MESSAGE
     session_id: str | None = None
     user_id: str | None = None
-    created_at: datetime = field(default_factory=datetime.utcnow)
+    created_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
     updated_at: datetime | None = None
     metadata: dict[str, Any] = field(default_factory=dict)
     score: float | None = None
@@ -98,7 +98,9 @@ class Memory:
             content=message.content,
             memory_type=MemoryType.MESSAGE,
             session_id=session_id,
-            created_at=message.created_at if hasattr(message, "created_at") else datetime.utcnow(),
+            created_at=message.created_at
+            if hasattr(message, "created_at")
+            else datetime.now(timezone.utc),
             metadata={
                 "role": message.role.value if hasattr(message.role, "value") else str(message.role),
                 **(message.metadata or {}),
@@ -165,7 +167,9 @@ class Memory:
             content=f"Task: {trace.task}\nOutcome: {trace.outcome or 'In progress'}",
             memory_type=MemoryType.TRACE,
             session_id=trace.session_id,
-            created_at=trace.started_at if hasattr(trace, "started_at") else datetime.utcnow(),
+            created_at=trace.started_at
+            if hasattr(trace, "started_at")
+            else datetime.now(timezone.utc),
             metadata={
                 "task": trace.task,
                 "outcome": trace.outcome,
@@ -219,4 +223,4 @@ class SessionContext:
     user_id: str | None = None
     namespace: str = "default"
     metadata: dict[str, Any] = field(default_factory=dict)
-    created_at: datetime = field(default_factory=datetime.utcnow)
+    created_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))

--- a/src/neo4j_agent_memory/integrations/base.py
+++ b/src/neo4j_agent_memory/integrations/base.py
@@ -8,10 +8,11 @@ from __future__ import annotations
 
 import asyncio
 import concurrent.futures
-from collections.abc import Callable
+from collections.abc import Callable, Coroutine
 from functools import wraps
-from typing import Any, TypeVar
+from typing import Any, ParamSpec, TypeVar
 
+P = ParamSpec("P")
 T = TypeVar("T")
 
 # Shared executor for all integrations to avoid per-call overhead
@@ -29,7 +30,7 @@ def _get_executor() -> concurrent.futures.ThreadPoolExecutor:
     return _executor
 
 
-def run_sync(func: Callable[..., T]) -> Callable[..., T]:
+def run_sync(func: Callable[P, Coroutine[Any, Any, T]]) -> Callable[P, T]:
     """
     Decorator to run an async function synchronously.
 
@@ -53,16 +54,17 @@ def run_sync(func: Callable[..., T]) -> Callable[..., T]:
     """
 
     @wraps(func)
-    def wrapper(*args: Any, **kwargs: Any) -> T:
+    def wrapper(*args: P.args, **kwargs: P.kwargs) -> T:
         try:
-            loop = asyncio.get_running_loop()
+            loop: asyncio.AbstractEventLoop | None = asyncio.get_running_loop()
         except RuntimeError:
             loop = None
 
         if loop is not None:
             # Running in async context - use thread pool
             executor = _get_executor()
-            future = executor.submit(asyncio.run, func(*args, **kwargs))
+            coro = func(*args, **kwargs)
+            future = executor.submit(lambda: asyncio.run(coro))
             return future.result(timeout=_SYNC_TIMEOUT_SECONDS)
         else:
             # Not in async context - run directly

--- a/src/neo4j_agent_memory/integrations/crewai/memory.py
+++ b/src/neo4j_agent_memory/integrations/crewai/memory.py
@@ -1,12 +1,15 @@
 """CrewAI memory integration."""
 
-from typing import TYPE_CHECKING, Any
+from collections.abc import Coroutine
+from typing import TYPE_CHECKING, Any, TypeVar
 
 if TYPE_CHECKING:
     from neo4j_agent_memory import MemoryClient
 
+_T = TypeVar("_T")
+
 try:
-    from crewai.memory import Memory
+    from crewai.memory.memory import Memory
 
     class Neo4jCrewMemory(Memory):
         """
@@ -44,7 +47,7 @@ try:
             self._client = memory_client
             self._crew_id = crew_id
 
-        def _run_async(self, coro: Any) -> Any:
+        def _run_async(self, coro: Coroutine[Any, Any, _T]) -> _T:
             """
             Run an async coroutine from sync context.
 

--- a/src/neo4j_agent_memory/integrations/google_adk/__init__.py
+++ b/src/neo4j_agent_memory/integrations/google_adk/__init__.py
@@ -41,7 +41,7 @@ def llm_provider_from_google_adk(model: Any) -> Any:
     return _passthrough(model)
 
 
-def __getattr__(name: str):
+def __getattr__(name: str) -> Any:
     if name == "Neo4jMemoryService":
         from neo4j_agent_memory.integrations.google_adk.memory_service import (
             Neo4jMemoryService,

--- a/src/neo4j_agent_memory/integrations/google_adk/memory_service.py
+++ b/src/neo4j_agent_memory/integrations/google_adk/memory_service.py
@@ -9,39 +9,52 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Any
 
-try:
-    from google.adk.memory.base_memory_service import BaseMemoryService, SearchMemoryResponse
-except ImportError:
-    BaseMemoryService = object
+if TYPE_CHECKING:
+    # google.adk ships no py.typed marker, so its exports resolve to Any.
+    # Alias the ADK base to ``object`` for static analysis (strict mode
+    # forbids subclassing Any) and import the response type for annotations.
+    # The runtime import / fallback lives in the ``else`` branch, which the
+    # type checkers treat as unreachable — so neither sees a redefinition.
+    from google.adk.memory.base_memory_service import SearchMemoryResponse
 
-    class SearchMemoryResponse:
-        """Exact replica of ADK's response objects for CI environments."""
+    _ADKBase = object
+else:
+    try:
+        from google.adk.memory.base_memory_service import (
+            BaseMemoryService as _ADKBase,
+        )
+        from google.adk.memory.base_memory_service import SearchMemoryResponse
+    except ImportError:
+        _ADKBase = object
 
-        def __init__(self, memories=None, **kwargs):
-            self.memories = []
-            for m in memories or []:
-                if isinstance(m, dict):
+        class SearchMemoryResponse:
+            """Exact replica of ADK's response objects for CI environments."""
 
-                    class MockPart:
-                        def __init__(self, text):
-                            self.text = text
+            def __init__(self, memories: list[dict[str, Any]] | None = None, **kwargs: Any) -> None:
+                self.memories: list[Any] = []
+                for m in memories or []:
+                    if isinstance(m, dict):
 
-                    class MockContent:
-                        def __init__(self, role, parts):
-                            self.role = role
-                            self.parts = [MockPart(p.get("text", "")) for p in parts]
+                        class MockPart:
+                            def __init__(self, text: str) -> None:
+                                self.text = text
 
-                    class MockEntry:
-                        def __init__(self, data):
-                            self.id = data.get("id")
-                            c_data = data.get("content", {})
-                            self.content = MockContent(
-                                c_data.get("role", "user"), c_data.get("parts", [])
-                            )
+                        class MockContent:
+                            def __init__(self, role: str, parts: list[dict[str, Any]]) -> None:
+                                self.role = role
+                                self.parts = [MockPart(p.get("text", "")) for p in parts]
 
-                    self.memories.append(MockEntry(m))
-                else:
-                    self.memories.append(m)
+                        class MockEntry:
+                            def __init__(self, data: dict[str, Any]) -> None:
+                                self.id = data.get("id")
+                                c_data = data.get("content", {})
+                                self.content = MockContent(
+                                    c_data.get("role", "user"), c_data.get("parts", [])
+                                )
+
+                        self.memories.append(MockEntry(m))
+                    else:
+                        self.memories.append(m)
 
 
 from neo4j_agent_memory.integrations.google_adk.types import (
@@ -59,7 +72,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-class Neo4jMemoryService(BaseMemoryService):
+class Neo4jMemoryService(_ADKBase):
     """Neo4j-backed memory service for Google ADK agents.
 
     Implements the ADK MemoryService interface to provide:

--- a/src/neo4j_agent_memory/integrations/langchain/memory.py
+++ b/src/neo4j_agent_memory/integrations/langchain/memory.py
@@ -1,11 +1,15 @@
 """LangChain memory integration."""
 
-from typing import TYPE_CHECKING, Any
+from collections.abc import Coroutine
+from typing import TYPE_CHECKING, Any, TypeVar
 
 from pydantic import BaseModel, ConfigDict
 
 if TYPE_CHECKING:
-    pass
+    from neo4j_agent_memory.memory.reasoning import ReasoningTrace
+    from neo4j_agent_memory.memory.short_term import Message
+
+_T = TypeVar("_T")
 
 
 class Neo4jAgentMemory(BaseModel):
@@ -40,7 +44,7 @@ class Neo4jAgentMemory(BaseModel):
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
-    def _run_async(self, coro: Any) -> Any:
+    def _run_async(self, coro: Coroutine[Any, Any, _T]) -> _T:
         """
         Run an async coroutine from sync context.
 
@@ -139,14 +143,14 @@ class Neo4jAgentMemory(BaseModel):
         """Clear conversation history for this session."""
         self._run_async(self.memory_client.short_term.clear_session(self.session_id))
 
-    def _format_messages(self, messages: list) -> str:
+    def _format_messages(self, messages: list["Message"]) -> str:
         """Format messages for context."""
         lines = []
         for msg in messages:
             lines.append(f"{msg.role.value}: {msg.content}")
         return "\n".join(lines)
 
-    def _format_traces(self, traces: list) -> str:
+    def _format_traces(self, traces: list["ReasoningTrace"]) -> str:
         """Format reasoning traces for context."""
         lines = []
         for trace in traces:

--- a/src/neo4j_agent_memory/integrations/langchain/retriever.py
+++ b/src/neo4j_agent_memory/integrations/langchain/retriever.py
@@ -57,7 +57,8 @@ try:
                 import concurrent.futures
 
                 with concurrent.futures.ThreadPoolExecutor() as executor:
-                    future = executor.submit(asyncio.run, self._get_relevant_documents_async(query))
+                    coro = self._get_relevant_documents_async(query)
+                    future = executor.submit(lambda: asyncio.run(coro))
                     return future.result()
             else:
                 return asyncio.run(self._get_relevant_documents_async(query))

--- a/src/neo4j_agent_memory/integrations/llamaindex/memory.py
+++ b/src/neo4j_agent_memory/integrations/llamaindex/memory.py
@@ -3,10 +3,14 @@
 import asyncio
 import json
 import re
-from typing import TYPE_CHECKING, Any
+from collections.abc import Coroutine
+from typing import TYPE_CHECKING, Any, TypeVar
 
 if TYPE_CHECKING:
     from neo4j_agent_memory import MemoryClient
+    from neo4j_agent_memory.memory.short_term import Message
+
+_T = TypeVar("_T")
 
 try:
     from llama_index.core.base.llms.types import ChatMessage, MessageRole
@@ -49,6 +53,7 @@ try:
         ):
             self._client = memory_client
             self._session_id = session_id
+            self._loop: asyncio.AbstractEventLoop | None
             try:
                 self._loop = asyncio.get_running_loop()
             except RuntimeError:
@@ -58,7 +63,7 @@ try:
         # Internal helpers
         # ------------------------------------------------------------------
 
-        def _run_async(self, coro: Any) -> Any:
+        def _run_async(self, coro: Coroutine[Any, Any, _T]) -> _T:
             """Run an async coroutine from sync context."""
             if self._loop is None or self._loop.is_closed():
                 return asyncio.run(coro)
@@ -106,7 +111,7 @@ try:
             return str(obj)
 
         @staticmethod
-        def _get_metadata_dict(msg: Any) -> dict:
+        def _get_metadata_dict(msg: Any) -> dict[str, Any]:
             """Safely extract the metadata dict from a stored message.
 
             Handles both dict and JSON-string forms of the metadata field.
@@ -143,7 +148,8 @@ try:
                 inner = m.group(1)
                 try:
                     # Try JSON-decoding in case it was a JSON-escaped string
-                    return json.loads(f'"{inner}"')
+                    decoded = json.loads(f'"{inner}"')
+                    return decoded if isinstance(decoded, str) else inner
                 except (json.JSONDecodeError, ValueError):
                     return inner.replace("\\'", "'").replace("\\n", "\n")
             return content
@@ -198,7 +204,7 @@ try:
                 additional_kwargs=stored_kwargs,
             )
 
-        def _ensure_tool_call_integrity(self, messages: list) -> list:
+        def _ensure_tool_call_integrity(self, messages: list["Message"]) -> list["Message"]:
             """Filter out incomplete tool-call pairs to prevent API errors.
 
             OpenAI requires that every assistant message with tool_calls is
@@ -224,7 +230,7 @@ try:
             # responses exist; keep tool responses only if their calling
             # assistant msg exists.
             kept_assistant_call_ids: set[str] = set()
-            filtered: list = []
+            filtered: list[Message] = []
             for msg in messages:
                 if self._is_tool_call_msg(msg):
                     needed = self._get_tool_call_ids(msg)
@@ -239,7 +245,7 @@ try:
                     filtered.append(msg)
 
             # Second pass: drop tool responses whose assistant was dropped
-            final: list = []
+            final: list[Message] = []
             for msg in filtered:
                 if self._is_tool_response_msg(msg):
                     tcid = self._get_tool_call_id(msg)
@@ -278,7 +284,7 @@ try:
         # ------------------------------------------------------------------
 
         async def aget(self, input: str | None = None, **kwargs: Any) -> list[ChatMessage]:
-            raw_messages: list = []
+            raw_messages: list[Message] = []
             seen_ids: set[str] = set()
 
             # ---- Always load session conversation history first ----
@@ -343,7 +349,7 @@ try:
                 else None
             )
 
-            content = message.content
+            content = message.content or ""
             # Clean MCP result repr on write so data is stored cleanly
             if role_str == "tool" and content:
                 content = self._extract_mcp_text(content)
@@ -364,7 +370,7 @@ try:
             await self._client.short_term.clear_session(self._session_id)
 
         @classmethod
-        def from_defaults(
+        def from_defaults(  # type: ignore[override]  # base is a loose **kwargs factory; this backend needs a client + session
             cls,
             memory_client: "MemoryClient",
             session_id: str,

--- a/src/neo4j_agent_memory/integrations/microsoft_agent/gds.py
+++ b/src/neo4j_agent_memory/integrations/microsoft_agent/gds.py
@@ -12,6 +12,8 @@ from enum import Enum
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
+    from neo4j import AsyncSession
+
     from neo4j_agent_memory import MemoryClient
 
 logger = logging.getLogger(__name__)
@@ -115,6 +117,13 @@ class GDSIntegration:
         self._gds_available: bool | None = None
         self._fallback_warned: bool = False
 
+    def _session(self) -> AsyncSession:
+        """Return a raw Neo4j session, narrowing the client's connected state."""
+        neo4j_client = self._client._client
+        if neo4j_client is None:
+            raise RuntimeError("MemoryClient is not connected; call connect() first.")
+        return neo4j_client.session()
+
     @property
     def config(self) -> GDSConfig:
         """Get the GDS configuration."""
@@ -132,7 +141,7 @@ class GDSIntegration:
 
         try:
             # Try to call gds.version()
-            async with self._client._client.session() as session:
+            async with self._session() as session:
                 result = await session.run("RETURN gds.version() AS version")
                 record = await result.single()
                 if record:
@@ -204,7 +213,7 @@ class GDSIntegration:
         ORDER BY score DESC
         """
         try:
-            async with self._client._client.session() as session:
+            async with self._session() as session:
                 result = await session.run(
                     query,
                     entity_ids=entity_ids,
@@ -243,7 +252,7 @@ class GDSIntegration:
         ORDER BY score DESC
         """
         try:
-            async with self._client._client.session() as session:
+            async with self._session() as session:
                 result = await session.run(simple_query, entity_ids=entity_ids)
                 records = await result.data()
                 return [(r["entity_id"], r["score"]) for r in records]
@@ -291,7 +300,7 @@ class GDSIntegration:
         RETURN e.id AS entity_id, communityId AS community_id
         """
         try:
-            async with self._client._client.session() as session:
+            async with self._session() as session:
                 result = await session.run(query, entity_ids=entity_ids)
                 records = await result.data()
                 return {r["entity_id"]: r["community_id"] for r in records}
@@ -319,7 +328,7 @@ class GDSIntegration:
         RETURN entity_id, group_id
         """
         try:
-            async with self._client._client.session() as session:
+            async with self._session() as session:
                 result = await session.run(query, entity_ids=entity_ids)
                 records = await result.data()
 
@@ -345,7 +354,7 @@ class GDSIntegration:
         source_entity: str,
         target_entity: str,
         max_hops: int = 5,
-    ) -> list[dict[str, Any]] | None:
+    ) -> dict[str, Any] | None:
         """
         Find shortest path between two entities.
 
@@ -355,15 +364,20 @@ class GDSIntegration:
             max_hops: Maximum path length to search.
 
         Returns:
-            List of nodes in the path, or None if no path exists.
+            A dict with ``"nodes"`` (the entities along the path) and
+            ``"relationships"`` (their connecting relationship types), or
+            ``None`` if no path exists.
         """
-        # This doesn't require GDS - use built-in shortestPath
+        # This doesn't require GDS - use built-in shortestPath.
+        # Cypher can't parameterize a variable-length path bound, so max_hops
+        # is interpolated; coerce it to int to keep the query injection-safe.
+        safe_hops = int(max_hops)
         query = f"""
         MATCH (source:Entity)
         WHERE source.name = $source OR source.id = $source
         MATCH (target:Entity)
         WHERE target.name = $target OR target.id = $target
-        MATCH path = shortestPath((source)-[*..{max_hops}]-(target))
+        MATCH path = shortestPath((source)-[*..{safe_hops}]-(target))
         RETURN [n IN nodes(path) | {{
             id: n.id,
             name: n.name,
@@ -372,9 +386,9 @@ class GDSIntegration:
         [r IN relationships(path) | {{type: type(r)}}] AS relationships
         """
         try:
-            async with self._client._client.session() as session:
+            async with self._session() as session:
                 result = await session.run(
-                    query,
+                    query,  # ty: ignore[invalid-argument-type]  # neo4j stubs type the query as LiteralString; ours is a runtime str built from a fixed template + an int bound (safe_hops)
                     source=source_entity,
                     target=target_entity,
                 )
@@ -447,7 +461,7 @@ class GDSIntegration:
         LIMIT $limit
         """
         try:
-            async with self._client._client.session() as session:
+            async with self._session() as session:
                 result = await session.run(query, entity_id=entity_id, limit=limit)
                 records = await result.data()
                 return [dict(r) for r in records]
@@ -478,7 +492,7 @@ class GDSIntegration:
             else:
                 # Get all entities
                 query = "MATCH (e:Entity) RETURN e.id AS id LIMIT 1000"
-                async with self._client._client.session() as session:
+                async with self._session() as session:
                     result = await session.run(query)
                     records = await result.data()
                     all_ids = [r["id"] for r in records]
@@ -493,7 +507,7 @@ class GDSIntegration:
             WHERE e.id IN $ids
             RETURN e.id AS id, e.name AS name, e.type AS type, e.description AS description
             """
-            async with self._client._client.session() as session:
+            async with self._session() as session:
                 result = await session.run(query, ids=top_ids)
                 records = await result.data()
                 return [{**dict(r), "score": score_map.get(r["id"], 0)} for r in records]

--- a/src/neo4j_agent_memory/integrations/microsoft_agent/tracing.py
+++ b/src/neo4j_agent_memory/integrations/microsoft_agent/tracing.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Any
 
+from neo4j_agent_memory.memory.reasoning import ToolCallStatus
+
 if TYPE_CHECKING:
     from neo4j_agent_memory.memory.reasoning import ReasoningTrace
 
@@ -112,7 +114,7 @@ try:
                             step_id=current_step.id,
                             tool_name=tool_name,
                             arguments=arguments,
-                            status="success",
+                            status=ToolCallStatus.SUCCESS,
                         )
 
                 elif content:
@@ -169,8 +171,10 @@ try:
             success=success,
         )
 
-        # Return the completed trace
-        return await client.reasoning.get_trace(trace.id)
+        # Return the completed trace, falling back to the in-memory trace
+        # if the re-fetch returns nothing.
+        completed = await client.reasoning.get_trace(trace.id)
+        return completed if completed is not None else trace
 
     async def get_similar_traces(
         memory: Neo4jMicrosoftMemory,
@@ -253,35 +257,41 @@ try:
     def _get_content(msg: Any) -> str:
         """Extract content from a message."""
         if isinstance(msg, dict):
-            return msg.get("content", "")
+            content = msg.get("content", "")
+            return content if isinstance(content, str) else ""
         # Message.text returns concatenated text from all TextContent items
         if hasattr(msg, "text"):
-            return msg.text or ""
+            text = msg.text or ""
+            return text if isinstance(text, str) else ""
         return ""
 
     def _get_tool_calls(msg: Any) -> list[Any]:
         """Extract tool calls from a message."""
         if isinstance(msg, dict):
-            return msg.get("tool_calls", [])
+            tool_calls = msg.get("tool_calls", [])
+            return tool_calls if isinstance(tool_calls, list) else []
         if hasattr(msg, "tool_calls"):
-            return msg.tool_calls or []
+            tool_calls = msg.tool_calls or []
+            return tool_calls if isinstance(tool_calls, list) else []
         return []
 
     def _get_tool_name(tc: Any) -> str:
         """Extract tool name from a tool call."""
         if isinstance(tc, dict):
             func = tc.get("function", {})
-            if isinstance(func, dict):
-                return func.get("name", "unknown")
-            return tc.get("name", "unknown")
+            name = (
+                func.get("name", "unknown") if isinstance(func, dict) else tc.get("name", "unknown")
+            )
+            return name if isinstance(name, str) else "unknown"
         if hasattr(tc, "function"):
             func = tc.function
             if hasattr(func, "name"):
-                return func.name
+                return func.name if isinstance(func.name, str) else "unknown"
             if isinstance(func, dict):
-                return func.get("name", "unknown")
+                name = func.get("name", "unknown")
+                return name if isinstance(name, str) else "unknown"
         if hasattr(tc, "name"):
-            return tc.name
+            return tc.name if isinstance(tc.name, str) else "unknown"
         return "unknown"
 
     def _get_tool_arguments(tc: Any) -> dict[str, Any]:
@@ -310,7 +320,8 @@ try:
         # Parse if string
         if isinstance(args, str):
             try:
-                return json.loads(args)
+                parsed = json.loads(args)
+                return parsed if isinstance(parsed, dict) else {"raw": args}
             except (json.JSONDecodeError, TypeError):
                 return {"raw": args}
 

--- a/src/neo4j_agent_memory/integrations/openai_agents/memory.py
+++ b/src/neo4j_agent_memory/integrations/openai_agents/memory.py
@@ -113,7 +113,7 @@ try:
             self,
             role: str,
             content: str,
-            tool_calls: list[dict] | None = None,
+            tool_calls: list[dict[str, Any]] | None = None,
             tool_call_id: str | None = None,
             extract_entities: bool = True,
             generate_embedding: bool = True,
@@ -132,7 +132,7 @@ try:
             Returns:
                 The saved Message object
             """
-            metadata = {}
+            metadata: dict[str, Any] = {}
             if tool_calls:
                 metadata["tool_calls"] = tool_calls
             if tool_call_id:
@@ -151,7 +151,7 @@ try:
             self,
             limit: int = 50,
             include_system: bool = True,
-        ) -> list[dict]:
+        ) -> list[dict[str, Any]]:
             """
             Get conversation history in OpenAI message format.
 
@@ -197,7 +197,7 @@ try:
             include_messages: bool = True,
             include_entities: bool = True,
             include_preferences: bool = True,
-        ) -> list[dict]:
+        ) -> list[dict[str, Any]]:
             """
             Search across all memory types.
 
@@ -297,7 +297,7 @@ try:
             query: str,
             category: str | None = None,
             limit: int = 10,
-        ) -> list[dict]:
+        ) -> list[dict[str, Any]]:
             """
             Search user preferences.
 
@@ -327,7 +327,7 @@ try:
             """Clear all messages in the current session."""
             await self._client.short_term.clear_session(self._session_id)
 
-    def create_memory_tools(memory: Neo4jOpenAIMemory) -> list[dict]:
+    def create_memory_tools(memory: Neo4jOpenAIMemory) -> list[dict[str, Any]]:
         """
         Create OpenAI function tools for memory operations.
 
@@ -446,7 +446,7 @@ try:
     async def execute_memory_tool(
         memory: Neo4jOpenAIMemory,
         tool_name: str,
-        arguments: dict,
+        arguments: dict[str, Any],
     ) -> str:
         """
         Execute a memory tool and return the result.

--- a/src/neo4j_agent_memory/integrations/openai_agents/tracing.py
+++ b/src/neo4j_agent_memory/integrations/openai_agents/tracing.py
@@ -4,7 +4,9 @@ Records OpenAI agent executions as reasoning traces for
 learning from past interactions and improving future responses.
 """
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
+
+from neo4j_agent_memory.memory.reasoning import ToolCallStatus
 
 if TYPE_CHECKING:
     from neo4j_agent_memory.memory.reasoning import ReasoningTrace
@@ -16,9 +18,9 @@ try:
 
     async def record_agent_trace(
         memory: "Neo4jOpenAIMemory",
-        messages: list[dict],
+        messages: list[dict[str, Any]],
         task: str,
-        tool_calls: list[dict] | None = None,
+        tool_calls: list[dict[str, Any]] | None = None,
         outcome: str | None = None,
         success: bool = True,
         generate_embedding: bool = True,
@@ -110,7 +112,7 @@ try:
                             step_id=current_step.id,
                             tool_name=tool_name,
                             arguments=arguments,
-                            status="success",  # Default to success
+                            status=ToolCallStatus.SUCCESS,  # Default to success
                         )
 
                 elif content:
@@ -165,8 +167,10 @@ try:
             success=success,
         )
 
-        # Return the completed trace
-        return await client.reasoning.get_trace(trace.id)
+        # Return the completed trace, falling back to the in-memory trace
+        # if the re-fetch returns nothing.
+        completed = await client.reasoning.get_trace(trace.id)
+        return completed if completed is not None else trace
 
     async def get_similar_traces(
         memory: "Neo4jOpenAIMemory",

--- a/src/neo4j_agent_memory/integrations/pydantic_ai/memory.py
+++ b/src/neo4j_agent_memory/integrations/pydantic_ai/memory.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, TypeVar
 
 if TYPE_CHECKING:
-    from pydantic_ai.result import RunResult
+    from pydantic_ai.agent import AgentRunResult
 
     from neo4j_agent_memory import MemoryClient
     from neo4j_agent_memory.memory.reasoning import ReasoningMemory, ReasoningTrace
@@ -128,7 +128,7 @@ class MemoryDependency:
         ]
 
 
-def create_memory_tools(memory: "MemoryClient") -> list[Callable]:
+def create_memory_tools(memory: "MemoryClient") -> list[Callable[..., Any]]:
     """
     Create Pydantic AI tools for memory operations.
 
@@ -230,7 +230,7 @@ def create_memory_tools(memory: "MemoryClient") -> list[Callable]:
 async def record_agent_trace(
     reasoning_memory: "ReasoningMemory",
     session_id: str,
-    result: "RunResult[T]",
+    result: "AgentRunResult[T]",
     *,
     task: str | None = None,
     include_tool_calls: bool = True,
@@ -287,16 +287,13 @@ async def record_agent_trace(
 
     # Extract task from first user message if not provided
     if task is None:
+        task = "PydanticAI agent run"
         for msg in result.all_messages():
             if isinstance(msg, ModelRequest):
-                for part in msg.parts:
-                    if isinstance(part, UserPromptPart):
-                        task = str(part.content)[:500]  # Truncate long tasks
-                        break
-            if task:
-                break
-        if task is None:
-            task = "PydanticAI agent run"
+                user_part = next((p for p in msg.parts if isinstance(p, UserPromptPart)), None)
+                if user_part is not None:
+                    task = str(user_part.content)[:500]  # Truncate long tasks
+                    break
 
     # Start the trace
     trace = await reasoning_memory.start_trace(
@@ -319,14 +316,8 @@ async def record_agent_trace(
                 for part in msg.parts:
                     if isinstance(part, ToolCallPart):
                         tool_call_id = part.tool_call_id or f"call_{len(tool_calls)}"
-                        # Extract args safely
-                        args = {}
-                        if hasattr(part.args, "args_dict"):
-                            args = part.args.args_dict
-                        elif hasattr(part.args, "model_dump"):
-                            args = part.args.model_dump()
-                        elif isinstance(part.args, dict):
-                            args = part.args
+                        # args_as_dict() normalizes str/dict args to a dict.
+                        args: dict[str, Any] = part.args_as_dict() if part.args is not None else {}
 
                         tool_calls[tool_call_id] = {
                             "name": part.tool_name,
@@ -334,10 +325,10 @@ async def record_agent_trace(
                         }
 
             elif isinstance(msg, ModelRequest):
-                for part in msg.parts:
-                    if isinstance(part, ToolReturnPart):
-                        tool_call_id = part.tool_call_id or ""
-                        tool_results[tool_call_id] = part.content
+                for req_part in msg.parts:
+                    if isinstance(req_part, ToolReturnPart):
+                        tool_call_id = req_part.tool_call_id or ""
+                        tool_results[tool_call_id] = req_part.content
 
         # Create steps for each tool call
         step_number = 0
@@ -415,7 +406,7 @@ def _is_error_result(result: Any) -> bool:
     return False
 
 
-def nams_memory_tools(memory: "MemoryClient") -> list[Callable]:
+def nams_memory_tools(memory: "MemoryClient") -> list[Callable[..., Any]]:
     """Pydantic AI tools exposing NAMS Platinum operations.
 
     Returns the standard :func:`create_memory_tools` set plus four

--- a/src/neo4j_agent_memory/integrations/strands/tools.py
+++ b/src/neo4j_agent_memory/integrations/strands/tools.py
@@ -25,8 +25,14 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from collections.abc import Coroutine
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal, TypeVar
+
+_T = TypeVar("_T")
+
+# Transport modes accepted by the NAMS backend (mirrors NamsConfig.transport_mode).
+TransportMode = Literal["auto", "rest", "bridge"]
 
 if TYPE_CHECKING:
     from neo4j_agent_memory import MemoryClient
@@ -49,14 +55,14 @@ def _is_valid_hf_model_id(model_id: str) -> bool:
     return "/" in model_id and not model_id.startswith("/") and not model_id.endswith("/")
 
 
-def _run_async(coro: Any) -> Any:
+def _run_async(coro: Coroutine[Any, Any, _T]) -> _T:
     """Run an async coroutine synchronously.
 
     Strands tools are synchronous, but MemoryClient is async.
     This helper runs async code in the appropriate event loop.
     """
     try:
-        loop = asyncio.get_running_loop()
+        loop: asyncio.AbstractEventLoop | None = asyncio.get_running_loop()
     except RuntimeError:
         loop = None
 
@@ -65,14 +71,14 @@ def _run_async(coro: Any) -> Any:
         import concurrent.futures
 
         with concurrent.futures.ThreadPoolExecutor() as executor:
-            future = executor.submit(asyncio.run, coro)
+            future = executor.submit(lambda: asyncio.run(coro))
             return future.result()
     else:
         # No running loop - safe to use asyncio.run
         return asyncio.run(coro)
 
 
-def _get_nams_cache_bucket(endpoint: str, transport_mode: str) -> tuple[str, str]:
+def _get_nams_cache_bucket(endpoint: str, transport_mode: TransportMode) -> tuple[str, str]:
     """Return the process-local cache bucket key for NAMS clients."""
     return (endpoint, transport_mode)
 
@@ -100,6 +106,8 @@ def _get_or_create_client(
     cache_key = f"{neo4j_uri}:{neo4j_user}:{neo4j_database}"
 
     if cache_key not in _client_cache:
+        from pydantic import SecretStr
+
         from neo4j_agent_memory import MemoryClient, MemorySettings
         from neo4j_agent_memory.config.settings import Neo4jConfig
         from neo4j_agent_memory.llm import from_provider
@@ -139,8 +147,8 @@ def _get_or_create_client(
 
         neo4j_config = Neo4jConfig(
             uri=neo4j_uri,
-            user=neo4j_user,
-            password=neo4j_password,
+            username=neo4j_user,
+            password=SecretStr(neo4j_password),
             database=neo4j_database,
         )
 
@@ -727,7 +735,7 @@ def context_graph_tools(
         )
 
     # Common config for all tools
-    config = {
+    config: dict[str, Any] = {
         "neo4j_uri": uri,
         "neo4j_user": neo4j_user,
         "neo4j_password": password,
@@ -763,7 +771,7 @@ def clear_client_cache() -> None:
 def _get_or_create_nams_client(
     endpoint: str,
     api_key: str,
-    transport_mode: str = "auto",
+    transport_mode: TransportMode = "auto",
 ) -> MemoryClient:
     """Build (or retrieve cached) a NAMS-backed MemoryClient for Strands tools.
 
@@ -800,7 +808,7 @@ def _get_or_create_nams_client(
     return client
 
 
-def _nams_search_context_tool(endpoint: str, api_key: str, transport_mode: str) -> Any:
+def _nams_search_context_tool(endpoint: str, api_key: str, transport_mode: TransportMode) -> Any:
     """NAMS-backed search_context tool (Strands @tool)."""
     try:
         from strands import tool
@@ -862,7 +870,9 @@ def _nams_search_context_tool(endpoint: str, api_key: str, transport_mode: str) 
     return search_context
 
 
-def _nams_set_entity_feedback_tool(endpoint: str, api_key: str, transport_mode: str) -> Any:
+def _nams_set_entity_feedback_tool(
+    endpoint: str, api_key: str, transport_mode: TransportMode
+) -> Any:
     """NAMS-only @tool — record positive/negative feedback on an entity."""
     try:
         from strands import tool
@@ -896,7 +906,9 @@ def _nams_set_entity_feedback_tool(endpoint: str, api_key: str, transport_mode: 
     return set_entity_feedback
 
 
-def _nams_get_entity_provenance_tool(endpoint: str, api_key: str, transport_mode: str) -> Any:
+def _nams_get_entity_provenance_tool(
+    endpoint: str, api_key: str, transport_mode: TransportMode
+) -> Any:
     """NAMS-only @tool — fetch sources + extractors for an entity."""
     try:
         from strands import tool
@@ -925,7 +937,7 @@ def _nams_get_entity_provenance_tool(endpoint: str, api_key: str, transport_mode
     return get_entity_provenance
 
 
-def _nams_cypher_tool(endpoint: str, api_key: str, transport_mode: str) -> Any:
+def _nams_cypher_tool(endpoint: str, api_key: str, transport_mode: TransportMode) -> Any:
     """NAMS-only @tool — read-only Cypher escape hatch (POST /v1/query)."""
     try:
         from strands import tool
@@ -959,7 +971,7 @@ def _nams_cypher_tool(endpoint: str, api_key: str, transport_mode: str) -> Any:
 def nams_context_graph_tools(
     endpoint: str | None = None,
     api_key: str | None = None,
-    transport_mode: str = "auto",
+    transport_mode: TransportMode = "auto",
 ) -> list[Any]:
     """Create Strands @tool functions backed by NAMS rather than direct Neo4j.
 


### PR DESCRIPTION
## Summary

Brings the entire `integrations/` tree (plus `integrations/base.py`) to **zero `mypy --strict` errors and zero `ty` diagnostics**, and lowers the enforced type-check ratchet: **mypy 102 → 13, ty 85 → 26**. The remaining mypy errors are confined to `testing/mocks.py` (a later workstream). Part of the type-safety effort tracked in #144.

Integrations cleaned: `langchain`, `crewai`, `agentcore`, `pydantic_ai`, `google_adk`, `openai_agents`, `strands`, `llamaindex`, `microsoft_agent`. `run_sync` in `integrations/base.py` is now `ParamSpec`-generic; the per-integration `_run_async` sync bridges are `TypeVar`-generic over `Coroutine`.

## Runtime bugs the type checkers surfaced (fixed)

- **Microsoft Agent GDS never used the GDS library.** `GDSIntegration` called `Neo4jClient.session()`, which didn't exist — every algorithm query threw `AttributeError`, was swallowed by the surrounding `try/except`, and silently fell back to basic Cypher even with GDS installed. The unit-test mock had drifted to expose a `.session` attribute the real object lacked, masking it. Added a public `Neo4jClient.session()` and routed GDS through it.
- **Strands `context_graph_tools()` raised `ValidationError` on every client cache-miss.** It built `Neo4jConfig(user=…, password=<str>)`, but the field is `username` with a `SecretStr` password and `extra="forbid"`. Now `username=…` + `password=SecretStr(…)`.
- **CrewAI `Neo4jCrewMemory` never subclassed the real base class.** `from crewai.memory import Memory` raised `ImportError` (the class lives at `crewai.memory.memory.Memory`), so it silently fell back to the stub.

## Public-API typing changes (in CHANGELOG)

- New public `Neo4jClient.session()` accessor for raw Cypher/session control.
- Strands `transport_mode` narrowed `str` → `Literal["auto", "rest", "bridge"]` on `context_graph_tools()` / `nams_context_graph_tools()`.
- `GDSIntegration.find_shortest_path()` return type corrected to `dict[str, Any] | None` (it always returned a dict, never a list).
- Pydantic AI `record_agent_trace(result=…)` typed `AgentRunResult` (`RunResult` moved to `pydantic_ai.agent`).

## Notes

- `google.adk.*` and `nest_asyncio` (no `py.typed`, used at a typed boundary in one/two files each) are suppressed per-module via `ignore_missing_imports`.
- Modernized `datetime.utcnow()` → `datetime.now(timezone.utc)` in `agentcore/types.py`.
- The `client.short_term` → `ShortTermProtocol` widening is intentionally **not** included here — it's a breaking return-type change that will land separately.

## Verification

- `make typecheck-ratchet` green (mypy 13 / ty 26, both at budget)
- 1444 unit tests pass; `ruff check` + `ruff format --check` clean
- All 15 touched integration modules import cleanly at runtime

Closes part of #144.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
