### PR TITLE
fix: align NAMS wrapper tool semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **BREAKING: NAMS feedback wrappers no longer accept the ignored
+  `user_identifier` / `user_id` arguments.** The MCP, Pydantic AI, and Strands
+  surfaces now match the backend contract; callers should stop passing these
+  keywords. MCP entity-history and reflection limits and the Pydantic AI
+  entity-history limit are now enforced locally and must be at least 1. This
+  does not change backend or multi-tenant isolation semantics.
 - `strands` extra requires `strands-agents>=1.44.0` (was `>=0.1.0`).
 - **`Neo4jSessionManager` now guards against a paired `Neo4jMemoryStore` duplicating its work**: raises if both would extract the same turns (always, on NAMS), warns once if both would inject context.
 - `ShortTermProtocol.bulk_add_messages` takes explicit keyword-only params

--- a/src/neo4j_agent_memory/integrations/pydantic_ai/memory.py
+++ b/src/neo4j_agent_memory/integrations/pydantic_ai/memory.py
@@ -444,7 +444,6 @@ def nams_memory_tools(memory: "MemoryClient") -> list[Callable[..., Any]]:
     async def set_entity_feedback(
         entity_id: str,
         feedback: str,
-        user_identifier: str | None = None,
     ) -> str:
         """
         Record feedback (e.g. "positive"/"negative") on an entity.
@@ -453,7 +452,6 @@ def nams_memory_tools(memory: "MemoryClient") -> list[Callable[..., Any]]:
             entity_id: Entity UUID.
             feedback: Feedback string — convention is "positive" or
                 "negative", but any string the server accepts works.
-            user_identifier: Optional per-user scoping.
 
         Returns:
             Confirmation message.
@@ -472,12 +470,14 @@ def nams_memory_tools(memory: "MemoryClient") -> list[Callable[..., Any]]:
 
         Args:
             entity_id: Entity UUID.
-            limit: Maximum history entries to return.
+            limit: Maximum history entries to return. Must be at least 1.
 
         Returns:
             Formatted history as plain text.
         """
-        entries = await memory.long_term.get_entity_history(entity_id)
+        if limit < 1:
+            raise ValueError("limit must be at least 1")
+        entries = (await memory.long_term.get_entity_history(entity_id))[:limit]
         if not entries:
             return "No history for this entity."
         lines = []

--- a/src/neo4j_agent_memory/integrations/strands/tools.py
+++ b/src/neo4j_agent_memory/integrations/strands/tools.py
@@ -876,13 +876,12 @@ def _nams_set_entity_feedback_tool(
         raise ImportError("strands-agents is required for Strands integration.") from e
 
     @tool
-    def set_entity_feedback(entity_id: str, feedback: str, user_id: str | None = None) -> str:
+    def set_entity_feedback(entity_id: str, feedback: str) -> str:
         """Record feedback on an entity in NAMS.
 
         Args:
             entity_id: Entity UUID.
             feedback: Feedback string ("positive" or "negative").
-            user_id: Optional per-user scoping.
 
         Returns:
             Confirmation message.

--- a/src/neo4j_agent_memory/mcp/_tools.py
+++ b/src/neo4j_agent_memory/mcp/_tools.py
@@ -816,7 +816,6 @@ def _register_platinum_tools(mcp: FastMCP) -> None:
         ctx: Context,
         entity_id: str,
         feedback: str,
-        user_identifier: str | None = None,
     ) -> str:
         """Record user feedback on an entity (NAMS Platinum).
 
@@ -829,7 +828,6 @@ def _register_platinum_tools(mcp: FastMCP) -> None:
                 memory_search).
             feedback: Free-form feedback — convention is "positive" or
                 "negative".
-            user_identifier: Optional per-user scoping (multi-tenant).
         """
         client = get_client(ctx)
         try:
@@ -856,11 +854,13 @@ def _register_platinum_tools(mcp: FastMCP) -> None:
 
         Args:
             entity_id: Entity UUID.
-            limit: Maximum history entries to return (default: 50).
+            limit: Maximum history entries to return (default: 50; minimum: 1).
         """
         client = get_client(ctx)
         try:
-            history = await client.long_term.get_entity_history(entity_id)
+            if limit < 1:
+                raise ValueError("limit must be at least 1")
+            history = (await client.long_term.get_entity_history(entity_id))[:limit]
             return json.dumps({"entity_id": entity_id, "history": history}, default=str)
         except Exception as e:
             logger.error(f"Error in memory_get_entity_history: {e}")
