### PR TITLE
docs: fix broken /v1 endpoint links in tutorials & reference

### DIFF
--- a/docs/modules/ROOT/pages/how-to/use-nams.adoc
+++ b/docs/modules/ROOT/pages/how-to/use-nams.adoc
@@ -70,7 +70,7 @@ async with MemoryClient(settings) as client:
 | Field | Default | Description
 
 | `endpoint`
-| `https://memory.neo4jlabs.com/v1`
+| `+https://memory.neo4jlabs.com/v1+`
 | Base URL. The `/v\d+` suffix triggers REST mode; other shapes use the TCK bridge protocol.
 | `api_key`
 | `None`

--- a/docs/modules/ROOT/pages/reference/authentication.adoc
+++ b/docs/modules/ROOT/pages/reference/authentication.adoc
@@ -62,7 +62,7 @@ The SDKs consume an existing key — set it once and the backend auto-selects NA
 | Variable | Purpose
 
 | `MEMORY_API_KEY` | Your `nams_…` key. When set (and `NAM_BACKEND` is unspecified) the backend defaults to NAMS.
-| `MEMORY_ENDPOINT` | Override the service URL (default `https://memory.neo4jlabs.com/v1`).
+| `MEMORY_ENDPOINT` | Override the service URL (default `+https://memory.neo4jlabs.com/v1+`).
 | `MEMORY_WORKSPACE_ID` | Workspace id, lifted into `NamsConfig.workspace_id` and sent as `X-Workspace-Id`.
 | `NAM_BACKEND` | Force `bolt` or `nams`.
 | `NAM_NAMS__*` | Nested `NamsConfig` overrides (timeout, retries, …).

--- a/docs/modules/ROOT/pages/reference/environment-variables.adoc
+++ b/docs/modules/ROOT/pages/reference/environment-variables.adoc
@@ -408,7 +408,7 @@ defaults to NAMS. Falls back to bolt when unset.
 
 | `MEMORY_ENDPOINT`
 | NAMS endpoint base URL. REST mode when the URL contains `/v\d+`.
-| `https://memory.neo4jlabs.com/v1`
+| `+https://memory.neo4jlabs.com/v1+`
 
 | `MEMORY_WORKSPACE_ID`
 | NAMS workspace id. Lifted into `NamsConfig.workspace_id` and sent as the

--- a/docs/modules/ROOT/pages/reference/rest-api.adoc
+++ b/docs/modules/ROOT/pages/reference/rest-api.adoc
@@ -1,7 +1,7 @@
 = REST API Reference
 :description: Hosted-service REST endpoints mapped to client SDK methods in each language.
 
-The hosted service at `https://memory.neo4jlabs.com/v1` exposes a REST API.
+The hosted service at `+https://memory.neo4jlabs.com/v1+` exposes a REST API.
 This page is a curated companion to the machine-readable contract — it maps
 every endpoint to its bridge-protocol equivalent and the corresponding method
 on each language client.
@@ -22,7 +22,7 @@ casing.
 == Base URL & versioning
 
 All endpoints are served under a major-version prefix: the production base URL
-is `https://memory.neo4jlabs.com/v1`. The SDK appends paths to the configured
+is `+https://memory.neo4jlabs.com/v1+`. The SDK appends paths to the configured
 `MEMORY_ENDPOINT` (default the URL above). The `/v{n}` prefix also selects the
 REST transport; endpoints without it use the TCK bridge protocol (see
 xref:explanation/backends.adoc[Bolt vs NAMS]).

--- a/docs/modules/ROOT/pages/reference/skills-api.adoc
+++ b/docs/modules/ROOT/pages/reference/skills-api.adoc
@@ -8,7 +8,7 @@
 icon:flask[] *Preview.* The Skills surface is exposed over the NAMS **REST API**
 and **MCP** only — there is no `client.skill` accessor in the Python or
 TypeScript SDK yet, and nothing on the bolt backend. Paths below are under the
-versioned base (e.g. `https://memory.neo4jlabs.com/v1`); all are workspace-scoped
+versioned base (e.g. `+https://memory.neo4jlabs.com/v1+`); all are workspace-scoped
 and gated by the `skills:read` / `skills:write` scopes. For the concept, see
 xref:explanation/skills.adoc[Agent Skills].
 ====

