### PR TITLE
docs: add generated OpenWiki evidence index and agent context files

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,12 @@
+<!-- OPENWIKI:START -->
+
+## OpenWiki
+
+This repository has a generated `openwiki/` evidence index. It is optional just-in-time context, not required startup reading.
+
+- Treat source code and tests as authoritative. A brief's unknowns and review items are verification gaps, not automatic requirements.
+- Prefer the narrowest quiet validation that proves the changed behavior. Preserve complete failure output.
+
+The scheduled OpenWiki GitHub Actions workflow refreshes the repository wiki. Do not hand-edit generated OpenWiki pages unless explicitly asked; prefer updating source code/docs and letting OpenWiki regenerate.
+
+<!-- OPENWIKI:END -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2422,3 +2422,11 @@ When adding or modifying documentation:
 - **Navigation**: `docs/modules/ROOT/nav.adoc` (single source, hand-maintained)
 - **Output**: Static HTML in `docs/build/site/`
 - **Deployment**: Vercel (`docs/vercel.json`, `outputDirectory: build/site`; auto-deploys on push to main)
+
+<!-- OPENWIKI:START -->
+
+## OpenWiki
+
+See [AGENTS.md](AGENTS.md) for OpenWiki agent instructions.
+
+<!-- OPENWIKI:END -->

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,35 @@
+# Neo4j Agent Memory
+
+A three-layer memory system for AI agents (short-term, long-term, reasoning) shipped as two SDKs (Python, TypeScript) over two backends: self-hosted Neo4j ("bolt") and the hosted Neo4j Agent Memory Service ("NAMS").
+
+## Language
+
+### Product & backends
+
+**NAMS**:
+The hosted Neo4j Agent Memory Service (`memory.neo4jlabs.com`, REST `/v1`). Ships continuously; has no product version of its own — never tie NAMS to an SDK version number.
+_Avoid_: "hosted SDK", "NAMS v0.x"
+
+**Bolt backend**:
+The self-hosted mode where the SDK talks to a user-managed Neo4j over the bolt protocol. The only backend where preferences, facts, client-side relationship creation, and the extraction pipeline configuration exist.
+_Avoid_: "local mode", "OSS mode"
+
+**POLE+O**:
+The default entity classification: **P**erson, **O**bject, **L**ocation, **E**vent — the POLE model from law-enforcement analysis — **plus O**rganization as the extension. Organization is the "+O"; Object is core POLE. (Confirmed by `POLEOEntityType` in the SDK and `PoleType` in the NAMS server.)
+_Avoid_: "Person, Organization, Location, Event + Object" (an inversion that appeared in one audit)
+
+**Conformance tier**:
+Bronze/Silver/Gold/Platinum labels from the agent-memory TCK certifying *client* behavioral conformance. Never a NAMS pricing, access, or service tier — NAMS has no paid tiers.
+_Avoid_: "NAMS Platinum", "higher tier", any feature "gated by tier"
+
+**Workspace**:
+The NAMS tenancy boundary. Selected by workspace-bound API key or `X-Workspace-Id` header (`MEMORY_WORKSPACE_ID`); distinct from per-conversation `user` scoping.
+_Avoid_: conflating with "user", "account"
+
+### Docs effort
+
+**Disposition table**:
+The triage artifact for an external docs audit: every finding classified as *already-fixed-in-repo* (→ ops handoff), *open* (→ fix now), or *rebutted* (audit wrong, with evidence).
+
+**Ops handoff**:
+Actions required to make merged docs true in public (tag releases, republish site, CDN purge, redirects) that cannot be done by editing this repo.

--- a/openwiki/INSTRUCTIONS.md
+++ b/openwiki/INSTRUCTIONS.md
@@ -1,0 +1,1 @@
+A code wiki for this repository.

--- a/openwiki/architecture/backends-and-querying.md
+++ b/openwiki/architecture/backends-and-querying.md
@@ -1,0 +1,141 @@
+---
+type: Reference
+title: Backends and safe Cypher querying
+description: Compare Bolt and NAMS capabilities, understand NAMS consistency behavior, and use the unified read-only Cypher interface safely.
+tags: [architecture, bolt, nams, cypher, security]
+---
+
+# Backends and safe Cypher querying
+
+The SDK has two storage backends. `backend="bolt"` connects directly to Neo4j through the Python driver. `backend="nams"` connects to the hosted Neo4j Agent Memory Service through HTTP. Both are accessed through `MemoryClient`, but they deliberately do not expose identical operational capabilities.
+
+## Capability matrix
+
+| Capability | Bolt | NAMS |
+| --- | --- | --- |
+| Conversations and messages | Yes | Yes, conversation-scoped |
+| Search messages | Yes, optionally session-scoped | Yes, requires a conversation `session_id` |
+| Create/list conversations | Yes | Yes; use `list_conversations`, not `list_sessions` |
+| Delete a single message | Yes | No |
+| Entities | Full POLE+O entity model and client-side resolution/deduplication | Entity endpoints; type mapping into NAMS-supported types |
+| Preferences, facts, relationship writes | Yes | No dedicated endpoint; protocol calls raise `NotSupportedError` |
+| Reasoning traces | Persisted traces, steps, tool calls, and queryable tool stats | Flat hosted steps/tool calls; synthetic traces are cached client-side |
+| Schema setup, graph adoption, raw graph export | Yes | No; schema is service-managed |
+| Buffered writes and consolidation hygiene | Yes | No; hosted writes commit through the service |
+| User-memory accessor | Yes | No; NAMS uses `userId` and API-key workspace scoping |
+| `client.eval` | Yes | Yes, using public protocol calls |
+| `client.query.cypher` | Yes, read-only | Yes, read-only |
+
+## NAMS operational behavior
+
+### Conversations, sessions, and extraction
+
+NAMS has conversations rather than a separate session resource. The SDK uses its `session_id` parameter as the NAMS conversation identifier; `conversation_id` is accepted as an alias for short-term methods. Create or retain a conversation identifier in the application and pass it consistently.
+
+NAMS entity extraction is asynchronous. A message write can succeed before extracted entities are searchable. `NamsLongTermMemory.wait_for_extraction()` avoids a fixed sleep:
+
+```python
+ready = await memory.long_term.wait_for_extraction(
+    session_id=conversation_id,
+    expected_names=["Lisbon"],
+    timeout=30.0,
+)
+if not ready:
+    # Retry later, return an in-progress response, or handle the timeout.
+    pass
+```
+
+With a `session_id`, the helper first polls that conversation's extraction status until no message has an in-progress status. If a query, expected names, or predicate is also supplied, it then confirms the entity search condition. Use `expected_names` or a predicate when verifying a particular extraction: a generic minimum-result count can be satisfied by pre-existing workspace entities.
+
+### Entity type adaptation
+
+The self-hosted default entity model is POLE+O: `PERSON`, `OBJECT`, `LOCATION`, `EVENT`, and `ORGANIZATION`. NAMS supports lowercase `person`, `organization`, `location`, `concept`, `tool`, and `custom`. The adapter maps `PERSON`, `ORGANIZATION`, and `LOCATION` directly, maps `OBJECT` and `EVENT` to `custom`, and returns types uppercase to present a consistent package model.
+
+NAMS creates entities with name, type, and optional description. Bolt-only entity inputs such as subtypes, aliases, attributes, explicit confidence, geocoding, enrichment, and local deduplication are not sent to the hosted entity endpoint.
+
+### Reasoning caveat
+
+NAMS records steps directly against a conversation and tool calls against a step. `start_trace()` creates a synthetic trace identifier in the local `NamsReasoningMemory` cache; later `add_step()` calls use that cached mapping to send hosted reasoning steps. The synthetic trace lifecycle is useful within the active client process, but it is not a first-class hosted Trace entity. Hosted trace retrieval is conversation-scoped.
+
+## Unified read-only Cypher
+
+Use `client.query.cypher()` for a custom inspection query that should work on either backend.
+
+```python
+rows = await memory.query.cypher(
+    "MATCH (e:Entity) WHERE e.type = $type RETURN e.name AS name LIMIT $limit",
+    {"type": "PERSON", "limit": 10},
+)
+```
+
+On Bolt, `BoltCypherQuery` forwards validated queries to `Neo4jClient.execute_read`. On the configured REST endpoint, `NamsCypherQuery` sends `{"cypher": query, "params": params}` to `POST /v1/query` and returns the response rows. NAMS also enforces read-only behavior server-side.
+
+```mermaid
+sequenceDiagram
+    participant App
+    participant Query as client.query.cypher
+    participant Guard as is_read_only_query
+    participant Backend
+    App->>Query: query and params
+    Query->>Guard: validate query text
+    Guard-->>Query: allowed or rejected
+    Query->>Backend: execute read or POST query
+    Backend-->>Query: result rows
+    Query-->>App: list of row dictionaries
+```
+
+This shows the shared client-side validation before the backend-specific read path.
+
+### What the guard rejects
+
+The shared `is_read_only_query()` validator uppercases the query and rejects text matching any of these write-capable patterns:
+
+- `CREATE`
+- `MERGE`
+- `DELETE` or `DETACH DELETE`
+- `SET`
+- `REMOVE`
+- `DROP`
+- `LOAD CSV`
+- `FOREACH`
+- `CALL {` subqueries
+- `IN TRANSACTIONS`
+
+Rejected `client.query.cypher()` calls raise `ValueError` before a backend round trip. The MCP `graph_query` tool returns an error payload for the same rejected text. Use the memory-layer write APIs instead of trying to issue a graph write through this accessor.
+
+The validation is a conservative keyword heuristic, not a complete Cypher parser. Ordinary read-only procedure calls such as `CALL db.index.vector.queryNodes(...)` and `CALL apoc...` are accepted because they are not a `CALL {` subquery. Treat accepted procedure calls as an authorization decision for the database and service configuration, not as proof of harmless behavior.
+
+## Backend-aware implementation pattern
+
+Use a common path for portable operations and explicitly branch for richer Bolt workflows:
+
+```python
+async with MemoryClient(settings) as memory:
+    await memory.short_term.add_message(
+        session_id=session_id,
+        role="user",
+        content=user_text,
+    )
+
+    entities = await memory.long_term.search_entities(user_text)
+
+    if not memory.is_nams:
+        await memory.long_term.add_preference(
+            category="communication_style",
+            preference="Prefers brief answers",
+        )
+```
+
+This prevents a hosted deployment from invoking an unsupported preferences endpoint. Do not rely on auto-selection in environments where a stray `MEMORY_API_KEY` could change the backend unexpectedly; pin `MemorySettings(backend="bolt", ...)` or `MemorySettings(backend="nams", ...)` for production deployments.
+
+## Source locations
+
+| Concern | Source |
+| --- | --- |
+| Backend selection and unsupported accessors | `src/neo4j_agent_memory/__init__.py` |
+| NAMS configuration and retry/connect controls | `src/neo4j_agent_memory/config/settings.py` |
+| NAMS conversations and extraction status | `src/neo4j_agent_memory/nams/short_term.py` |
+| NAMS entities and extraction waiting | `src/neo4j_agent_memory/nams/long_term.py` |
+| NAMS reasoning adaptation | `src/neo4j_agent_memory/nams/reasoning.py` |
+| Read-only validation and Bolt adapter | `src/neo4j_agent_memory/core/query.py` |
+| NAMS query adapter | `src/neo4j_agent_memory/nams/query.py` |

