### PR TITLE
fix: bound embedder input and make message writes resilient to embedding failures

### DIFF
--- a/src/neo4j_agent_memory/embeddings/openai.py
+++ b/src/neo4j_agent_memory/embeddings/openai.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING, Any
 
 from neo4j_agent_memory.core.exceptions import EmbeddingError
@@ -17,6 +18,63 @@ MODEL_DIMENSIONS = {
     "text-embedding-3-large": 3072,
     "text-embedding-ada-002": 1536,
 }
+
+logger = logging.getLogger(__name__)
+
+# Max input tokens per model. The API hard-fails (400) above this; we truncate to stay under it.
+# Target slightly below the true ceiling (8192) for safety headroom.
+MODEL_MAX_INPUT_TOKENS = {
+    "text-embedding-3-small": 8192,
+    "text-embedding-3-large": 8192,
+    "text-embedding-ada-002": 8192,
+}
+_DEFAULT_MAX_INPUT_TOKENS = 8192
+_TOKEN_HEADROOM = 192
+
+
+def _max_tokens_for(model: str) -> int:
+    """Return the safe token budget for ``model`` (ceiling minus headroom)."""
+    return MODEL_MAX_INPUT_TOKENS.get(model, _DEFAULT_MAX_INPUT_TOKENS) - _TOKEN_HEADROOM
+
+
+def _truncate_to_tokens(text: str, model: str) -> str:
+    """Truncate ``text`` so it fits within the token budget of ``model``.
+
+    Uses ``tiktoken`` when available for an accurate token count. Falls back to
+    a character-based estimate (4 chars per token) when ``tiktoken`` is not
+    installed or the encoding lookup fails, since ``tiktoken`` is an optional
+    dependency of this package.
+    """
+    budget = _max_tokens_for(model)
+    try:
+        import tiktoken  # tiktoken is an optional dependency, not declared in pyproject
+
+        try:
+            enc = tiktoken.encoding_for_model(model)
+        except KeyError:
+            enc = tiktoken.get_encoding("cl100k_base")
+        toks: list[int] = enc.encode(text)
+        if len(toks) <= budget:
+            return text
+        logger.warning(
+            "embedding input exceeds token budget (%d tokens > %d budget) for model %s; truncating",
+            len(toks),
+            budget,
+            model,
+        )
+        return str(enc.decode(toks[:budget]))
+    except Exception:
+        char_budget = budget * 4
+        if len(text) <= char_budget:
+            return text
+        logger.warning(
+            "embedding input exceeds char-estimate budget (%d chars > %d) for model %s "
+            "(tiktoken unavailable); truncating",
+            len(text),
+            char_budget,
+            model,
+        )
+        return text[:char_budget]
 
 
 class OpenAIEmbedder(BaseEmbedder):
@@ -71,6 +129,7 @@ class OpenAIEmbedder(BaseEmbedder):
     async def embed(self, text: str) -> list[float]:
         """Generate embedding for a single text."""
         client = self._ensure_client()
+        text = _truncate_to_tokens(text, self._model)
 
         try:
             kwargs: dict[str, Any] = {"input": text, "model": self._model}
@@ -87,6 +146,7 @@ class OpenAIEmbedder(BaseEmbedder):
         if not texts:
             return []
 
+        texts = [_truncate_to_tokens(t, self._model) for t in texts]
         client = self._ensure_client()
         all_embeddings: list[list[float]] = []
 

--- a/src/neo4j_agent_memory/memory/short_term.py
+++ b/src/neo4j_agent_memory/memory/short_term.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 from collections.abc import Awaitable, Callable
 from datetime import datetime, timezone
 from enum import Enum
@@ -16,6 +17,8 @@ from neo4j_agent_memory.core.memory import BaseMemory, MemoryEntry
 from neo4j_agent_memory.core.protocols import ShortTermProtocol
 from neo4j_agent_memory.graph import queries
 from neo4j_agent_memory.graph.query_builder import build_create_entity_query
+
+logger = logging.getLogger(__name__)
 
 
 def _llm_summarizer(
@@ -456,12 +459,23 @@ class ShortTermMemory(BaseMemory[Message], ShortTermProtocol):
                     )
                 )
 
