### PR TITLE
Fix first-embed deadlock on Windows (sentence-transformers)

### DIFF
--- a/src/neo4j_agent_memory/cli/main.py
+++ b/src/neo4j_agent_memory/cli/main.py
@@ -919,6 +919,26 @@ def mcp_serve(
         )
         sys.exit(1)
 
+    # Windows deadlock guard: when a local sentence-transformers embedder is
+    # configured, import its native stack (scipy/torch) up-front on the main
+    # thread, before the event loop starts. Importing it lazily inside the
+    # running loop on the first embed() call deadlocks in the Windows DLL loader
+    # lock (see SentenceTransformerEmbedder / preload()). No-op for cloud
+    # embedders and when sentence-transformers isn't installed.
+    if embedding:
+        from neo4j_agent_memory.embeddings.sentence_transformers import preload
+        from neo4j_agent_memory.llm.adapters.sentence_transformers import (
+            SentenceTransformersProvider,
+        )
+        from neo4j_agent_memory.llm.factory import from_provider
+
+        try:
+            resolved_embedder = from_provider(embedding, kind="embedding")
+        except Exception:
+            resolved_embedder = None
+        if isinstance(resolved_embedder, SentenceTransformersProvider):
+            preload()
+
     asyncio.run(
         run_server(
             neo4j_uri=uri,

--- a/src/neo4j_agent_memory/embeddings/sentence_transformers.py
+++ b/src/neo4j_agent_memory/embeddings/sentence_transformers.py
@@ -1,4 +1,12 @@
-"""Sentence Transformers embedding provider for local embeddings."""
+"""Sentence Transformers embedding provider for local embeddings.
+
+Note on Windows: importing ``sentence_transformers`` (which pulls in scipy's and
+torch's native extensions) for the first time *inside a running asyncio event
+loop* deadlocks in the Windows DLL loader lock — regardless of which thread runs
+the import — hanging the very first ``embed`` call forever. Startup code should
+call :func:`preload` from synchronous context before the event loop starts to
+do that native import safely on the main thread.
+"""
 
 from __future__ import annotations
 
@@ -10,6 +18,19 @@ from neo4j_agent_memory.embeddings.base import BaseEmbedder
 
 if TYPE_CHECKING:
     from sentence_transformers import SentenceTransformer
+
+
+def preload() -> None:
+    """Eagerly import the sentence-transformers stack on the current thread.
+
+    Call this from synchronous startup code *before* any asyncio event loop is
+    running (see the module docstring for why). No-op if sentence-transformers
+    is not installed.
+    """
+    import importlib.util
+
+    if importlib.util.find_spec("sentence_transformers") is not None:
+        importlib.import_module("sentence_transformers")
 
 
 # Model dimensions mapping (common models)
@@ -69,11 +90,16 @@ class SentenceTransformerEmbedder(BaseEmbedder):
 
     async def embed(self, text: str) -> list[float]:
         """Generate embedding for a single text."""
-        model = self._ensure_model()
-
         try:
-            # Run in thread pool since sentence-transformers is sync
+            # Run in thread pool since sentence-transformers is sync.
+            # _ensure_model() must ALSO run in the executor, not on the event
+            # loop thread: the first call lazily imports sentence_transformers
+            # (-> scipy/torch native extensions) and loads the model. Doing that
+            # on the loop thread blocks the whole server for the load; on Windows
+            # the first-time native import even deadlocks in the DLL loader lock
+            # (see the module docstring / preload()).
             loop = asyncio.get_event_loop()
+            model = await loop.run_in_executor(None, self._ensure_model)
             embedding = await loop.run_in_executor(
                 None, lambda: model.encode(text, convert_to_numpy=True)
             )
@@ -86,11 +112,11 @@ class SentenceTransformerEmbedder(BaseEmbedder):
         if not texts:
             return []
 
-        model = self._ensure_model()
-
         try:
-            # Run in thread pool since sentence-transformers is sync
+            # Run in thread pool since sentence-transformers is sync.
+            # _ensure_model() offloaded too — see the note in embed() above.
             loop = asyncio.get_event_loop()
+            model = await loop.run_in_executor(None, self._ensure_model)
             embeddings = await loop.run_in_executor(
                 None, lambda: model.encode(texts, convert_to_numpy=True)
             )

--- a/tests/unit/embeddings/test_sentence_transformers.py
+++ b/tests/unit/embeddings/test_sentence_transformers.py
@@ -1,0 +1,94 @@
+"""Unit tests for the local sentence-transformers embedding provider."""
+
+import threading
+from typing import Any
+from unittest.mock import patch
+
+from neo4j_agent_memory.embeddings.sentence_transformers import (
+    SentenceTransformerEmbedder,
+    preload,
+)
+
+
+class _FakeEncoding:
+    def tolist(self) -> list[float]:
+        return [0.1, 0.2, 0.3]
+
+
+class _FakeModel:
+    def encode(
+        self, text_or_texts: Any, *args: Any, **kwargs: Any
+    ) -> _FakeEncoding | list[_FakeEncoding]:
+        # Mirror sentence-transformers: a batch (list input) yields one encoding
+        # per text; a single string yields a single encoding.
+        if isinstance(text_or_texts, (list, tuple)):
+            return [_FakeEncoding() for _ in text_or_texts]
+        return _FakeEncoding()
+
+    def get_sentence_embedding_dimension(self) -> int:
+        return 3
+
+
+class TestSentenceTransformerEmbedderThreading:
+    """The heavy model load must never run on the asyncio event-loop thread."""
+
+    async def test_embed_loads_model_off_the_event_loop_thread(self) -> None:
+        """Regression guard for the Windows first-call hang.
+
+        The first ``embed`` call lazily imports ``sentence_transformers``
+        (-> scipy native libs) via ``_ensure_model``. Doing that import on the
+        event-loop thread deadlocks in the Windows DLL loader lock, so
+        ``_ensure_model`` must be offloaded to a worker thread.
+        """
+        embedder = SentenceTransformerEmbedder("all-MiniLM-L6-v2")
+        loop_thread_id = threading.get_ident()
+        seen: dict[str, int] = {}
+
+        def fake_ensure() -> _FakeModel:
+            seen["thread_id"] = threading.get_ident()
+            return _FakeModel()
+
+        with patch.object(embedder, "_ensure_model", side_effect=fake_ensure):
+            result = await embedder.embed("hello")
+
+        assert result == [0.1, 0.2, 0.3]
+        assert seen["thread_id"] != loop_thread_id
+
+    async def test_embed_batch_loads_model_off_the_event_loop_thread(self) -> None:
+        """``embed_batch`` offloads ``_ensure_model`` for the same reason."""
+        embedder = SentenceTransformerEmbedder("all-MiniLM-L6-v2")
+        loop_thread_id = threading.get_ident()
+        seen: dict[str, int] = {}
+
+        def fake_ensure() -> _FakeModel:
+            seen["thread_id"] = threading.get_ident()
+            return _FakeModel()
+
+        with patch.object(embedder, "_ensure_model", side_effect=fake_ensure):
+            result = await embedder.embed_batch(["a", "b"])
+
+        assert result == [[0.1, 0.2, 0.3], [0.1, 0.2, 0.3]]
+        assert seen["thread_id"] != loop_thread_id
+
+
+class TestPreload:
+    """``preload`` imports the native stack up-front, or no-ops if absent."""
+
+    def test_preload_is_noop_when_not_installed(self) -> None:
+        with (
+            patch("importlib.util.find_spec", return_value=None) as find_spec,
+            patch("importlib.import_module") as import_module,
+        ):
+            preload()
+
+        find_spec.assert_called_once_with("sentence_transformers")
+        import_module.assert_not_called()
+
+    def test_preload_imports_when_installed(self) -> None:
+        with (
+            patch("importlib.util.find_spec", return_value=object()),
+            patch("importlib.import_module") as import_module,
+        ):
+            preload()
+
+        import_module.assert_called_once_with("sentence_transformers")


### PR DESCRIPTION
## Summary

On Windows, the MCP server hangs **forever on the first `memory_add_fact` / `memory_search`** when using a local `sentence-transformers` embedder (`neo4j-agent-memory mcp serve --embedding sentence-transformers/...`). The tool call never returns and never errors — the process just wedges.

## Root cause

`SentenceTransformerEmbedder.embed()` correctly offloads `model.encode()` to a thread executor, but calls `self._ensure_model()` **synchronously on the asyncio event-loop thread**. `_ensure_model()` performs the first `import sentence_transformers`, which pulls in scipy's native BLAS extension.

Importing that native extension for the first time **while the asyncio event loop is already running deadlocks in the Windows DLL loader lock** — and it does so *regardless of which thread runs the import*.

Confirmed with two `py-spy` dumps of the hung process taken seconds apart: both wedged at the exact same frame, with zero CPU progress:

```
memory_add_fact (mcp/_tools.py) -> add_fact (integration.py)
  -> add_fact (memory/long_term.py) -> embed (embeddings/base.py)
    -> embed_one (llm/adapters/sentence_transformers.py)
      -> embed (embeddings/sentence_transformers.py)
        -> _ensure_model (embeddings/sentence_transformers.py)
          -> import sentence_transformers -> scipy ...
            -> create_module (importlib._bootstrap_external)
              -> <module> (scipy/linalg/blas.py)   # wedged here, 0 CPU growth
```

The model was already fully downloaded (no network activity), Neo4j was healthy, and the process used ~4.5s CPU across several hours — a deadlock, not slow loading or OOM.

## Why offloading `_ensure_model` alone is not enough

My first attempt was to move `_ensure_model()` into the same `run_in_executor` call. `py-spy` then showed the import running on a worker thread instead of the loop thread — but it **still deadlocked at the same `scipy/linalg/blas.py` frame**. The trigger is "first native `sentence_transformers` import while an event loop is running", not which thread performs it. The native import must happen *before* the loop starts.

## Fix

1. **`embeddings/sentence_transformers.py`** — offload `_ensure_model()` to the executor in `embed()` / `embed_batch()` (so a model load never blocks the event loop), and add a `preload()` helper that imports the native stack eagerly.
2. **`cli/main.py` (`mcp serve`)** — call `preload()` on the main thread **before `asyncio.run()`** when the configured embedder resolves to `SentenceTransformersProvider`, so the native import happens in a safe, no-loop context. No-op for cloud embedders and when `sentence-transformers` isn't installed.
3. **Tests** — regression tests asserting `embed()` / `embed_batch()` load the model off the event-loop thread, plus `preload()` unit tests.

## Verification

- New unit tests pass; `ruff check` and `ruff format --check` are clean.
- End-to-end on Windows 11 / Python 3.10 with `--embedding sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2 --embedding-dimensions 384`: `memory_add_fact` now returns `{"stored": true}` in ~9s instead of hanging indefinitely.

## Notes for reviewers

- I could not run the full `make check` (mypy `--strict` + ty) locally, as it needs `uv sync --all-extras` (torch etc.). The changes use only stdlib + internal, already-typed APIs and do not alter the existing typed surface, but please confirm in CI.
- The synchronous `_ensure_model()` on the event-loop thread is arguably a latent issue on all platforms (the first embed blocks the whole server while the model loads); the Windows DLL loader-lock deadlock is the platform-specific escalation of the same root cause.