--- a/openwiki/architecture/overview.md
+++ b/openwiki/architecture/overview.md
@@ -1,0 +1,91 @@
+---
+type: Architecture
+title: Neo4j Agent Memory architecture
+description: How MemoryClient composes backend-neutral memory contracts with Bolt graph services or the hosted NAMS HTTP service.
+tags: [architecture, python, neo4j, nams, memory]
+---
+
+# Neo4j Agent Memory architecture
+
+The Python SDK is organized around a single `MemoryClient` facade and four backend-neutral contracts: `ShortTermProtocol`, `LongTermProtocol`, `ReasoningProtocol`, and `CypherQueryProtocol`. At connection time, the client chooses concrete implementations from `MemorySettings.backend` and exposes them through `short_term`, `long_term`, `reasoning`, and `query`.
+
+> **Scope:** this page describes the Python implementation under `src/neo4j_agent_memory/`. The repository also contains a separately released TypeScript SDK under `typescript/`.
+
+## Component map
+
+```mermaid
+flowchart TD
+    App["Application or framework"] --> Client["MemoryClient"]
+    Client --> ST["short_term"]
+    Client --> LT["long_term"]
+    Client --> RM["reasoning"]
+    Client --> CQ["query"]
+    Client --> Mode{"backend"}
+    Mode -->|"bolt"| Bolt["Neo4jClient and SchemaManager"]
+    Bolt --> DB["Neo4j database"]
+    Mode -->|"nams"| Nams["NamsBackend and HTTP transport"]
+    Nams --> Service["NAMS service"]
+    Client --> Support["Bolt client layers"]
+    Support --> Ext["embedding extraction resolution geocoding enrichment"]
+```
+
+This shows the facade, protocol accessors, and the two storage paths selected during connection.
+
+### Stable application surface
+
+| Surface | Purpose | Portability notes |
+| --- | --- | --- |
+| `MemoryClient` | Async lifecycle and access to memory stores | Use `async with` or explicitly `connect()` and `close()` |
+| `client.short_term` | Messages, conversations, retrieval, context | NAMS maps `session_id` to its conversation identifier |
+| `client.long_term` | Entities and Bolt declarative memory | NAMS implements entity operations only; preferences, facts, and relationship writes are unavailable |
+| `client.reasoning` | Traces, steps, and tool calls | NAMS adapts its flat conversation-scoped reasoning API into a synthetic trace lifecycle |
+| `client.query.cypher` | Safe custom graph inspection | Always read-only; returns `list[dict[str, Any]]` |
+| `MemoryIntegration` | Simplified application/MCP wrapper | Resolves session IDs and can trigger extraction/preference workflows |
+
+The `client.graph` accessor is Bolt-only. Its `execute_read` method emits a one-time `DeprecationWarning`; prefer the portable `client.query.cypher(query, params)` for read queries. Direct graph access remains the route for Bolt-specific operations that are intentionally outside the portable API.
+
+## Connection paths
+
+### Bolt
+
+The Bolt path creates a `Neo4jClient`, connects the Neo4j driver, constructs a `SchemaManager`, and calls `setup_all()`. It then initializes the client-side layers and wires `ShortTermMemory`, `LongTermMemory`, `ReasoningMemory`, `UserMemory`, `BufferedWriter`, `ConsolidationMemory`, `EvalMemory`, and `BoltCypherQuery`.
+
+The schema manager creates unique constraints for memory nodes and regular/vector/point indexes. Its managed vector indexes cover embeddings for messages, entities, preferences, facts, reasoning-trace tasks, and reasoning steps. Existing managed vector dimensions are checked against the configured embedding provider at connection time.
+
+### NAMS
+
+The NAMS path lazily imports the HTTP backend, opens an `NamsBackend` transport, and performs an authenticated probe by default (`nams.validate_on_connect=True`). It wires NAMS implementations of the three memory protocols plus `NamsCypherQuery`.
+
+Embedding, extraction, resolution, geocoding, and enrichment configuration are client-side Bolt layers. When present for NAMS, the client warns that those settings are ignored; the hosted service manages embedding, extraction, and resolution. The configured LLM provider remains available for client-side LLM workflows such as summarization.
+
+Bolt-only accessors on NAMS return an unsupported sentinel that raises `NotSupportedError` when used: `users`, `buffered`, `consolidation`, `schema`, and `graph`. `eval` is available on both paths because it calls public protocol surfaces.
+
+## Settings and provider resolution
+
+`MemorySettings` is a Pydantic settings model. It accepts direct construction, `NAM_`-prefixed environment variables with `__` nested delimiters, and a `.env` source. The settings model resolves `backend` as follows:
+
+1. It imports `MEMORY_API_KEY`, `MEMORY_ENDPOINT`, and `MEMORY_WORKSPACE_ID` into `nams` fields if those fields were not explicitly supplied.
+2. An explicit `backend="bolt"` or `backend="nams"` wins.
+3. Otherwise, a populated NAMS API key selects NAMS; absent one selects Bolt.
+
+`embedding` and `llm` accept a provider-string shorthand or a provider object. `from_provider` uses native-first dispatch for OpenAI, Anthropic, and Bedrock LLMs and for OpenAI, Vertex AI, Bedrock, and sentence-transformers embeddings. If a matching native adapter is not available, it uses LiteLLM when installed. The older `EmbeddingConfig` and `LLMConfig` forms remain supported but warn when explicitly passed.
+
+## Design implications
+
+- **Prefer protocol methods for portable code.** They are the intentional common denominator between storage backends.
+- **Treat backend-specific capabilities as branches.** Check `client.is_nams` or `client.backend` before selecting a workflow that needs raw graph writes, schema management, preferences, facts, or buffered writes.
+- **Keep lifecycle ownership clear.** `MemoryIntegration(client=...)` does not close a supplied client. Without a client, it creates and owns a Bolt client from connection parameters.
+- **Use explicit cleanup.** Closing a Bolt client drains buffered work before it closes the driver; closing a NAMS client closes its HTTP transport.
+
+For the feature-by-feature decision table and read-only Cypher rules, see [Backends and querying](backends-and-querying.md). For the actual graph model, see [Memory model and operations](../memory/model-and-operations.md).
+
+## Source locations
+
+| Area | Primary implementation |
+| --- | --- |
+| Facade, backend selection, lifecycle | `src/neo4j_agent_memory/__init__.py` |
+| Settings and environment resolution | `src/neo4j_agent_memory/config/settings.py` |
+| Shared backend contracts | `src/neo4j_agent_memory/core/protocols.py` |
+| Bolt driver and schema management | `src/neo4j_agent_memory/graph/client.py`, `src/neo4j_agent_memory/graph/schema.py` |
+| Hosted backend and HTTP transport | `src/neo4j_agent_memory/nams/` |
+| Provider factory and runtime contracts | `src/neo4j_agent_memory/llm/factory.py`, `src/neo4j_agent_memory/llm/protocol.py` |

--- a/openwiki/development/contributor-workflow.md
+++ b/openwiki/development/contributor-workflow.md
@@ -1,0 +1,182 @@
+---
+type: Contributor Guide
+title: Development environment and verification workflow
+description: Set up the Python and TypeScript workspaces, select the narrowest useful validation, and understand the repository CI and release checks.
+tags: [development, testing, ci, python, typescript]
+---
+
+# Development environment and verification workflow
+
+This repository contains two independently released SDKs that share a memory model and NAMS service but have separate workspaces and toolchains:
+
+| Workspace | Package | Primary source | Package manager | Runtime baseline |
+| --- | --- | --- | --- | --- |
+| Python | `neo4j-agent-memory` | `src/neo4j_agent_memory/` | `uv` | Python 3.10+ |
+| TypeScript | `@neo4j-labs/agent-memory` | `typescript/src/` | `npm` | Node.js 20+ |
+
+Treat a change as belonging to one or both workspaces. Root `make` targets drive the Python workspace and provide convenience wrappers for the TypeScript workspace; the TypeScript `package.json` remains the authoritative definition of its own scripts.
+
+## First-time setup
+
+### Python SDK
+
+Install the development dependency group for ordinary Python work:
+
+```bash
+uv sync --group dev
+```
+
+Run this broader installation before changing typed Python code in `src/`, `benchmarks/`, top-level `examples/*.py`, or an optional framework integration:
+
+```bash
+uv sync --all-extras --group dev
+```
+
+Both `mypy` and `ty` inspect that surface in CI. Installing all extras makes framework types available to the checkers rather than relying on absent or shallow imports.
+
+`make install` runs `uv sync` and installs only core dependencies. `make install-dev` runs `uv sync --extra dev`; for the complete type-checking surface, use the explicit command above.
+
+### TypeScript SDK
+
+```bash
+cd typescript
+npm ci
+```
+
+`npm ci` uses `typescript/package-lock.json` for reproducible dependencies. The TypeScript package is built with `tsup` into `typescript/dist/`; its Node engine requirement is `>=20.0.0`.
+
+### Database-backed work
+
+Bolt integration tests and most complete example smoke tests need Docker. The repository's Compose service uses Neo4j `5.26-community`, exposes HTTP on `7474` and Bolt on `7687`, enables APOC, and keeps test data in named volumes.
+
+```bash
+make neo4j-start
+make neo4j-wait
+# work or test
+make neo4j-stop
+# remove the test volumes only when a clean database is intended
+make neo4j-clean
+```
+
+Alternatively, `make test-integration` uses testcontainers and asks Docker to provision Neo4j. `make test-docker` and `make test-ci` use `docker-compose.test.yml` with its configured test credentials. Do not use those test settings for a shared or production database.
+
+## Fast feedback and full validation
+
+### Python commands
+
+| Intent | Command | Scope and external requirements |
+| --- | --- | --- |
+| Format source and tests | `make format` | Modifies files with Ruff |
+| Check lint and formatting | `make lint` then `make format-check` | `src` and `tests`; no database |
+| Run strict static analysis | `make typecheck` and `make ty` | `src`, `benchmarks`, and `examples/*.py`; install all extras first |
+| Run all Python quality checks | `make check` | Lint, format check, mypy, and ty |
+| Run unit tests | `make test-unit` | `tests/unit`; no Docker required |
+| Stop at first unit-test failure | `make test-quick` | Unit tests with concise traceback |
+| Run one file | `make test-file FILE=tests/unit/test_config.py` | Any pytest target file |
+| Filter by test name | `make test-match PATTERN="test_add_message"` | Searches `tests` |
+| Run Bolt integration tests | `make test-integration` | Docker and testcontainers |
+| Run MCP integration and end-to-end tests | `make test-integration-mcp` | Docker and testcontainers |
+| Run all Python tests | `make test-all` | Docker and testcontainers |
+| Run tests without integration tests | `make test-no-docker` | Sets `SKIP_INTEGRATION_TESTS=1` |
+| Check documentation | `make test-docs` | Snippet syntax, links, and build-oriented checks |
+
+`make pre-commit` runs formatting, linting, both type checkers, and unit tests. `make ci` adds the full test suite, so it requires Docker; `make ci-no-docker` is the corresponding quality plus unit-test check.
+
+### TypeScript commands
+
+Use the root wrappers or run the equivalent `npm` script from `typescript/`:
+
+| Intent | Root command | Direct command | Notes |
+| --- | --- | --- | --- |
+| Install dependencies | `make ts-install` | `npm ci` | Uses the TypeScript lockfile |
+| Type check | `make ts-lint` | `npm run lint` | Runs `tsc --noEmit` |
+| Run unit tests | `make ts-test-unit` | `npm run test:unit` | Vitest unit suite |
+| Run unit plus integration tests | `make ts-test` | `npm test` | Vitest `test/unit` and `test/integration` |
+| Build package | `make ts-build` | `npm run build` | Validates version sync, then runs `tsup` |
+| Inspect npm package contents | `make ts-pack` | `npm pack --dry-run` | Does not publish |
+| Type check all shipped examples | `make ts-test-examples` | See Makefile loop | Builds first, then checks five example projects |
+| Run local TCK bridge | `make ts-conformance` | `npm run conformance:server` | Default `TCK_BRIDGE_PORT` is `3001` |
+
+The TypeScript `test:e2e` and `test:tck` scripts exist but are not part of the ordinary `npm test` command. Hosted end-to-end tests require an authorized NAMS key and are separately automated in `.github/workflows/e2e-typescript.yml`.
+
+## Select validation by change
+
+```mermaid
+flowchart TD
+    Change["Make a change"] --> Area{"Changed workspace"}
+    Area -->|"Python"| PyFast["Run focused pytest and Ruff checks"]
+    Area -->|"TypeScript"| TsFast["Run focused Vitest and tsc checks"]
+    Area -->|"Both"| Both["Validate each workspace"]
+    PyFast --> PyDb{"Uses Bolt or Docker integration"}
+    PyDb -->|"Yes"| PyInt["Run integration or example smoke tests"]
+    PyDb -->|"No"| PyDone["Run relevant unit coverage"]
+    TsFast --> TsBuild["Run npm run build"]
+    Both --> Full["Run relevant commands from both branches"]
+    PyInt --> Full
+    PyDone --> Full
+    TsBuild --> Full
+```
+
+This decision flow starts with targeted validation and adds infrastructure-dependent checks only when the changed behavior needs them.
+
+Examples:
+
+- A query-template or configuration change normally merits its targeted `tests/unit` file, then `make test-unit` if practical.
+- A Bolt graph or MCP server change needs an integration or end-to-end MCP check in addition to unit tests.
+- A TypeScript public API or export change needs `npm run lint`, unit tests, `npm run build`, and the affected example type checks.
+- A change to published documentation should include the relevant `make test-docs-*` target; a documentation build needs Node dependencies under `docs/`.
+
+## CI topology
+
+### Python CI
+
+`.github/workflows/ci-python.yml` runs on pushes and pull requests to `main` when Python sources, tests, examples, documentation, build configuration, or the workflow itself changes. It includes:
+
+- Ruff lint and format checks on Python 3.12;
+- strict mypy and `ty` checks on Python 3.12 with all extras installed;
+- unit tests on Python 3.10, 3.11, 3.12, and 3.13, with coverage recorded from 3.12;
+- Bolt integration tests on a GitHub Actions Neo4j service, followed by the other Python-version matrix;
+- complete and quick example smoke-test jobs;
+- documentation syntax, link, and build-pipeline tests using Node 20; and
+- an `uv build` packaging job.
+
+The workflow also combines unit and integration coverage and emits a warning if the merged report is below 55 percent; the threshold step is intentionally non-blocking.
+
+### Hosted-service checks
+
+Python NAMS integration tests live in `tests/integration/nams/` and have a dedicated workflow, `.github/workflows/nams-integration.yml`. It runs smoke and lifecycle tests first, reports TCK tiers and error paths independently, then runs a consolidated suite that controls the final status. The workflow skips cleanly if its NAMS secret is unavailable, but it requires an appropriate workspace configuration when the selected deployment is workspace-scoped.
+
+TypeScript hosted-service end-to-end tests are in `typescript/test/e2e/`. `.github/workflows/e2e-typescript.yml` skips them when `MEMORY_API_KEY` is unavailable; otherwise it builds the SDK and runs the hosted-service and Strands suites against the configured endpoint.
+
+### TypeScript CI
+
+`.github/workflows/ci-typescript.yml` tests Node 20 and 22. For each runtime it runs `npm ci`, `npm run lint`, unit tests, integration tests, the package build, and `npm pack --dry-run`. A follow-on matrix builds the SDK and type-checks the LangChain, Mastra, MCP, Strands, and Vercel AI example projects. The workflow also validates the separate Vercel AI provider package under `typescript/packages/vercel-ai-provider/`.
+
+## Contribution and release constraints
+
+The Python checker configuration is strict. Prefer precise types, `TYPE_CHECKING` imports, and protocol or generic types at framework boundaries. A `# type: ignore` must include a specific diagnostic code and a reason; do not use a bare ignore to conceal a new incompatibility.
+
+Documentation follows the Diataxis distinction described in `CONTRIBUTING.md`: tutorials teach, how-to guides accomplish a task, references look up a surface, and explanations describe design. Public API changes should update references; user-facing workflows should have a how-to; architectural changes should have an explanation.
+
+The packages release independently:
+
+| Package | Version source | Required tag prefix | Publish destination |
+| --- | --- | --- | --- |
+| `neo4j-agent-memory` | root `pyproject.toml` | `python-v*` | PyPI |
+| `@neo4j-labs/agent-memory` | `typescript/package.json` and `typescript/CHANGELOG.md` | `typescript-v*` | npm |
+
+Plain `v*` tags do not invoke the publish workflows. Use the package-specific tags only after the package version and, for TypeScript, its changelog are updated.
+
+## Important paths
+
+| Concern | Location |
+| --- | --- |
+| Python package metadata and quality configuration | `pyproject.toml` |
+| Root task entry points | `Makefile` |
+| Python CI | `.github/workflows/ci-python.yml` |
+| NAMS live integration CI | `.github/workflows/nams-integration.yml` |
+| TypeScript scripts and exports | `typescript/package.json` |
+| TypeScript CI | `.github/workflows/ci-typescript.yml` |
+| TypeScript hosted end-to-end CI | `.github/workflows/e2e-typescript.yml` |
+| Contribution conventions | `CONTRIBUTING.md` |
+| NAMS test-suite runbook | `tests/integration/nams/README.md` |

