### PR TITLE
Type-safety Phase 4: mypy-strict + ty clean testing/, extend checked surface to benchmarks/ + examples/*.py

### DIFF
--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -70,12 +70,14 @@ jobs:
       - name: Install dependencies
         run: uv sync --all-extras --group dev
 
+      # Checked surface: src, benchmarks, and the top-level examples/*.py demos
+      # (kept in sync with scripts/typecheck_ratchet.py `_targets()`).
       - name: Run mypy
-        run: uv run mypy src
+        run: uv run mypy src benchmarks examples/*.py
         continue-on-error: true # Advisory full-error view; the ratchet below is the gate.
 
       - name: Run ty
-        run: uv run ty check src
+        run: uv run ty check src benchmarks examples/*.py
         continue-on-error: true # Advisory until Phase 6 makes it blocking.
 
       # Blocking on regressions from day one: fails if the mypy/ty error counts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `ReasoningTrace.started_at`, and `_to_python_datetime` fallbacks) switched from
   naive `datetime.utcnow()` to `datetime.now(timezone.utc)`. Reads already produced
   aware datetimes; this makes the write side consistent.
+- **The remaining default timestamps are now timezone-aware (UTC).** Extends the
+  change above to the base `core.MemoryEntry.created_at` (inherited by `Entity`,
+  `Preference`, `Fact`, and every other memory model) and to
+  `EnrichmentResult.retrieved_at` / `EnrichmentTask.created_at` — the last
+  `datetime.utcnow()` call sites in the library. The whole library now writes
+  aware UTC timestamps.
+- **The type-check ratchet now covers `benchmarks/` and the top-level
+  `examples/*.py` demos in addition to `src/`, and all of `src/` is
+  `mypy --strict`-clean (0 errors).** `testing/mocks.py` was the last holdout:
+  `MockReasoningMemory.complete_trace()` now raises on an unknown trace id (matching
+  the real `ReasoningMemory`) instead of returning `None`, and
+  `MockMemoryClient.__aexit__` is fully typed. Three latent bugs in the example
+  scripts were fixed in the process: `basic_usage.py` passed a tool result
+  positionally to the keyword-only `StreamingTraceRecorder.record_tool_call(result=…)`;
+  `langchain_agent.py` used the pre-rename `include_/search_episodic|semantic`
+  keyword arguments (now `*_short_term` / `*_long_term`), which pydantic silently
+  dropped; and `enrichment_example.py` passed a non-existent `confidence=` argument
+  to `add_entity`.
 - **Fixed: GLiNER entity spans with `end_pos == 0`.** In `extraction/gliner_extractor.py`
   the span fallback changed from `entity.end_pos or len(name)` to an explicit
   `is not None` check, so a zero-width span at offset 0 is preserved instead of being

--- a/Makefile
+++ b/Makefile
@@ -112,12 +112,12 @@ format-check:
 	uv run ruff format --check src tests
 
 typecheck:
-	uv run mypy src
+	uv run mypy src benchmarks examples/*.py
 
 # Second, independent type checker (Astral's ty). Non-blocking by itself today;
 # the typecheck-ratchet target is what gates regressions in CI.
 ty:
-	uv run ty check src
+	uv run ty check src benchmarks examples/*.py
 
 # Monotonic error ratchet: fails if mypy/ty counts rise above the committed
 # budget (scripts/typecheck-budget.txt), or improve without recording it.

--- a/examples/basic_usage.py
+++ b/examples/basic_usage.py
@@ -23,7 +23,7 @@ from pathlib import Path
 from pydantic import SecretStr
 
 
-def load_env_files():
+def load_env_files() -> None:
     """Load environment variables from .env files."""
     # Try to load from dotenv if available
     try:
@@ -72,7 +72,7 @@ from neo4j_agent_memory import (
 )
 
 
-async def main():
+async def main() -> None:
     # v0.3+: pick an embedding model as a provider-string. The factory
     # resolves to the best available adapter — OpenAI native if [openai]
     # is installed, sentence-transformers local if the openai key is
@@ -420,7 +420,7 @@ async def main():
             await recorder.record_tool_call(
                 "analyze_text",
                 {"text": "Customer asking about returns"},
-                {"intent": "return_policy", "confidence": 0.95},
+                result={"intent": "return_policy", "confidence": 0.95},
             )
             await recorder.add_observation("Customer wants to know about return policy")
 

--- a/examples/enrichment_example.py
+++ b/examples/enrichment_example.py
@@ -26,7 +26,7 @@ import os
 from pathlib import Path
 
 
-def load_env_files():
+def load_env_files() -> None:
     """Load environment variables from .env files."""
     try:
         from dotenv import load_dotenv
@@ -53,7 +53,7 @@ def load_env_files():
 load_env_files()
 
 
-async def demo_direct_provider_usage():
+async def demo_direct_provider_usage() -> None:
     """Demonstrate using enrichment providers directly without Neo4j."""
     print("=" * 60)
     print("DEMO 1: Direct Provider Usage (No Neo4j Required)")
@@ -135,7 +135,7 @@ async def demo_direct_provider_usage():
     print(f"  Status: {result.status.value}")  # Should be SKIPPED
 
 
-async def demo_diffbot_provider():
+async def demo_diffbot_provider() -> None:
     """Demonstrate using Diffbot provider (requires API key)."""
     print("\n" + "=" * 60)
     print("DEMO 2: Diffbot Provider (Requires API Key)")
@@ -184,7 +184,7 @@ async def demo_diffbot_provider():
         print(f"  Error: {result.error_message}")
 
 
-async def demo_caching_and_composite():
+async def demo_caching_and_composite() -> None:
     """Demonstrate caching and composite providers."""
     print("\n" + "=" * 60)
     print("DEMO 3: Caching and Composite Providers")
@@ -252,7 +252,7 @@ async def demo_caching_and_composite():
         )
 
 
-async def demo_with_neo4j():
+async def demo_with_neo4j() -> None:
     """Demonstrate full integration with Neo4j and background enrichment."""
     print("\n" + "=" * 60)
     print("DEMO 4: Full Integration with Neo4j")
@@ -335,7 +335,6 @@ async def demo_with_neo4j():
                 name=name,
                 entity_type=entity_type,
                 description=description,
-                confidence=0.9,
             )
             added_entities.append(entity)
             print(f"  Added: {name} ({entity_type})")
@@ -370,7 +369,7 @@ async def demo_with_neo4j():
         print("Check Neo4j for 'enriched_description' property on Entity nodes.")
 
 
-async def main():
+async def main() -> None:
     """Run all demos."""
     print("=" * 60)
     print("Neo4j Agent Memory - Entity Enrichment Examples")

--- a/examples/entity_resolution.py
+++ b/examples/entity_resolution.py
@@ -22,7 +22,7 @@ from neo4j_agent_memory.resolution import (
 )
 
 
-async def main():
+async def main() -> None:
     print("=" * 60)
     print("Neo4j Agent Memory - Entity Resolution Demo")
     print("=" * 60)

--- a/examples/langchain_agent.py
+++ b/examples/langchain_agent.py
@@ -21,7 +21,7 @@ from pathlib import Path
 from pydantic import SecretStr
 
 
-def load_env_files():
+def load_env_files() -> None:
     """Load environment variables from .env files."""
     try:
         from dotenv import load_dotenv
@@ -54,7 +54,7 @@ load_env_files()
 from neo4j_agent_memory import MemoryClient, MemorySettings, Neo4jConfig
 
 
-async def main():
+async def main() -> None:
     # v0.3+: when you have a LangChain chat model already configured, use
     # llm_provider_from_langchain to feed it directly into MemorySettings.
     # This avoids declaring the same model twice (once for the agent,
@@ -62,7 +62,7 @@ async def main():
     # provider when LangChain is not installed.
     llm_provider = None
     try:
-        from langchain_openai import ChatOpenAI
+        from langchain_openai import ChatOpenAI  # type: ignore[import-not-found]  # optional example-only dependency, not a project dep
 
         from neo4j_agent_memory.integrations.langchain import (
             llm_provider_from_langchain,
@@ -127,8 +127,8 @@ async def main():
         memory = Neo4jAgentMemory(
             memory_client=client,
             session_id=session_id,
-            include_episodic=True,
-            include_semantic=True,
+            include_short_term=True,
+            include_long_term=True,
             include_reasoning=True,
         )
 
@@ -159,8 +159,8 @@ async def main():
 
         retriever = Neo4jMemoryRetriever(
             memory_client=client,
-            search_episodic=True,
-            search_semantic=True,
+            search_short_term=True,
+            search_long_term=True,
             k=5,
         )
 

--- a/examples/pydantic_ai_agent.py
+++ b/examples/pydantic_ai_agent.py
@@ -21,7 +21,7 @@ from pathlib import Path
 from pydantic import SecretStr
 
 
-def load_env_files():
+def load_env_files() -> None:
     """Load environment variables from .env files."""
     try:
         from dotenv import load_dotenv
@@ -54,19 +54,19 @@ load_env_files()
 from neo4j_agent_memory import MemoryClient, MemorySettings, Neo4jConfig
 
 
-async def main():
+async def main() -> None:
     # v0.3+: when you have a PydanticAI model already configured for your
     # agent, hand it to memory via llm_provider_from_pydantic_ai. The
     # extractor will use the same provider for entity extraction.
     llm_provider = None
     try:
-        from pydantic_ai.models.openai import OpenAIModel
+        from pydantic_ai.models.openai import OpenAIChatModel
 
         from neo4j_agent_memory.integrations.pydantic_ai import (
             llm_provider_from_pydantic_ai,
         )
 
-        agent_model = OpenAIModel("gpt-4o-mini")
+        agent_model = OpenAIChatModel("gpt-4o-mini")
         llm_provider = llm_provider_from_pydantic_ai(agent_model)
         print("Using shared PydanticAI model for memory extraction")
     except ImportError:
@@ -134,7 +134,7 @@ async def main():
         tools = create_memory_tools(client)
         print(f"Created {len(tools)} tools:")
         for tool in tools:
-            print(f"   - {tool.__name__}")
+            print(f"   - {getattr(tool, '__name__', str(tool))}")
 
         # Use the search_memory tool
         search_result = await tools[0]("vegetarian food")

--- a/scripts/typecheck-budget.txt
+++ b/scripts/typecheck-budget.txt
@@ -7,5 +7,5 @@
 # Measured with integration extras installed: `uv sync --all-extras --group dev`.
 # Refresh after improving a count: `make typecheck-ratchet-update`.
 
-mypy=13
-ty=26
+mypy=0
+ty=3

--- a/scripts/typecheck_ratchet.py
+++ b/scripts/typecheck_ratchet.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
 """Monotonic type-check error ratchet.
 
-Runs the project type checkers (``mypy`` and ``ty``) over ``src`` and compares
-their error/diagnostic counts against a committed budget
-(``scripts/typecheck-budget.txt``).
+Runs the project type checkers (``mypy`` and ``ty``) over the checked surface
+(``src``, ``benchmarks``, and the top-level ``examples/*.py`` demos — see
+``_targets()``) and compares their error/diagnostic counts against a committed
+budget (``scripts/typecheck-budget.txt``).
 
 The budget may only ever *decrease*. This makes CI blocking on regressions from
 day one even while the absolute count is still non-zero (see the type-safety
@@ -35,7 +36,25 @@ from pathlib import Path
 SCRIPT_DIR = Path(__file__).resolve().parent
 REPO_ROOT = SCRIPT_DIR.parent
 BUDGET_FILE = SCRIPT_DIR / "typecheck-budget.txt"
-TARGET = "src"
+
+
+def _targets() -> list[str]:
+    """The checked surface: ``src``, ``benchmarks``, and the top-level
+    single-file example demos (``examples/*.py``).
+
+    The example subdirectories (``examples/<name>/main.py`` etc.) and the
+    full-stack example applications are intentionally excluded here: their many
+    identically-named ``main.py`` modules collide under a single mypy
+    invocation, and the full apps are standalone projects with their own
+    tooling. They are brought under the checker in a later workstream. Adding a
+    new ``examples/*.py`` demo automatically extends the surface — if it does
+    not type-check, the ratchet count rises and CI fails until it is annotated.
+    """
+    examples = sorted(str(p.relative_to(REPO_ROOT)) for p in (REPO_ROOT / "examples").glob("*.py"))
+    return ["src", "benchmarks", *examples]
+
+
+TARGETS = _targets()
 
 BUDGET_HEADER = """\
 # Type-check error budget (monotonic ratchet).
@@ -75,7 +94,7 @@ def _resolve(tool: str) -> str:
 
 
 def count_mypy() -> int:
-    out = _run([_resolve("mypy"), TARGET])
+    out = _run([_resolve("mypy"), *TARGETS])
     m = re.search(r"Found (\d+) error", out)
     if m:
         return int(m.group(1))
@@ -85,7 +104,7 @@ def count_mypy() -> int:
 
 
 def count_ty() -> int:
-    out = _run([_resolve("ty"), "check", TARGET])
+    out = _run([_resolve("ty"), "check", *TARGETS])
     m = re.search(r"Found (\d+) diagnostic", out)
     if m:
         return int(m.group(1))

--- a/src/neo4j_agent_memory/core/memory.py
+++ b/src/neo4j_agent_memory/core/memory.py
@@ -2,7 +2,7 @@
 
 from abc import ABC, abstractmethod
 from collections.abc import AsyncIterator
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, Generic, Protocol, TypeVar
 from uuid import UUID, uuid4
 
@@ -21,7 +21,7 @@ class MemoryEntry(BaseModel):
     """Base model for all memory entries."""
 
     id: UUID = Field(default_factory=uuid4)
-    created_at: datetime = Field(default_factory=datetime.utcnow)
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     updated_at: datetime | None = None
     embedding: list[float] | None = None
     metadata: dict[str, Any] = Field(default_factory=dict)

--- a/src/neo4j_agent_memory/enrichment/base.py
+++ b/src/neo4j_agent_memory/enrichment/base.py
@@ -4,7 +4,7 @@ Defines the core interfaces for entity enrichment from external knowledge source
 """
 
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import datetime, timezone
 from enum import Enum
 from typing import Any, Protocol, runtime_checkable
 from uuid import UUID
@@ -56,7 +56,7 @@ class EnrichmentResult:
     # Confidence and provenance
     confidence: float = 1.0
     source_url: str | None = None
-    retrieved_at: datetime = field(default_factory=datetime.utcnow)
+    retrieved_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
 
     # Error information
     error_message: str | None = None
@@ -149,7 +149,7 @@ class EnrichmentTask:
     entity_type: str
     context: str | None = None
     priority: int = 0  # Higher = more urgent
-    created_at: datetime = field(default_factory=datetime.utcnow)
+    created_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
     retry_count: int = 0
     max_retries: int = 3
 

--- a/src/neo4j_agent_memory/testing/fixtures.py
+++ b/src/neo4j_agent_memory/testing/fixtures.py
@@ -1,6 +1,6 @@
 """Test fixtures and data factories for neo4j-agent-memory."""
 
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Any
 from uuid import UUID, uuid4
 
@@ -91,7 +91,7 @@ class MemoryFixtures:
             role=role,
             content=content,
             conversation_id=conversation_id or uuid4(),
-            created_at=created_at or datetime.utcnow(),
+            created_at=created_at or datetime.now(timezone.utc),
             metadata=metadata or {},
             embedding=embedding,
         )
@@ -125,7 +125,7 @@ class MemoryFixtures:
             Conversation instance with messages
         """
         conv_id = id or uuid4()
-        base_time = created_at or datetime.utcnow()
+        base_time = created_at or datetime.now(timezone.utc)
 
         if messages is None and message_count > 0:
             messages = []
@@ -169,7 +169,7 @@ class MemoryFixtures:
         return SessionInfo(
             session_id=session_id or f"test-session-{uuid4().hex[:8]}",
             title=title,
-            created_at=created_at or datetime.utcnow(),
+            created_at=created_at or datetime.now(timezone.utc),
             updated_at=updated_at,
             message_count=message_count,
             first_message_preview=first_message_preview or "First test message...",
@@ -226,7 +226,7 @@ class MemoryFixtures:
             description=description,
             canonical_name=canonical_name or name,
             confidence=confidence,
-            created_at=created_at or datetime.utcnow(),
+            created_at=created_at or datetime.now(timezone.utc),
             embedding=embedding,
         )
 
@@ -249,7 +249,7 @@ class MemoryFixtures:
             preference=preference or f"Test preference for {category}",
             context=context,
             confidence=confidence,
-            created_at=created_at or datetime.utcnow(),
+            created_at=created_at or datetime.now(timezone.utc),
             embedding=embedding,
         )
 
@@ -272,7 +272,7 @@ class MemoryFixtures:
             predicate=predicate,
             object=object_,
             confidence=confidence,
-            created_at=created_at or datetime.utcnow(),
+            created_at=created_at or datetime.now(timezone.utc),
             embedding=embedding,
         )
 
@@ -307,7 +307,7 @@ class MemoryFixtures:
             ReasoningTrace with optional steps
         """
         trace_id = id or uuid4()
-        base_time = started_at or datetime.utcnow()
+        base_time = started_at or datetime.now(timezone.utc)
 
         steps = []
         for i in range(step_count):
@@ -364,7 +364,7 @@ class MemoryFixtures:
             action=action or f"Taking action {step_number}",
             observation=observation or f"Observed result {step_number}",
             tool_calls=tool_calls,
-            created_at=created_at or datetime.utcnow(),
+            created_at=created_at or datetime.now(timezone.utc),
             embedding=embedding,
         )
 

--- a/src/neo4j_agent_memory/testing/mocks.py
+++ b/src/neo4j_agent_memory/testing/mocks.py
@@ -1,9 +1,14 @@
 """Mock implementations of memory classes for testing."""
 
-from collections.abc import Callable
-from datetime import datetime
-from typing import Any, Literal
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Any, Literal
 from uuid import UUID, uuid4
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from types import TracebackType
 
 from neo4j_agent_memory.memory.long_term import (
     Entity,
@@ -30,7 +35,7 @@ from neo4j_agent_memory.memory.short_term import (
 class MockShortTermMemory:
     """In-memory mock of ShortTermMemory for unit testing."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         self._conversations: dict[str, Conversation] = {}
         self._messages: dict[str, Message] = {}
 
@@ -55,7 +60,7 @@ class MockShortTermMemory:
                 id=uuid4(),
                 session_id=session_id,
                 messages=[],
-                created_at=datetime.utcnow(),
+                created_at=datetime.now(timezone.utc),
             )
 
         conv = self._conversations[session_id]
@@ -65,12 +70,12 @@ class MockShortTermMemory:
             role=role,
             content=content,
             conversation_id=conv.id,
-            created_at=timestamp or datetime.utcnow(),
+            created_at=timestamp or datetime.now(timezone.utc),
             metadata=metadata or {},
         )
 
         conv.messages.append(message)
-        conv.updated_at = datetime.utcnow()
+        conv.updated_at = datetime.now(timezone.utc)
         self._messages[str(message.id)] = message
 
         return message
@@ -125,7 +130,7 @@ class MockShortTermMemory:
                 id=uuid4(),
                 session_id=session_id,
                 messages=[],
-                created_at=datetime.utcnow(),
+                created_at=datetime.now(timezone.utc),
             )
 
         conv = self._conversations[session_id]
@@ -287,7 +292,7 @@ class MockShortTermMemory:
 class MockLongTermMemory:
     """In-memory mock of LongTermMemory for unit testing."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         self._entities: dict[str, Entity] = {}
         self._preferences: dict[str, Preference] = {}
         self._facts: dict[str, Fact] = {}
@@ -310,7 +315,7 @@ class MockLongTermMemory:
             type=entity_type,
             description=description,
             canonical_name=name,
-            created_at=datetime.utcnow(),
+            created_at=datetime.now(timezone.utc),
         )
 
         self._entities[str(entity.id)] = entity
@@ -332,7 +337,7 @@ class MockLongTermMemory:
             preference=preference,
             context=context,
             confidence=confidence,
-            created_at=datetime.utcnow(),
+            created_at=datetime.now(timezone.utc),
         )
 
         self._preferences[str(pref.id)] = pref
@@ -354,7 +359,7 @@ class MockLongTermMemory:
             predicate=predicate,
             object=object_,
             confidence=confidence,
-            created_at=datetime.utcnow(),
+            created_at=datetime.now(timezone.utc),
         )
 
         self._facts[str(fact.id)] = fact
@@ -425,7 +430,7 @@ class MockLongTermMemory:
         if entities:
             parts.append("### Entities")
             for e in entities:
-                parts.append(f"- {e.name} ({e.type.value})")
+                parts.append(f"- {e.name} ({e.type})")
 
         if prefs:
             parts.append("### Preferences")
@@ -438,7 +443,7 @@ class MockLongTermMemory:
 class MockReasoningMemory:
     """In-memory mock of ReasoningMemory for unit testing."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         self._traces: dict[str, ReasoningTrace] = {}
         self._steps: dict[str, ReasoningStep] = {}
         self._tool_calls: dict[str, ToolCall] = {}
@@ -456,7 +461,7 @@ class MockReasoningMemory:
             id=uuid4(),
             session_id=session_id,
             task=task,
-            started_at=datetime.utcnow(),
+            started_at=datetime.now(timezone.utc),
             metadata=metadata or {},
         )
 
@@ -484,7 +489,7 @@ class MockReasoningMemory:
             thought=thought,
             action=action,
             observation=observation,
-            created_at=datetime.utcnow(),
+            created_at=datetime.now(timezone.utc),
             metadata=metadata or {},
         )
 
@@ -558,10 +563,12 @@ class MockReasoningMemory:
     ) -> ReasoningTrace:
         """Complete a reasoning trace."""
         trace = self._traces.get(str(trace_id))
-        if trace:
-            trace.outcome = outcome
-            trace.success = success
-            trace.completed_at = datetime.utcnow()
+        if trace is None:
+            raise ValueError(f"Trace {trace_id} not found")
+
+        trace.outcome = outcome
+        trace.success = success
+        trace.completed_at = datetime.now(timezone.utc)
 
         return trace
 
@@ -667,16 +674,21 @@ class MockMemoryClient:
             assert len(conv.messages) == 1
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.short_term = MockShortTermMemory()
         self.long_term = MockLongTermMemory()
         self.reasoning = MockReasoningMemory()
 
-    async def __aenter__(self) -> "MockMemoryClient":
+    async def __aenter__(self) -> MockMemoryClient:
         """Async context manager entry."""
         return self
 
-    async def __aexit__(self, exc_type, exc_val, exc_tb) -> None:
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
         """Async context manager exit."""
         pass
 

--- a/src/neo4j_agent_memory/testing/mocks.py
+++ b/src/neo4j_agent_memory/testing/mocks.py
@@ -470,7 +470,7 @@ class MockReasoningMemory:
 
     async def add_step(
         self,
-        trace_id: UUID,
+        trace_id: UUID | str,
         *,
         thought: str | None = None,
         action: str | None = None,
@@ -555,7 +555,7 @@ class MockReasoningMemory:
 
     async def complete_trace(
         self,
-        trace_id: UUID,
+        trace_id: UUID | str,
         *,
         outcome: str | None = None,
         success: bool | None = None,
@@ -564,7 +564,7 @@ class MockReasoningMemory:
         """Complete a reasoning trace."""
         trace = self._traces.get(str(trace_id))
         if trace is None:
-            raise ValueError(f"Trace {trace_id} not found")
+            raise ValueError(f"Trace not found: {trace_id}")
 
         trace.outcome = outcome
         trace.success = success
@@ -572,7 +572,7 @@ class MockReasoningMemory:
 
         return trace
 
-    async def get_trace(self, trace_id: UUID) -> ReasoningTrace | None:
+    async def get_trace(self, trace_id: UUID | str) -> ReasoningTrace | None:
         """Get a trace by ID."""
         return self._traces.get(str(trace_id))
 

--- a/tests/examples/test_domain_schemas.py
+++ b/tests/examples/test_domain_schemas.py
@@ -62,7 +62,7 @@ class TestDomainSchemasStructure:
         if not script_path.exists():
             pytest.skip(f"Script not found: {script}")
         content = script_path.read_text(encoding="utf-8")
-        assert "async def main():" in content, f"{script} should have 'async def main()'"
+        assert "async def main(" in content, f"{script} should have 'async def main()'"
         assert '__name__ == "__main__"' in content, f"{script} should have main entry point"
 
     @pytest.mark.parametrize("script", ALL_SCHEMA_SCRIPTS)

--- a/tests/examples/test_full_stack_apps.py
+++ b/tests/examples/test_full_stack_apps.py
@@ -335,7 +335,9 @@ class TestExampleConsistency:
         for example in simple_examples:
             if example.exists():
                 content = example.read_text(encoding="utf-8")
-                assert "async def main():" in content, (
+                # Match the definition regardless of any return-type annotation
+                # (e.g. `async def main() -> None:`).
+                assert "async def main(" in content, (
                     f"{example.name} should have 'async def main()'"
                 )
                 assert 'if __name__ == "__main__":' in content, (

--- a/tests/examples/test_google_adk_demo.py
+++ b/tests/examples/test_google_adk_demo.py
@@ -62,7 +62,7 @@ class TestGoogleADKDemoStructure:
         """Verify demo.py has async main function."""
         demo = demo_dir / "demo.py"
         content = demo.read_text(encoding="utf-8")
-        assert "async def main():" in content, "demo.py should have 'async def main()'"
+        assert "async def main(" in content, "demo.py should have 'async def main()'"
         assert 'if __name__ == "__main__":' in content, "demo.py should have main entry point"
 
     def test_demo_valid_python(self, demo_dir):

--- a/tests/examples/test_langchain_agent.py
+++ b/tests/examples/test_langchain_agent.py
@@ -44,8 +44,8 @@ class TestLangchainAgentExample:
             memory = Neo4jAgentMemory(
                 memory_client=memory_client,
                 session_id=session_id,
-                include_episodic=True,
-                include_semantic=True,
+                include_short_term=True,
+                include_long_term=True,
                 include_reasoning=True,
             )
 
@@ -120,8 +120,8 @@ class TestLangchainAgentExample:
 
             retriever = Neo4jMemoryRetriever(
                 memory_client=memory_client,
-                search_episodic=True,
-                search_semantic=True,
+                search_short_term=True,
+                search_long_term=True,
                 k=5,
             )
 
@@ -145,8 +145,8 @@ class TestLangchainAgentExample:
 
             retriever = Neo4jMemoryRetriever(
                 memory_client=memory_client,
-                search_episodic=True,
-                search_semantic=True,
+                search_short_term=True,
+                search_long_term=True,
                 k=5,
             )
 

--- a/tests/examples/test_langchain_agent.py
+++ b/tests/examples/test_langchain_agent.py
@@ -177,7 +177,7 @@ class TestLangchainAgentExample:
         content = example_path.read_text(encoding="utf-8")
 
         # Check for main function and entry point
-        assert "async def main():" in content
+        assert "async def main(" in content
         assert 'if __name__ == "__main__":' in content
         assert "asyncio.run(main())" in content
 

--- a/tests/examples/test_pydantic_ai_agent.py
+++ b/tests/examples/test_pydantic_ai_agent.py
@@ -197,7 +197,7 @@ class TestPydanticAIAgentExample:
         content = example_path.read_text(encoding="utf-8")
 
         # Check for main function and entry point
-        assert "async def main():" in content
+        assert "async def main(" in content
         assert 'if __name__ == "__main__":' in content
         assert "asyncio.run(main())" in content
 


### PR DESCRIPTION
## Summary

Brings **all of `src/` to zero `mypy --strict` errors**, finishing the `src` sweep started in #150 (Phase 1), #162 (Phase 2), and #163 (Phase 3). `testing/mocks.py` was the last holdout. Also **extends the enforced checked surface** from `src` to `src` + `benchmarks/` + the top-level `examples/*.py` demos, and lowers the ratchet: **mypy 13 → 0, ty 26 → 3**. Part of the type-safety effort tracked in #144.

The 3 remaining `ty` diagnostics are the pre-existing `__init__.py` `# type: ignore[no-redef]` stubs — a genuine mypy-vs-ty disagreement (mypy needs them; ty thinks they're unused), left for the Phase 5 ignore audit.

## `testing/` cleanup (last of `src`)

- Annotated the four mock `__init__`s and `MockMemoryClient.__aexit__`.
- Fixed `mocks.py` accessing `.value` on `Entity.type` (which is a `str`).
- `MockReasoningMemory.complete_trace()` now **raises on an unknown trace id** to match the real `ReasoningMemory`, instead of returning `None` under a non-optional return type.
- Added `from __future__ import annotations` per the project typing conventions.

## Runtime change: timezone-aware timestamps everywhere

Converted the last naive `datetime.utcnow()` sites — testing mocks/fixtures, `core.MemoryEntry.created_at` (base of `Entity`/`Preference`/`Fact`/…), and `EnrichmentResult.retrieved_at` / `EnrichmentTask.created_at` — to `datetime.now(timezone.utc)`. The `memory/` layer already switched in #163; the whole library now writes aware UTC timestamps. In `CHANGELOG.md`.

## Checked-surface extension + 3 example bugs the checkers found

The ratchet (`scripts/typecheck_ratchet.py`), the advisory mypy/ty CI steps, and the `make typecheck`/`ty` targets now cover `src benchmarks examples/*.py`. Fixing those demos to clean surfaced three latent bugs:

- **`basic_usage.py`** passed a tool result positionally to the keyword-only `StreamingTraceRecorder.record_tool_call(result=…)`.
- **`langchain_agent.py`** used the pre-rename `include_/search_episodic|semantic` kwargs (now `*_short_term` / `*_long_term`) — pydantic **silently dropped** them, so the example wasn't configuring what it looked like.
- **`enrichment_example.py`** passed a non-existent `confidence=` argument to `add_entity`.

The langchain/pydantic-AI API-usage bugs were surfaced by `ty` (mypy missed them), and `ty` also caught the deprecated `OpenAIModel` alias (→ `OpenAIChatModel`) — the two-checker payoff in action.

## Deferred to a follow-up

- The `examples/<name>/main.py` subdirectory demos + full-stack example apps: their many identically-named `main.py` modules collide under a single mypy invocation, and the full apps are standalone projects with their own tooling.
- `tests/` — 2628 mypy errors, ~2439 mechanical `no-untyped-def`. Will land under a **relaxed profile** (allow untyped test fns/fixtures, still catch real type errors).

## Verification

- Ratchet green: `mypy 0 / ty 3`, both at budget.
- 1444 unit tests pass; `ruff check` + `ruff format --check` clean on `src tests`.
- All 5 top-level example demos compile; the phantom-methods guard passes.

Part of #144.

🤖 Generated with [Claude Code](https://claude.com/claude-code)