-            # Generate embeddings in batch if enabled
+            # Generate embeddings in batch if enabled. A batch embed failure must never abort the
+            # whole batch insert: I fall back to null vectors for every message in this batch and
+            # continue, matching the single-message add_message() resilience behavior above.
             if generate_embeddings and self._embedder is not None:
-                embeddings = await self._embedder.embed_batch(contents_for_embedding)
-                for j, emb in enumerate(embeddings):
-                    batch_data[j]["embedding"] = emb
-                    batch_messages[j].embedding = emb
+                try:
+                    embeddings = await self._embedder.embed_batch(contents_for_embedding)
+                except Exception as e:  # noqa: BLE001
+                    logger.warning(
+                        "batch embedding failed for %d message(s); storing this batch without "
+                        "vectors and continuing: %s",
+                        len(contents_for_embedding),
+                        str(e)[:200],
+                    )
+                else:
+                    for j, emb in enumerate(embeddings):
+                        batch_data[j]["embedding"] = emb
+                        batch_messages[j].embedding = emb
 
             # Insert batch into database
             await self._client.execute_write(
@@ -713,10 +727,21 @@ class ShortTermMemory(BaseMemory[Message], ShortTermProtocol):
             session_id, conversation_id, user_identifier=user_identifier
         )
 
-        # Generate embedding if enabled
-        embedding = None
+        # Generate embedding if enabled. An embedding failure must never drop the message or its
+        # extracted entities: I degrade to a null message-vector and continue. Entities extracted
+        # from this message carry their own embeddings, so the memory remains fully recallable even
+        # without the message-level vector.
+        embedding: list[float] | None = None
         if generate_embedding and self._embedder is not None:
-            embedding = await self._embedder.embed(content)
+            try:
+                embedding = await self._embedder.embed(content)
+            except Exception as e:  # noqa: BLE001
+                logger.warning(
+                    "message embedding failed; storing message without a vector and continuing "
+                    "with extraction: %s",
+                    str(e)[:200],
+                )
+                embedding = None
 
         # Create message
         message = Message(

--- a/tests/unit/embeddings/test_openai.py
+++ b/tests/unit/embeddings/test_openai.py
@@ -144,3 +144,96 @@ class TestOpenAIEmbedderTruncation:
 
         assert result == []
         mock_client.embeddings.create.assert_not_called()
+
+
+class TestTruncateToTokensWithRealTiktoken:
+    """Tests that exercise the real ``tiktoken`` path (no patching).
+
+    ``tiktoken`` is installed in the dev environment, so calling
+    ``_truncate_to_tokens`` without any fixture that hides it exercises the
+    primary code path: ``tiktoken.encoding_for_model`` / ``enc.encode`` /
+    ``enc.decode``, including the ``KeyError`` fallback to ``cl100k_base``.
+    """
+
+    def test_real_tiktoken_under_budget_passthrough(self):
+        """Real tiktoken path: short input returns unchanged."""
+        import tiktoken
+
+        from neo4j_agent_memory.embeddings.openai import _truncate_to_tokens
+
+        text = "hello world"
+        enc = tiktoken.encoding_for_model("text-embedding-3-small")
+        assert len(enc.encode(text)) < 8000
+
+        assert _truncate_to_tokens(text, "text-embedding-3-small") is text
+
+    def test_real_tiktoken_over_budget_truncates_to_exact_token_count(self, caplog):
+        """Real tiktoken path: oversize input is truncated to at-most-budget tokens."""
+        import tiktoken
+
+        from neo4j_agent_memory.embeddings.openai import (
+            _DEFAULT_MAX_INPUT_TOKENS,
+            _TOKEN_HEADROOM,
+            _truncate_to_tokens,
+        )
+
+        budget = _DEFAULT_MAX_INPUT_TOKENS - _TOKEN_HEADROOM
+        enc = tiktoken.encoding_for_model("text-embedding-3-small")
+        oversize = "hello world " * 5000
+        assert len(enc.encode(oversize)) > budget, (
+            "test fixture is not oversized under the real encoder; adjust the multiplier"
+        )
+
+        with caplog.at_level(logging.WARNING, logger="neo4j_agent_memory.embeddings.openai"):
+            result = _truncate_to_tokens(oversize, "text-embedding-3-small")
+
+        re_encoded = enc.encode(result)
+        assert len(re_encoded) <= budget
+        assert any(
+            "exceeds token budget" in rec.message and "truncating" in rec.message
+            for rec in caplog.records
+        )
+
+    def test_real_tiktoken_unknown_model_falls_back_to_cl100k_base_encoding(self, caplog):
+        """Unknown model: ``KeyError`` from ``encoding_for_model`` is caught, falls back to cl100k_base."""
+        import tiktoken
+
+        from neo4j_agent_memory.embeddings.openai import (
+            _DEFAULT_MAX_INPUT_TOKENS,
+            _TOKEN_HEADROOM,
+            _truncate_to_tokens,
+        )
+
+        budget = _DEFAULT_MAX_INPUT_TOKENS - _TOKEN_HEADROOM
+        cl100k = tiktoken.get_encoding("cl100k_base")
+
+        short_text = "hello world"
+        result_short = _truncate_to_tokens(short_text, "some-made-up-nonexistent-model-xyz")
+        assert result_short == short_text
+
+        oversize = "hello world " * 5000
+        assert len(cl100k.encode(oversize)) > budget, (
+            "test fixture is not oversized under cl100k_base; adjust the multiplier"
+        )
+
+        with caplog.at_level(logging.WARNING, logger="neo4j_agent_memory.embeddings.openai"):
+            result_long = _truncate_to_tokens(oversize, "some-made-up-nonexistent-model-xyz")
+
+        re_encoded = cl100k.encode(result_long)
+        assert len(re_encoded) <= budget
+
+    def test_real_tiktoken_truncated_output_is_never_longer_in_tokens_than_original(self):
+        """Sanity invariant: truncation strictly shrinks token count for oversize input."""
+        import tiktoken
+
+        from neo4j_agent_memory.embeddings.openai import _truncate_to_tokens
+
+        enc = tiktoken.encoding_for_model("text-embedding-3-small")
+        oversize = "hello world " * 5000
+        original_token_count = len(enc.encode(oversize))
+        assert original_token_count > 8000
+
+        result = _truncate_to_tokens(oversize, "text-embedding-3-small")
+        truncated_token_count = len(enc.encode(result))
+
+        assert truncated_token_count < original_token_count

--- a/tests/unit/embeddings/test_openai.py
+++ b/tests/unit/embeddings/test_openai.py
@@ -1,0 +1,146 @@
+"""Unit tests for OpenAI embedder token-budget truncation."""
+
+from __future__ import annotations
+
+import logging
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def force_char_fallback():
+    """Force the char-estimate fallback path by making ``import tiktoken`` fail.
+
+    Setting ``sys.modules["tiktoken"] = None`` causes a subsequent
+    ``import tiktoken`` to raise ``ImportError`` inside ``_truncate_to_tokens``,
+    which is the path we want to exercise since tiktoken is optional.
+    """
+    with patch.dict(sys.modules, {"tiktoken": None}):
+        yield
+
+
+class TestTruncateToTokens:
+    """Tests for the module-level ``_truncate_to_tokens`` helper."""
+
+    def test_under_budget_returns_input_unchanged(self, force_char_fallback):
+        """Char-estimate path: short input passes through untouched."""
+        from neo4j_agent_memory.embeddings.openai import _truncate_to_tokens
+
+        text = "hello world"
+        assert _truncate_to_tokens(text, "text-embedding-3-small") == text
+
+    def test_over_budget_truncates_and_warns(self, force_char_fallback, caplog):
+        """Char-estimate path: oversize input is truncated to char_budget and a warning is logged."""
+        from neo4j_agent_memory.embeddings.openai import (
+            _DEFAULT_MAX_INPUT_TOKENS,
+            _TOKEN_HEADROOM,
+            _truncate_to_tokens,
+        )
+
+        char_budget = (_DEFAULT_MAX_INPUT_TOKENS - _TOKEN_HEADROOM) * 4
+        oversize = "x" * (char_budget + 5000)
+
+        with caplog.at_level(logging.WARNING, logger="neo4j_agent_memory.embeddings.openai"):
+            result = _truncate_to_tokens(oversize, "text-embedding-3-small")
+
+        assert len(result) == char_budget
+        assert result == "x" * char_budget
+        assert any(
+            "exceeds char-estimate budget" in rec.message and "truncating" in rec.message
+            for rec in caplog.records
+        )
+
+    def test_unknown_model_uses_default_budget(self, force_char_fallback):
+        """Unknown models fall back to the default token budget."""
+        from neo4j_agent_memory.embeddings.openai import _truncate_to_tokens
+
+        text = "some short text"
+        assert _truncate_to_tokens(text, "made-up-model-name") == text
+
+
+class TestOpenAIEmbedderTruncation:
+    """Tests that ``OpenAIEmbedder`` truncates before hitting the API."""
+
+    @pytest.mark.asyncio
+    async def test_embed_truncates_oversize_input(self, force_char_fallback):
+        """``embed()`` must truncate before calling the OpenAI client."""
+        from neo4j_agent_memory.embeddings.openai import (
+            _DEFAULT_MAX_INPUT_TOKENS,
+            _TOKEN_HEADROOM,
+            OpenAIEmbedder,
+        )
+
+        char_budget = (_DEFAULT_MAX_INPUT_TOKENS - _TOKEN_HEADROOM) * 4
+        oversize = "y" * (char_budget + 10_000)
+
+        embedder = OpenAIEmbedder(model="text-embedding-3-small", api_key="test-key")
+
+        mock_response = MagicMock()
+        mock_response.data = [MagicMock(embedding=[0.1, 0.2, 0.3])]
+        mock_client = MagicMock()
+        mock_client.embeddings = MagicMock()
+        mock_client.embeddings.create = AsyncMock(return_value=mock_response)
+        embedder._client = mock_client
+
+        result = await embedder.embed(oversize)
+
+        assert result == [0.1, 0.2, 0.3]
+        mock_client.embeddings.create.assert_awaited_once()
+        sent_input = mock_client.embeddings.create.await_args.kwargs["input"]
+        assert len(sent_input) == char_budget
+
+    @pytest.mark.asyncio
+    async def test_embed_batch_truncates_every_item(self, force_char_fallback):
+        """``embed_batch()`` must truncate every text before calling the API."""
+        from neo4j_agent_memory.embeddings.openai import (
+            _DEFAULT_MAX_INPUT_TOKENS,
+            _TOKEN_HEADROOM,
+            OpenAIEmbedder,
+        )
+
+        char_budget = (_DEFAULT_MAX_INPUT_TOKENS - _TOKEN_HEADROOM) * 4
+        oversize_a = "a" * (char_budget + 500)
+        oversize_b = "b" * (char_budget + 1500)
+        small = "c" * 10
+        texts = [oversize_a, small, oversize_b]
+
+        embedder = OpenAIEmbedder(model="text-embedding-3-small", api_key="test-key")
+
+        mock_response = MagicMock()
+        mock_response.data = [
+            MagicMock(index=0, embedding=[0.1]),
+            MagicMock(index=1, embedding=[0.2]),
+            MagicMock(index=2, embedding=[0.3]),
+        ]
+        mock_client = MagicMock()
+        mock_client.embeddings = MagicMock()
+        mock_client.embeddings.create = AsyncMock(return_value=mock_response)
+        embedder._client = mock_client
+
+        result = await embedder.embed_batch(texts)
+
+        assert result == [[0.1], [0.2], [0.3]]
+        mock_client.embeddings.create.assert_awaited_once()
+        sent_batch = mock_client.embeddings.create.await_args.kwargs["input"]
+        assert len(sent_batch) == 3
+        assert len(sent_batch[0]) == char_budget
+        assert sent_batch[1] == small
+        assert len(sent_batch[2]) == char_budget
+
+    @pytest.mark.asyncio
+    async def test_embed_batch_empty_list_short_circuits(self):
+        """Empty list must not touch the client or the truncator."""
+        from neo4j_agent_memory.embeddings.openai import OpenAIEmbedder
+
+        embedder = OpenAIEmbedder(model="text-embedding-3-small", api_key="test-key")
+        mock_client = MagicMock()
+        mock_client.embeddings = MagicMock()
+        mock_client.embeddings.create = AsyncMock()
+        embedder._client = mock_client
+
+        result = await embedder.embed_batch([])
+
+        assert result == []
+        mock_client.embeddings.create.assert_not_called()

--- a/tests/unit/test_relation_storage.py
+++ b/tests/unit/test_relation_storage.py
@@ -1,5 +1,6 @@
 """Unit tests for relation storage in short-term memory."""
 
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
@@ -379,3 +380,145 @@ class TestCypherQueries:
         assert "MERGE (source)-[r:RELATED_TO]->(target)" in query
         assert "relation_type" in query
         assert "confidence" in query
+
+
+class _FailingEmbedder:
+    """Embedder whose ``embed`` and ``embed_batch`` always raise."""
+
+    dimensions = 3
+
+    def __init__(self, error: Exception | None = None) -> None:
+        self._error = error or RuntimeError("simulated embed failure")
+
+    async def embed(self, text: str) -> list[float]:
+        raise self._error
+
+    async def embed_batch(self, texts: list[str]) -> list[list[float]]:
+        raise self._error
+
+
+class _SucceedingEmbedder:
+    """Embedder that returns a deterministic vector for happy-path checks."""
+
+    dimensions = 3
+
+    def __init__(self, vector: list[float] | None = None) -> None:
+        self._vector = vector or [0.1, 0.2, 0.3]
+
+    async def embed(self, text: str) -> list[float]:
+        return list(self._vector)
+
+    async def embed_batch(self, texts: list[str]) -> list[list[float]]:
+        return [list(self._vector) for _ in texts]
+
+
+class TestEmbeddingResilience:
+    """Message writes and entity extraction must survive embedding failures.
+
+    Regression coverage for bug #104: an ``embed()`` failure on oversize input
+    was aborting the whole write path and silently dropping the message and its
+    extracted entities.
+    """
+
+    @pytest.fixture
+    def mock_client(self) -> MagicMock:
+        client = MagicMock()
+        client.execute_write = AsyncMock(return_value=[])
+        client.execute_read = AsyncMock(return_value=[])
+        return client
+
+    def _find_create_message_call(self, mock_client: MagicMock) -> Any:
+        from neo4j_agent_memory.graph import queries
+
+        for call in mock_client.execute_write.call_args_list:
+            args = call[0]
+            if args and args[0] == queries.CREATE_MESSAGE:
+                return call
+        raise AssertionError("CREATE_MESSAGE was never called")
+
+    def _find_batch_create_call(self, mock_client: MagicMock) -> Any:
+        from neo4j_agent_memory.graph import queries
+
+        for call in mock_client.execute_write.call_args_list:
+            args = call[0]
+            if args and args[0] == queries.CREATE_MESSAGES_BATCH:
+                return call
+        raise AssertionError("CREATE_MESSAGES_BATCH was never called")
+
+    @pytest.mark.asyncio
+    async def test_add_message_survives_embed_failure(self, mock_client: MagicMock) -> None:
+        """``embed()`` raising must not abort the message write or entity extraction."""
+        entities = [ExtractedEntity(name="Alice", type="PERSON", confidence=0.9)]
+        extractor = MockExtractorWithRelations(entities, [])
+        memory = ShortTermMemory(
+            mock_client,
+            embedder=_FailingEmbedder(),
+            extractor=extractor,
+        )
+
+        message = await memory.add_message(
+            "session-fail",
+            MessageRole.USER,
+            "Alice said hello",
+            extract_entities=True,
+            extract_relations=False,
+        )
+
+        assert message.embedding is None
+        create_call = self._find_create_message_call(mock_client)
+        params = create_call[0][1]
+        assert params["embedding"] is None
+        assert params["content"] == "Alice said hello"
+
+        entity_calls = [
+            call
+            for call in mock_client.execute_write.call_args_list
+            if len(call[0]) > 1 and "name" in str(call[0][1]) and "Alice" in str(call[0][1])
+        ]
+        assert entity_calls, "entity extraction must still run when embedding fails"
+
+    @pytest.mark.asyncio
+    async def test_add_message_happy_path_stores_embedding(self, mock_client: MagicMock) -> None:
+        """Regression: when the embedder succeeds, the vector must flow through."""
+        vector = [0.4, 0.5, 0.6]
+        memory = ShortTermMemory(mock_client, embedder=_SucceedingEmbedder(vector))
+
+        message = await memory.add_message(
+            "session-ok",
+            MessageRole.USER,
+            "hi",
+            extract_entities=False,
+        )
+
+        assert message.embedding == vector
+        params = self._find_create_message_call(mock_client)[0][1]
+        assert params["embedding"] == vector
+
+    @pytest.mark.asyncio
+    async def test_add_messages_batch_survives_embed_batch_failure(
+        self, mock_client: MagicMock
+    ) -> None:
+        """``embed_batch()`` raising must not abort the batch insert."""
+        memory = ShortTermMemory(mock_client, embedder=_FailingEmbedder())
+
+        messages = [
+            {"role": "user", "content": "first"},
+            {"role": "assistant", "content": "second"},
+            {"role": "user", "content": "third"},
+        ]
+
+        created = await memory.add_messages_batch(
+            "session-batch-fail",
+            messages,
+            extract_entities=False,
+        )
+
+        assert len(created) == 3
+        assert all(m.embedding is None for m in created)
+
+        batch_call = self._find_batch_create_call(mock_client)
+        params = batch_call[0][1]
+        stored = params["messages"]
+        assert len(stored) == 3
+        assert all(row["embedding"] is None for row in stored)
+        assert [row["content"] for row in stored] == ["first", "second", "third"]


### PR DESCRIPTION
## Summary

Oversize input to the OpenAI embedder caused a silent data loss bug: if the input exceeded the token budget, the API returned a 400 error, the message write aborted, and the extracted entities were lost. This PR closes the gap with a three-layer fix.

## Root cause

`OpenAIEmbedder.embed()` and `embed_batch()` passed raw text to the OpenAI API with no token budget check. When the input was too long, the API returned a 400 error, which bubbled up through `add_message()` and `add_messages_batch()`, aborting the whole write. Same for the batch path: one failing batch meant all messages in it were dropped.

## Fix

Three layers, each addressing a different failure mode:

**Layer 1: Input-bounded embedder.** `_truncate_to_tokens()` truncates text to the model token budget before calling the API. Uses `tiktoken` when available for an accurate count, falls back to a 4-char-per-token estimate otherwise. Called in both `embed()` and `embed_batch()`.

**Layer 2: Resilient `add_message()`.** Wraps the single-message embed in a try/except. On failure, stores the message with a null vector and continues to entity extraction. The entities carry their own embeddings, so the memory stays fully recallable.

**Layer 3: Batch-level degradation in `add_messages_batch()`.** Same pattern at batch level: if the whole batch embed fails, all messages in the batch get null vectors and insertion continues.

## Verification

- **Unit tests:** 1518/1518 pass (1514 implementer + 4 verifier-added tests for the real tiktoken code path that was never exercised before).
- **Integration tests:** 444/444 pass (133 pre-existing unrelated skips).
- **Lint/format/typecheck:** mypy strict, ty, ruff lint, and formatting all clean.
- **Build:** `uv build` produces a wheel that installs and imports cleanly.
- **Spec checklist:** model token budget with headroom confirmed, add_message degrade-to-null confirmed, add_messages_batch same-guard confirmed, truncate called in both embed paths confirmed.

## Files changed

- `src/neo4j_agent_memory/embeddings/openai.py` (added `_truncate_to_tokens()`, `MODEL_MAX_INPUT_TOKENS`, `_max_tokens_for()`, `_DEFAULT_MAX_INPUT_TOKENS`, `_TOKEN_HEADROOM`; wired truncation into `embed()` and `embed_batch()`)
- `src/neo4j_agent_memory/memory/short_term.py` (try/except wrappers around `embed()` and `embed_batch()` in `add_message()` and `add_messages_batch()`, with warning logs on failure)
- `tests/unit/embeddings/test_openai.py` (new file: 93 lines covering the char-fallback path, the real tiktoken path, embedder truncation in `embed()` and `embed_batch()`, and empty-list short-circuit)
- `tests/unit/test_relation_storage.py` (new tests for embedding resilience: `add_message` survives embed failure with entity extraction intact, `add_messages_batch` survives embed_batch failure, happy-path vector flow confirmed)

Fixes #104