--- a/openwiki/examples-guide.md
+++ b/openwiki/examples-guide.md
@@ -1,0 +1,114 @@
+---
+type: Example Guide
+title: Choosing, running, and validating examples
+description: Select a Neo4j Agent Memory example by backend and use case, configure only non-sensitive settings, and understand how example smoke tests prevent API drift.
+tags: [examples, getting-started, python, typescript, nams]
+---
+
+# Choosing, running, and validating examples
+
+The repository's `examples/` directory is a set of runnable Python demonstrations, from small scripts to full-stack and multi-agent applications. `typescript/examples/` contains independently installable examples for the NAMS-focused TypeScript SDK. Examples are useful reference implementations, but their credentials and infrastructure requirements vary; choose the smallest example that proves the behavior you need.
+
+## Choose by goal
+
+| Goal | Recommended example | Backend and major requirements |
+| --- | --- | --- |
+| Start with hosted NAMS and no Neo4j | `examples/nams-quickstart/` | NAMS API key; hosted extraction and embeddings |
+| Put NAMS memory in a FastAPI service | `examples/nams-fastapi/` | NAMS API key |
+| Use NAMS with a LangChain agent | `examples/nams-langchain/` | NAMS API key and LangChain dependencies |
+| Learn the three Python memory domains | `examples/basic_usage.py` | Bolt Neo4j and a configured embedding/LLM route |
+| Test entity matching without a database | `examples/entity_resolution.py` | No Neo4j required |
+| Enrich entities | `examples/enrichment_example.py` | Neo4j; optional external provider setup for some enrichment |
+| Run without an LLM | `examples/no_llm/` | Local sentence-transformers, spaCy, and GLiNER configuration |
+| Use a pre-existing Neo4j graph | `examples/existing-graph/` | Bolt Neo4j |
+| Keep response latency off the Bolt write path | `examples/buffered-writes/` | Bolt Neo4j |
+| Create reasoning audit edges and evaluate quality | `examples/audit-trail/` and `examples/eval-harness/` | Bolt Neo4j |
+| Tailor extraction schemas | `examples/domain-schemas/` | GLiNER dependencies; Neo4j is optional for some flows |
+| Integrate a framework | `examples/langchain_agent.py`, `examples/pydantic_ai_agent.py`, `examples/google_adk_demo/`, `examples/google_cloud_integration/` | Framework-specific extras and configuration |
+| Study a full-stack reference application | `examples/full-stack-chat-agent/` or `examples/lennys-memory/` | Neo4j, Node.js, and application-specific configuration |
+| Study a multi-agent compliance workflow | `examples/financial-services-advisor/` | Neo4j Aura plus cloud/framework requirements |
+| Use the TypeScript SDK | `typescript/examples/` | Node.js 20+ and NAMS API key |
+
+The Python `examples/README.md` is the canonical detailed index. It also identifies full-stack applications and describes their separate requirements.
+
+## Backend decision
+
+```mermaid
+flowchart TD
+    Goal["Choose an example"] --> Hosted{"Want hosted NAMS only"}
+    Hosted -->|"Yes"| Nams["Use nams-quickstart or NAMS framework examples"]
+    Hosted -->|"No"| NeedBolt{"Need graph control or Bolt-only feature"}
+    NeedBolt -->|"Yes"| Bolt["Use a Bolt-backed example"]
+    NeedBolt -->|"No"| Small["Start with the smallest focused script"]
+    Bolt --> Feature{"Feature area"}
+    Feature -->|"Existing graph"| Existing["existing-graph"]
+    Feature -->|"Buffered writes"| Buffer["buffered-writes"]
+    Feature -->|"Audit or evaluation"| Audit["audit-trail or eval-harness"]
+    Small --> Resolution["entity_resolution or basic_usage"]
+```
+
+This decision flow distinguishes the managed NAMS examples from examples that rely on direct Neo4j features unavailable on the hosted backend.
+
+For a capability comparison, see [Backends and safe Cypher querying](architecture/backends-and-querying.md). NAMS has no product tiers; Bronze, Silver, Gold, and Platinum are conformance tiers used by the cross-language TCK, not service plans.
+
+## Run Python examples safely
+
+The usual entry point is `uv run python`:
+
+```bash
+uv run python examples/entity_resolution.py
+uv run python examples/nams-quickstart/main.py
+```
+
+Some root Makefile shortcuts load `examples/.env` when present and otherwise start the repository's test Docker Neo4j container for the selected Bolt example:
+
+```bash
+make example-resolution
+make example-basic
+make example-langchain
+make example-pydantic
+```
+
+The example environment template is `examples/.env.example`. Create your local copy and populate it through your local secret-management practice; do not commit it. For an existing Neo4j instance, configure its URI and authentication in that local configuration. Hosted NAMS examples need `MEMORY_API_KEY`; the backend auto-selects NAMS when the key is available unless the example explicitly pins backend selection.
+
+Examples are async-first: use `asyncio.run(...)` in a script and `await` in an existing asynchronous environment. `async with MemoryClient(settings)` is the standard lifecycle. `add_entity()` returns `(entity, deduplication_result)`, not a single entity.
+
+## TypeScript examples
+
+The five TypeScript examples are under `typescript/examples/`:
+
+| Directory | Shows |
+| --- | --- |
+| `vercel-ai/` | Vercel AI SDK memory middleware |
+| `mcp/` | A self-hosted stdio MCP wrapper around the 12 NAMS memory tools |
+| `langchain/` | Chat history and entity retriever shapes for LangChain JS |
+| `mastra/` | A Mastra-compatible memory provider |
+| `strands/` | AWS Strands session persistence, three-tier context, and reasoning capture |
+
+Each project uses an in-tree `file:../..` dependency during repository development. To adapt one to a separate application, replace that local dependency with a published `@neo4j-labs/agent-memory` version. Install dependencies within the selected example and provide `MEMORY_API_KEY` locally before running it.
+
+The TypeScript MCP example is not the Python command-line FastMCP server. It has 12 tools shaped for the hosted service, while the Python server supports separate core and extended profiles. See [MCP server](integrations/mcp-server.md) for the Python server and [TypeScript SDK for the hosted memory service](typescript-sdk.md) for TypeScript MCP behavior.
+
+## Example validation in CI
+
+Examples are protected against API drift in two ways:
+
+| Check | Command | What it proves |
+| --- | --- | --- |
+| Quick Python examples | `make test-examples-quick` | Structure/import/API validation for selected examples, without Neo4j |
+| Complete Python examples | `make test-examples` | Smoke tests under `tests/examples`, with Docker/testcontainers available |
+| Individual example no-DB subset | `make test-examples-no-neo4j` | Entity resolution and full-stack application structural checks |
+| TypeScript example type matrix | `make ts-test-examples` | Builds the SDK and runs `tsc --noEmit` in each of the five TypeScript examples |
+
+Python CI runs a quick example job and a complete Neo4j-backed example job. TypeScript CI builds `typescript/dist/`, installs each example without a package lock, and type-checks it. Passing a type check does not run a hosted example against NAMS; that still requires credentials and a deployed service.
+
+## Source map
+
+| Topic | Location |
+| --- | --- |
+| Full Python example index | `examples/README.md` |
+| Python example tests | `tests/examples/` |
+| Example task shortcuts | `Makefile` |
+| TypeScript example index | `typescript/examples/README.md` |
+| TypeScript example CI | `.github/workflows/ci-typescript.yml` |
+| Python example CI | `.github/workflows/ci-python.yml` |

--- a/openwiki/integrations/framework-adapters.md
+++ b/openwiki/integrations/framework-adapters.md
@@ -1,0 +1,144 @@
+---
+type: Integration Reference
+title: Python framework adapters and async boundaries
+description: Map Python framework integrations to their public surfaces, optional dependencies, backend constraints, and safe lifecycle patterns around MemoryClient.
+tags: [integrations, python, frameworks, async, memory]
+---
+
+# Python framework adapters and async boundaries
+
+The Python package integrates the three memory domains into framework-specific abstractions. The common architectural rule is that an integration consumes a connected `MemoryClient`; the application retains responsibility for creating and closing that client unless a particular constructor explicitly owns one. All memory APIs remain asynchronous even where an adapter offers a synchronous framework-facing method.
+
+```mermaid
+flowchart TD
+    App["Application owns MemoryClient lifecycle"] --> Client["Connected MemoryClient"]
+    Client --> ST["short_term"]
+    Client --> LT["long_term"]
+    Client --> RM["reasoning"]
+    Framework["Agent framework callback"] --> Adapter["Framework adapter"]
+    Adapter --> Client
+    ST --> Store["Configured backend"]
+    LT --> Store
+    RM --> Store
+```
+
+This shows the normal ownership boundary: adapters shape calls for a framework, while the configured client remains the gateway to memory operations.
+
+## Install optional integrations deliberately
+
+The root package does not install every framework SDK. Install the matching extra before importing the associated adapter:
+
+| Framework | Package extra | Main Python import | Primary role |
+| --- | --- | --- | --- |
+| LangChain | `[langchain]` | `neo4j_agent_memory.integrations.langchain` | Memory variables and entity retrieval |
+| Pydantic AI | `[pydantic-ai]` | `neo4j_agent_memory.integrations.pydantic_ai` | Dependency object, memory tools, trace capture |
+| Google ADK | `[google-adk]` | `neo4j_agent_memory.integrations.google_adk` | ADK memory service |
+| AWS Strands | `[strands]` | `neo4j_agent_memory.integrations.strands` | Context-graph tools and session manager |
+| CrewAI | `[crewai]` | `neo4j_agent_memory.integrations.crewai` | Crew memory interface |
+| LlamaIndex | `[llamaindex]` | `neo4j_agent_memory.integrations.llamaindex` | LlamaIndex `BaseMemory` implementation |
+| OpenAI Agents | `[openai-agents]` | `neo4j_agent_memory.integrations.openai_agents` | Context, function tools, and agent trace recording |
+| Microsoft Agent Framework | `[microsoft-agent]` | `neo4j_agent_memory.integrations.microsoft_agent` | Context provider, chat store, tools, and tracing |
+| AWS Bedrock AgentCore | no declared package extra | `neo4j_agent_memory.integrations.agentcore` | Context-graph-backed memory provider |
+
+Framework imports are commonly guarded so the package can be installed without all framework dependencies. A missing optional framework can therefore limit the symbols exported by that integration module rather than affecting core `MemoryClient` use. Test an integration in an environment that includes both its extra and the provider/backend extras it requires.
+
+## What each adapter provides
+
+### LangChain
+
+`Neo4jAgentMemory` provides LangChain-style synchronous `load_memory_variables`, `save_context`, and `clear` methods backed by an asynchronous client. Depending on its `include_short_term`, `include_long_term`, and `include_reasoning` flags, it supplies:
+
+- conversation history;
+- long-term context and preferences; and
+- similar past reasoning tasks.
+
+It supports configurable message, preference, and trace limits. `Neo4jMemoryRetriever`, when `langchain_core` is available, provides a retriever surface. `llm_provider_from_langchain()` adapts an already-configured LangChain model to the package `LLMProvider` contract.
+
+### Pydantic AI
+
+`MemoryDependency` is a natural `deps_type` value. It exposes async `get_context`, `save_interaction`, `add_preference`, and `search_preferences` functions for a specified session. `create_memory_tools(client)` produces agent-callable memory tools for multi-domain search, saving a preference, and recalling preferences. `record_agent_trace()` translates a completed Pydantic AI run into a reasoning trace and can record its tool calls.
+
+`nams_memory_tools` is also exported by the integration for hosted use. Since preferences are unsupported on NAMS through the portable Python protocol, keep tools that write or search preferences on the Bolt path and choose backend-aware tool sets in hosted deployments.
+
+### Google ADK
+
+`Neo4jMemoryService` adapts a connected client as an ADK memory service. `llm_provider_from_google_adk()` accepts an ADK/Gemini model: a bare string is resolved through the `vertex_ai/` provider prefix, while an object is inspected by the shared pass-through adapter. The `examples/google_adk_demo/` and `examples/google_cloud_integration/` directories provide runnable reference configurations.
+
+### AWS Strands
+
+`context_graph_tools()` builds tools for the self-hosted/Bolt path. `nams_context_graph_tools()` is the hosted counterpart. The integration also exports `StrandsConfig`, Bedrock model constants, `Neo4jSessionManager`, and `Neo4jRetrievalConfig`.
+
+The synchronous Strands session manager uses the shared `AsyncBridge`: it maintains one background event loop for a long-lived client, rather than starting a fresh event loop for each callback. Flush and close the manager according to its lifecycle so work completes before its bridge stops. Use `llm_provider_from_strands()` to turn a bare Strands Bedrock model ID into a `bedrock/` provider string or adapt a framework object.
+
+### CrewAI and LlamaIndex
+
+`Neo4jCrewMemory` implements CrewAI's memory methods. It can store a short-term message, a fact, or a preference based on metadata and retrieves messages, entities, and preferences for a query. That fact/preference behavior requires the Bolt backend.
+
+`Neo4jLlamaIndexMemory` implements LlamaIndex `BaseMemory`, including synchronous and asynchronous methods. It converts memory records back to `ChatMessage` objects and preserves serializable message metadata. When reconstructing tool calls, it removes incomplete assistant tool-call/tool-response pairs so downstream model APIs do not receive invalid conversation history. It can add semantic short-term results and long-term entities as system context to its session history.
+
+### OpenAI Agents and Microsoft Agent Framework
+
+`Neo4jOpenAIMemory` supplies session-based context; `create_memory_tools()` provides functions for an OpenAI Agents workflow; and `record_agent_trace()` writes a reasoning trace from agent messages.
+
+The Microsoft integration has more components:
+
+| Export | Role |
+| --- | --- |
+| `Neo4jContextProvider` | Injects graph-enhanced memory context into an agent |
+| `Neo4jChatMessageStore` | Persists chat history for a session |
+| `Neo4jMicrosoftMemory` | Combines the integration around a `MemoryClient` |
+| `create_memory_tools` and `execute_memory_tool` | Tool definitions and dispatch |
+| `record_agent_trace`, `get_similar_traces`, `format_traces_for_prompt` | Reasoning capture and retrieval |
+| `GDSConfig`, `GDSAlgorithm`, `GDSIntegration` | Graph Data Science integration configuration |
+
+The Microsoft adapter targets Microsoft Agent Framework version `1.0.0b260212`, which is also the minimum version stated by its module.
+
+### AWS Bedrock AgentCore
+
+`Neo4jMemoryProvider` is an asynchronous provider that maps a memory type to the appropriate client domain:
+
+| `memory_type` | Write destination |
+| --- | --- |
+| `message` | `short_term.add_message` with optional extraction and embeddings |
+| `preference` | `long_term.add_preference` |
+| `fact` | `long_term.add_fact` |
+
+It adds its configured `namespace` to message metadata and supports a hybrid query across messages, entities, and preferences. As implemented, it reaches the connected underlying Neo4j client and uses preference/fact APIs, so it is a Bolt-oriented integration rather than a portable NAMS abstraction. `HybridMemoryProvider` and `RoutingStrategy` are exported for AgentCore routing scenarios.
+
+## LLM-provider pass-through helpers
+
+Several integrations export `llm_provider_from_<framework>()`. These helpers let memory configuration reuse a model already configured for the host framework instead of duplicating provider setup. They inspect known model names or attributes, then construct an `LLMProvider` through the shared pass-through machinery.
+
+| Helper | Special handling |
+| --- | --- |
+| `llm_provider_from_langchain` | Uses LangChain model metadata and class naming to identify provider/model |
+| `llm_provider_from_pydantic_ai` | Uses the Pydantic AI model name and class naming |
+| `llm_provider_from_google_adk` | Bare strings become `vertex_ai/<model>` |
+| `llm_provider_from_strands` | Bare strings become `bedrock/<model>` |
+| `llm_provider_from_crewai` | Reads the CrewAI/LiteLLM model configuration |
+| `llm_provider_from_llamaindex` | Reads LlamaIndex LLM metadata |
+| `llm_provider_from_openai_agents` | Bare strings become `openai/<model>` |
+| `llm_provider_from_microsoft_agent` | Reads underlying Azure OpenAI or OpenAI client metadata |
+
+Provider resolution is a Bolt-side client feature. NAMS performs extraction and embeddings server-side and warns when those client-side layer settings are supplied. See [Backends and safe Cypher querying](../architecture/backends-and-querying.md) before choosing a hosted workflow.
+
+## Async and session rules
+
+1. **Create one client per application lifecycle.** Prefer `async with MemoryClient(settings) as client:` for an async application. When a framework asks for an adapter, pass that active client into it.
+2. **Avoid closing a client that an adapter did not create.** In particular, `MemoryIntegration(client=...)` does not own the supplied client.
+3. **Use a stable application session or conversation ID.** Framework wrappers use it to locate conversation history and associate reasoning; do not generate a new identifier on every turn unless each turn really is isolated.
+4. **Do not assume all integration methods are portable.** Adapters that call preferences, facts, raw graph, Graph Data Science, client-side extraction, or direct Neo4j access require Bolt. Branch on `client.is_nams`/`client.backend` or choose a NAMS-specific adapter before calling them.
+5. **Treat framework bridges as blocking adapters.** Synchronous callbacks can wait on asynchronous I/O. Do not call a framework's synchronous interface from a latency-critical path without understanding its event-loop and timeout behavior.
+
+## Examples and source map
+
+| Need | Reference |
+| --- | --- |
+| LangChain agent | `examples/langchain_agent.py` |
+| Pydantic AI agent | `examples/pydantic_ai_agent.py` |
+| Google ADK service | `examples/google_adk_demo/` and `examples/google_cloud_integration/` |
+| Microsoft Agent retail application | `examples/microsoft_agent_retail_assistant/` |
+| AWS Strands workflow | `examples/financial-services-advisor/` and `examples/strands-session-manager/` |
+| Framework adapter source | `src/neo4j_agent_memory/integrations/` |
+| Shared sync/async bridge | `src/neo4j_agent_memory/integrations/base.py` |
+| Backend capability limits | [Backends and safe Cypher querying](../architecture/backends-and-querying.md) |

