### PR TITLE
ci: fix invalid YAML that has disabled TypeScript CI since May

### DIFF
--- a/.github/workflows/ci-typescript.yml
+++ b/.github/workflows/ci-typescript.yml
@@ -72,7 +72,7 @@ jobs:
           cache: 'npm'
           cache-dependency-path: typescript/package-lock.json
 
-      - name: Build SDK (populates typescript/dist for file: deps)
+      - name: 'Build SDK (populates typescript/dist for file: deps)'
         working-directory: typescript
         run: |
           npm ci


### PR DESCRIPTION
## The bug

`.github/workflows/ci-typescript.yml:75` has an unquoted step name containing a colon-space:

```yaml
- name: Build SDK (populates typescript/dist for file: deps)
```

YAML reads `file: deps` as a nested mapping, so the **entire workflow file** is unparseable:

```
mapping values are not allowed here
  in ".github/workflows/ci-typescript.yml", line 75, column 60
```

Introduced in 870e98b (2026-05-21, "update examples").

## What this has cost

TypeScript pull requests have had **no CI coverage for about three months** — no lint, no tests, no build.

| Signal | Observed |
|---|---|
| Actions list entry | shown as `.github/workflows/ci-typescript.yml`, not `TypeScript CI` — GitHub cannot read `name:` |
| Last triggered run ([32247142272](https://github.com/neo4j-labs/agent-memory/actions/runs/32247142272), push to `main`) | `failure` — *"This run likely failed because of a workflow file issue"* |
| Checks on a TypeScript-only PR | no `lint-test` job appears at all |

Every other file in `.github/workflows/` parses; this is the only broken one.

## The fix

Quote the string. That's the whole change.

Verified locally that the file then parses and declares the three jobs it always intended:

- `lint-test` (Node 20 and 22)
- `type-check-examples`
- `vercel-ai-provider`

## Note for reviewers

Once this merges, those three jobs will run against pull requests for the first time since May, so they may surface pre-existing breakage that has been accumulating unseen. That's the point of the fix, but it's worth expecting rather than being surprised by.

Suggested merge order: this first, so the TypeScript refactor in the companion PR gets validated by real CI.