@@ -902,11 +902,13 @@ def _register_platinum_tools(mcp: FastMCP) -> None:
 
         Args:
             session_id: Session identifier.
-            limit: Maximum reflections to return (default: 20).
+            limit: Maximum reflections to return (default: 20; minimum: 1).
         """
         client = get_client(ctx)
         try:
-            reflections = await client.short_term.get_reflections(session_id)
+            if limit < 1:
+                raise ValueError("limit must be at least 1")
+            reflections = (await client.short_term.get_reflections(session_id))[:limit]
             return json.dumps({"session_id": session_id, "reflections": reflections}, default=str)
         except Exception as e:
             logger.error(f"Error in memory_get_reflections: {e}")

--- a/tests/unit/integrations/test_strands.py
+++ b/tests/unit/integrations/test_strands.py
@@ -272,6 +272,25 @@ class TestToolDescriptions:
             assert "min_score" in params
             assert "include_relationships" in params
 
+    def test_nams_feedback_tool_does_not_expose_ignored_user_id(
+        self, mock_strands: MagicMock
+    ) -> None:
+        # NAMS feedback exposes only arguments honored by the backend.
+        with patch.dict("sys.modules", {"strands": mock_strands}):
+            from neo4j_agent_memory.integrations.strands.tools import (
+                _nams_set_entity_feedback_tool,
+            )
+
+            tool = _nams_set_entity_feedback_tool(
+                endpoint="https://memory.test/v1",
+                api_key="test-key",
+                transport_mode="rest",
+            )
+
+            import inspect
+
+            assert list(inspect.signature(tool).parameters) == ["entity_id", "feedback"]
+
     def test_get_entity_graph_tool_signature(self, mock_strands: MagicMock) -> None:
         """Test get_entity_graph tool has correct parameters."""
         with patch.dict("sys.modules", {"strands": mock_strands}):

--- a/tests/unit/nams/test_mcp_platinum.py
+++ b/tests/unit/nams/test_mcp_platinum.py
@@ -70,12 +70,17 @@ class TestPlatinumToolExecution:
         client = make_mock_client()
         client.long_term.set_entity_feedback = AsyncMock(return_value=None)
         client.long_term.get_entity_history = AsyncMock(
-            return_value=[{"conversation_id": "c1", "mention_count": 3}]
+            return_value=[
+                {"conversation_id": "c1", "mention_count": 3},
+                {"conversation_id": "c2", "mention_count": 1},
+            ]
         )
         client.long_term.get_entity_provenance = AsyncMock(
             return_value={"sources": [{"message_id": "m1"}], "extractors": []}
         )
-        client.short_term.get_reflections = AsyncMock(return_value=[{"text": "reflection one"}])
+        client.short_term.get_reflections = AsyncMock(
+            return_value=[{"text": "reflection one"}, {"text": "reflection two"}]
+        )
         return client
 
     @pytest.fixture
@@ -95,9 +100,44 @@ class TestPlatinumToolExecution:
         mock_client.long_term.set_entity_feedback.assert_awaited_once()
 
     @pytest.mark.asyncio
+    async def test_platinum_schema_matches_supported_arguments(self, server):
+        async with Client(server) as client:
+            tools = {tool.name: tool for tool in await client.list_tools()}
+
+        feedback_properties = tools["memory_set_entity_feedback"].inputSchema.get("properties", {})
+        assert "user_identifier" not in feedback_properties
+
+        history_limit = tools["memory_get_entity_history"].inputSchema["properties"]["limit"]
+        assert history_limit["default"] == 50
+
+        reflections_limit = tools["memory_get_reflections"].inputSchema["properties"]["limit"]
+        assert reflections_limit["default"] == 20
+
+    @pytest.mark.asyncio
+    async def test_non_positive_limits_are_rejected_before_backend_access(
+        self, server, mock_client
+    ):
+        async with Client(server) as client:
+            history_result = await client.call_tool(
+                "memory_get_entity_history", {"entity_id": "e1", "limit": 0}
+            )
+            reflections_result = await client.call_tool(
+                "memory_get_reflections", {"session_id": "s1", "limit": -1}
+            )
+
+        assert json.loads(history_result.content[0].text) == {"error": "limit must be at least 1"}
+        assert json.loads(reflections_result.content[0].text) == {
+            "error": "limit must be at least 1"
+        }
+        mock_client.long_term.get_entity_history.assert_not_awaited()
+        mock_client.short_term.get_reflections.assert_not_awaited()
+
+    @pytest.mark.asyncio
     async def test_get_entity_history(self, server, mock_client):
         async with Client(server) as client:
-            result = await client.call_tool("memory_get_entity_history", {"entity_id": "e1"})
+            result = await client.call_tool(
+                "memory_get_entity_history", {"entity_id": "e1", "limit": 1}
+            )
             data = json.loads(result.content[0].text)
         assert data["entity_id"] == "e1"
         assert len(data["history"]) == 1
@@ -114,7 +154,9 @@ class TestPlatinumToolExecution:
     @pytest.mark.asyncio
     async def test_get_reflections(self, server, mock_client):
         async with Client(server) as client:
-            result = await client.call_tool("memory_get_reflections", {"session_id": "s1"})
+            result = await client.call_tool(
+                "memory_get_reflections", {"session_id": "s1", "limit": 1}
+            )
             data = json.loads(result.content[0].text)
         assert data["session_id"] == "s1"
         assert len(data["reflections"]) == 1

--- a/tests/unit/nams/test_pydantic_ai_nams.py
+++ b/tests/unit/nams/test_pydantic_ai_nams.py
@@ -61,10 +61,26 @@ class TestSetEntityFeedback:
     async def test_calls_long_term_method(self, mock_client):
         tools = nams_memory_tools(mock_client)
         set_feedback = next(t for t in tools if t.__name__ == "set_entity_feedback")
-        result = await set_feedback(entity_id="e1", feedback="positive", user_identifier="alice")
+        result = await set_feedback(entity_id="e1", feedback="positive")
         mock_client.long_term.set_entity_feedback.assert_awaited_once_with("e1", "positive")
         assert "positive" in result
         assert "e1" in result
+
+    def test_signature_does_not_expose_ignored_user_identifier(self, mock_client):
+        import inspect
+
+        tools = nams_memory_tools(mock_client)
+        set_feedback = next(t for t in tools if t.__name__ == "set_entity_feedback")
+        assert list(inspect.signature(set_feedback).parameters) == ["entity_id", "feedback"]
+
+    async def test_rejects_ignored_user_identifier(self, mock_client):
+        tools = nams_memory_tools(mock_client)
+        set_feedback = next(t for t in tools if t.__name__ == "set_entity_feedback")
+
+        with pytest.raises(TypeError, match="unexpected keyword argument 'user_identifier'"):
+            await set_feedback(entity_id="e1", feedback="positive", user_identifier="alice")
+
+        mock_client.long_term.set_entity_feedback.assert_not_awaited()
 
 
 class TestGetEntityHistory:
@@ -77,9 +93,10 @@ class TestGetEntityHistory:
         )
         tools = nams_memory_tools(mock_client)
         get_history = next(t for t in tools if t.__name__ == "get_entity_history")
-        result = await get_history("e1", limit=10)
+        result = await get_history("e1", limit=1)
         assert "c1" in result
         assert "mentions=5" in result
+        assert "c2" not in result
 
     async def test_empty_history(self, mock_client):
         mock_client.long_term.get_entity_history = AsyncMock(return_value=[])
@@ -87,6 +104,16 @@ class TestGetEntityHistory:
         get_history = next(t for t in tools if t.__name__ == "get_entity_history")
         result = await get_history("e1")
         assert "No history" in result
+
+    @pytest.mark.parametrize("limit", [0, -1])
+    async def test_rejects_non_positive_limit(self, mock_client, limit):
+        tools = nams_memory_tools(mock_client)
+        get_history = next(t for t in tools if t.__name__ == "get_entity_history")
+
+        with pytest.raises(ValueError, match="limit must be at least 1"):
+            await get_history("e1", limit=limit)
+
+        mock_client.long_term.get_entity_history.assert_not_awaited()
 
 
 class TestGetEntityProvenance:


### PR DESCRIPTION
Closes #170

## Summary

- Remove the ignored user_identifier/user_id parameters from the NAMS feedback wrappers and update their docstrings.
- Enforce non-negative limit slicing for MCP entity history/reflections and Pydantic AI entity history.
- Add schema/signature regressions and a changelog entry.

This is wrapper-surface cleanup only. It does not change the NAMS transport, backend protocols, or multi-tenant isolation semantics; #137 remains separate.

## Tests

- make check
- make test-unit — 1508 passed
- Focused NAMS/integration tests — 47 passed