--- a/openwiki/integrations/mcp-server.md
+++ b/openwiki/integrations/mcp-server.md
@@ -1,0 +1,180 @@
+---
+type: Integration Guide
+title: Model Context Protocol server
+description: Configure the FastMCP integration, select a tool profile and transport, and understand the tools, resources, prompts, and hosted extensions it exposes.
+tags: [mcp, integration, ai-agents, fastmcp, neo4j]
+---
+
+# Model Context Protocol server
+
+The optional MCP integration exposes Neo4j Agent Memory to MCP-compatible hosts through FastMCP. It provides tools for memory reads and writes, resources for injectable context, and prompts that guide memory-aware workflows.
+
+Install the optional dependency first:
+
+```bash
+pip install "neo4j-agent-memory[mcp]"
+```
+
+## Run the server
+
+The CLI entry point is `neo4j-agent-memory mcp serve`.
+
+```bash
+# Local MCP host using stdio and a self-hosted Bolt database
+neo4j-agent-memory mcp serve --transport stdio --password "$NEO4J_PASSWORD"
+
+# Network deployment using SSE
+neo4j-agent-memory mcp serve \
+  --transport sse \
+  --host 127.0.0.1 \
+  --port 8080 \
+  --password "$NEO4J_PASSWORD"
+
+# Hosted backend using an environment-provided NAMS key
+neo4j-agent-memory mcp serve --backend nams --transport stdio
+```
+
+The CLI accepts `stdio`, `sse`, and `http` transports. `stdio` is the default and is the normal choice for a local desktop or coding-agent host. For a network transport, bind deliberately: the default host is `127.0.0.1`, while `0.0.0.0` exposes the server on all interfaces.
+
+The CLI resolves a backend from `--backend` or `NAM_BACKEND`. Without an explicit setting, it selects NAMS when an API key is provided and Bolt otherwise. A Bolt server requires a Neo4j password; a NAMS server requires `MEMORY_API_KEY` or `--api-key`. Keep credentials in the host environment or its secret storage rather than an MCP configuration file committed to source control.
+
+Useful configuration options:
+
+| Option | Default | Meaning |
+| --- | --- | --- |
+| `--profile` | `extended` | Choose `core` or `extended` tools/resources/prompts |
+| `--session-strategy` | `per_conversation` | `per_conversation`, `per_day`, or `persistent` session resolution |
+| `--user-id` | unset | User identity used by `per_day` and `persistent` strategies |
+| `--observation-threshold` | `30000` | Approximate token threshold for observer-driven compression |
+| `--no-auto-preferences` | off | Disables background preference detection for user messages |
+| `--llm` / `--embedding` | unset | Provider strings passed through the provider factory |
+| `--embedding-dimensions` | unset | Override dimensions for an embedding model missing from defaults |
+
+## Server lifecycle
+
+`create_mcp_server(settings, ...)` is the preferred programmatic factory. It opens a `MemoryClient` inside FastMCP's lifespan, creates a `MemoryIntegration`, and attaches a `MemoryObserver`. `Neo4jMemoryMCPServer` remains as a wrapper for callers that already own a connected client.
+
+```mermaid
+sequenceDiagram
+    participant Host as MCP host
+    participant Server as FastMCP server
+    participant Client as MemoryClient
+    participant Int as MemoryIntegration
+    participant Store as Selected backend
+    Host->>Server: initialize
+    Server->>Client: open lifespan
+    Client->>Store: connect
+    Server->>Int: create with session strategy
+    Host->>Server: invoke memory tool
+    Server->>Int: delegate high-level operation
+    Int->>Client: call memory accessor
+    Client->>Store: read or write
+    Store-->>Host: tool result through server
+    Host->>Server: shutdown
+    Server->>Client: close lifespan
+```
+
+This shows how FastMCP owns a configured client for the lifetime of a server created by `create_mcp_server`.
+
+`memory_store_message` delegates to `MemoryIntegration.store_message`. With its default settings, it stores the message with entity extraction enabled, starts background preference detection for user messages, and notifies the observer in a background task. Those background follow-ups log errors rather than failing the tool response.
+
+## Profiles and tools
+
+The `core` profile contains six essential tools:
+
+| Tool | Operation |
+| --- | --- |
+| `memory_search` | Search messages, entities, preferences, and optionally traces |
+| `memory_get_context` | Return assembled short-term, long-term, and reasoning context |
+| `memory_store_message` | Store a conversation message |
+| `memory_add_entity` | Add or update an entity through the integration layer |
+| `memory_add_preference` | Store a categorized user preference |
+| `memory_add_fact` | Store a temporal subject-predicate-object fact |
+
+`extended` adds the following ten tools, for sixteen tools total:
+
+| Tool | Operation |
+| --- | --- |
+| `memory_get_conversation` | Return chronological messages for one session |
+| `memory_list_sessions` | List session previews with pagination |
+| `memory_get_entity` | Find an entity and optionally traverse up to three graph hops |
+| `memory_export_graph` | Export nodes and relationships for visualization |
+| `memory_create_relationship` | Resolve two entities by name and create a typed relationship |
+| `memory_start_trace` | Begin a reasoning trace for a task |
+| `memory_record_step` | Add thought/action/observation and optional tool-call data |
+| `memory_complete_trace` | Record trace outcome and success |
+| `memory_get_observations` | Return observer reflections, observations, and session statistics |
+| `graph_query` | Run a read-only custom Cypher query |
+
+Tools are annotated as read-only or write operations for hosts that use MCP tool annotations. The server registers the same broad profiles for both backends, but a tool that calls a Bolt-only method can return an error on NAMS. In particular, NAMS does not implement first-class preferences, facts, relationship writes, session listings, or the Bolt graph export. Select NAMS-specific entity and conversation workflows when targeting the hosted backend.
+
+When the profile is `extended` **and** the configured backend is NAMS, the server also registers four hosted Platinum tools:
+
+- `memory_set_entity_feedback`
+- `memory_get_entity_history`
+- `memory_get_entity_provenance`
+- `memory_get_reflections`
+
+## Safe graph inspection
+
+`graph_query` calls the shared `is_read_only_query()` guard and then `client.query.cypher()`. It allows `MATCH`/`RETURN` queries and regular read-only procedure calls, but rejects text that includes write-capable patterns such as `CREATE`, `MERGE`, `DELETE`, `SET`, `REMOVE`, `DROP`, `LOAD CSV`, `FOREACH`, `CALL {`, or `IN TRANSACTIONS`.
+
+Use a memory tool for mutation rather than attempting a write query. See [Backends and safe Cypher querying](../architecture/backends-and-querying.md) for the complete behavior and why accepted query text is not a substitute for database authorization.
+
+## Resources and prompts
+
+### Resources
+
+| Profile | Resource | Returned content |
+| --- | --- | --- |
+| Core | `memory://context/{session_id}` | A JSON envelope containing assembled context for a session |
+| Extended | `memory://entities` | Up to 100 entity records from an empty-query entity search |
+| Extended | `memory://preferences` | Up to 100 preference records from an empty-query preference search |
+| Extended | `memory://graph/stats` | Counts grouped by graph-node labels from a read-only Cypher query |
+
+The extended entity and preference catalog resources inherit backend limitations. In a hosted NAMS deployment, a preference catalog is not supported because NAMS exposes no preferences endpoint.
+
+### Prompts
+
+| Profile | Prompt | Guided workflow |
+| --- | --- | --- |
+| Core | `memory-conversation` | Load context, store important messages, and record learned preferences/entities |
+| Extended | `memory-reasoning` | Start a trace, record significant steps and tool calls, then complete it |
+| Extended | `memory-review` | Browse stored knowledge and request a contradiction/outdated-information review |
+
+The prompts guide a host model; they do not perform mutations on their own. Treat their recommended tools as subject to the same backend capability rules above.
+
+## Observational memory
+
+The observer keeps in-process state per session. It estimates token count as characters divided by four. After the total exceeds its threshold and at least the configured recent-message window has passed since the last compression, it fetches the conversation and generates a reflection over older messages.
+
+With an `LLMProvider`, the observer requests a concise summary. Without one, or after a provider error, it falls back to keyword/entity heuristics. It retains recent messages in full and returns reflections, inline observations from user-message markers, and counts through `memory_get_observations`. This is server-process state rather than a separate persistent graph model.
+
+## Programmatic construction
+
+```python
+from neo4j_agent_memory import MemorySettings
+from neo4j_agent_memory.mcp.server import create_mcp_server
+
+settings = MemorySettings(backend="bolt", neo4j={"password": "from-secret-storage"})
+server = create_mcp_server(
+    settings,
+    profile="core",
+    session_strategy="persistent",
+    user_id="application-user",
+)
+```
+
+Do not embed a real password in code as in the placeholder above. The factory returns a configured FastMCP application; FastMCP controls how the selected transport is run.
+
+## Source locations
+
+| Concern | Source |
+| --- | --- |
+| Server factory, lifespan, transports | `src/neo4j_agent_memory/mcp/server.py` |
+| Tool registrations and backend-gated hosted tools | `src/neo4j_agent_memory/mcp/_tools.py` |
+| Resources | `src/neo4j_agent_memory/mcp/_resources.py` |
+| Prompts | `src/neo4j_agent_memory/mcp/_prompts.py` |
+| Observer | `src/neo4j_agent_memory/mcp/_observer.py` |
+| High-level tool delegation and session strategies | `src/neo4j_agent_memory/integration.py` |
+| CLI options | `src/neo4j_agent_memory/cli/main.py` |

