### PR TITLE
fix three retrieval and extraction defects in nams provider

### DIFF
--- a/typescript/packages/vercel-ai-provider/README.md
+++ b/typescript/packages/vercel-ai-provider/README.md
@@ -444,17 +444,6 @@ mint entities *about remembering* (`long-term memories [Concept]`,
 next such question, so they outrank the real facts and every ask degrades the
 next one. Skipped entities are logged at `warn`.
 
-The guard keys on the distinction extraction already asks for: **named** — i.e.
-proper-noun — entities. An agent describing its own recall yields common nouns
-(`profile details`, `preferences`); the facts worth keeping are proper nouns
-(`Priya`, `Bangalore`, `Acme Analytics`). No vocabulary list is involved, so it
-holds as models rephrase, and it declines to fire on caseless scripts (`北京`,
-`القاهرة`) rather than rejecting them. A second rule drops names that are just
-their own type repeated (`Organization [Organization]`).
-
-Known cost: brand names styled all-lowercase (`npm`, `git`) read as common nouns
-and are skipped. Override the guard if your domain is full of them:
-
 ```ts
 extractionOptions: {
   // "preferences" is a real entity here; drop raw identifiers instead.

--- a/typescript/packages/vercel-ai-provider/README.md
+++ b/typescript/packages/vercel-ai-provider/README.md
@@ -264,7 +264,7 @@ return createUIMessageStreamResponse({ stream });
 Expose `query_memory` and `store_memory` as explicit AI SDK tools. The model decides when to call them, and the calls are visible in your UI — useful for debugging or when you want the user to see memory activity:
 
 ```ts
-import { createNams, enforceQueryMemory } from '@neo4j-labs/nams-ai-provider';
+import { createNams, enforceQueryMemory, ensureMemoryStored } from '@neo4j-labs/nams-ai-provider';
 import { openai } from '@ai-sdk/openai';
 import {
   ToolLoopAgent,
@@ -284,6 +284,7 @@ const agent = new ToolLoopAgent({
     'giving your final answer.',
   tools,
   prepareStep:  enforceQueryMemory(),
+  onFinish:     ensureMemoryStored(tools),
   stopWhen:     stepCountIs(10),
 });
 
@@ -306,11 +307,51 @@ memory. After `graceSteps` steps (default: 3) without a query, the next step
 forces `query_memory` directly, so the loop can never exhaust its budget
 without the query having run; `{ graceSteps: 0 }` forces it as the literal
 first step. Keep `graceSteps` at least two below your `stopWhen` budget so the
-forced query and the final answer both fit. There is no equivalent forcing
-hook for `store_memory` (the loop ends when the model emits final text) — if
-persistence must be guaranteed, check `steps` in `onFinish` and call
-`store_memory.execute()` yourself, or use provider / middleware mode where
-both directions happen unconditionally in code.
+forced query and the final answer both fit.
+
+### Guaranteeing persistence with `ensureMemoryStored()`
+
+`prepareStep` cannot guarantee the *write* side: the loop ends when the model
+emits final text, so there is no later step to force `store_memory` into.
+`ensureMemoryStored(tools)` is an `onFinish` hook that closes the gap after the
+loop instead — if the model never called `store_memory`, it persists the turn
+itself:
+
+```ts
+const tools = nams.tools({ userId: session.userId });
+
+const agent = new ToolLoopAgent({
+  model:       openai('gpt-5.4-mini'),
+  tools,
+  prepareStep: enforceQueryMemory(),      // retrieval guaranteed mid-loop
+  onFinish:    ensureMemoryStored(tools), // persistence guaranteed after it
+  stopWhen:    stepCountIs(10),
+});
+```
+
+It returns `{ stored: true, input }` when it wrote, or `{ stored: false, reason }`
+where `reason` is `'already-stored'`, `'nothing-to-store'`, or `'failed'` — a
+failed write logs and reports rather than throwing into a response that has
+already been generated.
+
+By default it stores the assistant's final text as an **`interaction`**
+(short-term conversation memory), matching what middleware mode records. It
+deliberately does not store it as a `fact`: an agent's summary of what it
+remembers is exactly the self-referential input that degrades recall, which is
+why the graph extractor skips such entities. Pass `fallback` to decide for
+yourself — including returning `null` to store nothing:
+
+```ts
+onFinish: ensureMemoryStored(tools, {
+  // The onFinish event carries no user message; close over your own prompt.
+  fallback: ({ text }) => ({ content: `User: ${prompt}\nAssistant: ${text}`, type: 'interaction' }),
+})
+```
+
+Pass the tool set object itself, not a copy — `ensureMemoryStored({ ...tools })`
+throws immediately, because a spread loses the binding to the memory client.
+In provider and middleware mode you need none of this: both directions happen
+unconditionally in code.
 
 ### Tools Mode with MCP (optional)
 

--- a/typescript/packages/vercel-ai-provider/README.md
+++ b/typescript/packages/vercel-ai-provider/README.md
@@ -397,6 +397,7 @@ createNamsProvider({
   maxMemories?:         number,   // Max memories retrieved and injected into the prompt per turn (capped at 12). Default: 6
   persistInteractions?: boolean,  // Save each turn. Default: true
   extractionModel?:     LanguageModel, // Enables graph entity extraction
+  extractionOptions?:   GraphExtractorOptions, // Tunes extraction, e.g. { skipEntity }
 });
 ```
 
@@ -435,6 +436,31 @@ const nams = createNamsProvider({
 > currently doesn't), extracted entities are stored and relationship writes
 > are skipped with a warning — the graph gains edges automatically once the
 > endpoint is available.
+
+Extraction skips **self-referential** entities: when the agent answers "what do
+you remember about me?" and stores its own answer, extraction would otherwise
+mint entities *about remembering* (`long-term memories [Concept]`,
+`profile details [Object]`). Those meta-entities are the closest match for the
+next such question, so they outrank the real facts and every ask degrades the
+next one. Skipped entities are logged at `warn`.
+
+The guard keys on the distinction extraction already asks for: **named** — i.e.
+proper-noun — entities. An agent describing its own recall yields common nouns
+(`profile details`, `preferences`); the facts worth keeping are proper nouns
+(`Priya`, `Bangalore`, `Acme Analytics`). No vocabulary list is involved, so it
+holds as models rephrase, and it declines to fire on caseless scripts (`北京`,
+`القاهرة`) rather than rejecting them. A second rule drops names that are just
+their own type repeated (`Organization [Organization]`).
+
+Known cost: brand names styled all-lowercase (`npm`, `git`) read as common nouns
+and are skipped. Override the guard if your domain is full of them:
+
+```ts
+extractionOptions: {
+  // "preferences" is a real entity here; drop raw identifiers instead.
+  skipEntity: (e) => /^[a-z0-9_]+$/.test(e.name),
+}
+```
 
 ---
 

--- a/typescript/packages/vercel-ai-provider/examples/tools-chat.ts
+++ b/typescript/packages/vercel-ai-provider/examples/tools-chat.ts
@@ -16,6 +16,8 @@
  *     tool call: store_memory({"content":"User uses Neovim as their editor","type":"fact","confidence":0.9,"tags":["e…
  *   step 2 [unconstrained]
  *
+ *   ensureMemoryStored: already-stored
+ *
  *   assistant: Try Telescope for fuzzy finding and Harpoon for quick file
  *   switching.
  *
@@ -28,7 +30,7 @@
 
 import { openai } from '@ai-sdk/openai';
 import { ToolLoopAgent, stepCountIs } from 'ai';
-import { createNams, enforceQueryMemory } from '../src/index';
+import { createNams, enforceQueryMemory, ensureMemoryStored } from '../src/index';
 
 const userId = process.env.NAMS_DEMO_USER ?? 'demo-user-tools-chat';
 const model = process.env.NAMS_DEMO_MODEL ?? 'gpt-5.4-mini';
@@ -45,6 +47,12 @@ async function main(): Promise<void> {
       'giving your final answer.',
     tools,
     prepareStep: enforceQueryMemory(),
+    onFinish: async (event) => {
+      const outcome = await ensureMemoryStored(tools)(event);
+      console.log(
+        `\nensureMemoryStored: ${outcome.stored ? 'persisted the turn' : outcome.reason}`,
+      );
+    },
     stopWhen: stepCountIs(6),
   });
 

--- a/typescript/packages/vercel-ai-provider/src/index.ts
+++ b/typescript/packages/vercel-ai-provider/src/index.ts
@@ -30,8 +30,11 @@ export { makeClient, getLogger, resolveConversation, findExistingConversation, r
 export { createGraphExtractor } from './vercel-ai-provider-extract';
 export type { GraphExtractorOptions } from './vercel-ai-provider-extract';
 export { createNamsMemory } from './vercel-ai-provider-middleware';
-export { createNamsMemoryTools, createNamsTools, enforceQueryMemory, NamsMemoryTools, NamsMcpConnectionError } from './vercel-ai-provider-tools';
-export type { EnforceQueryMemoryOptions } from './vercel-ai-provider-tools';
+export { createNamsMemoryTools, createNamsTools, enforceQueryMemory, ensureMemoryStored, NamsMemoryTools, NamsMcpConnectionError } from './vercel-ai-provider-tools';
+export type {
+  EnforceQueryMemoryOptions, EnsureMemoryStoredOptions, EnsureMemoryStoredResult,
+  FinishedTurn, UnstoredTurn,
+} from './vercel-ai-provider-tools';
 export { createNamsProvider } from './vercel-ai-provider';
 
 import type { LanguageModel } from 'ai';

--- a/typescript/packages/vercel-ai-provider/src/index.ts
+++ b/typescript/packages/vercel-ai-provider/src/index.ts
@@ -28,6 +28,7 @@ export type { NamsProviderOptions } from './vercel-ai-provider';
 
 export { makeClient, getLogger, resolveConversation, findExistingConversation, retrieveMemories, storeMemory } from './vercel-ai-provider-client';
 export { createGraphExtractor } from './vercel-ai-provider-extract';
+export type { GraphExtractorOptions } from './vercel-ai-provider-extract';
 export { createNamsMemory } from './vercel-ai-provider-middleware';
 export { createNamsMemoryTools, createNamsTools, enforceQueryMemory, NamsMemoryTools, NamsMcpConnectionError } from './vercel-ai-provider-tools';
 export type { EnforceQueryMemoryOptions } from './vercel-ai-provider-tools';
@@ -37,6 +38,7 @@ import type { LanguageModel } from 'ai';
 import type { LanguageModelV4 } from '@ai-sdk/provider';
 import type { NamsConfig, NamsScope } from './vercel-ai-provider-client';
 import type { NamsMemoryConfig } from './vercel-ai-provider-middleware';
+import type { GraphExtractorOptions } from './vercel-ai-provider-extract';
 import type { McpConfig } from './vercel-ai-provider-tools';
 import { createNamsMemory } from './vercel-ai-provider-middleware';
 import { createNamsMemoryTools, createNamsTools } from './vercel-ai-provider-tools';
@@ -46,6 +48,7 @@ export type NamsMode = 'provider' | 'middleware' | 'tools';
 
 export interface NamsFactoryConfig extends NamsConfig {
   extractionModel?: LanguageModel;
+  extractionOptions?: GraphExtractorOptions;
   maxMemories?: number;
   persistInteractions?: boolean;
 }
@@ -65,6 +68,7 @@ export function createNams(config: NamsFactoryConfig) {
     workspaceId: config.workspaceId,
     logger: config.logger,
     extractionModel: config.extractionModel,
+    extractionOptions: config.extractionOptions,
     maxMemories: config.maxMemories,
     persistInteractions: config.persistInteractions,
   };

--- a/typescript/packages/vercel-ai-provider/src/vercel-ai-provider-client.ts
+++ b/typescript/packages/vercel-ai-provider/src/vercel-ai-provider-client.ts
@@ -36,6 +36,55 @@ export function resolveLogger(config: NamsConfig): NamsLogger {
   return config.logger ?? defaultLogger;
 }
 
+/**
+ * Report a graph-extraction failure. The first one logs at `error`, the rest at
+ * `warn`.
+ *
+ * Extraction failing is not a transient miss: a rejected schema or a bad model
+ * config fails identically on every call, forever, while storage still succeeds
+ * and the request still returns. Logging the first occurrence at `warn` is how
+ * `extractionModel` stayed a silent no-op through a release.
+ */
+export function reportExtractionFailure(client: MemoryClient, message: string, err: unknown): void {
+  const state = getState(client);
+  if (state.extractionFailed) {
+    state.logger.warn(message, err);
+    return;
+  }
+  state.extractionFailed = true;
+  state.logger.error(
+    `${message} — graph extraction is disabled for every memory until this is fixed`,
+    err,
+  );
+}
+
+/**
+ * Report a failed relationship write.
+ *
+ * The hosted REST API has no relationship endpoint and raises `NotSupportedError`
+ * for every edge — a permanent condition, not a transient one. Since graph
+ * extraction attempts one write per extracted edge per stored memory, logging
+ * each occurrence would emit an unbounded stream of identical lines. The
+ * unsupported case is therefore reported once per client and then suppressed;
+ * genuine write failures still log every time.
+ */
+export function reportRelationshipFailure(client: MemoryClient, err: unknown): void {
+  const state = getState(client);
+
+  if ((err as { name?: string })?.name !== 'NotSupportedError') {
+    state.logger.warn('addRelationship failed', err);
+    return;
+  }
+
+  if (state.relationshipWritesUnsupported) return;
+  state.relationshipWritesUnsupported = true;
+  state.logger.warn(
+    'this backend has no relationship endpoint — extracted entities are stored, ' +
+    'edges are skipped. Further occurrences are suppressed.',
+    err,
+  );
+}
+
 export function makeClient(config: NamsConfig): MemoryClient {
   const client = new MemoryClient({
     endpoint: config.endpoint ?? DEFAULT_ENDPOINT,
@@ -127,11 +176,25 @@ const RETRIEVAL = {
   maxLongterm:5
 };
 
-function deduplicatePush(hits: MemoryHit[], seen: Set<string>, hit: MemoryHit): void {
+function deduplicatePush(
+  hits: MemoryHit[],
+  seen: Set<string>,
+  hit: MemoryHit,
+  aliasKey?: string,
+): void {
   const k = hit.content?.trim();
   if (!k || seen.has(k)) return;
   seen.add(k);
+  const alias = aliasKey?.trim();
+  if (alias) seen.add(alias);
   hits.push(hit);
+}
+
+function entityContent(e: { name?: string; description?: string }): string {
+  const name = e.name?.trim();
+  const description = e.description?.trim();
+  if (name && description) return `${name} — ${description}`;
+  return name || description || '';
 }
 
 // Keyword + case-variant fallback
@@ -281,7 +344,7 @@ export async function retrieveMemories(
     searchWithFallback(
       query,
       (q) => client.longTerm.searchEntities(q, { limit: RETRIEVAL.maxLongterm }),
-      (e) => e.description ?? e.name,
+      entityContent,
       log,
       'searchEntities',
     ),
@@ -295,11 +358,11 @@ export async function retrieveMemories(
 
   for (const e of longHits) {
     deduplicatePush(hits, seen, {
-      content: e.description ?? e.name,
+      content: entityContent(e),
       source: 'long-term',
       type: e.type ?? 'entity',
       score: e.confidence,
-    });
+    }, e.description ?? e.name);
   }
   for (const m of shortHits) {
     deduplicatePush(hits, seen, { content: m.content, source: 'conversation', type: 'message' });
@@ -348,7 +411,7 @@ export async function storeMemory(
       await opts.extractor(client, input);
       return;
     } catch (err) {
-      getLogger(client).warn('graph extraction failed, falling back to flat entity', err);
+      reportExtractionFailure(client, 'graph extraction failed, falling back to flat entity', err);
     }
   }
 

--- a/typescript/packages/vercel-ai-provider/src/vercel-ai-provider-extract.ts
+++ b/typescript/packages/vercel-ai-provider/src/vercel-ai-provider-extract.ts
@@ -3,7 +3,7 @@ import type { LanguageModel } from 'ai';
 import { z } from 'zod';
 import type { MemoryClient } from '@neo4j-labs/agent-memory';
 import { GraphExtractor, StoreInput } from './vercel-ai-provider-types';
-import { getLogger } from './vercel-ai-provider-client';
+import { getLogger, reportRelationshipFailure } from './vercel-ai-provider-client';
 
 const graphSchema = z.object({
   entities: z
@@ -11,7 +11,9 @@ const graphSchema = z.object({
       z.object({
         name: z.string().describe('Canonical entity name, e.g. "Alex", "Neovim", "TechCorp"'),
         type: z.string().describe('person | organization | tool | place | concept | preference | event'),
-        description: z.string().optional(),
+        description: z
+          .string()
+          .describe('Short description of the entity, or "" if the memory does not state one'),
       }),
     )
     .describe('Distinct, real, named entities only. Do not invent.'),
@@ -23,46 +25,89 @@ const graphSchema = z.object({
         type: z.string().describe('Relationship label, e.g. PREFERS, WORKS_AT, USES, LOCATED_IN'),
       }),
     )
-    .default([]),
+    .describe('Relationships between the entities above, or [] if none are stated'),
 });
+
+const normalize = (s: string): string => s.trim().toLowerCase().replace(/\s+/g, ' ');
+
+// "memories" -> "memory", "details" -> "detail". Crude by design: it only has to
+// collapse the plurals the extractor emits, not conjugate English.
+const singular = (s: string): string =>
+  s.endsWith('ies') ? `${s.slice(0, -3)}y` : s.endsWith('s') ? s.slice(0, -1) : s;
+
+/**
+ * True when a name is a common noun rather than a proper one.
+ *
+ * The second clause is what keeps this from being an English rule: a script
+ * without case ("北京", "القاهرة") reports equal upper and lower forms, so the
+ * test declines to fire rather than rejecting every entity in that language.
+ */
+const isCommonNoun = (name: string): boolean =>
+  name === name.toLowerCase() && name !== name.toUpperCase();
+
+/**
+ * True when an "entity" is really the memory system talking about itself.
+ */
+function isSelfReferential(name: string, type: string): boolean {
+  const n = normalize(name);
+  if (!n) return true;
+  if (isCommonNoun(name.trim())) return true;
+  return singular(n) === singular(normalize(type));
+}
+
+export interface GraphExtractorOptions {
+  skipEntity?: (entity: { name: string; type: string; description: string }) => boolean;
+}
 
 /**
  * Build a graph extractor backed by an AI SDK model. Extracts entities and
  * relationships from a stored memory so the graph actually forms, instead of
  * one sentence-shaped node. Costs one extra model call per stored memory.
  */
-export function createGraphExtractor(model: LanguageModel): GraphExtractor {
+export function createGraphExtractor(
+  model: LanguageModel,
+  options: GraphExtractorOptions = {},
+): GraphExtractor {
+  const skipEntity = options.skipEntity ?? ((e) => isSelfReferential(e.name, e.type));
+
   return async function extractAndStore(client: MemoryClient, input: StoreInput): Promise<void> {
     const { output: object } = await generateText({
       model,
       output: Output.object({ schema: zodSchema(graphSchema) }),
       prompt:
         `Extract entities and the relationships between them from the memory below. ` +
-        `Be conservative: only real, named entities; skip filler.\n\n` +
+        `Be conservative: only real, named entities; skip filler. Do not extract ` +
+        `entities about memory, recall, or stored profiles — only the subjects ` +
+        `they refer to.\n\n` +
         `Memory (${input.type}): ${input.content}`,
     });
 
+    const log = getLogger(client);
     const nameToId = new Map<string, string>();
+
     for (const e of object.entities) {
+      if (skipEntity(e)) {
+        log.warn(`skipped self-referential entity "${e.name}" [${e.type}]`);
+        continue;
+      }
       const entity = await client.longTerm.addEntity(e.name, e.type, {
-        description: e.description ?? input.content,
+        description: e.description?.trim() || input.content,
       });
       if (entity?.id) nameToId.set(e.name, entity.id);
       if (entity?.id && input.confidence !== undefined) {
         await client.longTerm
           .setEntityFeedback(entity.id, { userScore: input.confidence, confirmed: input.confidence >= 0.8 })
-          .catch((e: unknown) => getLogger(client).warn('setEntityFeedback failed', e));
+          .catch((e: unknown) => log.warn('setEntityFeedback failed', e));
       }
     }
 
-    const log = getLogger(client);
-    for (const r of object.relationships) {
+    for (const r of object.relationships ?? []) {
       const from = nameToId.get(r.from);
       const to = nameToId.get(r.to);
       if (from && to) {
         await client.longTerm
           .addRelationship(from, to, r.type)
-          .catch((e: unknown) => log.warn('addRelationship failed', e));
+          .catch((e: unknown) => reportRelationshipFailure(client, e));
       }
     }
   };

--- a/typescript/packages/vercel-ai-provider/src/vercel-ai-provider-middleware.ts
+++ b/typescript/packages/vercel-ai-provider/src/vercel-ai-provider-middleware.ts
@@ -13,8 +13,9 @@ import {
   getLogger,
   resolveConversation,
   retrieveMemories,
+  reportExtractionFailure,
 } from './vercel-ai-provider-client';
-import { createGraphExtractor } from './vercel-ai-provider-extract';
+import { createGraphExtractor, type GraphExtractorOptions } from './vercel-ai-provider-extract';
 import { GraphExtractor, MemoryHit, NamsConfig, NamsScope } from './vercel-ai-provider-types';
 
 export interface NamsMemoryConfig extends NamsConfig {
@@ -24,6 +25,8 @@ export interface NamsMemoryConfig extends NamsConfig {
   persistInteractions?: boolean;
   /** When set, build a real entity graph per stored turn (one extra model call). */
   extractionModel?: LanguageModel;
+  /** Tunes the extractor built from `extractionModel` (e.g. override the self-referential guard). */
+  extractionOptions?: GraphExtractorOptions;
 }
 
 
@@ -122,7 +125,7 @@ const buildMiddleware = (
     if (extractor && (userText || assistantText)) {
       const combined = `User: ${userText}\nAssistant: ${assistantText}`.trim();
       await extractor(client, { content: combined, type: 'interaction' })
-        .catch(e => log.warn('turn extraction failed', e));
+        .catch(e => reportExtractionFailure(client, 'turn extraction failed', e));
     }
   }
 
@@ -202,7 +205,9 @@ const buildMiddleware = (
  * LanguageModelV4 with transparent memory retrieval and persistence.
  */
 export function createNamsMemory(config: NamsMemoryConfig) {
-  const extractor = config.extractionModel ? createGraphExtractor(config.extractionModel) : undefined;
+  const extractor = config.extractionModel
+    ? createGraphExtractor(config.extractionModel, config.extractionOptions)
+    : undefined;
   const maxMemories = config.maxMemories ?? 6;
   const persist = config.persistInteractions ?? true;
 

--- a/typescript/packages/vercel-ai-provider/src/vercel-ai-provider-middleware.ts
+++ b/typescript/packages/vercel-ai-provider/src/vercel-ai-provider-middleware.ts
@@ -30,17 +30,29 @@ export interface NamsMemoryConfig extends NamsConfig {
 }
 
 
-const injectIntoLastUser = (prompt: any[], block: string): void => {
+const lastUserIndex = (prompt: any[]): number => {
   for (let i = prompt.length - 1; i >= 0; i--) {
-    const msg = prompt[i];
-    if (msg?.role !== 'user') continue;
-    if (typeof msg.content === 'string') {
-      msg.content = `${block}\n\n${msg.content}`;
-    } else if (Array.isArray(msg.content)) {
-      msg.content.unshift({ type: 'text', text: `${block}\n\n` });
-    }
-    return;
+    if (prompt[i]?.role === 'user') return i;
   }
+  return -1;
+}
+
+/**
+ * Return a copy of the prompt with `block` prepended to its last user message.
+ */
+const withMemoryBlock = (prompt: any[], block: string): any[] => {
+  const i = lastUserIndex(prompt);
+  if (i < 0) return prompt;
+
+  const msg = prompt[i];
+  let content: unknown;
+  if (typeof msg.content === 'string') content = `${block}\n\n${msg.content}`;
+  else if (Array.isArray(msg.content)) content = [{ type: 'text', text: `${block}\n\n` }, ...msg.content];
+  else return prompt;
+
+  const next = [...prompt];
+  next[i] = { ...msg, content };
+  return next;
 }
 
 const toolCallInput = (part: any): string => {
@@ -77,17 +89,16 @@ const formatMemoryBlock = (memories: MemoryHit[]): string => {
 
 // Text of the most recent user message in the prompt.
 const lastUserText = (prompt: any[]): string => {
-  for (let i = prompt.length - 1; i >= 0; i--) {
-    const msg = prompt[i];
-    if (msg?.role !== 'user') continue;
-    if (typeof msg.content === 'string') return msg.content;
-    if (Array.isArray(msg.content))
-      return msg.content
-        .filter((p: any) => p?.type === 'text')
-        .map((p: any) => p.text as string)
-        .join('')
-        .trim();
-  }
+  const i = lastUserIndex(prompt);
+  if (i < 0) return '';
+  const msg = prompt[i];
+  if (typeof msg.content === 'string') return msg.content;
+  if (Array.isArray(msg.content))
+    return msg.content
+      .filter((p: any) => p?.type === 'text')
+      .map((p: any) => p.text as string)
+      .join('')
+      .trim();
   return '';
 }
 
@@ -135,7 +146,6 @@ const buildMiddleware = (
     transformParams: async ({ params }) => {
       const userText = lastUserText(params.prompt);
       if (!userText) return params;
-
       originalUserText.set(params as object, userText);
 
       let convId: string;
@@ -151,8 +161,9 @@ const buildMiddleware = (
 
       if (memories.length === 0) return params;
 
-      injectIntoLastUser(params.prompt, formatMemoryBlock(memories));
-      return params;
+      const augmented = { ...params, prompt: withMemoryBlock(params.prompt, formatMemoryBlock(memories)) };
+      originalUserText.set(augmented as object, userText);
+      return augmented;
     },
 
     wrapGenerate: async ({ doGenerate, params }) => {

--- a/typescript/packages/vercel-ai-provider/src/vercel-ai-provider-tools.ts
+++ b/typescript/packages/vercel-ai-provider/src/vercel-ai-provider-tools.ts
@@ -15,6 +15,7 @@ import {
   type ToolSet,
 } from 'ai';
 import { z } from 'zod';
+import type { MemoryClient } from '@neo4j-labs/agent-memory';
 import {
   makeClient,
   getLogger,
@@ -25,6 +26,8 @@ import {
   type NamsConfig,
   type NamsScope,
   type MemoryHit,
+  type GraphExtractor,
+  type StoreInput as MemoryStoreInput,
 } from './vercel-ai-provider-client';
 import { createGraphExtractor, type GraphExtractorOptions } from './vercel-ai-provider-extract';
 
@@ -127,6 +130,14 @@ export class NamsMcpConnectionError extends Error {
   }
 }
 
+interface MemoryToolsHandle {
+  client: MemoryClient;
+  getConvId: () => Promise<string>;
+  extractor?: GraphExtractor;
+}
+
+const handleByToolSet = new WeakMap<object, MemoryToolsHandle>();
+
 export function createNamsMemoryTools(options: NamsToolsOptions) {
   const client = makeClient(options);
   const scope: NamsScope = { userId: options.userId, conversationId: options.conversationId };
@@ -183,7 +194,88 @@ export function createNamsMemoryTools(options: NamsToolsOptions) {
     },
   });
 
-  return { query_memory, store_memory };
+  const tools = { query_memory, store_memory };
+  handleByToolSet.set(tools, { client, getConvId, extractor });
+  return tools;
+}
+
+export interface FinishedTurn {
+  /** Assistant text from the final step. */
+  text?: string;
+  /** Tool calls across all steps, as the AI SDK aggregates them. */
+  toolCalls?: ReadonlyArray<{ toolName: string }>;
+  /** Per-step tool calls, used when the aggregate is absent. */
+  steps?: ReadonlyArray<{ toolCalls?: ReadonlyArray<{ toolName: string }> }>;
+}
+
+/** The turn as handed to a custom `fallback`, once it is known nothing was stored. */
+export interface UnstoredTurn {
+  /** Final assistant text, or `''` when the model produced none. */
+  text: string;
+  /** Every tool the model called this turn, deduplicated. */
+  toolNames: string[];
+}
+
+export interface EnsureMemoryStoredOptions {
+  /**
+   * What to persist when the model never called `store_memory`. Return `null`
+   * to store nothing. Default: the assistant's final text as an `interaction`.
+   */
+  fallback?: (turn: UnstoredTurn) => MemoryStoreInput | null;
+}
+
+export type EnsureMemoryStoredResult =
+  | { stored: true; input: MemoryStoreInput }
+  | { stored: false; reason: 'already-stored' | 'nothing-to-store' | 'failed' };
+
+/**
+ * `interaction` routes to short-term conversation memory, which mirrors what
+ * middleware mode guarantees. Storing the assistant's own text as a `fact`
+ * instead would feed it to the graph extractor — and an agent summarising what
+ * it remembers is precisely the self-referential input the extractor's skip
+ * guard exists to reject. Callers who do want facts pass their own `fallback`.
+ */
+const defaultFallback = (turn: UnstoredTurn): MemoryStoreInput | null =>
+  turn.text ? { content: turn.text, type: 'interaction' } : null;
+
+const toolNamesOf = (event: FinishedTurn): string[] => [
+  ...new Set([
+    ...(event.toolCalls ?? []).map(c => c.toolName),
+    ...(event.steps ?? []).flatMap(s => (s.toolCalls ?? []).map(c => c.toolName)),
+  ]),
+];
+
+
+export function ensureMemoryStored(
+  tools: ToolSet,
+  options: EnsureMemoryStoredOptions = {},
+): (event: FinishedTurn) => Promise<EnsureMemoryStoredResult> {
+  const handle = handleByToolSet.get(tools);
+  if (!handle) {
+    throw new Error(
+      'ensureMemoryStored() expects the tool set returned by createNamsMemoryTools() / ' +
+      'createNams().tools() / .toolsWithMcp(), not a copy of it. Pass that object directly — ' +
+      'spreading it into a new object ({ ...tools }) loses the memory client it is bound to.',
+    );
+  }
+  const fallback = options.fallback ?? defaultFallback;
+
+  return async (event) => {
+    const toolNames = toolNamesOf(event);
+    if (toolNames.includes('store_memory')) return { stored: false, reason: 'already-stored' };
+
+    const input = fallback({ text: event.text?.trim() ?? '', toolNames });
+    if (!input?.content?.trim()) return { stored: false, reason: 'nothing-to-store' };
+
+    try {
+      const convId = await handle.getConvId();
+      await storeMemory(handle.client, convId, input, { extractor: handle.extractor });
+      return { stored: true, input };
+    } catch (err) {
+      getLogger(handle.client).error('ensureMemoryStored failed to persist the turn', err);
+      return { stored: false, reason: 'failed' };
+    }
+  };
 }
 
 export interface EnforceQueryMemoryOptions {
@@ -289,9 +381,12 @@ export async function createNamsTools(options: NamsToolsWithMcpOptions): Promise
         (prefix ? '' : ' — set mcp.toolPrefix to namespace MCP tools and avoid this'),
       );
     }
+    const merged: ToolSet = { ...namsTools, ...mcpTools };
+    const handle = handleByToolSet.get(namsTools);
+    if (handle) handleByToolSet.set(merged, handle);
 
     return {
-      tools: { ...namsTools, ...mcpTools },
+      tools: merged,
       close: () => mcpClient.close(),
       mcp: { connected: true, toolNames },
     };

--- a/typescript/packages/vercel-ai-provider/src/vercel-ai-provider-tools.ts
+++ b/typescript/packages/vercel-ai-provider/src/vercel-ai-provider-tools.ts
@@ -26,7 +26,7 @@ import {
   type NamsScope,
   type MemoryHit,
 } from './vercel-ai-provider-client';
-import { createGraphExtractor } from './vercel-ai-provider-extract';
+import { createGraphExtractor, type GraphExtractorOptions } from './vercel-ai-provider-extract';
 
 //Schemas
 
@@ -61,6 +61,8 @@ type ToolContext = Record<string, unknown>;
 
 export interface NamsToolsOptions extends NamsConfig, NamsScope {
   extractionModel?: LanguageModel;
+  /** Tunes the extractor built from `extractionModel` (e.g. override the self-referential guard). */
+  extractionOptions?: GraphExtractorOptions;
 }
 
 /** MCP server connection config. Headers are sent on every request (e.g. Authorization). */
@@ -128,7 +130,9 @@ export class NamsMcpConnectionError extends Error {
 export function createNamsMemoryTools(options: NamsToolsOptions) {
   const client = makeClient(options);
   const scope: NamsScope = { userId: options.userId, conversationId: options.conversationId };
-  const extractor = options.extractionModel ? createGraphExtractor(options.extractionModel) : undefined;
+  const extractor = options.extractionModel
+    ? createGraphExtractor(options.extractionModel, options.extractionOptions)
+    : undefined;
 
   let convIdPromise: Promise<string> | null = null;
   const getConvId = (): Promise<string> =>
@@ -157,7 +161,10 @@ export function createNamsMemoryTools(options: NamsToolsOptions) {
     description:
       'Persist important information to NAMS (Neo4j graph). ' +
       'Call this BEFORE giving your final answer whenever the conversation ' +
-      'contains facts, preferences, or patterns worth remembering.',
+      'contains facts, preferences, or patterns worth remembering. ' +
+      'Store only NEW information the user supplied in this conversation. ' +
+      'Never store what query_memory returned, or a summary of what you ' +
+      'remember — that is already stored, and re-storing it degrades recall.',
     inputSchema: zodSchema(storeSchema),
     execute: async ({ content, type, confidence, tags }) => {
       try {

--- a/typescript/packages/vercel-ai-provider/src/vercel-ai-provider-types.ts
+++ b/typescript/packages/vercel-ai-provider/src/vercel-ai-provider-types.ts
@@ -43,4 +43,8 @@ export type GraphExtractor = (client: MemoryClient, input: StoreInput) => Promis
 export interface ClientState {
   convCache: Map<string, string>;
   logger: NamsLogger;
+  /** Set once graph extraction has failed, so only the first failure logs at error level. */
+  extractionFailed?: boolean;
+  /** Set once the backend has reported relationship writes unsupported, to suppress per-edge repeats. */
+  relationshipWritesUnsupported?: boolean;
 }

--- a/typescript/packages/vercel-ai-provider/src/vercel-ai-provider.ts
+++ b/typescript/packages/vercel-ai-provider/src/vercel-ai-provider.ts
@@ -9,6 +9,7 @@ import type { ProviderV4, LanguageModelV4, EmbeddingModelV4, ImageModelV4 } from
 import { NoSuchModelError } from '@ai-sdk/provider';
 import type { LanguageModel } from 'ai';
 import { createNamsMemory } from './vercel-ai-provider-middleware';
+import type { GraphExtractorOptions } from './vercel-ai-provider-extract';
 import { NamsConfig, NamsScope } from './vercel-ai-provider-types';
 
 export interface NamsProviderOptions extends NamsConfig {
@@ -24,6 +25,8 @@ export interface NamsProviderOptions extends NamsConfig {
   persistInteractions?: boolean;
   /** When set, builds a real entity graph per stored turn (one extra model call). */
   extractionModel?: LanguageModel;
+  /** Tunes the extractor built from `extractionModel` (e.g. override the self-referential guard). */
+  extractionOptions?: GraphExtractorOptions;
 }
 
 /**

--- a/typescript/packages/vercel-ai-provider/test/vercel-ai-provider-client.test.ts
+++ b/typescript/packages/vercel-ai-provider/test/vercel-ai-provider-client.test.ts
@@ -52,7 +52,7 @@ describe('retrieveMemories — substring-search fallback', () => {
     // lowercase "delhi" as typed AND its Title-Case variant are both tried.
     expect(fake.longTerm.searchEntities).toHaveBeenCalledWith('delhi', expect.anything());
     expect(fake.longTerm.searchEntities).toHaveBeenCalledWith('Delhi', expect.anything());
-    expect(hits).toContainEqual(expect.objectContaining({ content: 'User is from Delhi.' }));
+    expect(hits).toContainEqual(expect.objectContaining({ content: 'Fact — User is from Delhi.' }));
   });
 
   it('ranks noisy fallback candidates by word overlap with the original query', async () => {
@@ -69,7 +69,8 @@ describe('retrieveMemories — substring-search fallback', () => {
     const hits = await retrieveMemories(fake as any, scope, 'conv-1', 'is the user from Delhi', 5);
 
     const contents = hits.map(h => h.content);
-    expect(contents.indexOf('User is from Delhi.')).toBeLessThan(contents.indexOf("User's name is Alex."));
+    expect(contents.indexOf('e2 — User is from Delhi.'))
+      .toBeLessThan(contents.indexOf("e1 — User's name is Alex."));
   });
 
   it('does not throw when both the direct search and a fallback term reject', async () => {
@@ -85,5 +86,64 @@ describe('retrieveMemories — substring-search fallback', () => {
 
     expect(fake.longTerm.searchEntities).toHaveBeenCalledTimes(1);
     expect(hits).toEqual([]);
+  });
+});
+
+/**
+ * An entity's name is the fact; its description is only the entity's role
+ * ("Preferred language", "City where the user works"). A hit that carries the
+ * description alone cannot answer "which language do I prefer?" — the model
+ * either reports the memory as incomplete or invents a fragment of the name.
+ */
+describe('retrieveMemories — long-term hits carry the entity name', () => {
+  it('renders name and description together', async () => {
+    fake.longTerm.searchEntities.mockResolvedValue([
+      { name: 'Python', description: 'Preferred language', type: 'ProgrammingLanguage' },
+    ]);
+
+    const hits = await retrieveMemories(fake as any, scope, 'conv-1', 'Preferred language', 5);
+
+    expect(hits[0].content).toBe('Python — Preferred language');
+  });
+
+  it('falls back to the bare name when the entity has no description', async () => {
+    fake.longTerm.searchEntities.mockResolvedValue([
+      { name: 'Bangalore', type: 'Location' },
+    ]);
+
+    const hits = await retrieveMemories(fake as any, scope, 'conv-1', 'Bangalore', 5);
+
+    expect(hits[0].content).toBe('Bangalore');
+  });
+
+  it('lets name tokens participate in fallback overlap ranking', async () => {
+    fake.longTerm.searchEntities.mockImplementation(async (q: string) =>
+      q === 'prefer' || q === 'Prefer'
+        ? [
+            { name: 'Rust', description: 'A language the user prefers', type: 'lang' },
+            { name: 'Python', description: 'A language the user prefers', type: 'lang' },
+          ]
+        : [],
+    );
+
+    const hits = await retrieveMemories(fake as any, scope, 'conv-1', 'do i prefer Python', 5);
+    const contents = hits.map(h => h.content);
+
+    expect(contents.indexOf('Python — A language the user prefers'))
+      .toBeLessThan(contents.indexOf('Rust — A language the user prefers'));
+  });
+
+  it('keeps distinct entities that happen to share a description', async () => {
+    fake.longTerm.searchEntities.mockResolvedValue([
+      { name: 'Python', description: 'Preferred language', type: 'lang' },
+      { name: 'TypeScript', description: 'Preferred language', type: 'lang' },
+    ]);
+
+    const hits = await retrieveMemories(fake as any, scope, 'conv-1', 'Preferred language', 5);
+
+    expect(hits.map(h => h.content)).toEqual([
+      'Python — Preferred language',
+      'TypeScript — Preferred language',
+    ]);
   });
 });

--- a/typescript/packages/vercel-ai-provider/test/vercel-ai-provider-extract.test.ts
+++ b/typescript/packages/vercel-ai-provider/test/vercel-ai-provider-extract.test.ts
@@ -245,31 +245,31 @@ describe('createGraphExtractor — self-referential guard', () => {
   it('still stores the real entities alongside skipped ones, and drops their dangling edges', async () => {
     mockedGenerateText.mockResolvedValue(graphResult(
       [
-        { name: 'Priya', type: 'Person' },
+        { name: 'Alex', type: 'Person' },
         { name: 'Acme Analytics', type: 'Organization' },
         { name: 'stored memories', type: 'Concept' },
       ],
       [
-        { from: 'Priya', to: 'Acme Analytics', type: 'WORKS_AT' },
-        { from: 'Priya', to: 'stored memories', type: 'HAS' },
+        { from: 'Alex', to: 'Acme Analytics', type: 'WORKS_AT' },
+        { from: 'Alex', to: 'stored memories', type: 'HAS' },
       ],
     ));
 
     const extract = createGraphExtractor({} as any);
-    await extract(fake as any, { content: 'Priya works at Acme Analytics', type: 'fact' });
+    await extract(fake as any, { content: 'Alex works at Acme Analytics', type: 'fact' });
 
     const stored = fake.longTerm.addEntity.mock.calls.map((c: any[]) => c[0]);
-    expect(stored).toEqual(['Priya', 'Acme Analytics']);
+    expect(stored).toEqual(['Alex', 'Acme Analytics']);
     expect(fake.longTerm.addRelationship).toHaveBeenCalledTimes(1);
     expect(fake.longTerm.addRelationship).toHaveBeenCalledWith(
-      'ent-Priya', 'ent-Acme Analytics', 'WORKS_AT',
+      'ent-Alex', 'ent-Acme Analytics', 'WORKS_AT',
     );
   });
 
   it('honours a caller-supplied skipEntity override', async () => {
     mockedGenerateText.mockResolvedValue(graphResult([
       { name: 'preferences', type: 'Concept' },
-      { name: 'Priya', type: 'Person' },
+      { name: 'Alex', type: 'Person' },
     ]));
 
     // A domain where "preferences" is a real entity and people are not wanted.

--- a/typescript/packages/vercel-ai-provider/test/vercel-ai-provider-extract.test.ts
+++ b/typescript/packages/vercel-ai-provider/test/vercel-ai-provider-extract.test.ts
@@ -14,6 +14,7 @@ vi.mock('ai', async (importOriginal) => ({
 
 import { generateText } from 'ai';
 import { createGraphExtractor } from '../src/vercel-ai-provider-extract';
+import { makeClient } from '../src/vercel-ai-provider-client';
 
 const mockedGenerateText = vi.mocked(generateText);
 
@@ -61,6 +62,52 @@ describe('createGraphExtractor', () => {
     expect(fake.longTerm.addRelationship).not.toHaveBeenCalled();
   });
 
+  /**
+   * The hosted REST API has no relationship endpoint, so every extracted edge
+   * fails identically. Now that extraction actually runs, an unsuppressed log
+   * would emit one line per edge per stored memory forever.
+   */
+  it('logs an unsupported relationship backend once, not once per edge', async () => {
+    const warn = vi.fn();
+    const notSupported = Object.assign(new Error('no equivalent in the hosted API'), {
+      name: 'NotSupportedError',
+    });
+    fake.longTerm.addRelationship.mockRejectedValue(notSupported);
+    mockedGenerateText.mockResolvedValue(graphResult(
+      [{ name: 'A', type: 'x' }, { name: 'B', type: 'y' }, { name: 'C', type: 'z' }],
+      [
+        { from: 'A', to: 'B', type: 'R1' },
+        { from: 'B', to: 'C', type: 'R2' },
+        { from: 'A', to: 'C', type: 'R3' },
+      ],
+    ));
+
+    const client = makeClient({ apiKey: 'k', logger: { warn, error: vi.fn() } });
+    Object.assign(client, { longTerm: fake.longTerm });
+
+    await createGraphExtractor({} as any)(client, { content: 'A B C', type: 'fact' });
+
+    expect(fake.longTerm.addRelationship).toHaveBeenCalledTimes(3);
+    const relWarnings = warn.mock.calls.filter(([m]) => /relationship endpoint/.test(m));
+    expect(relWarnings).toHaveLength(1);
+  });
+
+  it('keeps logging genuine relationship write failures every time', async () => {
+    const warn = vi.fn();
+    fake.longTerm.addRelationship.mockRejectedValue(new Error('network blip'));
+    mockedGenerateText.mockResolvedValue(graphResult(
+      [{ name: 'A', type: 'x' }, { name: 'B', type: 'y' }],
+      [{ from: 'A', to: 'B', type: 'R1' }, { from: 'B', to: 'A', type: 'R2' }],
+    ));
+
+    const client = makeClient({ apiKey: 'k', logger: { warn, error: vi.fn() } });
+    Object.assign(client, { longTerm: fake.longTerm });
+
+    await createGraphExtractor({} as any)(client, { content: 'A B', type: 'fact' });
+
+    expect(warn.mock.calls.filter(([m]) => /addRelationship failed/.test(m))).toHaveLength(2);
+  });
+
   it('treats relationship write failures as non-fatal', async () => {
     mockedGenerateText.mockResolvedValue(graphResult(
       [
@@ -87,5 +134,151 @@ describe('createGraphExtractor', () => {
       userScore: 0.9,
       confirmed: true,
     });
+  });
+
+  it('falls back to the memory text when the model returns an empty description', async () => {
+    mockedGenerateText.mockResolvedValue(graphResult([
+      { name: 'Alex', type: 'person', description: '' },
+    ]));
+
+    const extract = createGraphExtractor({} as any);
+    await extract(fake as any, { content: 'Alex works at TechCorp', type: 'fact' });
+
+    expect(fake.longTerm.addEntity).toHaveBeenCalledWith('Alex', 'person', {
+      description: 'Alex works at TechCorp',
+    });
+  });
+});
+
+describe('graph extraction schema — OpenAI strict-mode compliance', () => {
+  const strictViolations = (node: any, path = '$'): string[] => {
+    if (!node || typeof node !== 'object') return [];
+    const out: string[] = [];
+    if (node.type === 'object' && node.properties) {
+      const keys = Object.keys(node.properties);
+      const required: string[] = node.required ?? [];
+      const missing = keys.filter(k => !required.includes(k));
+      if (missing.length) out.push(`${path}: ${missing.join(', ')}`);
+      for (const k of keys) out.push(...strictViolations(node.properties[k], `${path}.${k}`));
+    }
+    if (node.type === 'array' && node.items) out.push(...strictViolations(node.items, `${path}[]`));
+    return out;
+  };
+
+  it('marks every property required, at every level', async () => {
+    mockedGenerateText.mockResolvedValue(graphResult([]));
+
+    const extract = createGraphExtractor({} as any);
+    await extract(fake as any, { content: 'anything', type: 'fact' });
+
+    const { output } = mockedGenerateText.mock.calls[0][0] as any;
+    const { schema } = await output.responseFormat;
+
+    expect(strictViolations(schema)).toEqual([]);
+  });
+});
+
+describe('createGraphExtractor — self-referential guard', () => {
+  it('does not turn an agent memory summary into entities', async () => {
+    mockedGenerateText.mockResolvedValue(graphResult([
+      { name: 'long-term memories', type: 'Concept', description: 'Retrieved long-term memories indicate…' },
+      { name: 'past interactions', type: 'Event', description: 'The text lists past interactions…' },
+      { name: 'profile details', type: 'Object', description: 'Profile details were stored…' },
+      { name: 'preferences', type: 'Concept', description: 'The text lists preferences…' },
+    ]));
+
+    const extract = createGraphExtractor({} as any);
+    await extract(fake as any, {
+      content: 'Retrieved long-term memories indicate a preference for concise technical ' +
+        'answers. I also have profile details stored for future sessions.',
+      type: 'fact',
+    });
+
+    expect(fake.longTerm.addEntity).not.toHaveBeenCalled();
+  });
+
+  it('skips entities named after their own type and snake_case tool-output keys', async () => {
+    mockedGenerateText.mockResolvedValue(graphResult([
+      { name: 'Organization', type: 'Organization' },
+      { name: 'organization_count', type: 'Metric' },
+      { name: 'query_memory', type: 'SoftwareTool' },
+    ]));
+
+    const extract = createGraphExtractor({} as any);
+    await extract(fake as any, { content: 'tool output', type: 'fact' });
+
+    expect(fake.longTerm.addEntity).not.toHaveBeenCalled();
+  });
+
+  /**
+   * The guard keys on proper-vs-common noun, so a script that has no case must
+   * make it decline rather than reject every entity in that language.
+   */
+  it('does not reject entities written in caseless scripts', async () => {
+    mockedGenerateText.mockResolvedValue(graphResult([
+      { name: '北京', type: 'Location' },
+      { name: 'القاهرة', type: 'Location' },
+      { name: '田中', type: 'Person' },
+    ]));
+
+    const extract = createGraphExtractor({} as any);
+    await extract(fake as any, { content: 'locations', type: 'fact' });
+
+    const stored = fake.longTerm.addEntity.mock.calls.map((c: any[]) => c[0]);
+    expect(stored).toEqual(['北京', 'القاهرة', '田中']);
+  });
+
+  it('keeps proper nouns whose styling is unusual', async () => {
+    mockedGenerateText.mockResolvedValue(graphResult([
+      { name: 'iPhone', type: 'Product' },
+      { name: 'macOS', type: 'OperatingSystem' },
+      { name: 'eBay', type: 'Organization' },
+    ]));
+
+    const extract = createGraphExtractor({} as any);
+    await extract(fake as any, { content: 'products', type: 'fact' });
+
+    const stored = fake.longTerm.addEntity.mock.calls.map((c: any[]) => c[0]);
+    expect(stored).toEqual(['iPhone', 'macOS', 'eBay']);
+  });
+
+  it('still stores the real entities alongside skipped ones, and drops their dangling edges', async () => {
+    mockedGenerateText.mockResolvedValue(graphResult(
+      [
+        { name: 'Priya', type: 'Person' },
+        { name: 'Acme Analytics', type: 'Organization' },
+        { name: 'stored memories', type: 'Concept' },
+      ],
+      [
+        { from: 'Priya', to: 'Acme Analytics', type: 'WORKS_AT' },
+        { from: 'Priya', to: 'stored memories', type: 'HAS' },
+      ],
+    ));
+
+    const extract = createGraphExtractor({} as any);
+    await extract(fake as any, { content: 'Priya works at Acme Analytics', type: 'fact' });
+
+    const stored = fake.longTerm.addEntity.mock.calls.map((c: any[]) => c[0]);
+    expect(stored).toEqual(['Priya', 'Acme Analytics']);
+    expect(fake.longTerm.addRelationship).toHaveBeenCalledTimes(1);
+    expect(fake.longTerm.addRelationship).toHaveBeenCalledWith(
+      'ent-Priya', 'ent-Acme Analytics', 'WORKS_AT',
+    );
+  });
+
+  it('honours a caller-supplied skipEntity override', async () => {
+    mockedGenerateText.mockResolvedValue(graphResult([
+      { name: 'preferences', type: 'Concept' },
+      { name: 'Priya', type: 'Person' },
+    ]));
+
+    // A domain where "preferences" is a real entity and people are not wanted.
+    const extract = createGraphExtractor({} as any, {
+      skipEntity: (e) => e.type === 'Person',
+    });
+    await extract(fake as any, { content: 'anything', type: 'fact' });
+
+    const stored = fake.longTerm.addEntity.mock.calls.map((c: any[]) => c[0]);
+    expect(stored).toEqual(['preferences']);
   });
 });

--- a/typescript/packages/vercel-ai-provider/test/vercel-ai-provider-middleware.test.ts
+++ b/typescript/packages/vercel-ai-provider/test/vercel-ai-provider-middleware.test.ts
@@ -184,6 +184,65 @@ describe('middleware mode — persistence', () => {
     expect(assistantCalls).toHaveLength(2);
   });
 
+  it('injects exactly one memory block when a step is retried', async () => {
+    // The AI SDK rebuilds the params object per retry attempt but reuses the
+    // same prompt array, and transformParams re-runs on every attempt. Editing
+    // that array in place stacked a second memory block onto the first.
+    fake.longTerm.searchEntities.mockResolvedValue([
+      { name: 'Alex', description: 'works at TechCorp', type: 'person', confidence: 0.9 },
+    ]);
+
+    const seen: string[] = [];
+    const { model } = makeFakeModel();
+    (model as any).doGenerate = vi.fn(async (p: any) => {
+      seen.push(p.prompt.at(-1).content.map((c: any) => c.text).join(''));
+      return {
+        content: [{ type: 'text', text: 'ok' }],
+        finishReason: 'stop',
+        usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+        warnings: [],
+      };
+    });
+
+    const wrapped = createNamsMemory({ apiKey: 'k' }).wrap(model, {
+      userId: freshUser(),
+      conversationId: 'conv-retry',
+    });
+
+    const prompt = userPrompt('Where do I work?');
+    await wrapped.doGenerate({ prompt } as any);   // attempt 1
+    await wrapped.doGenerate({ prompt } as any);   // retry: same prompt array
+
+    const blocks = (s: string) => (s.match(/Relevant long-term memory/g) ?? []).length;
+    expect(blocks(seen[0])).toBe(1);
+    expect(blocks(seen[1])).toBe(1);
+    // The caller's array is never touched.
+    expect(prompt[0].content).toEqual([{ type: 'text', text: 'Where do I work?' }]);
+  });
+
+  it('persists the user text, never the memory-augmented prompt, across a retry', async () => {
+    fake.longTerm.searchEntities.mockResolvedValue([
+      { name: 'Alex', description: 'works at TechCorp', type: 'person', confidence: 0.9 },
+    ]);
+
+    const { model } = makeFakeModel('answer');
+    const wrapped = createNamsMemory({ apiKey: 'k' }).wrap(model, {
+      userId: freshUser(),
+      conversationId: 'conv-retry-persist',
+    });
+
+    const prompt = userPrompt('Where do I work?');
+    await wrapped.doGenerate({ prompt } as any);
+    await wrapped.doGenerate({ prompt } as any);
+
+    const userCalls = fake.shortTerm.addMessage.mock.calls.filter(c => c[1] === 'user');
+    expect(userCalls).toHaveLength(1);
+    expect(userCalls[0][2]).toBe('Where do I work?');
+    // A leaked memory block would poison short-term memory permanently, since
+    // the stored message is itself retrievable on later turns.
+    expect(userCalls[0][2]).not.toContain('Relevant long-term memory');
+  });
+
   it('does not persist when persistInteractions is false', async () => {
     const { model } = makeFakeModel();
     const wrapped = createNamsMemory({ apiKey: 'k', persistInteractions: false }).wrap(model, {

--- a/typescript/packages/vercel-ai-provider/test/vercel-ai-provider-tools.test.ts
+++ b/typescript/packages/vercel-ai-provider/test/vercel-ai-provider-tools.test.ts
@@ -34,6 +34,7 @@ import {
   createNamsMemoryTools,
   createNamsTools,
   enforceQueryMemory,
+  ensureMemoryStored,
 } from '../src/vercel-ai-provider-tools';
 import type { QueryOutput, StoreOutput } from '../src/vercel-ai-provider-tools';
 
@@ -246,6 +247,111 @@ describe('enforceQueryMemory', () => {
     expect(await prepareStep(stepOptions(0)))
       .toEqual({ toolChoice: { type: 'tool', toolName: 'query_memory' } });
     expect(await prepareStep(stepOptions(1, [['query_memory']]))).toBeUndefined();
+  });
+});
+
+describe('ensureMemoryStored', () => {
+  const tools = (conversationId: string) =>
+    createNamsMemoryTools({ apiKey: 'k', userId: freshUser(), conversationId });
+
+  it('persists the assistant turn as an interaction when store_memory never ran', async () => {
+    const t = tools('conv-e1');
+
+    const result = await ensureMemoryStored(t)({
+      text: 'Noted — you prefer dark mode.',
+      toolCalls: [{ toolName: 'query_memory' }],
+    });
+
+    expect(result).toEqual({
+      stored: true,
+      input: { content: 'Noted — you prefer dark mode.', type: 'interaction' },
+    });
+    expect(fake.shortTerm.addMessage).toHaveBeenCalledWith(
+      'conv-e1', 'assistant', 'Noted — you prefer dark mode.',
+    );
+    // interaction → short-term only. The agent's own summary must never become
+    // a long-term entity; that is the self-referential loop the extractor rejects.
+    expect(fake.longTerm.addEntity).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when the model already called store_memory', async () => {
+    const t = tools('conv-e2');
+
+    const result = await ensureMemoryStored(t)({
+      text: 'Stored that for you.',
+      toolCalls: [{ toolName: 'query_memory' }, { toolName: 'store_memory' }],
+    });
+
+    expect(result).toEqual({ stored: false, reason: 'already-stored' });
+    expect(fake.shortTerm.addMessage).not.toHaveBeenCalled();
+  });
+
+  it('reads per-step tool calls when the aggregate is absent', async () => {
+    const t = tools('conv-e3');
+
+    const result = await ensureMemoryStored(t)({
+      text: 'done',
+      steps: [{ toolCalls: [{ toolName: 'read_file' }] }, { toolCalls: [{ toolName: 'store_memory' }] }],
+    });
+
+    expect(result).toEqual({ stored: false, reason: 'already-stored' });
+  });
+
+  it('stores nothing when the turn produced no text', async () => {
+    const t = tools('conv-e4');
+
+    expect(await ensureMemoryStored(t)({ text: '   ', toolCalls: [] }))
+      .toEqual({ stored: false, reason: 'nothing-to-store' });
+    expect(fake.shortTerm.addMessage).not.toHaveBeenCalled();
+  });
+
+  it('honours a custom fallback, including returning null to skip', async () => {
+    const t = tools('conv-e5');
+
+    const stored = await ensureMemoryStored(t, {
+      fallback: ({ text, toolNames }) => ({
+        content: `[${toolNames.join(',')}] ${text}`,
+        type: 'fact',
+        confidence: 0.9,
+      }),
+    })({ text: 'Alex works at TechCorp', toolCalls: [{ toolName: 'query_memory' }] });
+
+    expect(stored).toMatchObject({ stored: true });
+    expect(fake.longTerm.addEntity).toHaveBeenCalledWith(
+      '[query_memory] Alex works at TechCorp', 'fact',
+      { description: '[query_memory] Alex works at TechCorp' },
+    );
+
+    const skipped = await ensureMemoryStored(t, { fallback: () => null })({ text: 'anything' });
+    expect(skipped).toEqual({ stored: false, reason: 'nothing-to-store' });
+  });
+
+  it('reports failure instead of throwing into a completed response', async () => {
+    fake.shortTerm.addMessage.mockRejectedValue(new Error('write failed'));
+    const t = tools('conv-e6');
+
+    expect(await ensureMemoryStored(t)({ text: 'hello' }))
+      .toEqual({ stored: false, reason: 'failed' });
+  });
+
+  it('works with the MCP-merged tool set', async () => {
+    mcpHolder.tools = { search: { description: 'mcp search' } };
+    const { tools: merged } = await createNamsTools({
+      apiKey: 'k',
+      userId: freshUser(),
+      conversationId: 'conv-e7',
+      mcp: { url: 'https://mcp.example.com/mcp', toolPrefix: 'mcp_' },
+    });
+
+    const result = await ensureMemoryStored(merged)({ text: 'merged turn' });
+
+    expect(result).toMatchObject({ stored: true });
+    expect(fake.shortTerm.addMessage).toHaveBeenCalledWith('conv-e7', 'assistant', 'merged turn');
+  });
+
+  it('throws at wiring time on a tool set it did not create', () => {
+    const t = tools('conv-e8');
+    expect(() => ensureMemoryStored({ ...t })).toThrow(/spreading it into a new object/);
   });
 });
 

--- a/typescript/packages/vercel-ai-provider/test/vercel-ai-provider-tools.test.ts
+++ b/typescript/packages/vercel-ai-provider/test/vercel-ai-provider-tools.test.ts
@@ -76,7 +76,7 @@ describe('query_memory', () => {
     expect(out.found).toBe(true);
     expect(out.count).toBe(2);
     // Scores present → sorted descending, long-term hit first.
-    expect(out.memories[0]).toMatchObject({ content: 'User is named Alex', source: 'long-term' });
+    expect(out.memories[0]).toMatchObject({ content: 'Alex — User is named Alex', source: 'long-term' });
     expect(out.memories[1]).toMatchObject({ content: 'I love terse answers', source: 'conversation' });
   });
 


### PR DESCRIPTION
Fixed these issues 

1. query_memory dropped entity names. Hits were built from `e.description ?? e.name`, and createGraphExtractor always writes a
description, so the name -- which is the actual fact -- never reached the model. Asked "which language do I prefer?" the agent replied that the memory didn't specify, and sometimes reconstructed a fragment of a name it had never been shown ("You're based in Ban."). Long-term hits now render as "name -- description". Dedup keys separately from display, so cross-source dedup is unchanged and two entities sharing a description both survive.

2. Extraction never ran on OpenAI. Strict structured-output mode requires every property to appear in `required`; both `.optional()` on entity.description and `.default([])` on relationships dropped their keys. OpenAI reports only the first, so fixing description alone would have left the feature dead. storeMemory swallowed the rejection and fell back to a flat entity, which is why this survived a release. A test now asserts strict compliance against the schema actually sent.

3. Memory extracted its own output. Answering "what do you remember about me?" and storing that answer minted entities about remembering (`profile details [Object]`), which then outranked the real facts on the next such question -- every ask degraded the next. store_memory's description previously invited exactly this; it now tells the model never to store recall output. Backing that up, extraction skips common nouns and keeps the proper nouns it already asks for, which needs no vocabulary list and does not misfire on caseless scripts.