### PR TITLE
ci: cache Hugging Face model dir to fix flaky integration-test-matrix

### DIFF
--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -169,6 +169,20 @@ jobs:
             sleep 2
           done
 
+      # Cache the whole Hugging Face cache dir so tests don't re-download any
+      # model on every run (a cold download can exceed the no-llm test's
+      # subprocess timeout). Repeated in each job that pulls a model.
+      - name: Cache Hugging Face models
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/huggingface
+          # Rotating key + restore-keys: restore the newest prior cache, then
+          # re-save with whatever models this run pulled. Model-agnostic — no
+          # per-model key to maintain.
+          key: hf-cache-${{ runner.os }}-${{ github.sha }}
+          restore-keys: |
+            hf-cache-${{ runner.os }}-
+
       - name: Run integration tests with coverage
         # NAMS integration tests have a dedicated workflow
         # (.github/workflows/nams-integration.yml) so we exclude them here.
@@ -248,6 +262,17 @@ jobs:
             sleep 2
           done
 
+      - name: Cache Hugging Face models
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/huggingface
+          # Rotating key + restore-keys: restore the newest prior cache, then
+          # re-save with whatever models this run pulled. Model-agnostic — no
+          # per-model key to maintain.
+          key: hf-cache-${{ runner.os }}-${{ github.sha }}
+          restore-keys: |
+            hf-cache-${{ runner.os }}-
+
       - name: Run integration tests
         # NAMS integration tests run in their own workflow
         # (.github/workflows/nams-integration.yml).
@@ -278,6 +303,17 @@ jobs:
 
       - name: Install dependencies
         run: uv sync --group dev --all-extras
+
+      - name: Cache Hugging Face models
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/huggingface
+          # Rotating key + restore-keys: restore the newest prior cache, then
+          # re-save with whatever models this run pulled. Model-agnostic — no
+          # per-model key to maintain.
+          key: hf-cache-${{ runner.os }}-${{ github.sha }}
+          restore-keys: |
+            hf-cache-${{ runner.os }}-
 
       - name: Run integration tests with testcontainers
         run: |
@@ -335,6 +371,17 @@ jobs:
             sleep 2
           done
 
+      - name: Cache Hugging Face models
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/huggingface
+          # Rotating key + restore-keys: restore the newest prior cache, then
+          # re-save with whatever models this run pulled. Model-agnostic — no
+          # per-model key to maintain.
+          key: hf-cache-${{ runner.os }}-${{ github.sha }}
+          restore-keys: |
+            hf-cache-${{ runner.os }}-
+
       - name: Run example smoke tests
         run: |
           uv run pytest tests/examples \
@@ -360,6 +407,17 @@ jobs:
 
       - name: Install dependencies
         run: uv sync --group dev --all-extras
+
+      - name: Cache Hugging Face models
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/huggingface
+          # Rotating key + restore-keys: restore the newest prior cache, then
+          # re-save with whatever models this run pulled. Model-agnostic — no
+          # per-model key to maintain.
+          key: hf-cache-${{ runner.os }}-${{ github.sha }}
+          restore-keys: |
+            hf-cache-${{ runner.os }}-
 
       - name: Run quick example validation
         run: |

--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -176,9 +176,10 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cache/huggingface
-          # Rotating key + restore-keys: restore the newest prior cache, then
-          # re-save with whatever models this run pulled. Model-agnostic — no
-          # per-model key to maintain.
+          # Rotating key: restore-keys restores the newest prior cache (so nothing
+          # re-downloads on a normal run), then the run re-saves under a fresh
+          # per-commit key so any newly-used model is folded in automatically —
+          # no manual version bump for contributors to remember.
           key: hf-cache-${{ runner.os }}-${{ github.sha }}
           restore-keys: |
             hf-cache-${{ runner.os }}-
@@ -266,9 +267,10 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cache/huggingface
-          # Rotating key + restore-keys: restore the newest prior cache, then
-          # re-save with whatever models this run pulled. Model-agnostic — no
-          # per-model key to maintain.
+          # Rotating key: restore-keys restores the newest prior cache (so nothing
+          # re-downloads on a normal run), then the run re-saves under a fresh
+          # per-commit key so any newly-used model is folded in automatically —
+          # no manual version bump for contributors to remember.
           key: hf-cache-${{ runner.os }}-${{ github.sha }}
           restore-keys: |
             hf-cache-${{ runner.os }}-