--- a/openwiki/memory/extraction-resolution-and-enrichment.md
+++ b/openwiki/memory/extraction-resolution-and-enrichment.md
@@ -1,0 +1,131 @@
+---
+type: Architecture Guide
+title: Bolt extraction, entity resolution, and enrichment
+description: Configure the self-hosted pipeline that converts text into entities, relations, and preferences; resolves duplicates; and optionally enriches graph records in the background.
+tags: [python, extraction, entity-resolution, enrichment, bolt]
+---
+
+# Bolt extraction, entity resolution, and enrichment
+
+On the self-hosted Bolt backend, `MemoryClient` can enrich messages and direct entity writes with three client-side layers:
+
+1. **Extraction** turns text into `ExtractedEntity`, `ExtractedRelation`, and `ExtractedPreference` records.
+2. **Resolution** chooses a canonical identity for an extracted entity before persistence.
+3. **Enrichment** optionally fetches external facts for persisted entities in the background.
+
+These are Bolt client features. NAMS manages extraction, embedding, and resolution server-side, and the Python client warns when these layer settings are supplied for NAMS. Use the NAMS API's asynchronous extraction status and entity endpoints rather than assuming that a local extractor configuration changes hosted behavior.
+
+## Extraction pipeline
+
+`ExtractionConfig` defaults to a multi-stage pipeline. The factory attempts the stages in this order:
+
+```mermaid
+flowchart TD
+    Text["Input message or document"] --> Spacy["spaCy statistical NER"]
+    Spacy --> Gliner["GLiNER zero-shot NER"]
+    Gliner --> Llm["LLM extraction fallback"]
+    Llm --> Merge["Merge entities relations and preferences"]
+    Merge --> Resolve["Resolve entity identity"]
+    Resolve --> Persist["Persist to Neo4j"]
+    Persist --> Enrich["Optionally enqueue enrichment"]
+```
+
+This is the default Bolt-side pipeline order; unavailable optional stages are skipped and an empty stage list becomes a `NoOpExtractor`.
+
+| Extractor type | Role | Requirements and notes |
+| --- | --- | --- |
+| `PIPELINE` | Configurable multi-stage extraction | Default `ExtractionConfig` type |
+| `SPACY` | Fast statistical named-entity recognition | Install `[spacy]` and an appropriate spaCy language model |
+| `GLINER` | Zero-shot, custom-label named-entity recognition | Install `[gliner]`; supports named domain schemas |
+| `LLM` | Model-driven entity, relation, and preference extraction | Requires a usable LLM configuration |
+| `NONE` | Disables extraction | Uses `NoOpExtractor` |
+
+The default pipeline enables spaCy, GLiNER, and LLM fallback. Its default `fallback_on_empty=True` means it continues to later stages instead of stopping after a non-empty earlier stage; if a configured stage cannot be created, the factory logs a warning and tries the remaining stages.
+
+`ExtractionPipeline` supports `UNION`, `INTERSECTION`, `CONFIDENCE`, `CASCADE`, and `FIRST_SUCCESS` merge strategies. Entity identity within a pipeline is normalized name plus type; union and confidence-based merging retain the highest-confidence duplicate. Relations are de-duplicated by source, relation type, and target. Preferences are de-duplicated by category and preference text.
+
+### Configure a local no-LLM path
+
+A self-hosted deployment can keep both extraction and embeddings local. When `llm=None`, disable LLM fallback as well; otherwise `MemorySettings` rejects the incompatible combination.
+
+```python
+from neo4j_agent_memory import MemorySettings
+from neo4j_agent_memory.config import ExtractionConfig, ExtractorType
+
+settings = MemorySettings(
+    llm=None,
+    embedding="sentence-transformers/all-MiniLM-L6-v2",
+    extraction=ExtractionConfig(
+        extractor_type=ExtractorType.PIPELINE,
+        enable_spacy=True,
+        enable_gliner=True,
+        enable_llm_fallback=False,
+    ),
+)
+```
+
+This needs the matching extras—at minimum `neo4j-agent-memory[extraction,sentence-transformers]`—and a downloaded spaCy model when spaCy is enabled. `examples/no_llm/main.py` is the runnable reference. The integration suite verifies both that `get_context()` works on an `llm=None` path and that this configuration does not import the OpenAI SDK along the LLM-extraction path.
+
+### Domain schemas and long documents
+
+A GLiNER domain schema can replace generic labels with typed descriptions. Built-in schema names include `poleo`, `podcast`, `news`, `scientific`, `business`, `entertainment`, `medical`, and `legal`. Custom `SchemaConfig` entity types also feed GLiNER labels and LLM entity type selection. The Bolt schema persistence layer can save, activate, and load versioned graph schemas; see the `schemas` CLI command and `src/neo4j_agent_memory/schema/` for the persistence surface.
+
+For large inputs, `StreamingExtractor` chunks a document, yields per-chunk results asynchronously, adjusts entity spans to document offsets, then can return a cross-chunk de-duplicated aggregate. Defaults are 4,000 characters with 200-character overlap, or approximately 1,000 tokens with 50-token overlap when token chunking is selected. Streaming extraction turns off preference extraction for individual chunks because preferences generally require whole-document context.
+
+`ExtractionPipeline.extract_batch()` processes text batches with a configurable concurrency cap, progress callback, and `fail_fast` choice. Its result includes per-item successes/errors and aggregate entity/relation counts.
+
+## Entity resolution and persistence
+
+The default `ResolutionConfig` strategy is `COMPOSITE`. `CompositeResolver` attempts exact, fuzzy, then semantic matching and returns the first canonical match:
+
+| Strategy | Default availability | Default threshold |
+| --- | --- | --- |
+| Exact | Always available | 1.0 |
+| Fuzzy | Available when RapidFuzz can be imported | 0.85 |
+| Semantic | Available when an embedder is configured | 0.8 |
+
+Resolution is type-aware by default. With type information, a `PERSON` named `John` is not matched with a `LOCATION` named `John`. Batch resolution also carries already-resolved canonical names forward so repeated same-type mentions can share an identity.
+
+Resolution is distinct from the later deduplication policy performed by long-term memory. `add_entity()` may normalize type, consult the resolver, check persisted duplicates, and return an existing entity with a `DeduplicationResult`. Do not interpret an extracted name as a guaranteed new graph node.
+
+## Background enrichment
+
+`EnrichmentConfig.enabled` is `False` by default. When enabled on the Bolt path, `create_enrichment_service()` builds providers in configured priority order, optionally wraps each in an in-memory TTL cache, and returns either one provider or a `CompositeEnrichmentProvider` fallback chain.
+
+| Provider | Credentials | Default delay between provider calls |
+| --- | --- | --- |
+| Wikimedia/Wikipedia | None | 0.5 seconds |
+| Diffbot knowledge graph | Diffbot API key | 0.2 seconds |
+
+The background service uses a bounded priority queue. It does not block the original extraction/store flow. An entity is skipped when it is already pending, the queue is full, its confidence is below `min_confidence`, its type is filtered out, or the provider does not support it. Defaults include a queue size of 1,000, minimum confidence 0.7, at most 3 retries, and a 60-second retry delay.
+
+When a provider returns usable data, the service updates the matched `:Entity` with `enriched_description`, `enriched_at`, `enrichment_provider`, and serialized `enrichment_data`. Its optional callback is isolated: callback errors are logged rather than stopping the worker. Rate-limited or failing work is re-queued until its retry limit; graceful `stop()` waits for the worker up to its timeout before cancelling it.
+
+External enrichment changes data provenance and may send entity names/context to third parties. Enable it only after approving that data flow. Store keys outside source control; the Diffbot factory rejects an empty API key.
+
+## Location enrichment versus geocoding
+
+Enrichment adds descriptive external knowledge. `GeocodingConfig` is a different, disabled-by-default Bolt feature for `LOCATION` entities: it can use Nominatim or Google Maps to add Neo4j point data for geospatial queries. Nominatim is the default provider and is configured for at most one request per second; Google requires a key. Both are client-side network integrations, not NAMS configuration.
+
+## Practical configuration checklist
+
+1. **Choose the backend first.** Configure these layers only when operating Bolt.
+2. **Install only enabled dependencies.** Optional extractors fail open at pipeline construction, which is helpful for partial installations but should not hide an unintended missing stage in production.
+3. **Decide merge and resolution policies before bulk ingestion.** They determine which entity variants become canonical and how extraction results combine.
+4. **Use domain schemas for specialized vocabulary.** Test against representative documents before depending on a schema for automated writes.
+5. **Treat enrichment as eventual.** A newly persisted entity may not yet have external metadata; inspect queue state or define application-level readiness requirements instead of assuming immediate completion.
+6. **Keep model/provider and external-service credentials secret.** Configuration objects use `SecretStr` for sensitive fields, but applications must still avoid logging them.
+
+## Source map
+
+| Concern | Location |
+| --- | --- |
+| Extraction and resolution configuration | `src/neo4j_agent_memory/config/settings.py` |
+| Extractor factory and pipeline | `src/neo4j_agent_memory/extraction/factory.py`, `src/neo4j_agent_memory/extraction/pipeline.py` |
+| Local extractors and domain schemas | `src/neo4j_agent_memory/extraction/spacy_extractor.py`, `src/neo4j_agent_memory/extraction/gliner_extractor.py`, `src/neo4j_agent_memory/extraction/llm_extractor.py` |
+| Streaming extraction | `src/neo4j_agent_memory/extraction/streaming.py` |
+| Resolver implementations | `src/neo4j_agent_memory/resolution/` |
+| Enrichment service and provider factory | `src/neo4j_agent_memory/enrichment/background.py`, `src/neo4j_agent_memory/enrichment/factory.py` |
+| No-LLM reference example | `examples/no_llm/main.py` |
+| Extraction, resolver, and enrichment tests | `tests/unit/test_extraction_pipeline.py`, `tests/unit/test_resolvers.py`, `tests/unit/test_enrichment.py` |
+| Backend boundaries | [Backends and safe Cypher querying](../architecture/backends-and-querying.md) |

--- a/openwiki/memory/model-and-operations.md
+++ b/openwiki/memory/model-and-operations.md
@@ -1,0 +1,152 @@
+---
+type: Data Model
+title: Memory model and operations
+description: Understand the Neo4j graph model for short-term, long-term, and reasoning memory, plus context assembly and Bolt maintenance features.
+tags: [memory, data-model, neo4j, reasoning, retrieval]
+---
+
+# Memory model and operations
+
+The library divides agent memory into three connected domains. On the Bolt backend these are Neo4j nodes and relationships backed by package-managed constraints and indexes. Their public models are `Conversation`/`Message`, `Entity`/`Preference`/`Fact`/`Relationship`, and `ReasoningTrace`/`ReasoningStep`/`ToolCall`.
+
+## Graph model
+
+```mermaid
+erDiagram
+    CONVERSATION ||--o{ MESSAGE : HAS_MESSAGE
+    CONVERSATION ||--o| MESSAGE : FIRST_MESSAGE
+    MESSAGE ||--o| MESSAGE : NEXT_MESSAGE
+    MESSAGE }o--o{ ENTITY : MENTIONS
+    ENTITY }o--o{ ENTITY : RELATED_TO
+    USER ||--o{ PREFERENCE : HAS_PREFERENCE
+    PREFERENCE }o--o{ ENTITY : ABOUT
+    CONVERSATION ||--o{ REASONING_TRACE : HAS_TRACE
+    REASONING_TRACE ||--o{ REASONING_STEP : HAS_STEP
+    REASONING_TRACE }o--o| MESSAGE : INITIATED_BY
+    REASONING_STEP ||--o{ TOOL_CALL : USES_TOOL
+    TOOL_CALL }o--|| TOOL : INSTANCE_OF
+    REASONING_STEP }o--o{ ENTITY : TOUCHED
+```
+
+This is the primary Bolt graph structure used to connect conversations, durable knowledge, and execution history.
+
+### Short-term memory
+
+| Model | Key contents | Key graph behavior |
+| --- | --- | --- |
+| `Conversation` | `id`, `session_id`, optional title and metadata | Owns messages through `HAS_MESSAGE`; updated when messages are added |
+| `Message` | role, content, timestamp, optional embedding and metadata | Ordered through `FIRST_MESSAGE` and `NEXT_MESSAGE`; can link to entities through `MENTIONS` |
+| `ConversationSummary` | generated summary, time range, key entities and topics | Returned by a summary workflow rather than represented as a primary graph node |
+
+`short_term.add_message()` can generate a message embedding and extract entities/relationships. `get_conversation()` returns messages ordered chronologically. `search_messages()` supports a session scope, result limit, similarity threshold, and metadata filters.
+
+For high-volume Bolt ingestion, `add_messages_batch()` writes in transaction batches and maintains the message sequence. It defaults to disabled entity extraction for the batch for performance; extraction can be run separately afterwards.
+
+### Long-term memory
+
+| Model | Purpose | Important fields or behavior |
+| --- | --- | --- |
+| `Entity` | A resolved person, object, location, event, organization, or custom domain object | Name, canonical name, POLE+O type, optional subtype, aliases, attributes, description, confidence |
+| `Relationship` | A typed entity-to-entity relation | Source and target IDs, type, confidence, temporal validity, and attributes |
+| `Preference` | A preference categorized for personalization | Category, text, context, confidence, optional entity links |
+| `Fact` | A declarative subject-predicate-object statement | Confidence and optional `valid_from`/`valid_until` time bounds |
+
+The default entity schema is POLE+O: `PERSON`, `OBJECT`, `LOCATION`, `EVENT`, and `ORGANIZATION`. The Bolt implementation can represent the base type and subtype as labels, while preserving the normalized type in properties. `add_entity()` normalizes types, optionally resolves them, checks duplicates, can geocode locations, and can enqueue configured enrichment. It returns an entity plus a `DeduplicationResult`; an auto-merged duplicate returns the existing entity.
+
+Entity deduplication is configurable. By default it uses embedding similarity and can also use fuzzy matching: candidates can be merged, flagged, or treated as distinct depending on thresholds. Facts and preferences can be searched semantically when their embeddings are present. For the Bolt-side text extraction pipeline, identity resolution order, and asynchronous external enrichment, see [Bolt extraction, entity resolution, and enrichment](extraction-resolution-and-enrichment.md).
+
+### Reasoning memory
+
+| Model | Purpose | Key graph behavior |
+| --- | --- | --- |
+| `ReasoningTrace` | A task-level execution record | Captures session, task, outcome, success, times, and task embedding |
+| `ReasoningStep` | One thought/action/observation unit | Ordered by `HAS_STEP.order`; can carry a step embedding |
+| `ToolCall` | A tool invocation during a step | Holds arguments, result, status, duration, and error; connects to a shared `Tool` |
+| `Tool` | A tool name and aggregated usage record | Stores total, success, failure, duration, and latest-use counters |
+
+A tool call can reference `touched_entities`. On Bolt this writes `(:ReasoningStep)-[:TOUCHED]->(:Entity)` edges for a compact audit path from an entity to the reasoning that affected it. The evaluator's audit-completeness dimension checks those edges.
+
+## Typical memory workflow
+
+```mermaid
+flowchart TD
+    Input["Agent receives a message"] --> Store["short_term.add_message"]
+    Store --> Conv["Conversation and Message"]
+    Store --> Embed["Optional message embedding"]
+    Store --> Extract["Optional entity and relation extraction"]
+    Extract --> Mention["Entity nodes and MENTIONS edges"]
+    Agent["Agent begins a task"] --> Trace["reasoning.start_trace"]
+    Trace --> Step["reasoning.add_step"]
+    Step --> Tool["reasoning.record_tool_call"]
+    Tool --> Touched["Optional TOUCHED edges"]
+    Touched --> Complete["reasoning.complete_trace"]
+    Conv --> Context["client.get_context"]
+    Mention --> Context
+    Complete --> Context
+    Context --> Prompt["Formatted prompt context"]
+```
+
+This shows how new conversation data and execution history can feed later context retrieval.
+
+## Assemble context for an agent
+
+`MemoryClient.get_context(query, ...)` fetches selected memory regions and joins non-empty sections into a string suitable for an LLM prompt:
+
+1. Short-term context, formatted under `## Conversation History`, is retrieved with the optional `session_id` and at most `max_items` messages.
+2. Long-term context, formatted under `## Relevant Knowledge`, includes relevant facts and preferences up to `max_items`.
+3. Reasoning context, formatted under `## Similar Past Tasks`, retrieves related traces with a maximum of `max_items // 2`.
+
+Each category can be disabled with `include_short_term`, `include_long_term`, or `include_reasoning`. `MemoryIntegration.get_context()` wraps this result with the resolved session identifier and a `has_context` flag.
+
+On NAMS, short-term context uses the hosted three-tier conversation context endpoint, while the NAMS long-term and reasoning `get_context()` implementations return an empty string. Use the hosted conversation context, entity search, and application-level composition as appropriate; see [Backends and querying](../architecture/backends-and-querying.md).
+
+## Sessions, users, and tenancy
+
+`MemoryIntegration` resolves a session identifier before every operation:
+
+| `session_strategy` | Resolved session identifier |
+| --- | --- |
+| `per_conversation` | A UUID generated once per `MemoryIntegration` instance |
+| `per_day` | `<user_id>-YYYY-MM-DD` in UTC, or `default-YYYY-MM-DD` without a user ID |
+| `persistent` | The supplied user ID, or `default` |
+
+An explicit `session_id` always wins over the strategy. On Bolt, setting `MemorySettings.memory.multi_tenant=True` makes memory APIs that accept `user_identifier=` reject an omitted identifier. Use it in production to make tenant scoping explicit. NAMS has different hosted scoping semantics: `userId` is sent where its endpoint supports it, and the API key scopes the workspace.
+
+## Bolt-only operations for production upkeep
+
+### Buffered writes
+
+Set `MemorySettings.memory.write_mode="buffered"` to use `client.buffered.submit(query, params)` for explicit fire-and-forget Neo4j writes. The background drainer starts lazily. A full queue applies back pressure rather than dropping data. Call `await client.flush()` or `await client.wait_for_pending()` at shutdown; `MemoryClient.close()` also drains it before closing Bolt. Failures are retained in `client.write_errors` and do not stop later queued jobs.
+
+The default `write_mode="sync"` does not queue: `submit()` awaits the underlying write and propagates its errors. Standard memory methods that return models remain synchronous persistence operations; buffering is an explicit low-level API.
+
+### Consolidation and audit records
+
+`client.consolidation` supplies Bolt maintenance primitives. They default to `dry_run=True` and return a `ConsolidationReport` with candidate details:
+
+| Method | Non-dry-run effect |
+| --- | --- |
+| `dedupe_entities()` | Adds `SAME_AS` edges for high-similarity entity pairs |
+| `summarize_long_traces()` | Marks long, unsummarized traces as `summarization_pending`; callers choose and run the actual summarizer |
+| `detect_superseded_preferences()` | Adds `SUPERSEDED_BY` and closes the older preference validity window |
+| `archive_expired_conversations(ttl_days=...)` | Marks older conversations as archived without deleting them |
+| `record_read_audit(...)` | Writes an explicit `MemoryReadAudit`, optionally linked from a user |
+
+Mutating consolidation runs also create a `ConsolidationRun` audit node. Read auditing is explicit: the library does not automatically record every graph read.
+
+### Evaluation harness
+
+`client.eval.run(EvalSuite(...))` evaluates supplied labeled cases independently across retrieval, audit, and preference dimensions. Retrieval is average recall at `k` over expected entity IDs. Audit coverage measures expected `TOUCHED` reasoning-step IDs. Preference fidelity uses F1 against expected active preference IDs. `EvalReport.overall_score` averages only dimensions that ran.
+
+## Source locations
+
+| Area | Source |
+| --- | --- |
+| Client context assembly and Bolt accessors | `src/neo4j_agent_memory/__init__.py` |
+| Conversation models and operations | `src/neo4j_agent_memory/memory/short_term.py` |
+| Entities, facts, preferences, and deduplication | `src/neo4j_agent_memory/memory/long_term.py` |
+| Traces, steps, tool calls, and touched-entity hooks | `src/neo4j_agent_memory/memory/reasoning.py` |
+| Bolt Cypher templates | `src/neo4j_agent_memory/graph/queries.py` |
+| Buffered writer | `src/neo4j_agent_memory/memory/buffered.py` |
+| Consolidation and read audit | `src/neo4j_agent_memory/memory/consolidation.py` |
+| Evaluation types and scoring | `src/neo4j_agent_memory/memory/eval.py` |

