### PR TITLE
Type-safety Phase 5: `# type: ignore` audit + `Any` census (src ignores 29→18, ty→0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   raw Cypher access (session-level control the `execute_read`/`execute_write`
   helpers don't offer, e.g. streaming GDS algorithm results). Thin wrapper over the
   existing private `_get_session()`.
+- **The self-hosted (bolt) memory classes now implement the full memory
+  Protocols.** `ShortTermMemory` gains the Gold-tier conversation-lifecycle
+  methods `create_conversation()`, `list_conversations()`, and `bulk_add_messages()`
+  (real, graph-backed — `bulk_add_messages` delegates to the existing
+  `add_messages_batch`). The Platinum-tier NAMS features that have no self-hosted
+  semantics — `ShortTermMemory.get_observations()` / `get_reflections()` and
+  `LongTermMemory.set_entity_feedback()` / `get_entity_history()` — are now present
+  and raise `NotSupportedError(backend="bolt", …)` with a workaround hint (previously
+  they raised `AttributeError`). This lets `client.short_term` / `client.long_term`
+  type-check without per-call-site `attr-defined` suppressions.
 
 ### Changed
 
@@ -131,6 +141,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   given, it waits for the conversation to finish *then* confirms via search. Fully
   backward-compatible: the search-only path is unchanged when no conversation id is
   passed.
+- **`LongTermMemory.get_entity_provenance()` first parameter is now
+  `entity_id: Entity | UUID | str`** (was `entity: Entity | UUID`, positional).
+  The runtime already accepted an id string (it does `entity.id if isinstance(…,
+  Entity) else …`); only the annotation was too narrow, forcing an `arg-type`
+  suppression at every id-string call site. **Public-API typing change** — the
+  parameter was renamed `entity` → `entity_id` (all in-tree callers pass it
+  positionally); code using the `entity=` keyword must switch to `entity_id=`.
+- **`neo4j_agent_memory.llm.from_provider()` is now `@overload`-typed on `kind`.**
+  `kind="llm"` (the default) is statically typed to return `LLMProvider` and
+  `kind="embedding"` to return `EmbeddingProvider`, instead of the
+  `LLMProvider | EmbeddingProvider` union. This removes a downstream `assignment`
+  suppression and a `cast` at the call sites. Annotation-only; runtime is unchanged.
+- **Type-safety Phase 5 — `# type: ignore` audit.** The `src/` suppression count
+  dropped from 29 to 18: the two remaining bare/uncoded ignores were coded and
+  justified, and the bolt-vs-NAMS `attr-defined`/`arg-type` cluster (9 suppressions
+  across `mcp/_tools.py`, `strands/tools.py`, `pydantic_ai/memory.py`) was eliminated
+  by the full-Protocol conformance above rather than suppressed. `ty` diagnostics for
+  `src/` reached **0** (the 3 optional-dep `no-redef` fallbacks now carry a paired
+  `# ty: ignore[unused-ignore-comment]`, matching the existing `mcp/server.py`
+  pattern). Every surviving `# type: ignore` is coded and carries an inline reason.
 
 > **Docs note:** when this ships, flip the "REST-only / no SDK method" notes in
 > `reference/rest-api.adoc`, `reference/ontology-api.adoc`, and

--- a/docs/modules/ROOT/pages/explanation/backends.adoc
+++ b/docs/modules/ROOT/pages/explanation/backends.adoc
@@ -91,11 +91,11 @@ This is the canonical capability reference. Backend-sensitive how-to pages link 
 | `client.short_term.create_conversation` / `bulk_add_messages`
 | (synthesized) | Yes
 | `client.short_term.get_observations` / `get_reflections`
-| No | Yes
+| `NotSupportedError` | Yes
 | `client.long_term.add_entity` / `search_entities`
 | Yes (with dedup) | Yes (server-side dedup)
 | `client.long_term.set_entity_feedback` / `get_entity_history`
-| No | Yes
+| `NotSupportedError` | Yes
 | `client.long_term.get_entity_provenance`
 | Yes | Yes
 | `client.long_term.geocode_locations` / `search_locations_near`

--- a/scripts/typecheck-budget.txt
+++ b/scripts/typecheck-budget.txt
@@ -8,4 +8,4 @@
 # Refresh after improving a count: `make typecheck-ratchet-update`.
 
 mypy=0
-ty=3
+ty=0

--- a/src/neo4j_agent_memory/__init__.py
+++ b/src/neo4j_agent_memory/__init__.py
@@ -148,7 +148,7 @@ try:
     from neo4j_agent_memory.embeddings.vertex_ai import VertexAIEmbedder
 except ImportError:
 
-    class VertexAIEmbedder:  # type: ignore[no-redef]
+    class VertexAIEmbedder:  # type: ignore[no-redef]  # ty: ignore[unused-ignore-comment]  # optional-dep fallback: mypy needs no-redef, ty disagrees
         """Stub for VertexAIEmbedder when google-cloud-aiplatform is not installed."""
 
         def __init__(self, *args: Any, **kwargs: Any) -> None:
@@ -162,7 +162,7 @@ try:
     from neo4j_agent_memory.integrations.google_adk import Neo4jMemoryService
 except ImportError:
 
-    class Neo4jMemoryService:  # type: ignore[no-redef]
+    class Neo4jMemoryService:  # type: ignore[no-redef]  # ty: ignore[unused-ignore-comment]  # optional-dep fallback: mypy needs no-redef, ty disagrees
         """Stub for Neo4jMemoryService when google-adk is not installed."""
 
         def __init__(self, *args: Any, **kwargs: Any) -> None:
@@ -176,7 +176,7 @@ try:
     from neo4j_agent_memory.mcp.server import Neo4jMemoryMCPServer
 except ImportError:
 
-    class Neo4jMemoryMCPServer:  # type: ignore[no-redef]
+    class Neo4jMemoryMCPServer:  # type: ignore[no-redef]  # ty: ignore[unused-ignore-comment]  # optional-dep fallback: mypy needs no-redef, ty disagrees
         """Stub for Neo4jMemoryMCPServer when mcp is not installed."""
 
         def __init__(self, *args: Any, **kwargs: Any) -> None:
@@ -519,10 +519,16 @@ class MemoryClient:
         default_llm_provider = (
             self._settings.llm if isinstance(self._settings.llm, _LLMProvider) else None
         )
-        # Concrete bolt impls satisfy the Protocols structurally — mypy's
-        # @runtime_checkable check is conservative, so we suppress the
-        # assignment errors here. Runtime ``isinstance(..., ShortTermProtocol)``
-        # checks pass (covered in tests/unit/nams/test_protocols.py).
+        # The bolt impls implement every Protocol *method* (short-term
+        # conformance is asserted in tests/unit/nams/test_protocols.py;
+        # Platinum-only methods raise NotSupportedError), but their concrete
+        # signatures are narrower than the intentionally-permissive
+        # ``**kwargs`` Protocol signatures (e.g. bolt ``list_sessions(*,
+        # prefix, limit, …)`` vs Protocol ``list_sessions(**kwargs)``), so
+        # mypy does not treat them as structural subtypes. They still hold
+        # the full behavior; the property getters re-narrow to the concrete
+        # bolt type. The NAMS path (below) fills the same fields with the
+        # hosted impls, which is why the field type is the Protocol.
         self._short_term = ShortTermMemory(  # type: ignore[assignment]
             self._client,
             self._embedder,
@@ -777,10 +783,12 @@ class MemoryClient:
         """
         if self._short_term is None:
             raise NotConnectedError("Client not connected. Use 'async with' or call connect().")
-        # Declared return type is the bolt class so bolt users get
-        # type-checked access to bolt-only methods. On NAMS the runtime
-        # type is NamsShortTermMemory, which structurally implements the
-        # Protocol — see ShortTermProtocol in core.protocols.
+        # The field is Protocol-typed (it holds the bolt impl or the NAMS
+        # impl), but the property advertises the concrete bolt class so bolt
+        # users get type-checked access to bolt-only methods (geocoding,
+        # dedup, provenance, …). Returning the Protocol-typed field as the
+        # concrete class is an intentional downcast; on NAMS the runtime type
+        # is NamsShortTermMemory, which implements ShortTermProtocol.
         return self._short_term  # type: ignore[return-value]
 
     @property
@@ -796,6 +804,8 @@ class MemoryClient:
         """
         if self._long_term is None:
             raise NotConnectedError("Client not connected. Use 'async with' or call connect().")
+        # Intentional Protocol-field → concrete-class downcast; see the
+        # short_term property above for the rationale.
         return self._long_term  # type: ignore[return-value]
 
     @property
@@ -811,6 +821,8 @@ class MemoryClient:
         """
         if self._reasoning is None:
             raise NotConnectedError("Client not connected. Use 'async with' or call connect().")
+        # Intentional Protocol-field → concrete-class downcast; see the
+        # short_term property above for the rationale.
         return self._reasoning  # type: ignore[return-value]
 
     @property
@@ -888,6 +900,8 @@ class MemoryClient:
         if self._settings.backend == "nams":
             from neo4j_agent_memory.nams._unsupported import _NamsUnsupported
 
+            # NAMS shim stands in for SchemaManager and raises on use; the
+            # accessor's declared type is the bolt SchemaManager.
             return _NamsUnsupported(  # type: ignore[return-value]
                 accessor="schema",
                 message="Schema operations are server-managed on NAMS.",
@@ -1010,6 +1024,8 @@ class MemoryClient:
             )
         if self._client is None:
             raise NotConnectedError("Client not connected. Use 'async with' or call connect().")
+        # Proxy wraps Neo4jClient to warn on deprecated access while
+        # forwarding calls; the property's declared type is Neo4jClient.
         return _DeprecatedGraphProxy(self._client)  # type: ignore[return-value]
 
     async def get_context(

--- a/src/neo4j_agent_memory/extraction/factory.py
+++ b/src/neo4j_agent_memory/extraction/factory.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any
 
 from neo4j_agent_memory.config.settings import (
     ExtractionConfig,
@@ -23,7 +23,6 @@ from neo4j_agent_memory.extraction.pipeline import (
 )
 
 if TYPE_CHECKING:
-    from neo4j_agent_memory.llm.protocol import LLMProvider
     from neo4j_agent_memory.schema.models import EntitySchemaConfig
 
 logger = logging.getLogger(__name__)
@@ -206,9 +205,8 @@ def create_llm_extractor(
         kwargs: dict[str, Any] = {}
         if llm_config.api_key is not None:
             kwargs["api_key"] = llm_config.api_key.get_secret_value()
-        llm_provider = cast(
-            "LLMProvider", from_provider(model_id, kind="llm", **kwargs)
-        )  # kind="llm" guarantees LLMProvider
+        # from_provider is @overloaded: kind="llm" is typed to return LLMProvider.
+        llm_provider = from_provider(model_id, kind="llm", **kwargs)
         return LLMEntityExtractor(provider=llm_provider, **common_kwargs)
 
     # No llm_config: let LLMEntityExtractor build its own default provider

--- a/src/neo4j_agent_memory/extraction/llm_extractor.py
+++ b/src/neo4j_agent_memory/extraction/llm_extractor.py
@@ -295,10 +295,15 @@ class LLMEntityExtractor(EntityExtractor):
 
         # Reached only for the non-structured path (extract() dispatches
         # StructuredExtractor providers elsewhere), so the provider is a
-        # plain LLMProvider with .complete(); narrow off the None/structured
-        # union arms.
+        # plain LLMProvider with .complete(). Guard explicitly (not via
+        # assert, which -O strips) to narrow off the None/structured union
+        # arms and fail loudly on a misconfigured provider.
         provider = self._provider
-        assert isinstance(provider, LLMProvider)
+        if not isinstance(provider, LLMProvider):
+            raise ExtractionError(
+                "LLM extraction requires a provider implementing LLMProvider.complete(); "
+                f"got {type(provider).__name__}."
+            )
 
         prompt = self._build_prompt(text, types_to_use)
         messages = [

--- a/src/neo4j_agent_memory/extraction/llm_extractor.py
+++ b/src/neo4j_agent_memory/extraction/llm_extractor.py
@@ -166,7 +166,7 @@ class LLMEntityExtractor(EntityExtractor):
             kwargs: dict[str, Any] = {}
             if api_key is not None:
                 kwargs["api_key"] = api_key
-            provider = from_provider(resolved_model, kind="llm", **kwargs)  # type: ignore[assignment]
+            provider = from_provider(resolved_model, kind="llm", **kwargs)
         self._provider = provider
         self._model_label = getattr(provider, "model", "unknown")
         self._entity_types = entity_types or list(DEFAULT_ENTITY_TYPES)
@@ -290,7 +290,15 @@ class LLMEntityExtractor(EntityExtractor):
         :class:`StructuredExtractor`. Less reliable than the structured
         path but still works for any LLM.
         """
+        from neo4j_agent_memory.llm.protocol import LLMProvider
         from neo4j_agent_memory.llm.types import ChatMessage
+
+        # Reached only for the non-structured path (extract() dispatches
+        # StructuredExtractor providers elsewhere), so the provider is a
+        # plain LLMProvider with .complete(); narrow off the None/structured
+        # union arms.
+        provider = self._provider
+        assert isinstance(provider, LLMProvider)
 
         prompt = self._build_prompt(text, types_to_use)
         messages = [
@@ -298,7 +306,7 @@ class LLMEntityExtractor(EntityExtractor):
             ChatMessage(role="user", content=prompt),
         ]
         try:
-            completion = await self._provider.complete(  # type: ignore[union-attr]
+            completion = await provider.complete(
                 messages,
                 temperature=self._temperature,
             )

--- a/src/neo4j_agent_memory/graph/queries.py
+++ b/src/neo4j_agent_memory/graph/queries.py
@@ -57,6 +57,14 @@ ORDER BY c.updated_at DESC
 LIMIT $limit
 """
 
+LIST_ALL_CONVERSATIONS = """
+MATCH (c:Conversation)
+WHERE $user_identifier IS NULL OR c.user_identifier = $user_identifier
+RETURN c
+ORDER BY c.updated_at DESC
+LIMIT $limit
+"""
+
 CREATE_MESSAGE = """
 MATCH (c:Conversation {id: $conversation_id})
 OPTIONAL MATCH (c)-[:HAS_MESSAGE]->(last:Message)

--- a/src/neo4j_agent_memory/integrations/_passthrough.py
+++ b/src/neo4j_agent_memory/integrations/_passthrough.py
@@ -23,7 +23,10 @@ constructing the adapter directly.
 from __future__ import annotations
 
 import logging
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from neo4j_agent_memory.llm.protocol import LLMProvider
 
 logger = logging.getLogger(__name__)
 
@@ -102,7 +105,7 @@ def _extract_optional_kwargs(model: Any) -> dict[str, Any]:
     return kwargs
 
 
-def llm_provider_from_framework_model(model: Any) -> Any:
+def llm_provider_from_framework_model(model: Any) -> LLMProvider:
     """Translate a framework-native chat model into an :class:`LLMProvider`.
 
     Strategy:
@@ -149,7 +152,10 @@ def llm_provider_from_framework_model(model: Any) -> Any:
         model_id,
         sorted(kwargs.keys()),
     )
-    return from_provider(model_id, **kwargs)
+    # kwargs carries only api_key/api_base/region (never kind), so pass
+    # kind="llm" explicitly: it resolves from_provider's overload to
+    # LLMProvider (the **kwargs spread would otherwise erase it).
+    return from_provider(model_id, kind="llm", **kwargs)
 
 
 __all__ = [

--- a/src/neo4j_agent_memory/integrations/crewai/__init__.py
+++ b/src/neo4j_agent_memory/integrations/crewai/__init__.py
@@ -1,13 +1,18 @@
 """CrewAI integration for neo4j-agent-memory."""
 
-from typing import Any
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
 
 from neo4j_agent_memory.integrations._passthrough import (
     llm_provider_from_framework_model as _passthrough,
 )
 
+if TYPE_CHECKING:
+    from neo4j_agent_memory.llm import LLMProvider
 
-def llm_provider_from_crewai(model: Any) -> Any:
+
+def llm_provider_from_crewai(model: Any) -> LLMProvider:
     """Translate a CrewAI agent's LLM into an :class:`LLMProvider`.
 
     CrewAI uses LiteLLM under the hood, so a CrewAI ``LLM`` exposes a

--- a/src/neo4j_agent_memory/integrations/google_adk/__init__.py
+++ b/src/neo4j_agent_memory/integrations/google_adk/__init__.py
@@ -12,11 +12,17 @@ Example:
         # Use with Google ADK agent
 """
 
-from typing import Any
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
 
 from neo4j_agent_memory.integrations._passthrough import (
     llm_provider_from_framework_model as _passthrough,
 )
+
+if TYPE_CHECKING:
+    from neo4j_agent_memory.integrations.google_adk.memory_service import Neo4jMemoryService
+    from neo4j_agent_memory.llm import LLMProvider
 
 __all__ = [
     "Neo4jMemoryService",
@@ -24,7 +30,7 @@ __all__ = [
 ]
 
 
-def llm_provider_from_google_adk(model: Any) -> Any:
+def llm_provider_from_google_adk(model: Any) -> LLMProvider:
     """Translate a Google ADK / Gemini model into an :class:`LLMProvider`.
 
     ADK agents typically use ``gemini-2.5-flash`` / ``gemini-2.5-pro``

--- a/src/neo4j_agent_memory/integrations/langchain/__init__.py
+++ b/src/neo4j_agent_memory/integrations/langchain/__init__.py
@@ -1,14 +1,19 @@
 """LangChain integration for neo4j-agent-memory."""
 
-from typing import Any
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
 
 from neo4j_agent_memory.integrations._passthrough import (
     llm_provider_from_framework_model as _passthrough,
 )
 from neo4j_agent_memory.integrations.langchain.memory import Neo4jAgentMemory
 
+if TYPE_CHECKING:
+    from neo4j_agent_memory.llm import LLMProvider
 
-def llm_provider_from_langchain(model: Any) -> Any:
+
+def llm_provider_from_langchain(model: Any) -> LLMProvider:
     """Translate a LangChain ``BaseChatModel`` into an :class:`LLMProvider`.
 
     Lets users pass through their already-configured LangChain model::

--- a/src/neo4j_agent_memory/integrations/llamaindex/__init__.py
+++ b/src/neo4j_agent_memory/integrations/llamaindex/__init__.py
@@ -1,13 +1,18 @@
 """LlamaIndex integration for neo4j-agent-memory."""
 
-from typing import Any
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
 
 from neo4j_agent_memory.integrations._passthrough import (
     llm_provider_from_framework_model as _passthrough,
 )
 
+if TYPE_CHECKING:
+    from neo4j_agent_memory.llm import LLMProvider
 
-def llm_provider_from_llamaindex(model: Any) -> Any:
+
+def llm_provider_from_llamaindex(model: Any) -> LLMProvider:
     """Translate a LlamaIndex ``LLM`` into an :class:`LLMProvider`.
 
     LlamaIndex LLM classes expose ``model``; class names like

--- a/src/neo4j_agent_memory/integrations/microsoft_agent/__init__.py
+++ b/src/neo4j_agent_memory/integrations/microsoft_agent/__init__.py
@@ -41,18 +41,23 @@ Example:
         )
 """
 
-from typing import Any
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
 
 from neo4j_agent_memory.integrations._passthrough import (
     llm_provider_from_framework_model as _passthrough,
 )
+
+if TYPE_CHECKING:
+    from neo4j_agent_memory.llm import LLMProvider
 
 # Target API version - document for compatibility tracking
 MICROSOFT_AGENT_FRAMEWORK_VERSION = "1.0.0b260212"
 MICROSOFT_AGENT_FRAMEWORK_MIN_VERSION = "1.0.0b260212"
 
 
-def llm_provider_from_microsoft_agent(model: Any) -> Any:
+def llm_provider_from_microsoft_agent(model: Any) -> LLMProvider:
     """Translate a Microsoft Agent Framework chat client into an :class:`LLMProvider`.
 
     The Agent Framework wraps Azure OpenAI and OpenAI clients. The

--- a/src/neo4j_agent_memory/integrations/openai_agents/__init__.py
+++ b/src/neo4j_agent_memory/integrations/openai_agents/__init__.py
@@ -28,14 +28,19 @@ Example:
         await record_agent_trace(memory, messages, task="Help user")
 """
 
-from typing import Any
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
 
 from neo4j_agent_memory.integrations._passthrough import (
     llm_provider_from_framework_model as _passthrough,
 )
 
+if TYPE_CHECKING:
+    from neo4j_agent_memory.llm import LLMProvider
 
-def llm_provider_from_openai_agents(model: Any) -> Any:
+
+def llm_provider_from_openai_agents(model: Any) -> LLMProvider:
     """Translate an OpenAI Agents SDK model into an :class:`LLMProvider`.
 
     The Agents SDK uses OpenAI ``AsyncOpenAI`` clients and bare model

--- a/src/neo4j_agent_memory/integrations/pydantic_ai/__init__.py
+++ b/src/neo4j_agent_memory/integrations/pydantic_ai/__init__.py
@@ -1,13 +1,18 @@
 """Pydantic AI integration for neo4j-agent-memory."""
 
-from typing import Any
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
 
 from neo4j_agent_memory.integrations._passthrough import (
     llm_provider_from_framework_model as _passthrough,
 )
 
+if TYPE_CHECKING:
+    from neo4j_agent_memory.llm import LLMProvider
 
-def llm_provider_from_pydantic_ai(model: Any) -> Any:
+
+def llm_provider_from_pydantic_ai(model: Any) -> LLMProvider:
     """Translate a Pydantic AI ``Model`` into an :class:`LLMProvider`.
 
     Pydantic AI Models expose ``model_name``; class names like

--- a/src/neo4j_agent_memory/integrations/pydantic_ai/memory.py
+++ b/src/neo4j_agent_memory/integrations/pydantic_ai/memory.py
@@ -458,9 +458,9 @@ def nams_memory_tools(memory: "MemoryClient") -> list[Callable[..., Any]]:
         Returns:
             Confirmation message.
         """
-        # Platinum-tier method — present on NamsLongTermMemory at runtime; the
-        # bolt LongTermMemory class doesn't declare it (Protocol-vs-class lie).
-        await memory.long_term.set_entity_feedback(  # type: ignore[attr-defined]
+        # Platinum-tier method: NAMS records the feedback; bolt raises
+        # NotSupportedError (both backends declare the method).
+        await memory.long_term.set_entity_feedback(
             entity_id,
             feedback,
             user_identifier=user_identifier,
@@ -478,9 +478,7 @@ def nams_memory_tools(memory: "MemoryClient") -> list[Callable[..., Any]]:
         Returns:
             Formatted history as plain text.
         """
-        entries = await memory.long_term.get_entity_history(  # type: ignore[attr-defined]
-            entity_id, limit=limit
-        )
+        entries = await memory.long_term.get_entity_history(entity_id, limit=limit)
         if not entries:
             return "No history for this entity."
         lines = []
@@ -500,7 +498,7 @@ def nams_memory_tools(memory: "MemoryClient") -> list[Callable[..., Any]]:
         Returns:
             Formatted provenance summary.
         """
-        prov = await memory.long_term.get_entity_provenance(entity_id)  # type: ignore[arg-type]
+        prov = await memory.long_term.get_entity_provenance(entity_id)
         sources = prov.get("sources") or []
         extractors = prov.get("extractors") or []
         lines = [f"Sources ({len(sources)}):"]

--- a/src/neo4j_agent_memory/integrations/strands/__init__.py
+++ b/src/neo4j_agent_memory/integrations/strands/__init__.py
@@ -46,9 +46,9 @@ def llm_provider_from_strands(model: Any) -> LLMProvider:
         from neo4j_agent_memory.llm import from_provider
 
         model_id = model if "/" in model else f"bedrock/{model}"
-        # from_provider returns LLMProvider | EmbeddingProvider (not overloaded);
-        # kind defaults to "llm", so the result is an LLMProvider here.
-        return cast("LLMProvider", from_provider(model_id))
+        # from_provider is @overloaded on kind; kind defaults to "llm", so
+        # this returns an LLMProvider (no cast needed).
+        return from_provider(model_id)
     # _passthrough introspects an arbitrary framework model object (returns Any).
     return cast("LLMProvider", _passthrough(model))
 

--- a/src/neo4j_agent_memory/integrations/strands/__init__.py
+++ b/src/neo4j_agent_memory/integrations/strands/__init__.py
@@ -24,7 +24,7 @@ Example:
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any
 
 from neo4j_agent_memory.integrations._passthrough import (
     llm_provider_from_framework_model as _passthrough,
@@ -49,8 +49,8 @@ def llm_provider_from_strands(model: Any) -> LLMProvider:
         # from_provider is @overloaded on kind; kind defaults to "llm", so
         # this returns an LLMProvider (no cast needed).
         return from_provider(model_id)
-    # _passthrough introspects an arbitrary framework model object (returns Any).
-    return cast("LLMProvider", _passthrough(model))
+    # _passthrough introspects an arbitrary framework model object.
+    return _passthrough(model)
 
 
 try:

--- a/src/neo4j_agent_memory/integrations/strands/tools.py
+++ b/src/neo4j_agent_memory/integrations/strands/tools.py
@@ -895,8 +895,9 @@ def _nams_set_entity_feedback_tool(
         async def _set() -> str:
             client = _get_or_create_nams_client(endpoint, api_key, transport_mode)
             async with client:
-                # Platinum-tier — present on NamsLongTermMemory at runtime.
-                await client.long_term.set_entity_feedback(  # type: ignore[attr-defined]
+                # Platinum-tier — NAMS records the feedback (bolt would
+                # raise NotSupportedError, but this tool is NAMS-only).
+                await client.long_term.set_entity_feedback(
                     entity_id, feedback, user_identifier=user_id
                 )
             return f"Recorded {feedback!r} feedback on entity {entity_id}."
@@ -929,7 +930,7 @@ def _nams_get_entity_provenance_tool(
         async def _get() -> dict[str, Any]:
             client = _get_or_create_nams_client(endpoint, api_key, transport_mode)
             async with client:
-                return await client.long_term.get_entity_provenance(entity_id)  # type: ignore[arg-type]
+                return await client.long_term.get_entity_provenance(entity_id)
 
         result = _run_async(_get())
         return result if isinstance(result, dict) else {}

--- a/src/neo4j_agent_memory/llm/factory.py
+++ b/src/neo4j_agent_memory/llm/factory.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 
 import logging
 from importlib.util import find_spec
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any, Literal, overload
 
 if TYPE_CHECKING:
     from neo4j_agent_memory.llm.protocol import EmbeddingProvider, LLMProvider
@@ -95,6 +95,26 @@ def _looks_like_huggingface_id(model: str) -> bool:
         "palm",
     }
     return org not in known_prefixes
+
+
+@overload
+def from_provider(
+    model: str,
+    *,
+    kind: Literal["llm"] = ...,
+    prefer_litellm: bool = ...,
+    **kwargs: Any,
+) -> LLMProvider: ...
+
+
+@overload
+def from_provider(
+    model: str,
+    *,
+    kind: Literal["embedding"],
+    prefer_litellm: bool = ...,
+    **kwargs: Any,
+) -> EmbeddingProvider: ...
 
 
 def from_provider(

--- a/src/neo4j_agent_memory/mcp/_tools.py
+++ b/src/neo4j_agent_memory/mcp/_tools.py
@@ -833,8 +833,9 @@ def _register_platinum_tools(mcp: FastMCP) -> None:
         """
         client = get_client(ctx)
         try:
-            # Platinum-tier — present on NamsLongTermMemory at runtime.
-            await client.long_term.set_entity_feedback(  # type: ignore[attr-defined]
+            # Platinum-tier: bolt raises NotSupportedError (caught below);
+            # NAMS records the feedback.
+            await client.long_term.set_entity_feedback(
                 entity_id, feedback, user_identifier=user_identifier
             )
             return json.dumps({"status": "ok", "entity_id": entity_id, "feedback": feedback})
@@ -861,9 +862,7 @@ def _register_platinum_tools(mcp: FastMCP) -> None:
         """
         client = get_client(ctx)
         try:
-            history = await client.long_term.get_entity_history(  # type: ignore[attr-defined]
-                entity_id, limit=limit
-            )
+            history = await client.long_term.get_entity_history(entity_id, limit=limit)
             return json.dumps({"entity_id": entity_id, "history": history}, default=str)
         except Exception as e:
             logger.error(f"Error in memory_get_entity_history: {e}")
@@ -884,7 +883,7 @@ def _register_platinum_tools(mcp: FastMCP) -> None:
         """
         client = get_client(ctx)
         try:
-            prov = await client.long_term.get_entity_provenance(entity_id)  # type: ignore[arg-type]
+            prov = await client.long_term.get_entity_provenance(entity_id)
             return json.dumps(prov, default=str)
         except Exception as e:
             logger.error(f"Error in memory_get_entity_provenance: {e}")
@@ -909,9 +908,7 @@ def _register_platinum_tools(mcp: FastMCP) -> None:
         """
         client = get_client(ctx)
         try:
-            reflections = await client.short_term.get_reflections(  # type: ignore[attr-defined]
-                session_id, limit=limit
-            )
+            reflections = await client.short_term.get_reflections(session_id, limit=limit)
             return json.dumps({"session_id": session_id, "reflections": reflections}, default=str)
         except Exception as e:
             logger.error(f"Error in memory_get_reflections: {e}")

--- a/src/neo4j_agent_memory/memory/long_term.py
+++ b/src/neo4j_agent_memory/memory/long_term.py
@@ -12,6 +12,7 @@ from uuid import UUID, uuid4
 
 from pydantic import Field
 
+from neo4j_agent_memory.core.exceptions import NotSupportedError
 from neo4j_agent_memory.core.memory import BaseMemory, MemoryEntry
 from neo4j_agent_memory.graph import queries
 from neo4j_agent_memory.graph.query_builder import build_create_entity_query
@@ -1697,7 +1698,7 @@ class LongTermMemory(BaseMemory[Entity]):
 
     async def get_entity_provenance(
         self,
-        entity: Entity | UUID,
+        entity_id: Entity | UUID | str,
     ) -> dict[str, Any]:
         """Get provenance information for an entity.
 
@@ -1705,16 +1706,18 @@ class LongTermMemory(BaseMemory[Entity]):
         and which extractor(s) produced it.
 
         Args:
-            entity: Entity or entity ID
+            entity_id: Entity, entity UUID, or entity id string. (``str`` is
+                accepted to match ``LongTermProtocol.get_entity_provenance``;
+                an :class:`Entity` is also accepted for convenience.)
 
         Returns:
             Dict with 'sources' (messages) and 'extractors' lists
         """
-        entity_id = entity.id if isinstance(entity, Entity) else entity
+        resolved_id = entity_id.id if isinstance(entity_id, Entity) else entity_id
 
         results = await self._client.execute_read(
             queries.GET_ENTITY_PROVENANCE,
-            {"entity_id": str(entity_id)},
+            {"entity_id": str(resolved_id)},
         )
 
         if not results:
@@ -1773,6 +1776,42 @@ class LongTermMemory(BaseMemory[Entity]):
             "sources": sources,
             "extractors": extractors,
         }
+
+    # ── Platinum tier (NAMS-hosted only) ────────────────────────────────
+    #
+    # These complete LongTermProtocol so MemoryClient.long_term (which
+    # advertises the concrete bolt type) type-checks without per-call-site
+    # attr-defined suppressions. They have no self-hosted (bolt) semantics —
+    # entity feedback and edit history are NAMS server-side features — so
+    # they raise NotSupportedError, consistent with the NAMS impls raising
+    # for bolt-only methods.
+
+    async def set_entity_feedback(
+        self,
+        entity_id: UUID | str,
+        feedback: str,
+        **kwargs: Any,
+    ) -> None:
+        """Not supported on the self-hosted (bolt) backend — NAMS only."""
+        raise NotSupportedError(
+            backend="bolt",
+            method="LongTermMemory.set_entity_feedback",
+            message="Entity feedback is a NAMS-hosted (Platinum-tier) feature.",
+            workaround="Use the hosted NAMS backend to record entity feedback.",
+        )
+
+    async def get_entity_history(
+        self,
+        entity_id: UUID | str,
+        **kwargs: Any,
+    ) -> list[dict[str, Any]]:
+        """Not supported on the self-hosted (bolt) backend — NAMS only."""
+        raise NotSupportedError(
+            backend="bolt",
+            method="LongTermMemory.get_entity_history",
+            message="Entity edit/mention history is a NAMS-hosted (Platinum-tier) feature.",
+            workaround="Use get_entity_provenance() for source/extractor provenance on bolt.",
+        )
 
     async def get_entities_from_message(
         self,

--- a/src/neo4j_agent_memory/memory/short_term.py
+++ b/src/neo4j_agent_memory/memory/short_term.py
@@ -532,7 +532,10 @@ class ShortTermMemory(BaseMemory[Message]):
         :meth:`get_conversation` to load a conversation's messages.
         """
         user_identifier: str | None = kwargs.get("user_identifier")
-        limit: int = kwargs.get("limit", 100)
+        # Coerce an explicit ``limit=None`` to the default: Neo4j rejects a
+        # null LIMIT, and NAMS likewise drops a None limit.
+        limit = kwargs.get("limit")
+        limit = 100 if limit is None else limit
         results = await self._client.execute_read(
             queries.LIST_ALL_CONVERSATIONS,
             {"user_identifier": user_identifier, "limit": limit},

--- a/src/neo4j_agent_memory/memory/short_term.py
+++ b/src/neo4j_agent_memory/memory/short_term.py
@@ -11,6 +11,7 @@ from uuid import UUID, uuid4
 
 from pydantic import BaseModel, Field
 
+from neo4j_agent_memory.core.exceptions import NotSupportedError
 from neo4j_agent_memory.core.memory import BaseMemory, MemoryEntry
 from neo4j_agent_memory.graph import queries
 from neo4j_agent_memory.graph.query_builder import build_create_entity_query
@@ -498,6 +499,101 @@ class ShortTermMemory(BaseMemory[Message]):
                 await self._extract_and_link_entities(msg, extract_relations=extract_relations)
 
         return all_created
+
+    # ── Gold tier: explicit conversation lifecycle ──────────────────────
+    #
+    # These complete ShortTermProtocol so MemoryClient.short_term (which
+    # advertises the concrete bolt type) type-checks without per-call-site
+    # attr-defined suppressions.
+
+    async def create_conversation(
+        self,
+        session_id: str,
+        **kwargs: Any,
+    ) -> Conversation:
+        """Explicitly create (or return the existing) conversation node.
+
+        Idempotent on bolt: if a conversation already exists for
+        ``session_id`` it is returned unchanged. Pass ``user_identifier``
+        to link the conversation to a :User node (multi-tenant).
+        """
+        await self._ensure_conversation(
+            session_id,
+            user_identifier=kwargs.get("user_identifier"),
+        )
+        return await self.get_conversation(session_id)
+
+    async def list_conversations(self, **kwargs: Any) -> list[Conversation]:
+        """List conversations (most-recently-updated first).
+
+        Pass ``user_identifier`` to scope to a single tenant's
+        conversations; ``limit`` (default 100) bounds the result. Returned
+        ``Conversation`` objects carry metadata only (no messages) — use
+        :meth:`get_conversation` to load a conversation's messages.
+        """
+        user_identifier: str | None = kwargs.get("user_identifier")
+        limit: int = kwargs.get("limit", 100)
+        results = await self._client.execute_read(
+            queries.LIST_ALL_CONVERSATIONS,
+            {"user_identifier": user_identifier, "limit": limit},
+        )
+        conversations = []
+        for row in results:
+            conv_data = dict(row["c"])
+            conversations.append(
+                Conversation(
+                    id=UUID(conv_data["id"]),
+                    session_id=conv_data["session_id"],
+                    title=conv_data.get("title"),
+                    created_at=_to_python_datetime(conv_data.get("created_at")),
+                    updated_at=_to_python_datetime(conv_data.get("updated_at"))
+                    if conv_data.get("updated_at")
+                    else None,
+                )
+            )
+        return conversations
+
+    async def bulk_add_messages(
+        self,
+        session_id: str,
+        messages: list[dict[str, Any]],
+        **kwargs: Any,
+    ) -> list[Message]:
+        """Bulk-insert messages in one call (bolt: batched transactions).
+
+        Thin ``ShortTermProtocol`` alias over :meth:`add_messages_batch`;
+        extra keyword arguments (``batch_size``, ``generate_embeddings``,
+        ``extract_entities``, …) are forwarded.
+        """
+        return await self.add_messages_batch(session_id, messages, **kwargs)
+
+    # ── Platinum tier (NAMS-hosted only) ────────────────────────────────
+
+    async def get_observations(
+        self,
+        session_id: str,
+        **kwargs: Any,
+    ) -> list[dict[str, Any]]:
+        """Not supported on the self-hosted (bolt) backend — NAMS only."""
+        raise NotSupportedError(
+            backend="bolt",
+            method="ShortTermMemory.get_observations",
+            message="Inline observations are a NAMS-hosted (Platinum-tier) feature.",
+            workaround="Use the MemoryObserver / observational-memory layer for bolt.",
+        )
+
+    async def get_reflections(
+        self,
+        session_id: str,
+        **kwargs: Any,
+    ) -> list[dict[str, Any]]:
+        """Not supported on the self-hosted (bolt) backend — NAMS only."""
+        raise NotSupportedError(
+            backend="bolt",
+            method="ShortTermMemory.get_reflections",
+            message="LLM-generated reflections are a NAMS-hosted (Platinum-tier) feature.",
+            workaround="Use the MemoryObserver reflection generator for bolt.",
+        )
 
     async def generate_embeddings_batch(
         self,

--- a/src/neo4j_agent_memory/observability/base.py
+++ b/src/neo4j_agent_memory/observability/base.py
@@ -205,7 +205,10 @@ class Tracer(ABC):
                             )
                             raise
 
-                return async_wrapper  # type: ignore
+                # functools.wraps copies func's metadata but the static type of
+                # the wrapper is (...) -> Any, not the input F; the decorator
+                # contract preserves F's signature at runtime.
+                return async_wrapper  # type: ignore[return-value]
             else:
 
                 @functools.wraps(func)
@@ -226,7 +229,9 @@ class Tracer(ABC):
                             )
                             raise
 
-                return sync_wrapper  # type: ignore
+                # See async_wrapper above: functools.wraps preserves F at
+                # runtime; the wrapper's static type is (...) -> Any.
+                return sync_wrapper  # type: ignore[return-value]
 
         return decorator
 

--- a/tests/unit/nams/test_protocols.py
+++ b/tests/unit/nams/test_protocols.py
@@ -164,23 +164,15 @@ class TestBoltImplsImplementProtocols:
         from neo4j_agent_memory.memory.short_term import ShortTermMemory
 
         # We can't easily instantiate ShortTermMemory without dependencies,
-        # but we can check class-level method presence.
+        # but we can check class-level method presence. As of the type-safety
+        # Phase 5 audit, bolt implements the *full* protocol — the Gold-tier
+        # conversation methods are real, the Platinum-tier
+        # observation/reflection methods raise NotSupportedError — so no
+        # method may be missing.
         proto_methods = _method_names(ShortTermProtocol)
         impl_methods = {name for name in dir(ShortTermMemory) if not name.startswith("_")}
         missing = proto_methods - impl_methods
-        # Platinum tier methods are not on bolt impl in Phase 1 — they get
-        # added (or stubbed with NotSupportedError) in Phase 3+. Filter them.
-        platinum_only = {
-            "bulk_add_messages",
-            "get_observations",
-            "get_reflections",
-            "create_conversation",
-            "list_conversations",
-        }
-        unexpected_missing = missing - platinum_only
-        assert not unexpected_missing, (
-            f"ShortTermMemory missing protocol methods: {unexpected_missing}"
-        )
+        assert not missing, f"ShortTermMemory missing protocol methods: {missing}"
 
     def test_long_term_memory_satisfies_protocol(self):
         from neo4j_agent_memory.memory.long_term import LongTermMemory
@@ -188,11 +180,7 @@ class TestBoltImplsImplementProtocols:
         proto_methods = _method_names(LongTermProtocol)
         impl_methods = {name for name in dir(LongTermMemory) if not name.startswith("_")}
         missing = proto_methods - impl_methods
-        platinum_only = {"set_entity_feedback", "get_entity_history"}
-        unexpected_missing = missing - platinum_only
-        assert not unexpected_missing, (
-            f"LongTermMemory missing protocol methods: {unexpected_missing}"
-        )
+        assert not missing, f"LongTermMemory missing protocol methods: {missing}"
 
     def test_reasoning_memory_satisfies_protocol(self):
         from neo4j_agent_memory.memory.reasoning import ReasoningMemory

--- a/tests/unit/test_bolt_nams_boundary.py
+++ b/tests/unit/test_bolt_nams_boundary.py
@@ -151,3 +151,14 @@ async def test_list_conversations_returns_conversations():
     assert len(convs) == 2
     assert all(isinstance(c, Conversation) for c in convs)
     assert {c.session_id for c in convs} == {"s1", "s2"}
+
+
+@pytest.mark.asyncio
+async def test_list_conversations_coerces_none_limit():
+    # An explicit limit=None must not reach Cypher (Neo4j rejects LIMIT null).
+    client = _ClientStub(read_result=[])
+    st = _short_term(client)
+    await st.list_conversations(limit=None)
+    assert client.reads, "expected a read query"
+    _, params = client.reads[-1]
+    assert params["limit"] == 100

--- a/tests/unit/test_bolt_nams_boundary.py
+++ b/tests/unit/test_bolt_nams_boundary.py
@@ -46,12 +46,23 @@ class _ClientStub:
         return []
 
 
+# _ClientStub duck-types Neo4jClient (a concrete class, not a Protocol), so
+# the constructor's `client: Neo4jClient` param needs an arg-type override;
+# these helpers localize that single suppression instead of repeating it.
+def _long_term(client: _ClientStub | None = None) -> LongTermMemory:
+    return LongTermMemory(client or _ClientStub())  # type: ignore[arg-type]
+
+
+def _short_term(client: _ClientStub | None = None) -> ShortTermMemory:
+    return ShortTermMemory(client or _ClientStub(), embedder=None, extractor=None)  # type: ignore[arg-type]
+
+
 # ── Platinum-tier NAMS boundary: bolt raises NotSupportedError ──────────
 
 
 @pytest.mark.asyncio
 async def test_long_term_set_entity_feedback_not_supported_on_bolt():
-    lt = LongTermMemory(_ClientStub())  # type: ignore[arg-type]
+    lt = _long_term()
     with pytest.raises(NotSupportedError) as exc:
         await lt.set_entity_feedback(uuid4(), "positive")
     assert exc.value.backend == "bolt"
@@ -60,7 +71,7 @@ async def test_long_term_set_entity_feedback_not_supported_on_bolt():
 
 @pytest.mark.asyncio
 async def test_long_term_get_entity_history_not_supported_on_bolt():
-    lt = LongTermMemory(_ClientStub())  # type: ignore[arg-type]
+    lt = _long_term()
     with pytest.raises(NotSupportedError) as exc:
         await lt.get_entity_history(uuid4())
     assert exc.value.backend == "bolt"
@@ -69,7 +80,7 @@ async def test_long_term_get_entity_history_not_supported_on_bolt():
 
 @pytest.mark.asyncio
 async def test_short_term_get_observations_not_supported_on_bolt():
-    st = ShortTermMemory(_ClientStub(), embedder=None, extractor=None)  # type: ignore[arg-type]
+    st = _short_term()
     with pytest.raises(NotSupportedError) as exc:
         await st.get_observations("session-1")
     assert exc.value.backend == "bolt"
@@ -78,7 +89,7 @@ async def test_short_term_get_observations_not_supported_on_bolt():
 
 @pytest.mark.asyncio
 async def test_short_term_get_reflections_not_supported_on_bolt():
-    st = ShortTermMemory(_ClientStub(), embedder=None, extractor=None)  # type: ignore[arg-type]
+    st = _short_term()
     with pytest.raises(NotSupportedError) as exc:
         await st.get_reflections("session-1")
     assert exc.value.backend == "bolt"
@@ -90,7 +101,7 @@ async def test_short_term_get_reflections_not_supported_on_bolt():
 
 @pytest.mark.asyncio
 async def test_bulk_add_messages_delegates_to_batch(monkeypatch):
-    st = ShortTermMemory(_ClientStub(), embedder=None, extractor=None)  # type: ignore[arg-type]
+    st = _short_term()
     captured: dict[str, Any] = {}
 
     async def fake_batch(session_id: str, messages: list[dict[str, Any]], **kwargs: Any):
@@ -109,7 +120,7 @@ async def test_bulk_add_messages_delegates_to_batch(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_create_conversation_returns_conversation(monkeypatch):
-    st = ShortTermMemory(_ClientStub(), embedder=None, extractor=None)  # type: ignore[arg-type]
+    st = _short_term()
     conv_id = uuid4()
 
     async def fake_ensure(session_id: str, *args: Any, **kwargs: Any):
@@ -135,7 +146,7 @@ async def test_list_conversations_returns_conversations():
             {"c": {"id": str(uuid4()), "session_id": "s2", "title": None}},
         ]
     )
-    st = ShortTermMemory(client, embedder=None, extractor=None)  # type: ignore[arg-type]
+    st = _short_term(client)
     convs = await st.list_conversations(limit=10)
     assert len(convs) == 2
     assert all(isinstance(c, Conversation) for c in convs)

--- a/tests/unit/test_bolt_nams_boundary.py
+++ b/tests/unit/test_bolt_nams_boundary.py
@@ -1,0 +1,142 @@
+"""Bolt (self-hosted) backend fully implements the memory Protocols.
+
+Type-safety Phase 5 made the concrete bolt ``ShortTermMemory`` /
+``LongTermMemory`` conform to ``ShortTermProtocol`` / ``LongTermProtocol``
+so ``MemoryClient.short_term``/``.long_term`` no longer need
+``attr-defined``/``arg-type`` suppressions at call sites:
+
+* Gold-tier conversation methods (``create_conversation``,
+  ``list_conversations``, ``bulk_add_messages``) are real, graph-backed.
+* Platinum-tier NAMS features (``get_observations``, ``get_reflections``
+  on short-term; ``set_entity_feedback``, ``get_entity_history`` on
+  long-term) raise :class:`NotSupportedError` on bolt.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from uuid import uuid4
+
+import pytest
+
+from neo4j_agent_memory.core.exceptions import NotSupportedError
+from neo4j_agent_memory.memory.long_term import LongTermMemory
+from neo4j_agent_memory.memory.short_term import (
+    Conversation,
+    Message,
+    MessageRole,
+    ShortTermMemory,
+)
+
+
+class _ClientStub:
+    """Minimal stand-in for Neo4jClient recording the queries it is given."""
+
+    def __init__(self, read_result: list[dict[str, Any]] | None = None) -> None:
+        self._read_result = read_result or []
+        self.reads: list[tuple[str, dict[str, Any]]] = []
+        self.writes: list[tuple[str, dict[str, Any]]] = []
+
+    async def execute_read(self, query: str, params: dict[str, Any]) -> list[dict[str, Any]]:
+        self.reads.append((query, params))
+        return self._read_result
+
+    async def execute_write(self, query: str, params: dict[str, Any]) -> list[dict[str, Any]]:
+        self.writes.append((query, params))
+        return []
+
+
+# ── Platinum-tier NAMS boundary: bolt raises NotSupportedError ──────────
+
+
+@pytest.mark.asyncio
+async def test_long_term_set_entity_feedback_not_supported_on_bolt():
+    lt = LongTermMemory(_ClientStub())  # type: ignore[arg-type]
+    with pytest.raises(NotSupportedError) as exc:
+        await lt.set_entity_feedback(uuid4(), "positive")
+    assert exc.value.backend == "bolt"
+    assert "set_entity_feedback" in exc.value.method
+
+
+@pytest.mark.asyncio
+async def test_long_term_get_entity_history_not_supported_on_bolt():
+    lt = LongTermMemory(_ClientStub())  # type: ignore[arg-type]
+    with pytest.raises(NotSupportedError) as exc:
+        await lt.get_entity_history(uuid4())
+    assert exc.value.backend == "bolt"
+    assert "get_entity_history" in exc.value.method
+
+
+@pytest.mark.asyncio
+async def test_short_term_get_observations_not_supported_on_bolt():
+    st = ShortTermMemory(_ClientStub(), embedder=None, extractor=None)  # type: ignore[arg-type]
+    with pytest.raises(NotSupportedError) as exc:
+        await st.get_observations("session-1")
+    assert exc.value.backend == "bolt"
+    assert "get_observations" in exc.value.method
+
+
+@pytest.mark.asyncio
+async def test_short_term_get_reflections_not_supported_on_bolt():
+    st = ShortTermMemory(_ClientStub(), embedder=None, extractor=None)  # type: ignore[arg-type]
+    with pytest.raises(NotSupportedError) as exc:
+        await st.get_reflections("session-1")
+    assert exc.value.backend == "bolt"
+    assert "get_reflections" in exc.value.method
+
+
+# ── Gold-tier conversation methods: real, graph-backed on bolt ──────────
+
+
+@pytest.mark.asyncio
+async def test_bulk_add_messages_delegates_to_batch(monkeypatch):
+    st = ShortTermMemory(_ClientStub(), embedder=None, extractor=None)  # type: ignore[arg-type]
+    captured: dict[str, Any] = {}
+
+    async def fake_batch(session_id: str, messages: list[dict[str, Any]], **kwargs: Any):
+        captured["session_id"] = session_id
+        captured["messages"] = messages
+        return [Message(role=MessageRole.USER, content=messages[0]["content"])]
+
+    monkeypatch.setattr(st, "add_messages_batch", fake_batch)
+
+    out = await st.bulk_add_messages("s1", [{"role": "user", "content": "hi"}])
+    assert captured["session_id"] == "s1"
+    assert captured["messages"] == [{"role": "user", "content": "hi"}]
+    assert len(out) == 1
+    assert out[0].content == "hi"
+
+
+@pytest.mark.asyncio
+async def test_create_conversation_returns_conversation(monkeypatch):
+    st = ShortTermMemory(_ClientStub(), embedder=None, extractor=None)  # type: ignore[arg-type]
+    conv_id = uuid4()
+
+    async def fake_ensure(session_id: str, *args: Any, **kwargs: Any):
+        return conv_id
+
+    async def fake_get(session_id: str, *args: Any, **kwargs: Any) -> Conversation:
+        return Conversation(id=conv_id, session_id=session_id)
+
+    monkeypatch.setattr(st, "_ensure_conversation", fake_ensure)
+    monkeypatch.setattr(st, "get_conversation", fake_get)
+
+    conv = await st.create_conversation("s1")
+    assert isinstance(conv, Conversation)
+    assert conv.session_id == "s1"
+    assert conv.id == conv_id
+
+
+@pytest.mark.asyncio
+async def test_list_conversations_returns_conversations():
+    client = _ClientStub(
+        read_result=[
+            {"c": {"id": str(uuid4()), "session_id": "s1", "title": "First"}},
+            {"c": {"id": str(uuid4()), "session_id": "s2", "title": None}},
+        ]
+    )
+    st = ShortTermMemory(client, embedder=None, extractor=None)  # type: ignore[arg-type]
+    convs = await st.list_conversations(limit=10)
+    assert len(convs) == 2
+    assert all(isinstance(c, Conversation) for c in convs)
+    assert {c.session_id for c in convs} == {"s1", "s2"}


### PR DESCRIPTION
Phase 5 of the project-wide type-safety effort (tracking issue #144;
follows #150, #162, #163, and #164). Scope: the **`# type: ignore`
audit** and the **`Any` census review** (Phase 5 of the type-safety
plan).

## `# type: ignore` audit — `src/` 29 → 18, `ty check src` 3 → 0

Every surviving suppression is now **coded and carries an inline
reason**; the two remaining bare/uncoded ignores are gone.

**Bolt/NAMS protocol cluster — fixed the types, did not suppress.**
The `client.short_term`/`client.long_term` properties advertise the
concrete bolt classes, but those classes didn't implement the full
Protocol, forcing `attr-defined`/`arg-type` suppressions at every
call site. Instead of suppressing, the bolt classes now implement the
full Protocol:

- `ShortTermMemory` gains real, graph-backed `create_conversation()`,
  `list_conversations()`, `bulk_add_messages()` (the Cypher/`add_messages_batch`
  already existed — Phase 3 flagged this).
- The Platinum-tier NAMS features with no self-hosted semantics —
  `get_observations()`/`get_reflections()` (short-term),
  `set_entity_feedback()`/`get_entity_history()` (long-term) — are now
  present and raise `NotSupportedError(backend="bolt", …)` with a
  workaround hint (previously `AttributeError`).
- `get_entity_provenance` param widened `Entity | UUID` → `Entity | UUID | str`
  (the runtime already accepted a str id); param renamed `entity` → `entity_id`.

This **removed the 6 `attr-defined` + 3 `arg-type` suppressions** across
`mcp/_tools.py`, `strands/tools.py`, `pydantic_ai/memory.py`.

**Other fixes surfaced by the audit:**
- `llm.from_provider()` is now `@overload`-typed on `kind` (`"llm"` →
  `LLMProvider`, `"embedding"` → `EmbeddingProvider`) — removed an
  `assignment` ignore in `llm_extractor` and a `cast` in `extraction/factory`.
- `llm_extractor._extract_with_complete` narrows the provider via a local
  `assert isinstance(..., LLMProvider)` — dropped a `union-attr` ignore.
- Observability decorator: 2 bare `# type: ignore` → `[return-value]`.
- The 3 optional-dep `no-redef` fallbacks in `__init__.py` now carry a
  paired `# ty: ignore[unused-ignore-comment]` (matching the existing
  `mcp/server.py` pattern), resolving the mypy-vs-ty tension **deferred
  from Phase 4** → `ty check src` is now **0**.

**Survivors (all justified):** 3 `assignment` + 3 `return-value` in
`__init__.py` (the intentional Protocol-field / concrete-property seam
that unifies the bolt and NAMS backends — the permissive `**kwargs`
Protocol signatures are deliberately looser than bolt's concrete ones),
the optional-dep fallback stubs, and the `mcp/server`, `gliner`,
`llamaindex` boundary ignores.

## `Any` census — reviewed, not blanket-removed

Reviewed `dict[str, Any]` ×315, `: Any` ×215, `-> Any` ×51, `list[Any]`
×23. The census is dominated by legitimate boundaries: Neo4j record
rows, arbitrary JSON tool I/O, `**kwargs` forwarding, lazy-loaded
optional SDK/ML client objects (boto3, GCP creds, Opik, spaCy/GLiNER),
framework model adapters, dynamic `__getattr__`, and deliberately
heterogeneous cross-backend Protocol returns (`add_entity`,
`get_related_entities` — documented "shape not locked"). No blanket
removal is warranted; a few `dict[str,Any]` return shapes are TypedDict
candidates but tightening them is a breaking public-API type change,
deferred as breaking public-API type changes.

## Public-API typing changes (see CHANGELOG)

- `LongTermMemory.get_entity_provenance()` first param `entity` →
  `entity_id: Entity | UUID | str` (in-tree callers all positional).
- `from_provider()` is `@overload`-typed on `kind`.
- Bolt now implements the full memory Protocols (Platinum methods raise
  `NotSupportedError` instead of `AttributeError`).

## Verification

- `mypy src` = 0, `ty check src` = 0 (ratchet budget updated to
  `mypy=0, ty=0`); ratchet PASSES.
- `tests/unit/nams/test_protocols.py` tightened to require **full** bolt
  Protocol conformance (no more Platinum escape-hatch filter).
- New `tests/unit/test_bolt_nams_boundary.py` covers the stubs +
  graph-backed methods.
- **1451 unit tests pass**; lint/format clean.
- Integration smoke of all five new bolt methods run against a live
  Neo4j (create/list conversations, bulk add, the four
  `NotSupportedError` stubs, `get_entity_provenance(str)`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)