--- a/docs/modules/ROOT/pages/reference/typescript-api.adoc
+++ b/docs/modules/ROOT/pages/reference/typescript-api.adoc
@@ -73,7 +73,7 @@ const memory = new MemoryClient({
 |`endpoint`
 |`string`
 |The NAMS REST endpoint. Auto-selects REST transport when ending in `/v\d+`.
-|`https://memory.neo4jlabs.com/v1`
+|`+https://memory.neo4jlabs.com/v1+`
 
 |`apiKey`
 |`string`

--- a/docs/modules/ROOT/pages/tutorials/first-agent-memory-typescript.adoc
+++ b/docs/modules/ROOT/pages/tutorials/first-agent-memory-typescript.adoc
@@ -13,7 +13,7 @@ A simple chat application where the AI assistant remembers conversation history 
 
 * Node.js 20+ or Bun
 * An OpenAI API key
-* Either a `nams_*` API key for `https://memory.neo4jlabs.com/v1` (recommended) or a local Neo4j + bridge server
+* Either a `nams_*` API key for the link:https://memory.neo4jlabs.com/[hosted service] (recommended) or a local Neo4j + bridge server
 
 == Step 1: Create the Project
 

--- a/docs/modules/ROOT/pages/tutorials/hosted-quickstart-typescript.adoc
+++ b/docs/modules/ROOT/pages/tutorials/hosted-quickstart-typescript.adoc
@@ -2,8 +2,8 @@
 :description: Five-minute quickstart for the hosted Neo4j Agent Memory Service.
 
 This tutorial walks you from zero to a working agent against the hosted
-service at `https://memory.neo4jlabs.com/v1`, using whichever language client
-fits your stack.
+service at link:https://memory.neo4jlabs.com/[memory.neo4jlabs.com], using
+whichever language client fits your stack.
 
 == Prerequisites
 

--- a/docs/modules/ROOT/pages/tutorials/nams-quickstart.adoc
+++ b/docs/modules/ROOT/pages/tutorials/nams-quickstart.adoc
@@ -146,7 +146,7 @@ The same Cypher query works on bolt too — `client.query.cypher` is backend-agn
 == What just happened?
 
 * `MemoryClient()` with no arguments inspected the environment, saw `MEMORY_API_KEY`, and built a NAMS-backed client.
-* Every method call became an HTTPS POST/GET to `https://memory.neo4jlabs.com/v1/...`.
+* Every method call became an HTTPS POST/GET to `+https://memory.neo4jlabs.com/v1/...+`.
 * NAMS embedded your messages, deduplicated the entity, and stored the trace — all server-side.
 * `client.query.cypher` ran a read-only query against the hosted graph.
 


### PR DESCRIPTION
## Problem

Reported by Erik Bijl (neo4j-labs/project-nams#192): the link `https://memory.neo4jlabs.com/v1` renders as a **clickable 404** on the published tutorials (e.g. [first-agent-memory-typescript](https://neo4j.com/labs/agent-memory/tutorials/first-agent-memory-typescript/) and [hosted-quickstart-typescript](https://neo4j.com/labs/agent-memory/tutorials/hosted-quickstart-typescript/)).

**Root cause:** AsciiDoc auto-links any bare URL — even inside backtick monospace — into an `<a class="bare">`. Visiting the bare `https://memory.neo4jlabs.com/v1` returns **404**, so every inline mention became a broken clickable link. This affected **9 spots across 9 pages**, not just the two tutorials Erik happened to notice.

## Why not just strip `/v1` everywhere

The API genuinely lives under `/v1`:

- `https://memory.neo4jlabs.com/v1/conversations` → 401 (route exists), but `https://memory.neo4jlabs.com/conversations` → 404.
- The TS SDK's `pickTransport` selects REST mode **only when the endpoint matches `/\/v\d+\b/`** — so `/v1` in the documented `MEMORY_ENDPOINT` default and SDK `endpoint` values is load-bearing.

Blanket-replacing `/v1` with `/` would make the reference docs factually wrong. So the fix stops the inline URLs from **linking**, rather than removing `/v1`.

## Changes

- **Tutorial prose pointers** ("hosted service at …", "API key for …") now link to `https://memory.neo4jlabs.com/` (a valid landing page, 200).
- **Reference/how-to mentions** where `/v1` is the documented API base keep `/v1` via the `+…+` passthrough, so they render as non-clickable monospace (same idiom already used in `reference/deployment.adoc`).
- **Code-block and curl values** under `[source]` are unchanged — AsciiDoc never auto-links those, and they must keep `/v1`.

Verified: no backtick-wrapped bare `/v1` remains linkable; the 17 code-block/curl `/v1` values are preserved.

Fixes neo4j-labs/project-nams#192