--- a/openwiki/observability/tracing.md
+++ b/openwiki/observability/tracing.md
@@ -1,0 +1,158 @@
+---
+type: Observability Guide
+title: Tracing and request observability
+description: Instrument Python application code with the tracer abstraction and capture TypeScript NAMS request events, timing, and request IDs without making telemetry break memory operations.
+tags: [observability, tracing, python, typescript, nams]
+---
+
+# Tracing and request observability
+
+The repository has two observability surfaces with different purposes:
+
+- The **Python SDK** exposes a generic tracing abstraction with no-op, OpenTelemetry, and Opik implementations. Applications can use it to trace their own work, including extraction or agent orchestration.
+- The **TypeScript SDK** exposes a per-request `logger` callback from its HTTP transports. It reports NAMS request start, success/error status, duration, and a service request ID when available.
+
+Neither surface is a guarantee that every memory operation is automatically traced. Add instrumentation deliberately at the application boundary and ensure that sensitive prompts, API keys, and tool inputs are not emitted to logs or span attributes without an explicit data-handling decision.
+
+## Python tracer abstraction
+
+Import from `neo4j_agent_memory.observability`:
+
+```python
+from neo4j_agent_memory.observability import get_tracer
+
+tracer = get_tracer(provider="noop", service_name="support-agent")
+
+@tracer.trace("prepare_agent_context", {"component": "memory"})
+async def prepare_context() -> str:
+    return "context"
+```
+
+`get_tracer()` accepts a `TracingProvider` value or its lowercase string equivalent:
+
+| Provider | Behavior |
+| --- | --- |
+| `"noop"` | Returns a `NoOpTracer`; all span operations are safe no-ops |
+| `"opentelemetry"` | Instantiates `OpenTelemetryTracer`; requires OpenTelemetry packages |
+| `"opik"` | Instantiates `OpikTracer`; requires the `opik` package |
+| `"auto"` | Selects Opik when importable, otherwise OpenTelemetry when importable, otherwise the no-op tracer |
+
+Each call to `get_tracer()` replaces the module-level current tracer. `get_current_tracer()` returns the configured global tracer or a new no-op tracer when none has been configured.
+
+### Span lifecycle and exception behavior
+
+`Tracer` provides three equivalent ways to open a span:
+
+```python
+# Synchronous code
+with tracer.span("prepare") as span:
+    span.set_attribute("memory.backend", "bolt")
+
+# Asynchronous code
+async with tracer.async_span("prepare") as span:
+    span.set_attribute("memory.backend", "nams")
+
+# Decorate either a synchronous or asynchronous callable
+@tracer.trace("prepare")
+def prepare() -> None:
+    pass
+```
+
+```mermaid
+sequenceDiagram
+    participant App
+    participant Tracer
+    participant Span
+    App->>Tracer: open span or call decorated function
+    Tracer->>Span: start span and set supplied attributes
+    App->>Span: set attributes during work
+    alt work succeeds
+        App->>Span: leave scope
+    else work raises exception
+        Tracer->>Span: record exception and set ERROR status
+        Tracer->>Span: end span
+        Tracer-->>App: re-raise original exception
+    end
+    Tracer->>Span: end span after successful scope
+```
+
+This is the base `Tracer` contract: errors are recorded and then propagated rather than swallowed by the tracing helper.
+
+The decorator adds `function.name`, `function.module`, and `function.duration_ms`. The context managers do not add those function attributes automatically; set context-specific attributes yourself. A no-op tracer preserves the same control-flow and exception behavior without exporting telemetry, which makes it appropriate as a default in applications and tests.
+
+## Python providers
+
+### OpenTelemetry
+
+Install the optional dependency group:
+
+```bash
+pip install "neo4j-agent-memory[opentelemetry]"
+```
+
+`OpenTelemetryTracer(service_name=..., endpoint=..., headers=...)` creates an OpenTelemetry `TracerProvider` with a `service.name` resource. When `endpoint` is provided it first tries the OTLP gRPC exporter, then the OTLP HTTP exporter. If neither exporter package is importable, it leaves the provider without an exporter rather than throwing during setup.
+
+OpenTelemetry attributes accept scalar values directly. Lists and tuples have unsupported values converted to strings; other unsupported values are stringified. Supply only values acceptable for your collector and privacy policy.
+
+### Opik
+
+Install the optional dependency group:
+
+```bash
+pip install "neo4j-agent-memory[opik]"
+```
+
+`OpikTracer` accepts `service_name`, `project_name`, `api_key`, and `workspace`. If explicit Opik credentials are needed, source them through authorized environment or secret configuration rather than code. The adapter exposes the generic span interface and `track()` for Opik's native decorator. It also exposes `log_feedback(trace_id, name, value, reason=None)` for supported Opik client versions.
+
+The Opik adapter makes its own span integration best-effort: failures in the dynamic Opik calls do not intentionally fail the traced application work. That is different from the base context manager's exception behavior, which still re-raises exceptions from the application body.
+
+## TypeScript request logger
+
+`MemoryClient` accepts `logger` in `MemoryClientOptions`. Both built-in transports invoke it for request, response, and error events. Logger errors are caught and ignored by the transports so an observability callback cannot make a memory request fail.
+
+```ts
+import { MemoryClient, type LogEvent } from "@neo4j-labs/agent-memory";
+
+const memory = new MemoryClient({
+  logger: (event: LogEvent) => {
+    if (event.kind === "error") {
+      console.error({
+        method: event.method,
+        status: event.status,
+        requestId: event.requestId,
+        durationMs: event.durationMs,
+        message: event.message,
+      });
+    }
+  },
+});
+```
+
+| Event kind | Always present | May be present |
+| --- | --- | --- |
+| `request` | SDK method name, URL | HTTP method |
+| `response` | SDK method name, URL, HTTP status, duration | `requestId` |
+| `error` | SDK method name, URL, duration, message | HTTP status and `requestId` |
+
+The REST and bridge transports derive `requestId` from `x-request-id`, `request-id`, or `x-amzn-requestid` response headers. SDK errors also retain the value on `MemoryError.requestId`. Include that identifier in a support issue, but do not add bearer tokens or unredacted sensitive data to the report.
+
+The transports use a 30-second timeout by default and use `AbortSignal.timeout`. Network and timeout failures are surfaced as `ConnectionError`; authentication responses become `AuthenticationError`; other HTTP failures become `TransportError` with its status and parsed response body when available. See [TypeScript SDK for the hosted memory service](../typescript-sdk.md) for the full error model.
+
+## Operational guidance
+
+- **Assign meaningful names.** Use span and logger labels that identify a workflow stage, such as context assembly or entity extraction, rather than embedding raw user text.
+- **Set safe attributes.** Backend choice, operation names, durations, and anonymous correlation IDs are generally safer than prompts, memory contents, or credentials.
+- **Correlate at the service edge.** Record NAMS `requestId` from logger events or `MemoryError` for failed hosted calls.
+- **Preserve application behavior.** Keep logging and exporter integration non-blocking where possible. The TypeScript logger is explicitly isolated; the Python tracer's context-manager contract intentionally preserves exceptions.
+- **Validate optional providers.** Unit tests may skip provider-specific cases when an optional dependency is absent. Test a real exporter setup in its target deployment environment.
+
+## Source map
+
+| Concern | Location |
+| --- | --- |
+| Python tracing interfaces and provider selection | `src/neo4j_agent_memory/observability/base.py` |
+| Python OpenTelemetry adapter | `src/neo4j_agent_memory/observability/otel.py` |
+| Python Opik adapter | `src/neo4j_agent_memory/observability/opik.py` |
+| Python observability exports and tests | `src/neo4j_agent_memory/observability/__init__.py`, `tests/unit/test_observability.py` |
+| TypeScript log event types and request-ID extraction | `typescript/src/observability.ts` |
+| TypeScript REST and bridge logging behavior | `typescript/src/transport/rest.ts`, `typescript/src/transport/bridge.ts` |

