### PR TITLE
docs(strands): cross-link the Python and TypeScript Strands guides

### DIFF
--- a/docs/modules/ROOT/pages/how-to/integrations/aws-strands.adoc
+++ b/docs/modules/ROOT/pages/how-to/integrations/aws-strands.adoc
@@ -2,6 +2,15 @@
 :description: Integrate Neo4j Agent Memory with AWS Strands Agents SDK
 :keywords: strands, aws, bedrock, neo4j, agent, tools, session manager
 
+[NOTE]
+====
+This is the *Python* guide, which covers both backends, the hosted NAMS and
+the self-hosted Neo4j or Aura over Bolt. If you are using TypeScript, see
+xref:how-to/typescript/strands.adoc[Strands Agents (TypeScript)]. That SDK
+wires up different Strands surfaces (`SnapshotStorage`,
+`ConversationManager`, reasoning hooks) and is NAMS-only.
+====
+
 This guide shows how to add Neo4j Context Graph memory to AWS Strands agents.
 The integration offers two complementary modes, usable independently or
 together on the same agent:
@@ -613,6 +622,7 @@ requires no LLM or API key.
 
 == See Also
 
+* xref:how-to/typescript/strands.adoc[Strands Agents (TypeScript)] — the TypeScript guide
 * xref:tutorials/strands-agent-quickstart.adoc[Strands Agent Tutorial]
 * xref:how-to/integrations/aws-bedrock-embeddings.adoc[Configure Bedrock Embeddings]
 * xref:how-to/integrations/aws-hybrid-memory.adoc[Hybrid Memory Provider]

--- a/docs/modules/ROOT/pages/how-to/typescript/integrations-overview.adoc
+++ b/docs/modules/ROOT/pages/how-to/typescript/integrations-overview.adoc
@@ -1,5 +1,5 @@
 = Framework Integrations
-:description: Memory-augmented LLM applications with Vercel AI SDK, LangChain JS, Mastra, LangGraph, PydanticAI, Semantic Kernel, ellmer.
+:description: Memory-augmented LLM applications with Vercel AI SDK, LangChain JS, Mastra, Strands Agents, LangGraph, PydanticAI, Semantic Kernel, ellmer.
 
 Each first-class agent framework ships a thin wrapper around `MemoryClient`.
 Pick yours below.
@@ -61,6 +61,27 @@ import { Agent } from "@mastra/core/agent";
 const memory = new Neo4jMastraMemory(client);
 const agent = new Agent({ name: "scout", memory });
 ----
+
+== Strands Agents (TypeScript)
+
+`connectMemoryToAgent` returns the `sessionManager` and
+`conversationManager` for a Strands `Agent` — session state persists to a
+NAMS conversation, three-tier context is injected on every model call, and
+reasoning hooks capture each turn.
+
+[source,ts]
+----
+import { Agent } from "@strands-agents/sdk";
+import { connectMemoryToAgent } from "@neo4j-labs/agent-memory/integrations/strands";
+
+const conv = await client.shortTerm.createConversation({ userId: "alice" });
+const agent = new Agent({
+  ...await connectMemoryToAgent(client, { conversationId: conv.id }),
+  model,
+});
+----
+
+See xref:how-to/typescript/strands.adoc[Strands Agents (TypeScript)].
 
 == LangGraph (Python)
 

--- a/docs/modules/ROOT/pages/how-to/typescript/strands.adoc
+++ b/docs/modules/ROOT/pages/how-to/typescript/strands.adoc
@@ -2,6 +2,15 @@
 :toc: left
 :source-highlighter: rouge
 
+[NOTE]
+====
+This is the *TypeScript* guide, and it is NAMS-only. The TypeScript client
+has no Bolt transport. If you are using Python, see
+xref:how-to/integrations/aws-strands.adoc[AWS Strands Agents (Python)]. That
+SDK covers both backends and exposes a different surface set (session
+manager with opt-in retrieval injection, plus agent-callable memory tools).
+====
+
 The `@neo4j-labs/agent-memory/integrations/strands` subpath plugs into
 all three of Strands' orthogonal extension surfaces:
 
@@ -170,4 +179,5 @@ of `@neo4j-labs/agent-memory` without a CHANGELOG callout.
 - link:https://github.com/neo4j-labs/agent-memory/tree/main/typescript/examples/strands[Runnable Strands example]
 - link:observability.adoc[Enable request logging]
 - link:handle-errors.adoc[Error handling]
+- xref:how-to/integrations/aws-strands.adoc[AWS Strands Agents (Python)] — the Python guide
 - https://strandsagents.com[Strands Agents docs]


### PR DESCRIPTION
## Why

The [Strands integrations catalog card](https://strandsagents.com/integrations) (merged in strands-agents/harness-sdk#3757) carries a single `docsUrl`, pointing at the Python guide. Strands declined to host an on-site docs page (harness-sdk#3871) because partner pages drift stale in their repo, so that one link is now the only route in — and a TypeScript reader following it landed on the Python guide with nothing pointing onward. Neither guide mentioned the other.

## What

- **`how-to/integrations/aws-strands.adoc`** — NOTE at the top naming the TypeScript guide, plus a *See Also* entry.
- **`how-to/typescript/strands.adoc`** — NOTE at the top naming the Python guide, plus a *See also* entry.
- **`how-to/typescript/integrations-overview.adoc`** — added the missing Strands (TypeScript) section; the overview listed every framework except Strands.

Each NOTE carries the one fact a reader needs before switching: Python covers both backends (NAMS and self-hosted Neo4j/Aura over Bolt) and offers the session manager with opt-in retrieval injection plus agent-callable memory tools; TypeScript is NAMS-only and wires `SnapshotStorage`, `ConversationManager`, and reasoning hooks.

## Testing

- `make test-docs-links` — 13 passed
- `make test-docs-syntax` — 579 passed, 91 skipped
- All three touched pages convert cleanly through Asciidoctor

`make test-docs-build` fails locally for an unrelated reason: Antora 3.1.14 exits 0 producing no output on Node v24.16.0, reproduced on a throwaway minimal component. Not caused by this change, but worth confirming which Node the docs CI job and Vercel run.

Docs-only, so per the path filters this triggers Python CI and not TypeScript CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)