@@ -308,9 +310,10 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cache/huggingface
-          # Rotating key + restore-keys: restore the newest prior cache, then
-          # re-save with whatever models this run pulled. Model-agnostic — no
-          # per-model key to maintain.
+          # Rotating key: restore-keys restores the newest prior cache (so nothing
+          # re-downloads on a normal run), then the run re-saves under a fresh
+          # per-commit key so any newly-used model is folded in automatically —
+          # no manual version bump for contributors to remember.
           key: hf-cache-${{ runner.os }}-${{ github.sha }}
           restore-keys: |
             hf-cache-${{ runner.os }}-
@@ -375,9 +378,10 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cache/huggingface
-          # Rotating key + restore-keys: restore the newest prior cache, then
-          # re-save with whatever models this run pulled. Model-agnostic — no
-          # per-model key to maintain.
+          # Rotating key: restore-keys restores the newest prior cache (so nothing
+          # re-downloads on a normal run), then the run re-saves under a fresh
+          # per-commit key so any newly-used model is folded in automatically —
+          # no manual version bump for contributors to remember.
           key: hf-cache-${{ runner.os }}-${{ github.sha }}
           restore-keys: |
             hf-cache-${{ runner.os }}-
@@ -412,9 +416,10 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cache/huggingface
-          # Rotating key + restore-keys: restore the newest prior cache, then
-          # re-save with whatever models this run pulled. Model-agnostic — no
-          # per-model key to maintain.
+          # Rotating key: restore-keys restores the newest prior cache (so nothing
+          # re-downloads on a normal run), then the run re-saves under a fresh
+          # per-commit key so any newly-used model is folded in automatically —
+          # no manual version bump for contributors to remember.
           key: hf-cache-${{ runner.os }}-${{ github.sha }}
           restore-keys: |
             hf-cache-${{ runner.os }}-

--- a/tests/integration/test_memory_client_no_llm.py
+++ b/tests/integration/test_memory_client_no_llm.py
@@ -162,10 +162,7 @@ class TestMemoryClientNoLLM:
             [sys.executable, "-c", script],
             capture_output=True,
             text=True,
-            # Generous cap: the subprocess may cold-download the
-            # sentence-transformers model on a CI cache miss. CI caches
-            # ~/.cache/huggingface (see ci-python.yml) so warm runs are fast.
-            timeout=300,
+            timeout=120,
         )
         if result.returncode != 0:
             pytest.fail(

--- a/tests/integration/test_memory_client_no_llm.py
+++ b/tests/integration/test_memory_client_no_llm.py
@@ -162,7 +162,10 @@ class TestMemoryClientNoLLM:
             [sys.executable, "-c", script],
             capture_output=True,
             text=True,
-            timeout=120,
+            # Generous cap: the subprocess may cold-download the
+            # sentence-transformers model on a CI cache miss. CI caches
+            # ~/.cache/huggingface (see ci-python.yml) so warm runs are fast.
+            timeout=300,
         )
         if result.returncode != 0:
             pytest.fail(


### PR DESCRIPTION
## Problem

The integration and example CI jobs configure a sentence-transformers embedder
(`all-MiniLM-L6-v2`). Nothing caches the model, so **every run re-downloads it
from Hugging Face**. `tests/integration/test_memory_client_no_llm.py::
test_no_openai_import_with_llm_none` caps its subprocess at **120 s**, so a cold
or slow HF pull blows the cap and fails `integration-test-matrix`.

This surfaced on a feature branch where `integration-test-matrix` was red across
all four Python versions while `main` was green — purely download-timing
variance (no cache → success depends on HF's speed at run time), not a code
change. The sibling `integration-test` job passed the same test in the same run.

## Fix

- **Cache `~/.cache/huggingface`** in each job that pulls a model
  (`integration-test`, `integration-test-matrix`,
  `integration-test-testcontainers`, `example-tests`, `example-tests-quick`).
  The cache is **model-agnostic**: a rotating
  `key: hf-cache-${{ runner.os }}-${{ github.sha }}` plus
  `restore-keys: hf-cache-${{ runner.os }}-` restores the newest prior cache and
  re-saves with whatever models the run pulled — no per-model key to maintain,
  and any future model is picked up automatically.
- **Raise the no-llm subprocess timeout 120 s → 300 s** so the first
  (cache-populating) run tolerates a cold download.

## Notes

- Independent of the type-safety work (PR #167); either can merge first. Both
  touch `.github/workflows/ci-python.yml`, so a trivial rebase may be needed for
  whichever lands second.
- `.github/workflows/ci-python.yml` change → CI runs on this PR; the first run
  populates the cache, subsequent runs restore it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