--- a/openwiki/quickstart.md
+++ b/openwiki/quickstart.md
@@ -1,0 +1,178 @@
+---
+type: Guide
+title: Neo4j Agent Memory quickstart
+description: Install and use the asynchronous Python SDK with either a self-hosted Neo4j Bolt database or the hosted NAMS backend.
+tags: [getting-started, python, memory, neo4j, nams]
+---
+
+# Neo4j Agent Memory quickstart
+
+`neo4j-agent-memory` is an asynchronous Python library for agent memory. A `MemoryClient` exposes three stores through one API:
+
+- `short_term` for conversation messages;
+- `long_term` for entities, preferences, facts, and entity relationships;
+- `reasoning` for task traces, steps, and tool calls.
+
+Choose the backend before writing application logic:
+
+| Use case | Backend | Install | What you operate |
+| --- | --- | --- | --- |
+| Managed conversations, entities, and hosted extraction | NAMS | `pip install "neo4j-agent-memory[nams]"` | An account and `MEMORY_API_KEY` |
+| Full graph control, preferences/facts/relationship writes, schema access, or local operation | Bolt | `pip install neo4j-agent-memory` plus the provider extras you use | Neo4j plus any chosen model providers |
+
+The Python package requires Python 3.10 or later. The Bolt path depends on `neo4j>=5.20.0`; vector indexes are created when the connected Neo4j supports them.
+
+## 1. Use the client as an async resource
+
+Every memory operation is a coroutine. In a script, put calls inside `asyncio.run`; inside an existing async framework or notebook, await them directly. The context manager connects the chosen backend before use and closes it afterwards.
+
+```python
+import asyncio
+from neo4j_agent_memory import MemoryClient
+
+
+async def main() -> None:
+    async with MemoryClient() as memory:
+        await memory.short_term.add_message(
+            session_id="support-42",
+            role="user",
+            content="Please help me compare two options.",
+        )
+
+
+asyncio.run(main())
+```
+
+The configuration determines which backend `MemoryClient()` uses. Do not create a client once and use its accessors after the context manager has closed.
+
+```mermaid
+sequenceDiagram
+    participant App
+    participant Client as MemoryClient
+    participant Store as Configured backend
+    App->>Client: async with MemoryClient(settings)
+    Client->>Store: connect and initialize accessors
+    App->>Client: await memory operation
+    Client->>Store: persist or retrieve memory
+    App->>Client: context manager exit
+    Client->>Store: drain supported work and close transport
+```
+
+This shows the normal client lifecycle for either configured backend.
+
+## 2. Hosted NAMS setup
+
+NAMS is selected automatically when `MEMORY_API_KEY` is available during `MemorySettings` construction. Install the NAMS extra, keep the real key in the environment or a secret manager, and pass a conversation identifier as `session_id`.
+
+```bash
+pip install "neo4j-agent-memory[nams]"
+export MEMORY_API_KEY="your-NAMS-key"
+```
+
+```python
+import asyncio
+from neo4j_agent_memory import MemoryClient
+
+
+async def main() -> None:
+    async with MemoryClient() as memory:
+        conversation_id = "conversation-uuid-from-your-application"
+
+        await memory.short_term.add_message(
+            session_id=conversation_id,
+            role="user",
+            content="I am planning a trip to Lisbon.",
+        )
+        await memory.long_term.add_entity("Lisbon", "LOCATION")
+
+        context = await memory.get_context(
+            "What travel context is available?",
+            session_id=conversation_id,
+        )
+        print(context)
+
+
+asyncio.run(main())
+```
+
+On NAMS, `session_id` is the hosted conversation identifier. Message extraction runs asynchronously; use `await memory.long_term.wait_for_extraction(session_id=conversation_id, expected_names=[...])` when application logic or a test must wait for a newly extracted entity to become searchable. See [backends and querying](architecture/backends-and-querying.md) for NAMS capability limits and consistency behavior.
+
+## 3. Self-hosted Bolt setup
+
+Pass `MemorySettings` for direct Neo4j access. Provider strings are resolved by `from_provider`; install the matching provider extra. The example uses environment variables rather than putting credentials in source control.
+
+```bash
+pip install "neo4j-agent-memory[openai]"
+export NEO4J_PASSWORD="your-Neo4j-password"
+export OPENAI_API_KEY="your-provider-key"
+```
+
+```python
+import asyncio
+import os
+
+from pydantic import SecretStr
+from neo4j_agent_memory import MemoryClient, MemorySettings, Neo4jConfig
+
+
+async def main() -> None:
+    settings = MemorySettings(
+        backend="bolt",
+        neo4j=Neo4jConfig(
+            uri="bolt://localhost:7687",
+            username="neo4j",
+            password=SecretStr(os.environ["NEO4J_PASSWORD"]),
+        ),
+        embedding="openai/text-embedding-3-small",
+        llm="openai/gpt-4o-mini",
+    )
+
+    async with MemoryClient(settings) as memory:
+        await memory.short_term.add_message(
+            session_id="support-42",
+            role="user",
+            content="I prefer concise answers.",
+        )
+        await memory.long_term.add_preference(
+            category="communication_style",
+            preference="Prefers concise answers",
+        )
+        context = await memory.get_context(
+            "How should I respond?",
+            session_id="support-42",
+        )
+        print(context)
+
+
+asyncio.run(main())
+```
+
+On connection, the Bolt client creates the package-managed constraints and indexes, initializes the configured embedding, extraction, resolution, geocoding, and enrichment layers, and validates managed vector-index dimensions against the configured embedder. A dimension mismatch raises an actionable error rather than silently running searches with incompatible vectors.
+
+## 4. Common next steps
+
+| Goal | Start with |
+| --- | --- |
+| Persist and retrieve conversations | `client.short_term.add_message`, `get_conversation`, `search_messages` |
+| Build a knowledge graph | `client.long_term.add_entity`, `add_relationship`, `add_fact` |
+| Personalize per user | `add_preference(..., user_identifier=...)` with `memory.multi_tenant=True` in production |
+| Record how an agent solved a task | `start_trace`, `add_step`, `record_tool_call`, `complete_trace` |
+| Use memory from an MCP host | `neo4j-agent-memory mcp serve`; see [MCP server](integrations/mcp-server.md) |
+| Run a safe custom inspection query | `client.query.cypher`; it accepts read-only Cypher only |
+| Understand the storage model | [Memory model and operations](memory/model-and-operations.md) |
+
+## Provider and optional-feature installs
+
+The core install contains the Neo4j driver and configuration support. Install extras only for integrations in use:
+
+| Capability | Extra |
+| --- | --- |
+| Native OpenAI, Anthropic, or AWS Bedrock adapters | `[openai]`, `[anthropic]`, `[bedrock]` |
+| Local Hugging Face embeddings | `[sentence-transformers]` |
+| Universal provider adapter | `[litellm]` |
+| Hosted NAMS transport | `[nams]` |
+| FastMCP server | `[mcp]` |
+| Local extraction pipeline | `[spacy]`, `[gliner]`, or `[extraction]` |
+| Framework adapters | `[langchain]`, `[pydantic-ai]`, `[google-adk]`, `[strands]`, `[crewai]`, `[llamaindex]`, `[openai-agents]`, or `[microsoft-agent]` |
+
+For a provider string such as `"openai/gpt-4o-mini"`, native adapters are preferred when installed; LiteLLM is the fallback. See [architecture overview](architecture/overview.md) for component boundaries.

--- a/openwiki/typescript-sdk.md
+++ b/openwiki/typescript-sdk.md
@@ -1,0 +1,210 @@
+---
+type: SDK Guide
+title: TypeScript SDK for the hosted memory service
+description: Use @neo4j-labs/agent-memory with NAMS, understand its client, hosted REST operations, transport behavior, framework adapters, error model, and contributor boundaries.
+tags: [typescript, nams, sdk, memory, integrations]
+---
+
+# TypeScript SDK for the hosted memory service
+
+`@neo4j-labs/agent-memory` is the repository's TypeScript client for the hosted Neo4j Agent Memory Service (NAMS). It is a separate npm package from the Python SDK, built from `typescript/src/` and released independently. It requires Node.js 20 or later and uses `fetch`, so the supported runtime set includes Node, Bun, Deno, Cloudflare Workers, and Vercel Edge.
+
+> **Scope boundary:** the TypeScript SDK targets NAMS. It does not create a direct Bolt connection or expose the Python SDK's self-hosted-only helpers such as schema management and buffered writes. Use the Python SDK when direct Neo4j Bolt operation is required.
+
+## Install and construct the client
+
+```bash
+npm install @neo4j-labs/agent-memory
+```
+
+The default constructor sends requests to `https://memory.neo4jlabs.com/v1` and, where `process.env` exists, reads `MEMORY_API_KEY`. Keep real keys out of source and provide them through the deployment environment or secret manager.
+
+```ts
+import { MemoryClient } from "@neo4j-labs/agent-memory";
+
+const memory = new MemoryClient();
+
+const conversation = await memory.shortTerm.createConversation({
+  userId: "user-42",
+});
+await memory.shortTerm.addMessage(conversation.id, "user", "I prefer concise answers.");
+
+const context = await memory.shortTerm.getContext(conversation.id);
+console.log(context.reflections, context.observations, context.recentMessages);
+
+await memory.close();
+```
+
+For an edge request handler, provide the key explicitly because it is normally exposed by the request environment rather than `process.env` at module scope:
+
+```ts
+const memory = new MemoryClient({ apiKey: env.MEMORY_API_KEY });
+```
+
+`connect()` is optional. By design, the first real request serves as the implicit connectivity and authentication check. Call `await memory.connect()` at startup when an application instead needs a fail-fast probe. `close()` delegates to the underlying transport; the built-in HTTP transports currently have no persistent connection to tear down, but calling it makes lifecycle ownership explicit and keeps code compatible with injected transports.
+
+## Client surface and memory domains
+
+`MemoryClient` constructs six accessors around one transport:
+
+| Accessor | Role | Examples of hosted-native operations |
+| --- | --- | --- |
+| `shortTerm` | Conversations, messages, and three-tier context | `createConversation`, `getContext`, `bulkAddMessages`, `getObservations`, `getReflections` |
+| `longTerm` | Entities, graph views, feedback, history, and extraction wait | `listEntities`, `getEntity`, `updateEntity`, `mergeEntities`, `expandGraph` |
+| `reasoning` | Conversation-scoped agent steps, tool calls, and provenance | `recordStep`, `getTraceByConversation`, `explainStep`, `getEntityProvenance` |
+| `query` | Read-only graph inspection | `cypher({ cypher, params })` |
+| `auth` | Hosted API keys and refresh-token exchange | `listApiKeys`, `createApiKey`, `rotateApiKey`, `revokeApiKey` |
+| `ontology` | Versioned domain schemas extending POLE+O | `list`, `create`, `update`, `activate`, `diff`, `migrate` |
+
+The primary response models use camelCase. The package translates its bridge-compatible internal method names and the REST wire format so application code uses the accessor APIs rather than calling routes itself.
+
+### Conversation-scoped hosted data
+
+NAMS uses a conversation identifier. `shortTerm.addMessage` and `getConversation` accept `sessionId` as the canonical client parameter and `conversationId` as an alias in their options; if both appear, `sessionId` wins. Hosted-native APIs, such as `createConversation` and `getContext`, use `conversationId` directly.
+
+The rich hosted context is a `ConversationContext` with these layers:
+
+- `reflections`: higher-level material derived from observations;
+- `observations`: summaries over message windows; and
+- `recentMessages`: the current recent conversation window.
+
+Use that three-tier result when preparing an agent prompt. `bulkAddMessages` accepts at most 100 messages per request. Entity extraction can be asynchronous; `longTerm.waitForExtraction()` polls entity search with a query, expected names, or a predicate until the requested condition is true or its timeout expires. For a specific new entity, `expectedNames` or a predicate is safer than a raw minimum-result count because a populated workspace may already satisfy that count.
+
+### Hosted capabilities and bridge-only methods
+
+Some classes retain bridge/TCK-shaped methods alongside the hosted-native API. The default transport selects REST for an endpoint whose path includes `/vN`, including the default NAMS endpoint. On REST, operations that have no NAMS REST equivalent, such as `addPreference`, `addFact`, `addRelationship`, `startTrace`, and `completeTrace`, throw `NotSupportedError`.
+
+Use the hosted-native alternatives rather than assuming all bridge methods work against NAMS:
+
+| Goal | Use with NAMS REST |
+| --- | --- |
+| Create and manage conversations | `shortTerm.createConversation`, `listConversations`, `deleteConversation` |
+| Add and retrieve messages | `addMessage`, `bulkAddMessages`, `getConversation` |
+| Build three-tier prompt context | `getContext`, `getObservations`, `getReflections` |
+| Record agent reasoning | `reasoning.recordStep` and `reasoning.recordToolCall` |
+| Inspect agent history | `getTraceByConversation`, `explainStep`, `getEntityProvenance` |
+| Manage entities | `addEntity`, `getEntity`, `updateEntity`, `setEntityFeedback`, `mergeEntities` |
+| Inspect the graph | `query.cypher` with read-only Cypher |
+
+The `BridgeTransport` speaks a TCK conformance protocol, posts snake_case method names, and is intended for conformance testing or local adapters. It is not the application path for NAMS. It is exposed from `@neo4j-labs/agent-memory/testing`; `RestTransport` is the public production transport.
+
+```mermaid
+sequenceDiagram
+    participant App
+    participant Client as MemoryClient
+    participant Accessor as Memory accessor
+    participant Rest as RestTransport
+    participant NAMS as NAMS REST service
+    App->>Client: call hosted-native operation
+    Client->>Accessor: delegate operation
+    Accessor->>Rest: request method and parameters
+    Rest->>NAMS: authenticated HTTP request
+    NAMS-->>Rest: response and optional request id
+    Rest-->>Accessor: normalized response
+    Accessor-->>App: typed model
+```
+
+This shows the default NAMS REST request path; the accessors own wire-shape conversion before returning SDK models.
+
+## Configuration, authentication, and tenant scope
+
+The constructor accepts this application-facing configuration:
+
+| Option | Purpose |
+| --- | --- |
+| `endpoint` | NAMS REST base URL; defaults to `https://memory.neo4jlabs.com/v1` |
+| `apiKey` | Static bearer token; falls back to `MEMORY_API_KEY` unless explicitly set, including an intentional empty string |
+| `tokenProvider` | Synchronous or asynchronous token callback; takes precedence over `apiKey` |
+| `workspaceId` | Adds `X-Workspace-Id`; falls back to `MEMORY_WORKSPACE_ID` |
+| `transport` | `"auto"`, `"rest"`, or `"bridge"`; auto chooses REST for `/vN` endpoint paths |
+| `timeout` | Per-request limit in milliseconds; default `30000` |
+| `headers` | Additional headers for every request |
+| `logger` | Receives request, response, and error events |
+| `namespace` | Declared in `MemoryClientOptions`, but not forwarded during built-in transport construction; do not rely on it for runtime scoping |
+
+An explicit `X-Workspace-Id` within `headers` wins over `workspaceId`. Workspace is the NAMS tenancy boundary and is distinct from `userId`, which identifies the user recorded on a conversation. The client applies bearer authentication using `tokenProvider` when supplied, otherwise the static API key.
+
+The `auth` accessor can create, list, rotate, reveal, and revoke service keys, and can exchange a refresh token. API key responses may contain plaintext `key` values only when the service returns them. Treat any such value as sensitive: persist it only in authorized secret storage and never log it or commit it to an example.
+
+## Errors and request correlation
+
+All SDK-specific errors derive from `MemoryError`. Failed HTTP calls carry a `requestId` when NAMS emits a supported request-ID response header. Include that ID in a support report; it helps correlate the client failure with service logs.
+
+| Error | Meaning |
+| --- | --- |
+| `ConnectionError` | A network failure, timeout, or service error while connecting/requesting |
+| `AuthenticationError` | NAMS responded with 401 or 403 |
+| `TransportError` | A non-success transport response; includes `statusCode` and `responseBody` when available |
+| `NotSupportedError` | The selected transport cannot implement the requested SDK method |
+| `NotFoundError` | An SDK operation did not find its requested resource |
+| `ValidationError` | The SDK rejected invalid client input or transport configuration |
+
+The optional `logger` receives typed events for request start, response, and error. Response and error events can carry the HTTP status, request ID, and duration; logger failures are intentionally suppressed so observability code does not break a memory operation.
+
+## Ontology lifecycle
+
+`client.ontology` manages NAMS-hosted domain schemas. An `OntologyDocument` has a `domain`, typed `entityTypes` that map to a POLE+O base type, and typed relationships. The service stores versions with a revision and validation mode. Conceptually, the lifecycle is:
+
+```mermaid
+flowchart TD
+    Draft["Ontology document"] --> Create["Create version"]
+    Create --> Review["Inspect or diff revisions"]
+    Review --> Activate["Activate a version"]
+    Activate --> Use["Use active workspace ontology"]
+    Review --> Update["Update creates next revision"]
+    Update --> Review
+    Review --> Migrate["Optionally start migration"]
+    Migrate --> Job["Poll migration job"]
+```
+
+This reflects the versioned ontology API: activation targets a version, and a migration is an asynchronous job rather than a synchronous label rewrite.
+
+`ontology.import()` accepts either inline `content` or an HTTPS `url`, not both, and returns a non-persisted draft plus conversion warnings. Persist a successful draft with `ontology.create()`. The ontology sub-API intentionally sends snake_case bodies even though the rest of the TypeScript client presents camelCase models.
+
+## Framework and MCP adapters
+
+The package exports optional integration surfaces without requiring their frameworks at its own compile time:
+
+| Consumer | Import | Integration behavior |
+| --- | --- | --- |
+| Vercel AI SDK v4+ | `@neo4j-labs/agent-memory/middleware/vercel-ai` | Injects three-tier context when available, can persist user input before generation and assistant text afterward, and falls back to flat history |
+| LangChain JS | `@neo4j-labs/agent-memory/integrations/langchain` | Provides `Neo4jChatMessageHistory` and `Neo4jEntityRetriever` shapes |
+| Mastra | `@neo4j-labs/agent-memory/integrations/mastra` | Maps Mastra threads and messages to hosted conversations and messages |
+| AWS Strands | `@neo4j-labs/agent-memory/integrations/strands` | Provides session storage, context injection, and best-effort reasoning hooks |
+| MCP tool host | `@neo4j-labs/agent-memory/mcp` | Exposes tool definitions plus `handleMemoryToolCall` for an MCP server you own |
+
+The TypeScript MCP module defines **12** hosted-standard tools. It is distinct from the Python FastMCP server, whose `extended` profile exposes 16 tools for the Python SDK's two-backend model. Do not use tool counts or exact tool names from one SDK as documentation for the other.
+
+The repository also ships the independently released `@neo4j-labs/nams-ai-provider` package. It is a Vercel AI SDK v7 `ProviderV4`/middleware/tools integration with cross-session retrieval and optional MCP tool merging, rather than a subpath of this SDK. See [NAMS provider for Vercel AI SDK](typescript/nams-ai-provider.md) for its scope, lifecycle, and helper behavior.
+
+The in-tree `typescript/examples/mcp/` application shows how to register the 12 TypeScript tool definitions on `@modelcontextprotocol/sdk` over stdio. The hosted service also exposes an MCP endpoint at `https://memory.neo4jlabs.com/mcp`; self-hosting is useful when a caller needs to log, audit, filter, or rewrite tool calls on the path to NAMS.
+
+## Develop and validate the package
+
+```bash
+cd typescript
+npm ci
+npm run lint
+npm run test:unit
+npm run test:integration
+npm run build
+npm pack --dry-run
+```
+
+`npm run lint` runs `tsc --noEmit`. `npm test` runs both unit and integration suites. The CI workflow tests Node 20 and 22, builds the artifact, checks its package contents, and type-checks every in-tree framework example after building `dist/`. See [Development environment and verification workflow](development/contributor-workflow.md) for the root `make ts-*` equivalents and hosted end-to-end test rules.
+
+## Source map
+
+| Concern | Location |
+| --- | --- |
+| Package metadata, exports, scripts | `typescript/package.json` |
+| Client construction and transport selection | `typescript/src/client.ts` |
+| Memory data types and options | `typescript/src/types.ts` |
+| REST route mapping and error conversion | `typescript/src/transport/rest.ts` |
+| TCK bridge transport | `typescript/src/transport/bridge.ts` |
+| Short-term, long-term, reasoning, and query accessors | `typescript/src/short-term/`, `typescript/src/long-term/`, `typescript/src/reasoning/`, `typescript/src/query/` |
+| API-key authentication | `typescript/src/auth/` |
+| Hosted ontologies | `typescript/src/ontology/` |
+| Framework and MCP integration modules | `typescript/src/integrations/`, `typescript/src/middleware/`, `typescript/src/mcp/` |
+| Runnable integration examples | `typescript/examples/` |
+| Tests | `typescript/test/` |

