### PR TITLE
fix: normalize bare hosted NAMS endpoint to /v1 (#129)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -144,6 +144,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > `reference/authentication.adoc`, and the Python↔TS parity note in
 > `reference/typescript-api.adoc`, to reflect the new SDK surface.
 
+### Fixed
+
+- **A bare hosted NAMS endpoint no longer falls back to the bridge protocol
+  (#129).** `NamsConfig(endpoint="https://memory.neo4jlabs.com")` — the base
+  URL as printed in the docs, without the `/v1` suffix — was auto-detected as
+  the TCK bridge protocol, so the SDK spoke the wrong wire format to the
+  REST-only hosted service and failed silently. The endpoint is now normalized
+  to `https://memory.neo4jlabs.com/v1` when it targets the hosted host and
+  carries no `/v<N>` segment, via both `NamsConfig` and the `MEMORY_ENDPOINT`
+  env alias. Version-less on-prem and `localhost` endpoints are untouched and
+  keep their bridge behavior.
+
 ## [0.5.0] - 2026-05-30
 
 The NAMS-alignment release. Adds workspace addressing, a first-class

--- a/src/neo4j_agent_memory/config/settings.py
+++ b/src/neo4j_agent_memory/config/settings.py
@@ -2,17 +2,44 @@
 
 from __future__ import annotations
 
+import re
 import warnings
 from enum import Enum
 from typing import Any, Literal
+from urllib.parse import urlsplit, urlunsplit
 
-from pydantic import BaseModel, ConfigDict, Field, SecretStr, model_validator
+from pydantic import BaseModel, ConfigDict, Field, SecretStr, field_validator, model_validator
 from pydantic_settings import BaseSettings, PydanticBaseSettingsSource, SettingsConfigDict
 from pydantic_settings.sources import DotEnvSettingsSource
 
 # Strict config shared by every child config model. Misspelled fields raise
 # at construction time instead of being silently dropped.
 _STRICT_CONFIG = ConfigDict(extra="forbid")
+
+# Host of the managed, REST-only NAMS service. Endpoints pointed here must
+# carry a ``/v<N>`` segment (see ``nams.endpoints.detect_protocol``); a bare
+# host would otherwise fall back to the TCK bridge protocol and silently fail.
+_HOSTED_NAMS_HOST = "memory.neo4jlabs.com"
+# Matches a ``/v<digits>`` path segment — mirrors ``nams.endpoints._REST_RE``.
+_VERSION_SEGMENT_RE = re.compile(r"/v\d+(/|$)")
+
+
+def _normalize_nams_endpoint(endpoint: str) -> str:
+    """Append ``/v1`` to a bare hosted-service URL.
+
+    The managed service at ``memory.neo4jlabs.com`` is REST-only and served
+    under ``/v1``. A user who copies the base URL from the docs (without the
+    suffix) would otherwise be auto-routed to the TCK bridge protocol and fail
+    silently. Normalize only for the hosted host so version-less on-prem /
+    localhost endpoints keep their bridge behavior. See issue #129.
+    """
+    parts = urlsplit(endpoint)
+    if parts.hostname != _HOSTED_NAMS_HOST:
+        return endpoint
+    if _VERSION_SEGMENT_RE.search(parts.path):
+        return endpoint
+    new_path = parts.path.rstrip("/") + "/v1"
+    return urlunsplit(parts._replace(path=new_path))
 
 
 class EmbeddingProvider(str, Enum):
@@ -500,8 +527,17 @@ class NamsConfig(BaseModel):
     endpoint: str = Field(
         default="https://memory.neo4jlabs.com/v1",
         description="NAMS endpoint base URL. REST shape ends in /v<N> (e.g. /v1); "
-        "anything else is treated as TCK bridge unless overridden by transport_mode.",
+        "anything else is treated as TCK bridge unless overridden by transport_mode. "
+        f"A bare hosted URL (https://{_HOSTED_NAMS_HOST}) is normalized to /v1, "
+        "since the hosted service is REST-only.",
     )
+
+    @field_validator("endpoint")
+    @classmethod
+    def _ensure_hosted_endpoint_is_versioned(cls, endpoint: str) -> str:
+        """Normalize a bare hosted-service URL to include ``/v1`` (issue #129)."""
+        return _normalize_nams_endpoint(endpoint)
+
     api_key: SecretStr | None = Field(
         default=None,
         description="NAMS API key (format 'nams_...'). When constructed via "
@@ -767,7 +803,8 @@ class MemorySettings(BaseSettings):
 
         env_endpoint = os.environ.get("MEMORY_ENDPOINT")
         if env_endpoint and "endpoint" not in self.nams.model_fields_set:
-            self.nams.endpoint = env_endpoint
+            # Assignment bypasses the field validator, so normalize here too.
+            self.nams.endpoint = _normalize_nams_endpoint(env_endpoint)
 
         env_workspace = os.environ.get("MEMORY_WORKSPACE_ID")
         if env_workspace and self.nams.workspace_id is None:

--- a/tests/unit/nams/test_settings.py
+++ b/tests/unit/nams/test_settings.py
@@ -94,6 +94,51 @@ class TestNamsConfigValidation:
         config = NamsConfig(endpoint="https://nams.internal/v2")
         assert config.endpoint == "https://nams.internal/v2"
 
+
+class TestNamsConfigEndpointNormalization:
+    """The hosted NAMS service is REST-only and lives under ``/v1``.
+
+    A user who copies the bare base URL from the docs
+    (``https://memory.neo4jlabs.com``) must not silently fall into TCK
+    bridge mode. NamsConfig appends the ``/v1`` suffix for the hosted
+    host when no ``/v<N>`` segment is present. See issue #129.
+
+    Normalization is scoped to the hosted host so that version-less
+    on-prem / localhost endpoints keep their (bridge) behavior.
+    """
+
+    def test_bare_hosted_url_gets_v1_suffix(self):
+        config = NamsConfig(endpoint="https://memory.neo4jlabs.com")
+        assert config.endpoint == "https://memory.neo4jlabs.com/v1"
+
+    def test_bare_hosted_url_with_trailing_slash_gets_v1_suffix(self):
+        config = NamsConfig(endpoint="https://memory.neo4jlabs.com/")
+        assert config.endpoint == "https://memory.neo4jlabs.com/v1"
+
+    def test_normalized_hosted_url_selects_rest_protocol(self):
+        # The whole point: after normalization, auto-detection is REST.
+        from neo4j_agent_memory.nams import detect_protocol
+
+        config = NamsConfig(endpoint="https://memory.neo4jlabs.com")
+        assert detect_protocol(config.endpoint) == "rest"
+
+    def test_hosted_url_already_versioned_is_unchanged(self):
+        config = NamsConfig(endpoint="https://memory.neo4jlabs.com/v1")
+        assert config.endpoint == "https://memory.neo4jlabs.com/v1"
+
+    def test_hosted_url_with_higher_version_is_unchanged(self):
+        config = NamsConfig(endpoint="https://memory.neo4jlabs.com/v2")
+        assert config.endpoint == "https://memory.neo4jlabs.com/v2"
+
+    def test_localhost_without_version_is_untouched(self):
+        # On-prem / TCK bridge must keep working — no forced /v1.
+        config = NamsConfig(endpoint="http://localhost:8000")
+        assert config.endpoint == "http://localhost:8000"
+
+    def test_other_host_without_version_is_untouched(self):
+        config = NamsConfig(endpoint="https://nams.internal")
+        assert config.endpoint == "https://nams.internal"
+
     def test_api_key_is_secret(self):
         config = NamsConfig(api_key=SecretStr("nams_test_key"))
         assert config.api_key is not None
@@ -167,6 +212,14 @@ class TestEnvFallback:
         settings = MemorySettings()
         assert settings.backend == "nams"
         assert settings.nams.endpoint == "https://nams.sandbox/v1"
+
+    def test_bare_hosted_endpoint_via_env_is_normalized(self, monkeypatch):
+        # Same bug as issue #129 via the MEMORY_ENDPOINT alias: a bare
+        # hosted URL set through env must also gain the /v1 suffix.
+        monkeypatch.setenv("MEMORY_API_KEY", "nams_test")
+        monkeypatch.setenv("MEMORY_ENDPOINT", "https://memory.neo4jlabs.com")
+        settings = MemorySettings()
+        assert settings.nams.endpoint == "https://memory.neo4jlabs.com/v1"
 
     def test_explicit_endpoint_wins_over_env(self, monkeypatch):
         monkeypatch.setenv("MEMORY_API_KEY", "nams_test")


### PR DESCRIPTION
## Summary

**A bare hosted endpoint silently spoke the wrong wire protocol.** `NamsConfig(endpoint="https://memory.neo4jlabs.com")` — the base URL as printed in the docs, without the `/v1` suffix — fails the `/v<N>` search in `detect_protocol`, which falls back to the TCK bridge protocol. The SDK then sent snake-case bridge POSTs to the REST-only hosted service and failed with no indication that the endpoint was the cause. Now normalized to `https://memory.neo4jlabs.com/v1` when the endpoint targets the hosted host and carries no version segment.

## Normalizing the endpoint, not `detect_protocol`

The obvious fix — make `detect_protocol` return `"rest"` for the hosted host — is insufficient. `build_url` constructs REST URLs as `base + rest_path`, so the request would still go to `https://memory.neo4jlabs.com/conversations/…` with no `/v1`: right protocol, wrong path. The version segment has to live in the endpoint string itself, which fixes both the detection and the URL in one move.

## Scoped to the hosted host

A blanket "append `/v1` when missing" would break the TCK bridge. `test_localhost_no_version_is_bridge` asserts that `http://localhost:8000` resolves to `bridge`, and that's deliberate — the bridge protocol is what the conformance reference implementation speaks. Normalization therefore keys on the hostname; version-less on-prem and `localhost` endpoints are untouched.

## The `MEMORY_ENDPOINT` env alias was a second vector

`_resolve_backend` sets the endpoint by direct assignment (`self.nams.endpoint = env_endpoint`), and Pydantic v2 does not run field validators on assignment unless `validate_assignment=True`. A `NamsConfig` validator alone would have left this path broken, so the normalization is factored into a module-level helper applied at both entry points.

## Deferred to a follow-up

This is a targeted fix and does not address the underlying design:

- **It fixes one host, not the bug class.** Any REST-only deployment reached at a version-less URL still falls back to bridge silently.
- **The hostname is hardcoded.** Regional hosts or a rename would make the normalization stop applying, with no test to catch it.
- **The fallback direction is arguably inverted.** Bridge is the rare case, but it is the default for any unrecognized endpoint. REST-by-default with `transport_mode="bridge"` as the explicit opt-in would cover the whole class — but that is a breaking change and a maintainer call, not something to fold into a bug fix.
- **The real defect is that the mismatch is silent.** Surfacing it as an error ("this looks like a REST service — did you mean `/v1`?") would generalize the fix; `NamsConfig.validate_on_connect` looks like the natural hook.

Happy to open a follow-up issue for any of these if the direction is welcome.

## Verification

- 8 new tests in `tests/unit/nams/test_settings.py`: normalization (bare, trailing slash), resulting REST detection, no-ops (`/v1`, `/v2` already present), guards (`localhost`, other hosts), and the env alias path.
- Full unit suite green: 1415 passed, 4 skipped.
- `ruff check` + `ruff format --check` clean; `mypy` clean on the touched module.

Fixes #129.