--- a/openwiki/typescript/nams-ai-provider.md
+++ b/openwiki/typescript/nams-ai-provider.md
@@ -1,0 +1,163 @@
+---
+type: Integration Guide
+title: NAMS provider for Vercel AI SDK
+description: Add persistent NAMS-backed memory to Vercel AI SDK v7 models through provider, middleware, or explicit tool integration modes.
+tags: [typescript, vercel-ai, nams, provider, memory]
+---
+
+# NAMS provider for Vercel AI SDK
+
+`@neo4j-labs/nams-ai-provider` is a separately published TypeScript package that adds NAMS memory to Vercel AI SDK v7 applications. It is not the same surface as the minimal Vercel middleware exported from `@neo4j-labs/agent-memory/middleware/vercel-ai`: this package targets `ProviderV4`, supports cross-session retrieval, optional graph extraction, explicit memory tools, and optional MCP tool merging.
+
+It requires Node.js 20 or later. Its peer dependencies include `ai` v7, `@ai-sdk/provider` v4, `@neo4j-labs/agent-memory` approximately version `0.4`, and `zod`; `@ai-sdk/mcp` is optional and only needed for MCP tool merging.
+
+```bash
+npm install @neo4j-labs/nams-ai-provider ai @ai-sdk/provider @neo4j-labs/agent-memory zod
+```
+
+## Choose an integration mode
+
+| Mode | Primary API | Retrieval and persistence | Best fit |
+| --- | --- | --- | --- |
+| Provider | `createNamsProvider(options)` | Automatic on model calls | A Vercel AI provider registry or a straightforward model swap |
+| Middleware | `createNams(config).wrap(model, scope)` | Automatic on model calls | An existing `LanguageModelV4` instance that needs transparent memory |
+| Tools | `createNams(config).tools(scope)` | Model-driven through `query_memory` and `store_memory` | A tool loop where memory use should be visible and controllable |
+
+The provider and middleware modes retrieve relevant memories before generation and persist the turn after generation. Tools mode exposes that behavior as two model-callable tools, so prompt instructions and enforcement policy matter.
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant App
+    participant Nams as NAMS memory layer
+    participant Model as Base language model
+    User->>App: submit a message
+    App->>Nams: resolve conversation and retrieve memory
+    Nams-->>App: relevant memory hits
+    App->>Model: prompt with injected memory
+    Model-->>App: generated response
+    App->>Nams: persist interaction and optional extraction
+    App-->>User: response
+```
+
+This is the transparent provider/middleware path; tools mode lets the model issue its own retrieval and storage calls instead.
+
+## Configuration and scope
+
+All modes accept NAMS connection settings plus a user scope:
+
+| Setting | Required | Meaning |
+| --- | --- | --- |
+| `apiKey` | Yes | NAMS API key; read it from authorized environment or secret configuration |
+| `endpoint` | No | NAMS REST base URL; defaults to `https://memory.neo4jlabs.com/v1` |
+| `workspaceId` | No | NAMS workspace selector |
+| `logger` | No | Non-fatal warning/error sink; defaults to console output |
+| `scope.userId` | Yes | Identifies the application user for memory lookup and conversation resolution |
+| `scope.conversationId` | No | Pins the NAMS conversation instead of selecting or creating one |
+| `maxMemories` | No | Maximum memory hits injected or returned; default is 6 |
+| `persistInteractions` | No | Persist turns in transparent modes; default is `true` |
+| `extractionModel` | No | Enables client-side graph extraction for stored non-interaction memories |
+| `extractionOptions` | No | Adjusts graph-extractor behavior, such as `skipEntity` |
+
+Each provider, middleware, or tools factory call creates a `MemoryClient` with an instance-local conversation cache. Conversation resolution is ordered as: explicit `conversationId`, cached value for workspace/user, the user's most recent NAMS conversation, then creation of a new conversation. Create an instance per user session or otherwise maintain a scope discipline that prevents applying one user's cached conversation to another user's work.
+
+## Provider and middleware modes
+
+Provider mode returns a standard `ProviderV4`. It delegates language models to a base provider and wraps every returned model with NAMS memory.
+
+```ts
+import { createNamsProvider } from "@neo4j-labs/nams-ai-provider";
+import { openai } from "@ai-sdk/openai";
+
+const nams = createNamsProvider({
+  apiKey: process.env.MEMORY_API_KEY!,
+  baseProvider: openai,
+  scope: { userId: session.userId },
+});
+
+const model = nams.languageModel("gpt-5.4-mini");
+```
+
+`createNamsProvider()` is appropriate for `createProviderRegistry`. It implements `languageModel()` only: `embeddingModel()` and `imageModel()` deliberately throw `NoSuchModelError`.
+
+Middleware mode decorates an existing model instead:
+
+```ts
+import { createNams } from "@neo4j-labs/nams-ai-provider";
+import { openai } from "@ai-sdk/openai";
+
+const nams = createNams({ apiKey: process.env.MEMORY_API_KEY! });
+const model = nams.wrap(openai("gpt-5.4-mini"), { userId: session.userId });
+```
+
+Before a call, the middleware retrieves memory from long-term entities, current-conversation messages, past conversations for the same user, and selected reasoning steps. When it finds hits, it prepends a formatted memory block to the last user message. It attempts to save the original user text once per multi-step tool loop and saves a non-empty assistant result after generation or stream completion. Retrieval and persistence failures are logged and do not turn a successful model call into an error.
+
+## Tools mode and enforcement helpers
+
+`createNams(config).tools(scope)` returns Vercel AI SDK tools named `query_memory` and `store_memory`.
+
+| Tool | Input behavior | Effect |
+| --- | --- | --- |
+| `query_memory` | Query text and a `limit` from 1 to 20, default 5 | Retrieves ranked memory hits; failures become a `found: false` result and are logged |
+| `store_memory` | Text up to 2,000 characters, type, confidence, and tags | Persists an `interaction`, `fact`, `pattern`, or `user_preference` memory |
+
+Tool descriptions encourage retrieval before answering and storage of new user information, but language models may still skip a tool. The package offers two opt-in helpers for a tool-loop application:
+
+- `enforceQueryMemory()` returns a `prepareStep` hook. Until `query_memory` has run, it requires a tool call; after its grace window (default 3 steps), it forces `query_memory`. Keep the grace window at least two steps below the agent's stop budget so the query and final answer fit.
+- `ensureMemoryStored(tools)` returns an `onFinish` hook. If `store_memory` did not run, it stores a fallback memory—by default the final assistant text as an `interaction`. It needs the exact tools object returned by this package; a shallow copy loses its associated client handle and is rejected.
+
+Use these helpers only for pure tools mode. A middleware-wrapped model already retrieves memory unconditionally, so forcing a second `query_memory` call would duplicate work.
+
+## Graph extraction and hosted limitations
+
+By default, `store_memory` writes interactions to short-term conversation memory. For other memory types, it can optionally call a supplied `extractionModel` to extract entities and relations before writing them. Without an extractor—or after extraction fails—it falls back to one long-term entity named from the stored content and attempts to attach confidence feedback.
+
+NAMS REST currently has no relationship-write endpoint. With graph extraction, extracted entity writes can succeed while relationship writes are skipped; the package logs this unsupported condition once per client rather than flooding logs for every edge. An extraction failure is similarly logged at error level once and then as warnings. Treat successful turn persistence as distinct from successful graph extraction.
+
+The extractor includes a self-referential guard so an agent response about what it already remembers does not recursively create low-quality memory-about-memory entities. Use `extractionOptions.skipEntity` to add application-specific filters.
+
+## Merge MCP tools when needed
+
+`await nams.toolsWithMcp(scope, mcpConfig)` returns `{ tools, close, mcp }`, merging the two NAMS memory tools with tools fetched from an HTTP MCP server.
+
+```ts
+const { tools, close, mcp } = await nams.toolsWithMcp(
+  { userId: session.userId },
+  { url: "https://mcp.example.com/mcp", toolPrefix: "mcp_" },
+);
+
+try {
+  // Pass tools to the Vercel AI SDK agent.
+} finally {
+  await close();
+}
+```
+
+Call `close()` when the agent finishes. `mcp.toolNames` reflects the tool names actually available. If MCP connection is required, a refused/unreachable connection raises `NamsMcpConnectionError`, which can include the HTTP status and authentication challenge. With `mcp.optional: true`, the package reports that error in `mcp` and continues with NAMS memory tools only.
+
+Avoid name collisions: without a `toolPrefix`, an MCP tool with the same name as a NAMS tool overwrites the NAMS tool in the merged set after the package logs a warning.
+
+## Develop and validate
+
+```bash
+cd typescript/packages/vercel-ai-provider
+npm ci
+npm run typecheck
+npm test
+npm run build
+```
+
+This component releases independently when a `nams-ai-provider-v*` tag triggers `.github/workflows/publish-nams-ai-provider.yml`.
+
+## Source map
+
+| Concern | Location |
+| --- | --- |
+| Package metadata and peer dependencies | `typescript/packages/vercel-ai-provider/package.json` |
+| Public factory and exports | `typescript/packages/vercel-ai-provider/src/index.ts` |
+| ProviderV4 adapter | `typescript/packages/vercel-ai-provider/src/vercel-ai-provider.ts` |
+| Transparent middleware | `typescript/packages/vercel-ai-provider/src/vercel-ai-provider-middleware.ts` |
+| NAMS client, conversation cache, retrieval, and storage | `typescript/packages/vercel-ai-provider/src/vercel-ai-provider-client.ts` |
+| Tools and MCP merging | `typescript/packages/vercel-ai-provider/src/vercel-ai-provider-tools.ts` |
+| Package tests and examples | `typescript/packages/vercel-ai-provider/test/`, `typescript/packages/vercel-ai-provider/examples/` |
+| Main TypeScript SDK | [TypeScript SDK for the hosted memory service](../typescript-sdk.md) |


### PR DESCRIPTION
Adds a generated OpenWiki evidence index under `openwiki/` plus the root files that point agents at it.

## What's included

- **`openwiki/`** — 14 generated pages covering architecture (client facade, Bolt vs NAMS backends), the memory model and operations, extraction/resolution/enrichment, framework adapters, the MCP server, observability, the examples guide, quickstart, and the TypeScript SDK (including the NAMS AI provider).
- **`AGENTS.md`** (new) — OpenWiki agent instructions: treat source and tests as authoritative, don't hand-edit generated pages, let the scheduled OpenWiki workflow regenerate them.
- **`CONTEXT.md`** (new) — project domain language: NAMS, Bolt backend, POLE+O, conformance tier, workspace, plus docs-effort terms (disposition table, ops handoff), each with terms to avoid.
- **`CLAUDE.md`** — adds an OpenWiki section that links to `AGENTS.md`.

## Notes

- Documentation only, no source or test changes. All files are root-level or under `openwiki/`, so neither the Python nor TypeScript CI workflow will fire on this PR.
- The `openwiki/` pages are generated output. Future updates should come from the OpenWiki GitHub Actions workflow rather than manual edits.