### PR TITLE
feat(python): move adapters and extras to current framework majors; fix example-blocking bugs

### DIFF
--- a/docs/modules/ROOT/pages/how-to/bring-your-own-model.adoc
+++ b/docs/modules/ROOT/pages/how-to/bring-your-own-model.adoc
@@ -54,7 +54,7 @@ Embedding-only providers:
 | Provider                 | Example model string                  | Extra                     | Dimensions
 | OpenAI                   | `openai/text-embedding-3-small`       | `[openai]`                | 1536
 | OpenAI (large)           | `openai/text-embedding-3-large`       | `[openai]`                | 3072
-| Vertex AI                | `vertex_ai/text-embedding-004`        | `[vertex-ai]`             | 768
+| Vertex AI                | `vertex_ai/gemini-embedding-001`      | `[vertex-ai]`             | 768 (3072 native, truncated by default)
 | Bedrock Titan            | `bedrock/amazon.titan-embed-text-v2:0`| `[bedrock]`               | 1024
 | sentence-transformers    | `BAAI/bge-small-en-v1.5`              | `[sentence-transformers]` | 384
 | sentence-transformers    | `BAAI/bge-large-en-v1.5`              | `[sentence-transformers]` | 1024

--- a/docs/modules/ROOT/pages/how-to/configure-embedding-provider.adoc
+++ b/docs/modules/ROOT/pages/how-to/configure-embedding-provider.adoc
@@ -131,12 +131,22 @@ from neo4j_agent_memory.llm.adapters.vertex_ai import VertexAIEmbeddingProvider
 settings = MemorySettings(
     neo4j={"password": "p"},
     embedding=VertexAIEmbeddingProvider(
-        "vertex_ai/text-embedding-004",
+        "vertex_ai/gemini-embedding-001",
         project_id="my-gcp-project",
         location="us-central1",
+        dimensions=768,
     ),
 )
 ----
+
+`gemini-embedding-001` is the current Vertex AI embedding model; `text-embedding-004`
+and the `textembedding-gecko*` family were retired by Google and now raise an error
+naming the replacement.
+The underlying `VertexAIEmbedder` truncates to 768 dimensions by default (the model
+emits 3072 natively) so that vector indexes created against the previous default keep
+working -- pass `dimensions=` here to match whatever you configure there. See
+xref:how-to/integrations/google-cloud.adoc#vertex-ai-embedding-models[the Vertex AI
+model table] for the trade-off.
 
 Vertex AI as a *chat* provider routes through LiteLLM (no native LLM adapter). Embeddings are native because the existing Vertex AI embedder predates the Protocol and is well-tested.
 

--- a/docs/modules/ROOT/pages/how-to/create-context-graph-mcp.adoc
+++ b/docs/modules/ROOT/pages/how-to/create-context-graph-mcp.adoc
@@ -44,13 +44,29 @@ Add a convenient target to your project's `Makefile`:
 [source,makefile]
 ----
 .PHONY: mcp-server
-mcp-server:  ## Start MCP server for Claude Desktop
+mcp-server:  ## Start MCP server for Claude Desktop (stdio)
 	neo4j-agent-memory mcp serve \
 		--uri $(NEO4J_URI) \
 		--user $(NEO4J_USER) \
 		--password $(NEO4J_PASSWORD) \
 		--profile extended
+
+.PHONY: mcp-server-http
+mcp-server-http:  ## Start MCP server over Streamable HTTP on :8080 (/mcp/)
+	neo4j-agent-memory mcp serve \
+		--uri $(NEO4J_URI) \
+		--user $(NEO4J_USER) \
+		--password $(NEO4J_PASSWORD) \
+		--profile extended \
+		--transport http --host 0.0.0.0 --port 8080
 ----
+
+The `stdio` target is what Claude Desktop launches. The HTTP target is for the
+case where the scaffolded web app and an MCP host need to share one running
+server -- it serves Streamable HTTP at http://localhost:8080/mcp/. The
+`[mcp]` extra installs FastMCP 4, which dropped the legacy HTTP+SSE transport in
+favour of Streamable HTTP; see
+xref:../reference/mcp-tools.adoc#_transports[Transports].
 
 == Step 3: Generate Claude Desktop Configuration
 

--- a/docs/modules/ROOT/pages/how-to/integrations/aws-strands.adoc
+++ b/docs/modules/ROOT/pages/how-to/integrations/aws-strands.adoc
@@ -24,7 +24,9 @@ together on the same agent:
 | `Neo4jMemoryStore` on `MemoryManager(stores=[...])`: long-term recall
   (entities, preferences, facts) injected into the agent loop, plus writes
   that feed server-side extraction.
-| The preferred way to give an agent memory. Requires `strands-agents>=1.44.0`.
+| The preferred way to give an agent memory. Needs `strands.memory`, which
+  arrived in `strands-agents` 1.44 — and the `[strands]` extra floors at 1.52,
+  so it is always available.
 
 | *Session manager* (push-based)
 | `Neo4jSessionManager` on `Agent(session_manager=...)`: every turn is
@@ -35,8 +37,9 @@ together on the same agent:
 | *Memory tools* (pull-based)
 | `@tool` functions the agent calls on its own judgment: search memories,
   explore the entity graph, store facts, read preferences.
-| Deep graph queries the store doesn't cover, or `strands-agents<1.44`
-  (no `MemoryStore`).
+| Deep graph queries the store doesn't cover — or a `strands-agents<1.44`
+  pin of your own, below the `[strands]` extra's floor, where there is no
+  `MemoryStore` at all.
 |===
 
 [[_overview]]
@@ -57,6 +60,36 @@ every other agent can retrieve (see <<_the_shared_brain_pattern>>).
 pip install neo4j-agent-memory[aws,strands]
 ----
 
+The extra resolves `strands-agents>=1.52,<2`. Both adapters are tested against
+1.52 and 1.55.1.
+
+[[_model_ids]]
+=== Bedrock model ids
+
+Current-generation Claude models on Bedrock are invoked through a *cross-region
+inference profile* — a `<prefix>.anthropic.…` id such as
+`us.anthropic.claude-sonnet-4-6`, not the bare foundation-model id. Which
+prefixes (`us`, `eu`, `apac`, `global`) and which models your account can
+invoke is region- and account-specific, so the snippets below resolve the id
+rather than hard-coding one:
+
+[source,python]
+----
+from neo4j_agent_memory.integrations.strands import (
+    bedrock_embedding_model,
+    bedrock_llm_model,
+)
+
+bedrock_llm_model()                  # us.anthropic.claude-sonnet-4-6
+bedrock_llm_model("claude-opus")     # us.anthropic.claude-opus-5
+bedrock_embedding_model()            # amazon.titan-embed-text-v2:0
+----
+
+`BEDROCK_MODEL_ID` overrides the resolved LLM id verbatim,
+`BEDROCK_INFERENCE_PROFILE_PREFIX` swaps just the prefix, and
+`BEDROCK_EMBEDDING_MODEL_ID` overrides the embedding id. Confirm an id with
+`aws bedrock list-inference-profiles` before deploying.
+
 == Quick Start
 
 `Neo4jMemoryStore` is the preferred way to give a Strands agent memory —
@@ -68,7 +101,11 @@ from strands import Agent
 from strands.memory import ExtractionConfig, InvocationTrigger, MemoryManager
 
 from neo4j_agent_memory import MemorySettings
-from neo4j_agent_memory.integrations.strands import Neo4jMemoryStore, Neo4jMemoryStoreConfig
+from neo4j_agent_memory.integrations.strands import (
+    Neo4jMemoryStore,
+    Neo4jMemoryStoreConfig,
+    bedrock_llm_model,
+)
 
 settings = MemorySettings(
     neo4j={"uri": "neo4j+s://xxx.databases.neo4j.io", "password": "your-password"},
@@ -83,7 +120,7 @@ store = Neo4jMemoryStore(
 )
 
 agent = Agent(
-    model="anthropic.claude-sonnet-4-20250514-v1:0",
+    model=bedrock_llm_model(),  # cross-region inference-profile id
     memory_manager=MemoryManager(stores=[store]),
 )
 
@@ -105,6 +142,7 @@ combine on one agent:
 ----
 from neo4j_agent_memory.integrations.strands import (
     Neo4jSessionManager,
+    bedrock_llm_model,
     context_graph_tools,
 )
 
@@ -122,7 +160,7 @@ store = Neo4jMemoryStore(
 manager = Neo4jSessionManager("support-42", settings=settings, extract_entities=True)
 
 agent = Agent(
-    model="anthropic.claude-sonnet-4-20250514-v1:0",
+    model=bedrock_llm_model(),  # cross-region inference-profile id
     tools=tools,
     session_manager=manager,
     memory_manager=MemoryManager(stores=[store]),
@@ -465,7 +503,10 @@ export AWS_REGION=us-east-1
 
 === Pass-Through Your Strands Model
 
-Strands agents typically use Bedrock model strings (e.g. `"anthropic.claude-sonnet-4-20250514-v1:0"`). `llm_provider_from_strands` accepts either a bare string or a model object and prepends `bedrock/` when no provider prefix is present:
+Strands agents typically use Bedrock model strings (e.g.
+`"us.anthropic.claude-sonnet-4-6"`). `llm_provider_from_strands` accepts either
+a bare string or a model object and prepends `bedrock/` when no provider prefix
+is present:
 
 [source,python]
 ----
@@ -475,7 +516,7 @@ from neo4j_agent_memory.integrations.strands import (
 )
 
 provider = llm_provider_from_strands(
-    "anthropic.claude-sonnet-4-20250514-v1:0",
+    "us.anthropic.claude-sonnet-4-6",
 )
 
 settings = MemorySettings(
@@ -576,7 +617,7 @@ Guide your agent to use memory effectively:
 [source,python]
 ----
 agent = Agent(
-    model="anthropic.claude-sonnet-4-20250514-v1:0",
+    model=bedrock_llm_model(),  # cross-region inference-profile id
     tools=tools,
     system_prompt="""You are an assistant with persistent memory.
 
@@ -681,8 +722,9 @@ For new code, `MemoryManager` injection (via `Neo4jMemoryStore`, see
 <<_memory_store>>) supersedes `Neo4jRetrievalConfig`. Both together inject
 memory twice; the session manager logs a warning when it detects the
 combination. `Neo4jRetrievalConfig` remains fully supported — it is the only
-injection path on `strands-agents<1.44` and configures its sources
-declaratively rather than through a store.
+injection path on a self-pinned `strands-agents<1.44` (below the `[strands]`
+extra's floor) and configures its sources declaratively rather than through a
+store.
 ====
 
 When a `Neo4jRetrievalConfig` is supplied, each user message triggers
@@ -795,9 +837,15 @@ retrieval_config = Neo4jRetrievalConfig(
   `user_id` scopes *writes* (multi-tenant), not searches — the search APIs
   take no user filter.
 
-* **One agent per session manager instance.** Pass multiple agents their
-  own managers (the shared-brain pattern). Strands Graph/Swarm
-  orchestration persistence is not supported in v1.
+* **One `Agent` per session manager instance; no Graph/Swarm or bidirectional
+  persistence.** Strands' `SessionManager` base class registers multi-agent and
+  `BidiAgent` hooks unconditionally, and its implementations of them raise
+  `NotImplementedError` — so attaching `Neo4jSessionManager` to a Graph, a
+  Swarm, or a `BidiAgent` fails at the first dispatch, naming the class in the
+  error. Those topologies want one of Strands' own repository-backed managers
+  (`FileSessionManager`, `S3SessionManager`, `RepositorySessionManager`). The
+  shared-brain pattern below is N independent agents, each with its own
+  manager, over one graph — not a Strands multi-agent orchestrator.
 
 * **Loop-bound transports.** Pass `settings=` (or an *unconnected*
   `memory_client=`). A client already connected on another event loop
@@ -822,7 +870,7 @@ argument on each call; the session manager takes `user_id` at construction
 # The agent passes user_id with each tool call
 
 agent = Agent(
-    model="anthropic.claude-sonnet-4-20250514-v1:0",
+    model=bedrock_llm_model(),  # cross-region inference-profile id
     tools=tools,
     session_manager=Neo4jSessionManager(
         f"support-{user_id}",
@@ -874,7 +922,7 @@ manager_b = Neo4jSessionManager(
 )
 ----
 
-See `examples/strands-session-manager/` for a runnable three-phase demo that
+See `examples/strands-session-manager/` for a runnable four-phase demo (persist, inject, restore, reasoning/tool-call mirror) that
 requires no LLM or API key.
 
 == See Also

--- a/docs/modules/ROOT/pages/how-to/integrations/google-adk.adoc
+++ b/docs/modules/ROOT/pages/how-to/integrations/google-adk.adoc
@@ -5,6 +5,20 @@
 `BaseMemoryService` interface, backing an ADK agent's memory with
 neo4j-agent-memory — on either the bolt or the NAMS backend.
 
+[NOTE]
+====
+Supported range: *google-adk 2.x* (tested against 2.8.0). Install it with the
+extra:
+
+[source,bash]
+----
+pip install "neo4j-agent-memory[google-adk]"
+----
+
+The extra also pulls `google-genai`, because search results are returned as
+`google.genai.types.Content` objects.
+====
+
 == Setup
 
 [source,python]
@@ -18,17 +32,136 @@ settings = MemorySettings(backend="nams", nams={"api_key": "nams_...",
 async with MemoryClient(settings) as client:
     memory = Neo4jMemoryService(memory_client=client, extract_on_store=True)
 
-    await memory.add_session_to_memory(session)        # stores messages, extracts entities
-    results = await memory.search_memory("user preferences")
+    await memory.add_session_to_memory(session)   # stores messages, extracts entities
+    response = await memory.search_memory(
+        app_name="memory-demo", user_id="user-123", query="user preferences"
+    )
 ----
+
+== Wire it into a Runner
+
+The memory service is passed to `Runner` (or `App`), and the agent reaches it
+through ADK's memory tools: `load_memory` lets the model search memory on
+demand, `preload_memory` injects recent recall into every request.
+
+[source,python]
+----
+import os
+
+from google.adk.agents import LlmAgent
+from google.adk.runners import Runner
+from google.adk.sessions import InMemorySessionService
+from google.adk.tools import load_memory  # or: preload_memory
+from google.genai import types
+
+from neo4j_agent_memory import MemoryClient, MemorySettings
+from neo4j_agent_memory.integrations.google_adk import Neo4jMemoryService
+
+APP_NAME = "memory-demo"
+USER_ID = "user-123"
+
+async with MemoryClient(MemorySettings()) as client:
+    memory_service = Neo4jMemoryService(memory_client=client, user_id=USER_ID)
+    session_service = InMemorySessionService()
+
+    agent = LlmAgent(
+        name="memory_demo",
+        model=os.environ.get("ADK_MODEL", "gemini-2.5-flash"),
+        instruction="Use load_memory to recall anything the user told you before.",
+        tools=[load_memory],
+    )
+    runner = Runner(
+        app_name=APP_NAME,
+        agent=agent,
+        session_service=session_service,
+        memory_service=memory_service,
+    )
+
+    session = await session_service.create_session(app_name=APP_NAME, user_id=USER_ID)
+    async for event in runner.run_async(
+        user_id=USER_ID,
+        session_id=session.id,
+        new_message=types.Content(role="user", parts=[types.Part(text="My sister is Sarah.")]),
+    ):
+        pass  # stream events as you like
+
+    # Persist the turn so the next session can recall it.
+    await memory_service.add_session_to_memory(
+        await session_service.get_session(
+            app_name=APP_NAME, user_id=USER_ID, session_id=session.id
+        )
+    )
+----
+
+[TIP]
+====
+`Runner.run_async()` is an async *generator* — iterate it with `async for`, never
+`await` it. `InMemorySessionService.create_session()` / `get_session()` are
+coroutines and must be awaited.
+====
+
+== Reading search results
+
+`search_memory()` returns a `SearchMemoryResponse`, not a list. Each
+`MemoryEntry` carries ADK content plus attribution:
+
+[source,python]
+----
+response = await memory_service.search_memory(
+    app_name="memory-demo", user_id="user-123", query="project deadline"
+)
+
+for entry in response.memories:
+    text = "".join(part.text or "" for part in entry.content.parts)
+    print(entry.author, entry.timestamp, entry.custom_metadata["memory_type"], text)
+----
+
+* `content` — a `google.genai.types.Content` with text parts.
+* `author` — the message role or ADK agent name for conversation recall;
+  `entity` or `preference` for long-term recall.
+* `timestamp` — ISO-8601 creation time (what `preload_memory` renders).
+* `custom_metadata` — `memory_type`, the similarity `score`, and the source
+  `session_id` / `category` when present.
+
+Two library-side conveniences sit alongside the ADK contract:
+`get_memories_for_session(session_id)` returns the library's own `MemoryEntry`
+dataclass (with `.content` as a plain string and `.memory_type`), and
+`add_memory(content=..., memory_type="preference", category=...)` writes a
+single memory and returns it.
+
+== Writing memory
+
+[cols="1,2"]
+|===
+| Call | Effect
+
+| `add_session_to_memory(session)`
+| Ingests every text-bearing event in the session as a message.
+
+| `add_events_to_memory(app_name=..., user_id=..., events=[...], session_id=...)`
+| Ingests an incremental slice (e.g. just the latest turn) — what
+  `Context.add_events_to_memory()` sends.
+
+| `add_memory(app_name=..., user_id=..., memories=[MemoryEntry(...)])`
+| Writes explicit ADK memory items — what `Context.add_memory()` sends.
+
+| `add_memory(content=..., memory_type="message" \| "preference", ...)`
+| The library convenience form; returns the created entry.
+|===
+
+ADK authors model turns with the *agent name* (`memory_demo`, `supervisor`, …),
+while the library stores `MessageRole` values. Agent-authored events are stored
+as `assistant` messages with the original author preserved in the message
+metadata as `adk_author`, and re-attributed to that agent name on the way back
+out of `search_memory()`.
 
 == Conversation scoping on NAMS
 
 NAMS message search is *conversation-scoped*; ADK's `search_memory()` does not
 carry a session id. `Neo4jMemoryService` handles this for you:
 
-* It tracks the active session whenever you call `add_session_to_memory` or
-  `add_memory`, and scopes `search_memory` to it.
+* It tracks the active session whenever you call `add_session_to_memory`,
+  `add_events_to_memory` or `add_memory`, and scopes `search_memory` to it.
 * You can override per call: `search_memory(query, session_id=...)`.
 * When no session is known on NAMS, it *skips* message search (rather than
   issuing the unscoped search NAMS rejects) and still returns entity and
@@ -48,6 +181,8 @@ graph clean — tool JSON is not stringified into it.
 * `session_id` is the canonical short-term parameter; `conversation_id` is
   accepted as an alias (`session_id` wins).
 * `add_entity` takes `entity_type` (aliases: `type`, `label`).
+* `search_memory` accepts `query` positionally as well as by keyword; ADK itself
+  always calls it with keywords (`app_name=`, `user_id=`, `query=`).
 
 [NOTE]
 ====

--- a/docs/modules/ROOT/pages/how-to/integrations/google-cloud.adoc
+++ b/docs/modules/ROOT/pages/how-to/integrations/google-cloud.adoc
@@ -11,7 +11,7 @@ Neo4j Agent Memory provides comprehensive Google Cloud integration, including Ve
 | Feature | Description | Status
 
 | Vertex AI Embeddings
-| Generate embeddings using Google's text-embedding-004 model
+| Generate embeddings using Google's `gemini-embedding-001` model
 | Production Ready
 
 | Google ADK
@@ -19,7 +19,7 @@ Neo4j Agent Memory provides comprehensive Google Cloud integration, including Ve
 | Production Ready
 
 | MCP Server
-| Model Context Protocol server with 5 memory tools
+| Model Context Protocol server — 6 core / 16 extended memory tools
 | Production Ready
 
 | Cloud Run
@@ -40,8 +40,8 @@ pip install neo4j-agent-memory[google-adk]
 # MCP server
 pip install neo4j-agent-memory[mcp]
 
-# All Google Cloud features
-pip install neo4j-agent-memory[google,mcp]
+# All Google Cloud features ([google] is Vertex AI only)
+pip install "neo4j-agent-memory[google,google-adk,mcp]"
 ----
 
 == Pass-through your Google ADK / Gemini model
@@ -60,7 +60,7 @@ provider = llm_provider_from_google_adk("gemini-2.5-flash")
 settings = MemorySettings(
     neo4j={"password": "p"},
     llm=provider,
-    embedding="vertex_ai/text-embedding-004",     # Vertex AI embeddings
+    embedding="vertex_ai/gemini-embedding-001",   # Vertex AI embeddings
 )
 ----
 
@@ -89,12 +89,13 @@ You need a running Neo4j instance. Options:
 
 [source,bash]
 ----
-# Local Docker for development
+# Local Docker for development (matches what CI runs)
 docker run -d \
   --name neo4j \
   -p 7474:7474 -p 7687:7687 \
   -e NEO4J_AUTH=neo4j/password \
-  neo4j:5-enterprise
+  -e NEO4J_PLUGINS='["apoc"]' \
+  neo4j:5.26-community
 ----
 
 == Vertex AI Embeddings
@@ -107,9 +108,8 @@ Generate high-quality text embeddings using Google's Vertex AI models.
 ----
 from neo4j_agent_memory.embeddings.vertex_ai import VertexAIEmbedder
 
-# Create embedder
+# Create embedder (gemini-embedding-001 is the default model)
 embedder = VertexAIEmbedder(
-    model="text-embedding-004",
     project_id="your-gcp-project",  # or set GOOGLE_CLOUD_PROJECT
     location="us-central1",
 )
@@ -118,7 +118,9 @@ embedder = VertexAIEmbedder(
 embedding = await embedder.embed("Hello, world!")
 print(f"Dimensions: {len(embedding)}")  # 768
 
-# Batch embedding (up to 250 texts per batch)
+# Batch embedding. gemini-embedding-001 accepts one text per request, so the
+# embedder issues one call per text; text-embedding-005 and
+# text-multilingual-embedding-002 batch up to 250 per request.
 embeddings = await embedder.embed_batch([
     "First text",
     "Second text",
@@ -126,24 +128,61 @@ embeddings = await embedder.embed_batch([
 ])
 ----
 
+[[vertex-ai-embedding-dimensions]]
+=== Output dimensionality
+
+`gemini-embedding-001` emits 3072 dimensions natively and supports Matryoshka
+truncation to 1536 or 768. The embedder defaults to `output_dimensionality=768`:
+
+[source,python]
+----
+# Default: 768 dimensions, compatible with indexes created for the
+# retired text-embedding-004 model.
+embedder = VertexAIEmbedder()
+
+# Native 3072 dimensions -- best retrieval quality, but the Neo4j vector
+# indexes must be created at 3072 (they cannot be resized afterwards).
+embedder = VertexAIEmbedder(output_dimensionality=None)
+
+# Middle ground
+embedder = VertexAIEmbedder(output_dimensionality=1536)
+----
+
+The trade-off: Neo4j vector index dimensionality is fixed when the index is
+created, and `MemoryClient` sizes its indexes from `embedder.dimensions`.
+Keeping the default 768 means an existing database keeps working after the
+model change with no re-embedding. Raising it on an existing database means
+dropping the `Message`, `Entity`, `Preference` and `ReasoningTrace` vector
+indexes, recreating them at the new size, and re-embedding every node, so
+choose 1536 or 3072 at the start of a new project rather than later.
+
+[[vertex-ai-embedding-models]]
 === Supported Models
 
 [cols="2,1,2", options="header"]
 |===
-| Model | Dimensions | Notes
+| Model | Native dimensions | Notes
 
-| `text-embedding-004`
-| 768
-| Recommended for most use cases
+| `gemini-embedding-001`
+| 3072
+| Default. Truncatable to 1536 or 768; one text per request
 
-| `textembedding-gecko@003`
+| `text-embedding-005`
 | 768
-| Legacy model
+| English and code, task-specific; up to 250 texts per request
 
-| `textembedding-gecko-multilingual@001`
+| `text-multilingual-embedding-002`
 | 768
-| Multilingual support
+| Multilingual; up to 250 texts per request
 |===
+
+[IMPORTANT]
+====
+`text-embedding-004` (shut down 2026-01-14) and the `textembedding-gecko*`
+family (shut down 2025-04-09) no longer serve requests. Passing either id to
+`VertexAIEmbedder` or to `EmbeddingConfig(provider=VERTEX_AI, ...)` raises an
+error naming the replacement rather than failing at request time.
+====
 
 === Task Types
 
@@ -153,13 +192,13 @@ Vertex AI supports different task types for optimized embeddings:
 ----
 # For indexing documents
 doc_embedder = VertexAIEmbedder(
-    model="text-embedding-004",
+    model="gemini-embedding-001",
     task_type="RETRIEVAL_DOCUMENT",
 )
 
 # For search queries
 query_embedder = VertexAIEmbedder(
-    model="text-embedding-004",
+    model="gemini-embedding-001",
     task_type="RETRIEVAL_QUERY",
 )
 ----
@@ -177,11 +216,8 @@ Available task types:
 [source,python]
 ----
 from neo4j_agent_memory import MemoryClient, MemorySettings
-from neo4j_agent_memory.config.settings import (
-    EmbeddingConfig,
-    EmbeddingProvider,
-    Neo4jConfig,
-)
+from neo4j_agent_memory.config.settings import Neo4jConfig
+from neo4j_agent_memory.llm.adapters.vertex_ai import VertexAIEmbeddingProvider
 from pydantic import SecretStr
 
 settings = MemorySettings(
@@ -189,11 +225,11 @@ settings = MemorySettings(
         uri="bolt://localhost:7687",
         password=SecretStr("password"),
     ),
-    embedding=EmbeddingConfig(
-        provider=EmbeddingProvider.VERTEX_AI,
-        model="text-embedding-004",
+    embedding=VertexAIEmbeddingProvider(
+        "vertex_ai/gemini-embedding-001",
         project_id="your-gcp-project",
         location="us-central1",
+        dimensions=768,
     ),
 )
 
@@ -236,15 +272,26 @@ async with MemoryClient(settings) as client:
     }
     await memory_service.add_session_to_memory(session)
 
-    # Search across all memory types
-    results = await memory_service.search_memory(
+    # Search across all memory types. search_memory() returns an ADK
+    # SearchMemoryResponse — iterate response.memories, not the response.
+    response = await memory_service.search_memory(
         query="user preferences",
         limit=10,
     )
 
-    for entry in results:
-        print(f"[{entry.memory_type}] {entry.content}")
+    for entry in response.memories:
+        # entry.content is a google.genai.types.Content (a list of parts),
+        # and the memory type lives in custom_metadata.
+        text = "".join(part.text or "" for part in entry.content.parts)
+        kind = (entry.custom_metadata or {}).get("memory_type")
+        print(f"[{kind}/{entry.author}] {text}")
 ----
+
+TIP: The runnable version of this wiring — a real `Runner`, ADK's `load_memory`
+tool, and two turns across two sessions — is
+https://github.com/neo4j-labs/agent-memory/tree/main/examples/google_adk_demo[`examples/google_adk_demo/`].
+It runs without Google credentials by driving the same loop with a scripted
+model.
 
 === API Reference
 
@@ -267,17 +314,26 @@ await memory_service.add_session_to_memory(
 
 ==== search_memory
 
-Semantic search across all memory types.
+Semantic search across all memory types. Returns an ADK `SearchMemoryResponse`.
 
 [source,python]
 ----
-results = await memory_service.search_memory(
+response = await memory_service.search_memory(
     query="search query",
-    app_name="my-app",      # Optional app filter
-    user_id="user-id",      # Optional user filter
+    app_name="my-app",      # Accepted for ADK contract parity
+    user_id="user-id",      # Accepted for ADK contract parity
+    session_id="session-1", # Scopes message search (required on hosted NAMS)
     limit=10,
 )
+
+for entry in response.memories:
+    text = "".join(part.text or "" for part in entry.content.parts)
+    metadata = entry.custom_metadata or {}
+    print(entry.author, metadata.get("memory_type"), metadata.get("score"), text)
 ----
+
+Entity and preference recall is workspace-wide; only message search is scoped by
+`session_id`.
 
 ==== get_memories_for_session
 
@@ -317,42 +373,65 @@ await memory_service.clear_session(session_id="session-id")
 
 === Integration with ADK Agents
 
+Memory is a **`Runner`-level service** in Google ADK 2.x: pass it as
+`Runner(memory_service=...)`. `LlmAgent` has no `memory=` parameter, and there is
+no `@agent.tool` decorator — give the agent ADK's built-in `load_memory` tool
+(or `preload_memory`) and it reads from Neo4j.
+
 [source,python]
 ----
-from google.adk import Agent
+import os
+
+from google.adk.agents import LlmAgent
+from google.adk.runners import Runner
+from google.adk.sessions import InMemorySessionService
+from google.adk.tools import load_memory
+from google.genai import types
+
 from neo4j_agent_memory import MemoryClient, MemorySettings
 from neo4j_agent_memory.integrations.google_adk import Neo4jMemoryService
 
-# Initialize memory
-settings = MemorySettings(...)
-memory_client = MemoryClient(settings)
-await memory_client.connect()
+APP, USER, SID = "my-app", "user-123", "session-1"
+settings = MemorySettings()
 
-# Create memory service
-memory_service = Neo4jMemoryService(
-    memory_client=memory_client,
-    user_id="user-123",
-)
+async with MemoryClient(settings) as client:
+    session_service = InMemorySessionService()
+    memory_service = Neo4jMemoryService(memory_client=client, user_id=USER)
 
-# Use with ADK Agent
-agent = Agent(
-    name="my-agent",
-    memory=memory_service,
-)
+    runner = Runner(
+        app_name=APP,
+        agent=LlmAgent(
+            name="my-agent",
+            model=os.environ.get("ADK_MODEL", "gemini-2.5-flash"),
+            instruction="Call load_memory to recall anything the user told you before.",
+            tools=[load_memory],
+        ),
+        session_service=session_service,
+        memory_service=memory_service,
+    )
 
-# Create custom tools using memory
-@agent.tool
-async def remember_fact(fact: str) -> str:
-    """Store a fact for later recall."""
-    await memory_service.add_memory(content=fact, memory_type="message")
-    return f"Remembered: {fact}"
+    await session_service.create_session(app_name=APP, user_id=USER, session_id=SID)
 
-@agent.tool
-async def recall_memories(query: str) -> list[str]:
-    """Search memories for relevant information."""
-    results = await memory_service.search_memory(query, limit=5)
-    return [entry.content for entry in results]
+    # run_async() is an async generator — iterate it, never await it.
+    async for event in runner.run_async(
+        user_id=USER,
+        session_id=SID,
+        new_message=types.Content(
+            role="user", parts=[types.Part(text="I work on Project Alpha")]
+        ),
+    ):
+        pass
+
+    # Commit the finished ADK session to Neo4j so later sessions can recall it.
+    await memory_service.add_session_to_memory(
+        await session_service.get_session(app_name=APP, user_id=USER, session_id=SID)
+    )
+    await runner.close()
 ----
+
+To persist only the latest turn instead of re-ingesting the whole session, use
+the ADK 2.x delta API, `add_events_to_memory(app_name=..., user_id=...,
+events=[...], session_id=...)`.
 
 === Domain Data Access via MemoryClient.graph
 
@@ -381,7 +460,7 @@ async with MemoryClient(settings) as client:
     )
 ----
 
-This pattern is used in the **Financial Advisor example** (`examples/google-cloud-financial-advisor/`), where a `Neo4jDomainService` wraps `client.graph` to provide typed query methods for customers, transactions, alerts, sanctions screening, and network analysis.
+This pattern is used in the **Financial Advisor example** (`examples/financial-services-advisor/google-cloud-financial-advisor/`), where a `Neo4jDomainService` wraps `client.graph` to provide typed query methods for customers, transactions, alerts, sanctions screening, and network analysis.
 
 See xref:../../reference/api/memory-client.adoc#graph[MemoryClient.graph reference] for details.
 
@@ -427,8 +506,9 @@ The **extended** profile adds 10 more tools for conversation history, session li
 # stdio transport (for local MCP clients like Claude Desktop)
 neo4j-agent-memory mcp serve
 
-# SSE transport (for Cloud Run/HTTP deployment)
-neo4j-agent-memory mcp serve --transport sse --port 8080
+# Streamable HTTP transport (for Cloud Run/HTTP deployment).
+# Serves the MCP endpoint at POST/GET /mcp/.
+neo4j-agent-memory mcp serve --transport http --host 0.0.0.0 --port 8080
 
 # With custom Neo4j connection
 neo4j-agent-memory mcp serve \
@@ -469,8 +549,8 @@ async with MemoryClient(settings) as client:
     # stdio transport
     await server.run()
 
-    # Or SSE for HTTP
-    await server.run_sse(host="0.0.0.0", port=8080)
+    # Or Streamable HTTP
+    await server.run_http(host="0.0.0.0", port=8080)
 ----
 
 === Tool Schemas
@@ -534,7 +614,8 @@ WORKDIR /app
 COPY . .
 RUN pip install neo4j-agent-memory[google,mcp]
 EXPOSE 8080
-CMD ["neo4j-agent-memory", "mcp", "serve", "--transport", "sse", "--port", "8080"]
+CMD ["neo4j-agent-memory", "mcp", "serve", \
+     "--transport", "http", "--host", "0.0.0.0", "--port", "8080"]
 ----
 
 === Secret Manager Integration
@@ -594,10 +675,13 @@ See `deploy/cloudrun/service.yaml` for the full Cloud Run service configuration 
 
 Comprehensive examples are available in `examples/google_cloud_integration/`:
 
-* `vertex_ai_embeddings.py` - Vertex AI embedding generation
-* `adk_memory_service.py` - Google ADK integration patterns
-* `mcp_server_demo.py` - MCP server tools demonstration
-* `full_pipeline.py` - End-to-end demo combining all features
+* `vertex_ai_embeddings.py` - Vertex AI embedding generation and multi-tenant writes
+* `adk_memory_service.py` - entity-extraction and preference narratives through the ADK adapter
+* `mcp_server_demo.py` - MCP server tool profiles and live tool calls
+* `full_pipeline.py` - end-to-end demo: Vertex AI, ADK, MCP, a reasoning-trace audit query, buffered writes, consolidation
+
+The smaller ADK on-ramp — a real `Runner` loop with `load_memory` — is
+`examples/google_adk_demo/`.
 
 [source,bash]
 ----
@@ -607,7 +691,7 @@ python full_pipeline.py
 
 === Financial Advisor (Full Application)
 
-A complete multi-agent compliance investigation app in `examples/google-cloud-financial-advisor/`:
+A complete multi-agent compliance investigation app in `examples/financial-services-advisor/google-cloud-financial-advisor/`:
 
 * **Multi-agent architecture**: Supervisor + 4 specialist agents (KYC, AML, Relationship, Compliance)
 * **Neo4j domain data**: All customer, transaction, organization, sanctions, and PEP data stored and queried from Neo4j via `MemoryClient.graph`
@@ -616,7 +700,7 @@ A complete multi-agent compliance investigation app in `examples/google-cloud-fi
 
 [source,bash]
 ----
-cd examples/google-cloud-financial-advisor
+cd examples/financial-services-advisor/google-cloud-financial-advisor
 cp .env.example .env  # Set GOOGLE_API_KEY, NEO4J_URI, NEO4J_PASSWORD
 make install && make load-data && make dev
 ----

--- a/docs/modules/ROOT/pages/how-to/integrations/langchain.adoc
+++ b/docs/modules/ROOT/pages/how-to/integrations/langchain.adoc
@@ -6,947 +6,647 @@
 :icons: font
 :source-highlighter: highlight.js
 
-How to integrate neo4j-agent-memory with LangChain to build memory-enabled chains and agents with a persistent context graph.
+How to integrate neo4j-agent-memory with LangChain 1.x to build memory-enabled agents and chains backed by a persistent context graph.
+
+[NOTE]
+====
+**Supported LangChain range: 1.x.** The `[langchain]` extra installs
+`langchain-core>=1.0,<2`; the `[langchain-agents]` extra adds
+`langchain>=1.0,<2` (which pulls LangGraph) for the `create_agent` middleware.
+
+LangChain 1.0 retired the memory story this page used to teach.
+`langchain_core.memory.BaseMemory` no longer exists, and
+`ConversationChain`, `ConversationBufferMemory`, `AgentExecutor` and
+`create_openai_functions_agent` moved to the `langchain-classic`
+distribution. The supported shape is:
+
+* **thread history** — a `BaseChatMessageHistory` implementation (plus a
+  LangGraph checkpointer when you use the graph runtime), and
+* **context injection / persistence** — `create_agent` middleware hooks.
+
+Both are what this library ships. See <<legacy>> if you are maintaining a
+pre-1.0 application.
+====
+
+https://github.com/neo4j-labs/agent-memory/tree/main/examples/langchain_agent.py[examples/langchain_agent.py] is the runnable version of this page; https://github.com/neo4j-labs/agent-memory/tree/main/examples/nams-langchain[examples/nams-langchain] runs the same adapter against the hosted backend.
 
 == Overview
 
-LangChain is a popular framework for building LLM applications. Integrating with neo4j-agent-memory provides persistent memory that survives across sessions, enabling agents to build and query a context graph over time.
+The library ships three LangChain adapters, each implementing a base class that
+exists in LangChain 1.x, plus one pass-through helper.
+
+[cols="1,1,2", options="header"]
+|===
+| Adapter | Implements | Use it for
+
+| `Neo4jAgentMemory`
+| `langchain_core.chat_history.BaseChatMessageHistory`
+| Thread history for `RunnableWithMessageHistory`, and memory-context assembly
+  for hand-rolled prompts.
+
+| `Neo4jMemoryRetriever`
+| `langchain_core.retrievers.BaseRetriever`
+| RAG over all three memory layers — messages, entities, preferences and traces.
+
+| `Neo4jMemoryMiddleware`
+| `langchain.agents.middleware.AgentMiddleware`
+| Give a `create_agent` agent memory: inject context before the model call,
+  persist the turn after it.
+
+| `llm_provider_from_langchain`
+| —
+| Reuse your configured LangChain chat model as memory's own LLM.
+|===
 
 [cols="1", options="header"]
 |===
-| LangChain + Context Graph Architecture
+| LangChain 1.x + Context Graph Architecture
 
 a|
 [source,text]
 ----
-┌─────────────────────────────────────────────────────┐
-│                   LangChain Agent                   │
-│  ┌─────────────┐  ┌─────────────┐  ┌─────────────┐ │
-│  │    Tools    │  │   Memory    │  │    Chain    │ │
-│  │             │  │  Interface  │  │             │ │
-│  └──────┬──────┘  └──────┬──────┘  └─────────────┘ │
-│         │                │                          │
-│         ▼                ▼                          │
-│  ┌─────────────────────────────────────────────┐   │
-│  │        Neo4jAgentMemory Adapter             │   │
-│  │  • Implements BaseChatMessageHistory        │   │
-│  │  • Provides entity/preference tools         │   │
-│  │  • Callbacks for reasoning traces           │   │
-│  └──────────────────────┬──────────────────────┘   │
-└─────────────────────────┼───────────────────────────┘
-                          │
-                          ▼
-┌─────────────────────────────────────────────────────┐
-│               Neo4j Context Graph                   │
-│  Messages ──── Entities ──── Preferences            │
-│      │            │              │                  │
-│      └────────────┴──────────────┘                  │
-│            Reasoning Traces                         │
-└─────────────────────────────────────────────────────┘
+┌──────────────────────────────────────────────────────────┐
+│               create_agent(model, tools, …)              │
+│                                                          │
+│   abefore_model ──▶ awrap_model_call ──▶ aafter_model    │
+│        │                   │                   │         │
+│        │                   ▼                   │         │
+│        │          inject memory block          │         │
+│        │          into system message          │         │
+│        ▼                                       ▼         │
+│   persist user turn                    persist reply     │
+│  ┌────────────────────────────────────────────────────┐  │
+│  │              Neo4jMemoryMiddleware                 │  │
+│  └───────────────────────┬────────────────────────────┘  │
+└──────────────────────────┼───────────────────────────────┘
+                           │
+      Neo4jAgentMemory ────┤──── Neo4jMemoryRetriever
+     (BaseChatMessage…)    │         (BaseRetriever)
+                           ▼
+┌──────────────────────────────────────────────────────────┐
+│                   Neo4j Context Graph                    │
+│   Messages ──── Entities ──── Preferences ──── Traces    │
+└──────────────────────────────────────────────────────────┘
 ----
 |===
 
 == Prerequisites
 
 * Python 3.10+
-* `neo4j-agent-memory` and `langchain` installed
-* Neo4j database running
-* OpenAI API key (or other LLM provider)
+* A Neo4j database (or a hosted NAMS workspace — see xref:explanation/backends.adoc[Backends])
+* An API key for your model provider
 
 [source,bash]
 ----
-pip install neo4j-agent-memory langchain langchain-openai
+# Chat history + retriever only
+pip install "neo4j-agent-memory[langchain,openai]"
+
+# Plus the create_agent middleware
+pip install "neo4j-agent-memory[langchain-agents,openai]" langchain-openai
 ----
 
 == Pass-through your LangChain model
 
-To avoid double-declaring the same model on the agent side and the memory side, use `llm_provider_from_langchain` to feed your LangChain `BaseChatModel` directly into `MemorySettings`:
+To avoid declaring the same model twice — once for the agent, once for memory's
+entity extraction — convert your LangChain `BaseChatModel` into an
+`LLMProvider`:
 
 [source,python]
 ----
-from langchain_anthropic import ChatAnthropic
+import os
+
+from langchain_openai import ChatOpenAI
 
 from neo4j_agent_memory import MemoryClient, MemorySettings
 from neo4j_agent_memory.integrations.langchain import (
     llm_provider_from_langchain,
 )
 
-# Configure your LangChain model however you normally would.
-chat = ChatAnthropic(
-    model_name="claude-3-5-sonnet-latest",
-    temperature=0.0,
-)
+# Configure your LangChain model however you normally would. Temperature is
+# left at the provider default: the GPT-5 family rejects non-default values.
+chat = ChatOpenAI(model=os.getenv("OPENAI_MODEL", "gpt-5-mini"))
 
 # Convert it to an LLMProvider for the memory client.
 provider = llm_provider_from_langchain(chat)
 
 settings = MemorySettings(
-    neo4j={"password": "p"},
+    neo4j={"password": os.environ["NEO4J_PASSWORD"]},
     llm=provider,
     embedding="openai/text-embedding-3-small",
 )
 ----
 
-The helper introspects the model's class name and attributes (`model_name`, `anthropic_api_key`, `openai_api_key`, `openai_api_base`, …) and routes via `from_provider`. `ChatAnthropic` resolves to `AnthropicProvider`; `ChatOpenAI` to `OpenAIProvider`; everything else falls through to LiteLLM.
+The helper introspects the model's class name and attributes (`model_name`,
+`anthropic_api_key`, `openai_api_key`, `openai_api_base`, …) and routes via
+`from_provider`. `ChatOpenAI` resolves to `OpenAIProvider`; `ChatAnthropic` to
+`AnthropicProvider`; everything else falls through to LiteLLM.
+
+Note the spelling: `model=` is the current constructor argument. `model_name=`
+is a legacy alias.
 
 For the full pattern across all integrations, see xref:how-to/migrate-to-providers.adoc[Migrate to Pluggable Providers — Pattern 5].
 
-== Message History Integration
+[#agent]
+== Give an agent memory with middleware
 
-=== Create Custom Message History
-
-Implement LangChain's `BaseChatMessageHistory` interface:
-
-[source,python]
-----
-from typing import List
-from langchain_core.chat_history import BaseChatMessageHistory
-from langchain_core.messages import BaseMessage, HumanMessage, AIMessage
-from neo4j_agent_memory import MemoryClient, MemorySettings
-
-
-class Neo4jChatMessageHistory(BaseChatMessageHistory):
-    """LangChain message history backed by neo4j-agent-memory."""
-
-    def __init__(
-        self,
-        memory_client: MemoryClient,
-        session_id: str,
-        user_id: str | None = None,
-    ):
-        self.memory_client = memory_client
-        self.session_id = session_id
-        self.user_id = user_id
-
-    @property
-    def messages(self) -> List[BaseMessage]:
-        """Retrieve all messages for this session."""
-        import asyncio
-
-        # Run async method synchronously
-        loop = asyncio.get_event_loop()
-        conversation = loop.run_until_complete(
-            self.memory_client.short_term.get_conversation(
-                session_id=self.session_id,
-            )
-        )
-
-        result = []
-        for msg in conversation.messages:
-            if msg.role == "user":
-                result.append(HumanMessage(content=msg.content))
-            elif msg.role == "assistant":
-                result.append(AIMessage(content=msg.content))
-
-        return result
-
-    def add_message(self, message: BaseMessage) -> None:
-        """Add a message to the session."""
-        import asyncio
-
-        role = "user" if isinstance(message, HumanMessage) else "assistant"
-
-        loop = asyncio.get_event_loop()
-        loop.run_until_complete(
-            self.memory_client.short_term.add_message(
-                session_id=self.session_id,
-                role=role,
-                content=message.content,
-                metadata={"user_id": self.user_id} if self.user_id else None,
-            )
-        )
-
-    def clear(self) -> None:
-        """Clear all messages in the session."""
-        import asyncio
-
-        loop = asyncio.get_event_loop()
-        loop.run_until_complete(
-            self.memory_client.short_term.delete_session(
-                session_id=self.session_id,
-            )
-        )
-
-
-# Async version for async chains
-class AsyncNeo4jChatMessageHistory(BaseChatMessageHistory):
-    """Async LangChain message history backed by neo4j-agent-memory."""
-
-    def __init__(
-        self,
-        memory_client: MemoryClient,
-        session_id: str,
-        user_id: str | None = None,
-    ):
-        self.memory_client = memory_client
-        self.session_id = session_id
-        self.user_id = user_id
-        self._messages: List[BaseMessage] = []
-
-    async def aget_messages(self) -> List[BaseMessage]:
-        """Async retrieve all messages."""
-        conversation = await self.memory_client.short_term.get_conversation(
-            session_id=self.session_id,
-        )
-
-        result = []
-        for msg in conversation.messages:
-            if msg.role == "user":
-                result.append(HumanMessage(content=msg.content))
-            elif msg.role == "assistant":
-                result.append(AIMessage(content=msg.content))
-
-        return result
-
-    async def aadd_message(self, message: BaseMessage) -> None:
-        """Async add a message."""
-        role = "user" if isinstance(message, HumanMessage) else "assistant"
-
-        await self.memory_client.short_term.add_message(
-            session_id=self.session_id,
-            role=role,
-            content=message.content,
-            metadata={"user_id": self.user_id} if self.user_id else None,
-        )
-
-    async def aclear(self) -> None:
-        """Async clear messages."""
-        await self.memory_client.short_term.delete_session(
-            session_id=self.session_id,
-        )
-
-    # Sync methods that wrap async
-    @property
-    def messages(self) -> List[BaseMessage]:
-        import asyncio
-        return asyncio.get_event_loop().run_until_complete(self.aget_messages())
-
-    def add_message(self, message: BaseMessage) -> None:
-        import asyncio
-        asyncio.get_event_loop().run_until_complete(self.aadd_message(message))
-
-    def clear(self) -> None:
-        import asyncio
-        asyncio.get_event_loop().run_until_complete(self.aclear())
-----
-
-=== Use with Conversation Chain
+`Neo4jMemoryMiddleware` is the whole integration for an agent: nothing else to
+wire up, no prompt template to maintain.
 
 [source,python]
 ----
+import asyncio
+import os
+
+from langchain.agents import create_agent
 from langchain_openai import ChatOpenAI
-from langchain.chains import ConversationChain
-from langchain.memory import ConversationBufferMemory
+from pydantic import SecretStr
 
-# Initialize memory client
-settings = MemorySettings(
-    neo4j={"uri": "bolt://localhost:7687", "username": "neo4j", "password": "password"}
-)
-memory_client = MemoryClient(settings)
-await memory_client.connect()
-
-# Create message history
-message_history = Neo4jChatMessageHistory(
-    memory_client=memory_client,
-    session_id="langchain-session-001",
-    user_id="CUST-12345",
+from neo4j_agent_memory import BoltSettings, MemoryClient, Neo4jConfig
+from neo4j_agent_memory.integrations.langchain import (
+    Neo4jMemoryMiddleware,
+    llm_provider_from_langchain,
 )
 
-# Create LangChain memory with our history
-memory = ConversationBufferMemory(
-    chat_memory=message_history,
-    return_messages=True,
-)
 
-# Create conversation chain
-llm = ChatOpenAI(model="gpt-4o")
-conversation = ConversationChain(
-    llm=llm,
-    memory=memory,
-    verbose=True,
-)
+async def main() -> None:
+    model = ChatOpenAI(model=os.getenv("OPENAI_MODEL", "gpt-5-mini"))
 
-# Use the chain - messages persist to Neo4j
-response = conversation.predict(input="I'm looking for running shoes")
-print(response)
+    settings = BoltSettings(
+        neo4j=Neo4jConfig(
+            uri=os.getenv("NEO4J_URI", "bolt://localhost:7687"),
+            password=SecretStr(os.environ["NEO4J_PASSWORD"]),
+        ),
+        embedding="openai/text-embedding-3-small",
+        llm=llm_provider_from_langchain(model),
+    )
 
-# Later session can retrieve history
-response = conversation.predict(input="What did I ask about earlier?")
-print(response)
+    async with MemoryClient(settings) as client:
+        agent = create_agent(
+            model,
+            tools=[],
+            system_prompt="You are a helpful assistant.",
+            middleware=[
+                Neo4jMemoryMiddleware(client, session_id="user-123"),
+            ],
+        )
+
+        # Async invocation: the middleware implements the async hooks.
+        result = await agent.ainvoke(
+            {"messages": [("user", "Where should I eat tonight?")]}
+        )
+        print(result["messages"][-1].content)
+
+
+asyncio.run(main())
 ----
 
-== Custom Tools for Context Graph
+What the middleware does on each turn:
 
-=== Create Context Graph Tools
+`abefore_model`:: Persists any user message the agent has not stored yet, so the
+turn survives a failed model call.
+`awrap_model_call`:: Calls `client.get_context(query, session_id=...)` for the
+latest user message and appends the result to the request's system message. Agent
+state is left untouched, so the memory block never accumulates in the thread's
+message list.
+`aafter_model`:: Persists the assistant's reply. Messages are de-duplicated by
+id, so a tool-calling loop that re-sends the same history does not write it
+repeatedly.
+
+Options:
 
 [source,python]
 ----
-from langchain.tools import BaseTool, tool
-from pydantic import BaseModel, Field
-from typing import Optional
-
-
-class SearchEntitiesInput(BaseModel):
-    """Input for entity search."""
-    query: str = Field(description="Search query for entities")
-    entity_types: Optional[list[str]] = Field(
-        default=None,
-        description="Entity type filters (e.g., ['PRODUCT', 'PERSON', 'ORGANIZATION'])"
-    )
-    limit: int = Field(default=10, description="Maximum results to return")
-
-
-class SearchEntitesTool(BaseTool):
-    """Tool for searching the context graph."""
-
-    name: str = "search_entities"
-    description: str = """
-    Search the knowledge graph for entities like products, people, or organizations.
-    Use this to find information about things mentioned in past conversations.
-    """
-    args_schema: type[BaseModel] = SearchEntitiesInput
-
-    memory_client: MemoryClient
-
-    def _run(
-        self,
-        query: str,
-        entity_types: Optional[list[str]] = None,
-        limit: int = 10,
-    ) -> str:
-        import asyncio
-
-        entities = asyncio.get_event_loop().run_until_complete(
-            self.memory_client.long_term.search_entities(
-                query=query,
-                entity_types=entity_types,
-                limit=limit,
-            )
-        )
-
-        return json.dumps([
-            {
-                "name": e.name,
-                "type": e.type,
-                "description": e.description,
-            }
-            for e in entities
-        ])
-
-    async def _arun(
-        self,
-        query: str,
-        entity_types: Optional[list[str]] = None,
-        limit: int = 10,
-    ) -> str:
-        entities = await self.memory_client.long_term.search_entities(
-            query=query,
-            entity_types=entity_types,
-            limit=limit,
-        )
-
-        return json.dumps([
-            {
-                "name": e.name,
-                "type": e.type,
-                "description": e.description,
-            }
-            for e in entities
-        ])
-
-
-class GetPreferencesInput(BaseModel):
-    """Input for preference retrieval."""
-    user_id: str = Field(description="User ID to get preferences for")
-    category: Optional[str] = Field(
-        default=None,
-        description="Category filter (e.g., brand, style, shipping)"
-    )
-
-
-class GetPreferencesTool(BaseTool):
-    """Tool for retrieving user preferences."""
-
-    name: str = "get_user_preferences"
-    description: str = """
-    Get stored preferences for a user. Use this to personalize recommendations
-    based on what the user has previously stated they like or dislike.
-    """
-    args_schema: type[BaseModel] = GetPreferencesInput
-
-    memory_client: MemoryClient
-
-    def _run(self, user_id: str, category: Optional[str] = None) -> str:
-        import asyncio
-
-        preferences = asyncio.get_event_loop().run_until_complete(
-            self.memory_client.long_term.get_preferences(
-                user_id=user_id,
-                category=category,
-            )
-        )
-
-        return json.dumps([
-            {"category": p.category, "preference": p.preference}
-            for p in preferences
-        ])
-
-    async def _arun(self, user_id: str, category: Optional[str] = None) -> str:
-        preferences = await self.memory_client.long_term.get_preferences(
-            user_id=user_id,
-            category=category,
-        )
-
-        return json.dumps([
-            {"category": p.category, "preference": p.preference}
-            for p in preferences
-        ])
-
-
-# Function-based tools using @tool decorator
-@tool
-def search_conversation_history(
-    query: str,
-    session_id: str,
-    limit: int = 5,
-) -> str:
-    """Search past conversation messages for relevant context."""
-    import asyncio
-
-    messages = asyncio.get_event_loop().run_until_complete(
-        memory_client.short_term.search_messages(
-            query=query,
-            session_id=session_id,
-            limit=limit,
-        )
-    )
-
-    return json.dumps([
-        {"role": m.role, "content": m.content[:200]}
-        for m in messages
-    ])
-----
-
-== LangChain Agent with Memory
-
-=== Create Memory-Enabled Agent
-
-[source,python]
-----
-from langchain_openai import ChatOpenAI
-from langchain.agents import AgentExecutor, create_openai_functions_agent
-from langchain_core.prompts import ChatPromptTemplate, MessagesPlaceholder
-from langchain.memory import ConversationBufferMemory
-
-
-def create_memory_agent(
-    memory_client: MemoryClient,
-    user_id: str,
-    session_id: str,
-) -> AgentExecutor:
-    """Create a LangChain agent with neo4j-agent-memory."""
-
-    # Create tools
-    tools = [
-        SearchEntitesTool(memory_client=memory_client),
-        GetPreferencesTool(memory_client=memory_client),
-    ]
-
-    # Create message history
-    message_history = Neo4jChatMessageHistory(
-        memory_client=memory_client,
-        session_id=session_id,
-        user_id=user_id,
-    )
-
-    # Create memory
-    memory = ConversationBufferMemory(
-        chat_memory=message_history,
-        memory_key="chat_history",
-        return_messages=True,
-    )
-
-    # Create prompt with memory placeholder
-    prompt = ChatPromptTemplate.from_messages([
-        ("system", """You are a helpful assistant with access to a knowledge graph.
-
-Use the available tools to:
-1. Search for entities (products, people, organizations) in the knowledge graph
-2. Retrieve user preferences to personalize responses
-
-Current user ID: {user_id}
-
-Always use the user's preferences when making recommendations."""),
-        MessagesPlaceholder(variable_name="chat_history"),
-        ("human", "{input}"),
-        MessagesPlaceholder(variable_name="agent_scratchpad"),
-    ])
-
-    # Create LLM
-    llm = ChatOpenAI(model="gpt-4o", temperature=0)
-
-    # Create agent
-    agent = create_openai_functions_agent(llm, tools, prompt)
-
-    # Create executor
-    return AgentExecutor(
-        agent=agent,
-        tools=tools,
-        memory=memory,
-        verbose=True,
-        handle_parsing_errors=True,
-    )
-
-
-# Usage
-settings = MemorySettings(
-    neo4j={"uri": "bolt://localhost:7687", "username": "neo4j", "password": "password"}
+Neo4jMemoryMiddleware(
+    client,
+    session_id="user-123",
+    include_short_term=True,   # conversation history in the injected block
+    include_long_term=True,    # entities, facts and preferences
+    include_reasoning=True,    # similar past traces
+    max_items=10,              # per-layer cap
+    store_messages=True,       # set False for a read-only agent
+    extract_entities=True,     # entity extraction on persisted messages
+    context_header="# Memory",
 )
-memory_client = MemoryClient(settings)
-await memory_client.connect()
-
-agent = create_memory_agent(
-    memory_client=memory_client,
-    user_id="CUST-12345",
-    session_id="agent-session-001",
-)
-
-# Run the agent
-result = agent.invoke({
-    "input": "Find me some running shoes based on my preferences",
-    "user_id": "CUST-12345",
-})
-
-print(result["output"])
 ----
 
-== Ecommerce Example
+[IMPORTANT]
+====
+Only the async hooks are implemented, because neo4j-agent-memory is async all
+the way down. Invoke the agent with `ainvoke` or `astream`. The sync hooks raise
+`NotImplementedError` with that instruction rather than silently skipping
+memory.
+====
 
-Complete example for an ecommerce shopping assistant:
+=== Add tools that read the graph
+
+`create_agent` takes plain `@tool` functions, and async tools are first class —
+no `run_until_complete` bridging:
 
 [source,python]
 ----
 import json
-from datetime import datetime
-from langchain_openai import ChatOpenAI
-from langchain.agents import AgentExecutor, create_openai_functions_agent
+
+from langchain_core.tools import tool
+
+from neo4j_agent_memory import MemoryClient
+
+
+def build_memory_tools(client: MemoryClient) -> list:
+    """Tools that query the context graph directly."""
+
+    @tool
+    async def search_entities(query: str, limit: int = 10) -> str:
+        """Search the knowledge graph for people, places, products or organizations."""
+        entities = await client.long_term.search_entities(query, limit=limit)
+        return json.dumps(
+            [
+                {
+                    "name": e.display_name,
+                    "type": e.full_type,
+                    "description": e.description,
+                }
+                for e in entities
+            ]
+        )
+
+    @tool
+    async def save_preference(category: str, preference: str) -> str:
+        """Record a preference the user just expressed (category: food, brand, style, ...)."""
+        await client.long_term.add_preference(category, preference)
+        return f"Saved preference: {category} — {preference}"
+
+    @tool
+    async def search_history(query: str, session_id: str, limit: int = 5) -> str:
+        """Search earlier messages in a conversation."""
+        messages = await client.short_term.search_messages(
+            query, session_id=session_id, limit=limit
+        )
+        return json.dumps(
+            [{"role": m.role.value, "content": m.content[:200]} for m in messages]
+        )
+
+    return [search_entities, save_preference, search_history]
+
+
+# agent = create_agent(model, tools=build_memory_tools(client), middleware=[...])
+----
+
+== Thread history for a chain
+
+`Neo4jAgentMemory` is a `BaseChatMessageHistory`, so it drops straight into
+`RunnableWithMessageHistory` for chains that are not agents:
+
+[source,python]
+----
+from langchain_core.output_parsers import StrOutputParser
 from langchain_core.prompts import ChatPromptTemplate, MessagesPlaceholder
-from langchain.tools import BaseTool
-from langchain.memory import ConversationBufferMemory
-from pydantic import BaseModel, Field
-from neo4j_agent_memory import MemoryClient, MemorySettings
+from langchain_core.runnables.history import RunnableWithMessageHistory
 
+from neo4j_agent_memory.integrations.langchain import Neo4jAgentMemory
 
-# --- Tools ---
-
-class ProductSearchInput(BaseModel):
-    query: str = Field(description="Product search query")
-    category: str | None = Field(default=None, description="Product category")
-    brand: str | None = Field(default=None, description="Brand filter")
-    max_price: float | None = Field(default=None, description="Maximum price")
-
-
-class ProductSearchTool(BaseTool):
-    name: str = "search_products"
-    description: str = """
-    Search for products in the catalog. Can filter by category, brand, and price.
-    Use customer preferences to choose appropriate filters.
-    """
-    args_schema: type[BaseModel] = ProductSearchInput
-    memory_client: MemoryClient
-
-    def _run(
-        self,
-        query: str,
-        category: str | None = None,
-        brand: str | None = None,
-        max_price: float | None = None,
-    ) -> str:
-        import asyncio
-
-        filters = {}
-        if brand:
-            filters["brand"] = brand
-        if max_price:
-            filters["price"] = {"$lte": max_price}
-
-        products = asyncio.get_event_loop().run_until_complete(
-            self.memory_client.long_term.search_entities(
-                query=query,
-                entity_types=["PRODUCT"],
-                property_filter=filters if filters else None,
-                limit=10,
-            )
-        )
-
-        return json.dumps([
-            {
-                "name": p.name,
-                "brand": p.properties.get("brand"),
-                "price": p.properties.get("price"),
-                "rating": p.properties.get("rating"),
-                "description": p.description[:100] if p.description else None,
-            }
-            for p in products
-        ])
-
-
-class CustomerPreferencesTool(BaseTool):
-    name: str = "get_customer_preferences"
-    description: str = """
-    Get stored preferences for the current customer.
-    Returns brand preferences, size, style, and shipping preferences.
-    """
-    memory_client: MemoryClient
-    user_id: str
-
-    def _run(self) -> str:
-        import asyncio
-
-        prefs = asyncio.get_event_loop().run_until_complete(
-            self.memory_client.long_term.get_preferences(
-                user_id=self.user_id,
-            )
-        )
-
-        by_category = {}
-        for p in prefs:
-            if p.category not in by_category:
-                by_category[p.category] = []
-            by_category[p.category].append(p.preference)
-
-        return json.dumps(by_category)
-
-
-class SavePreferenceInput(BaseModel):
-    preference: str = Field(description="The preference to save")
-    category: str = Field(description="Category: brand, style, size, shipping, etc.")
-
-
-class SavePreferenceTool(BaseTool):
-    name: str = "save_preference"
-    description: str = """
-    Save a new customer preference learned during the conversation.
-    Use when customer expresses a like, dislike, or preference.
-    """
-    args_schema: type[BaseModel] = SavePreferenceInput
-    memory_client: MemoryClient
-    user_id: str
-
-    def _run(self, preference: str, category: str) -> str:
-        import asyncio
-
-        asyncio.get_event_loop().run_until_complete(
-            self.memory_client.long_term.add_preference(
-                preference=preference,
-                category=category,
-                confidence=0.85,
-            )
-        )
-
-        return f"Saved preference: {category} - {preference}"
-
-
-class PurchaseHistoryTool(BaseTool):
-    name: str = "get_purchase_history"
-    description: str = """
-    Get customer's recent purchase history from the context graph.
-    Useful for understanding what they've bought before.
-    """
-    memory_client: MemoryClient
-    user_id: str
-
-    def _run(self) -> str:
-        import asyncio
-
-        purchases = asyncio.get_event_loop().run_until_complete(
-            self.memory_client.graph.execute_read(
-                """
-                MATCH (c:Customer {id: $user_id})-[p:PURCHASED]->(product:Product)
-                RETURN product.name as name, product.brand as brand,
-                       p.purchase_date as date, p.price as price
-                ORDER BY p.purchase_date DESC
-                LIMIT 10
-                """,
-                parameters={"user_id": self.user_id},
-            )
-        )
-
-        return json.dumps(purchases)
-
-
-# --- Agent Factory ---
-
-def create_shopping_agent(
-    memory_client: MemoryClient,
-    user_id: str,
-    session_id: str,
-) -> AgentExecutor:
-    """Create shopping assistant agent with context graph memory."""
-
-    # Create tools
-    tools = [
-        ProductSearchTool(memory_client=memory_client),
-        CustomerPreferencesTool(memory_client=memory_client, user_id=user_id),
-        SavePreferenceTool(memory_client=memory_client, user_id=user_id),
-        PurchaseHistoryTool(memory_client=memory_client, user_id=user_id),
-    ]
-
-    # Message history
-    message_history = Neo4jChatMessageHistory(
-        memory_client=memory_client,
-        session_id=session_id,
-        user_id=user_id,
-    )
-
-    memory = ConversationBufferMemory(
-        chat_memory=message_history,
-        memory_key="chat_history",
-        return_messages=True,
-    )
-
-    # Prompt
-    prompt = ChatPromptTemplate.from_messages([
-        ("system", """You are a helpful shopping assistant for an online retailer.
-
-Your capabilities:
-1. Search for products using customer preferences
-2. Access and use customer preferences for personalization
-3. Save new preferences when customers express them
-4. Review purchase history for context
-
-Guidelines:
-- Always check customer preferences before making recommendations
-- When a customer expresses a preference, save it for future use
-- Reference past purchases when relevant
-- Be helpful and personalized in your recommendations
-
-Current customer: {user_id}"""),
-        MessagesPlaceholder(variable_name="chat_history"),
+prompt = ChatPromptTemplate.from_messages(
+    [
+        ("system", "You are a helpful assistant."),
+        MessagesPlaceholder("history"),
         ("human", "{input}"),
-        MessagesPlaceholder(variable_name="agent_scratchpad"),
-    ])
+    ]
+)
+chain = prompt | model | StrOutputParser()
 
-    llm = ChatOpenAI(model="gpt-4o", temperature=0.7)
-    agent = create_openai_functions_agent(llm, tools, prompt)
+chain_with_history = RunnableWithMessageHistory(
+    chain,
+    lambda session_id: Neo4jAgentMemory(memory_client=client, session_id=session_id),
+    input_messages_key="input",
+    history_messages_key="history",
+)
 
-    return AgentExecutor(
-        agent=agent,
-        tools=tools,
-        memory=memory,
-        verbose=True,
-    )
-
-
-# --- Main ---
-
-async def main():
-    settings = MemorySettings(
-        neo4j={"uri": "bolt://localhost:7687", "username": "neo4j", "password": "password"}
-    )
-    memory_client = MemoryClient(settings)
-    await memory_client.connect()
-
-    user_id = "CUST-12345"
-    session_id = f"shop-{datetime.now().strftime('%Y%m%d%H%M%S')}"
-
-    agent = create_shopping_agent(memory_client, user_id, session_id)
-
-    # Conversation loop
-    print("Shopping Assistant (type 'quit' to exit)\n")
-
-    while True:
-        user_input = input("You: ").strip()
-        if user_input.lower() == "quit":
-            break
-
-        result = agent.invoke({
-            "input": user_input,
-            "user_id": user_id,
-        })
-
-        print(f"\nAssistant: {result['output']}\n")
-
-
-if __name__ == "__main__":
-    import asyncio
-    asyncio.run(main())
+answer = await chain_with_history.ainvoke(
+    {"input": "I'm looking for running shoes"},
+    config={"configurable": {"session_id": "user-123"}},
+)
 ----
 
-== Callbacks for Reasoning Traces
+`RunnableWithMessageHistory` reads the history with `aget_messages()` and writes
+the turn back with `aadd_messages()` — both of which talk to Neo4j directly.
 
-Track LangChain execution in reasoning traces:
+=== Use it directly
 
 [source,python]
 ----
-from langchain.callbacks.base import BaseCallbackHandler
+from langchain_core.messages import AIMessage, HumanMessage
+
+history = Neo4jAgentMemory(memory_client=client, session_id="user-123")
+
+await history.aadd_messages(
+    [
+        HumanMessage(content="I prefer spicy food"),
+        AIMessage(content="Noted — I'll remember that."),
+    ]
+)
+
+messages = await history.aget_messages()  # list[BaseMessage], oldest first
+await history.aclear()                    # clears the session
+----
+
+Role mapping: `HumanMessage` ↔ `"user"`, `AIMessage` ↔ `"assistant"`,
+`SystemMessage` ↔ `"system"`, and `ChatMessage(role="tool")` ↔ `"tool"`.
+Messages with no text content (an `AIMessage` carrying only tool calls, say) are
+skipped — memory stores text.
+
+[WARNING]
+====
+The sync surface (`history.messages`, `add_messages`, `clear`) only works
+*outside* a running event loop; inside one it raises `RuntimeError` naming the
+coroutine to await. The async driver is bound to the loop that created it, so
+blocking on the caller's own loop would deadlock. Prefer `aget_messages` /
+`aadd_messages` / `aclear`.
+====
+
+=== Assemble a memory context block
+
+The same object can render a context block for a hand-rolled prompt:
+
+[source,python]
+----
+memory = Neo4jAgentMemory(
+    memory_client=client,
+    session_id="user-123",
+    include_short_term=True,
+    include_long_term=True,
+    include_reasoning=True,
+    max_messages=10,
+)
+
+variables = await memory.aload_memory_variables({"input": "restaurant recommendation"})
+# {"history": "...", "context": "...", "preferences": [...], "similar_tasks": "..."}
+
+await memory.asave_context(
+    {"input": "What's a good Thai restaurant?"},
+    {"output": "Based on your preferences, I recommend Thai Kitchen!"},
+)
+----
+
+`memory.memory_variables` lists the keys the current `include_*` flags produce.
+
+[NOTE]
+====
+`aload_memory_variables` / `asave_context` replaced the private
+`_load_memory_variables_async` / `_save_context_async` coroutines, which are kept
+as aliases for one release. Use the public names.
+====
+
+== Retrieve from memory
+
+`Neo4jMemoryRetriever` searches every memory layer and returns LangChain
+`Document` objects sorted by similarity:
+
+[source,python]
+----
+from neo4j_agent_memory.integrations.langchain import Neo4jMemoryRetriever
+
+retriever = Neo4jMemoryRetriever(
+    memory_client=client,
+    session_id="user-123",     # scopes message search
+    search_short_term=True,    # messages
+    search_long_term=True,     # entities + preferences
+    search_reasoning=True,     # reasoning traces
+    k=10,
+    threshold=0.7,
+)
+
+docs = await retriever.ainvoke("spicy food preferences")
+for doc in docs:
+    print(doc.metadata["type"], "-", doc.page_content)
+----
+
+Each document's `metadata["type"]` is one of `message`, `entity`, `preference` or
+`trace`, alongside `id` and `similarity`. Because it is a real `BaseRetriever`,
+it composes with anything that takes one — `create_retrieval_chain`, a
+retriever tool, LangSmith tracing — and `ainvoke` runs on the caller's event
+loop.
+
+Pass `session_id` whenever you can: it scopes message search, and the hosted
+NAMS backend *requires* it (its message search is conversation-scoped). Without
+it on NAMS, the message layer is skipped with a warning rather than failing the
+whole retrieval.
+
+To let the agent decide when to search memory, hand the retriever to LangChain's
+own tool wrapper instead of injecting context unconditionally:
+
+[source,python]
+----
+from langchain_core.tools.retriever import create_retriever_tool
+
+search_memory = create_retriever_tool(
+    retriever,
+    "search_memory",
+    "Search the user's memory: past messages, known entities, saved preferences.",
+)
+
+# agent = create_agent(model, tools=[search_memory], middleware=[...])
+----
+
+== Record reasoning traces
+
+Write the agent's run into reasoning memory with a second middleware, so you can
+later ask "what did the agent do, and which entities did it touch?":
+
+[source,python]
+----
+from typing import Any
+
+from langchain.agents.middleware import AgentMiddleware, AgentState
+from langchain_core.messages import AIMessage, HumanMessage
+
+from neo4j_agent_memory import MemoryClient
+from neo4j_agent_memory.schema.models import TraceOutcome
+
+
+class ReasoningTraceMiddleware(AgentMiddleware):
+    """Record each agent run as a reasoning trace."""
+
+    def __init__(self, client: MemoryClient, session_id: str) -> None:
+        super().__init__()
+        self.client = client
+        self.session_id = session_id
+        self.tools = []
+
+    async def abefore_agent(self, state: AgentState, runtime: Any) -> None:
+        task = next(
+            (m.text for m in reversed(state["messages"]) if isinstance(m, HumanMessage)),
+            "",
+        )
+        trace = await self.client.reasoning.start_trace(self.session_id, task)
+        self._trace_id = trace.id
+
+    async def aafter_model(self, state: AgentState, runtime: Any) -> None:
+        last = state["messages"][-1]
+        if not isinstance(last, AIMessage):
+            return
+        step = await self.client.reasoning.add_step(
+            self._trace_id,
+            thought=last.text or "(tool call only)",
+            action=", ".join(c["name"] for c in last.tool_calls) or "respond",
+        )
+        for call in last.tool_calls:
+            await self.client.reasoning.record_tool_call(
+                step.id,
+                call["name"],
+                call["args"],
+            )
+
+    async def aafter_agent(self, state: AgentState, runtime: Any) -> None:
+        await self.client.reasoning.complete_trace(
+            self._trace_id,
+            outcome=TraceOutcome(
+                success=True,
+                summary=state["messages"][-1].text[:200],
+                metrics={"model_calls": float(len(state["messages"]))},
+            ),
+        )
+----
+
+Add it alongside the memory middleware:
+
+[source,python]
+----
+agent = create_agent(
+    model,
+    tools=tools,
+    middleware=[
+        Neo4jMemoryMiddleware(client, session_id=session_id),
+        ReasoningTraceMiddleware(client, session_id=session_id),
+    ],
+)
+----
+
+Once traces exist, `Neo4jMemoryMiddleware(include_reasoning=True)` starts
+surfacing similar past runs in the injected block. Without them that layer is
+always empty, so leave `include_reasoning=False` until you record something.
+
+See xref:how-to/audit-reasoning.adoc[Audit Reasoning] for the one-hop audit query
+over `TOUCHED` edges.
+
+== Running on the hosted backend
+
+The adapters tolerate the hosted NAMS backend's narrower surface instead of
+raising:
+
+[cols="2,1,2", options="header"]
+|===
+| Call | On NAMS | Adapter behaviour
+
+| `short_term.*` | supported | full history and context
+| `long_term.search_entities` | supported | entity documents and context block
+| `long_term.get_context` | returns `""` | falls back to entity search
+| `long_term.search_preferences` | `NotSupportedError` | `preferences` comes back `[]`
+| `reasoning.get_similar_traces` | `NotSupportedError` | `similar_tasks` comes back `""`
+| `short_term.search_messages` | needs a conversation id | pass `session_id=`, else the layer is skipped
+|===
+
+Switching backends is a settings change; the adapter code is identical:
+
+[source,python]
+----
 from neo4j_agent_memory import MemoryClient, MemorySettings
 
+# Hosted: reads MEMORY_API_KEY (and optionally MEMORY_WORKSPACE_ID)
+settings = MemorySettings(backend="nams")
 
-class ReasoningTraceCallback(BaseCallbackHandler):
-    """Record LangChain execution as reasoning traces."""
-
-    def __init__(self, memory_client: MemoryClient, user_id: str):
-        self.memory_client = memory_client
-        self.user_id = user_id
-        self.trace_id = None
-        self.current_step_id = None
-
-    def on_chain_start(self, serialized, inputs, **kwargs):
-        """Start trace when chain begins."""
-        import asyncio
-
-        trace = asyncio.get_event_loop().run_until_complete(
-            self.memory_client.reasoning.start_trace(
-                task=str(inputs.get("input", ""))[:200],
-                user_id=self.user_id,
-                metadata={"chain_type": serialized.get("name", "unknown")},
-            )
-        )
-        self.trace_id = trace.id
-
-    def on_tool_start(self, serialized, input_str, **kwargs):
-        """Record tool invocation."""
-        import asyncio
-
-        if not self.trace_id:
-            return
-
-        tool_name = serialized.get("name", "unknown")
-
-        step = asyncio.get_event_loop().run_until_complete(
-            self.memory_client.reasoning.add_step(
-                trace_id=self.trace_id,
-                description=f"Using tool: {tool_name}",
-                reasoning=f"Input: {input_str[:100]}",
-            )
-        )
-        self.current_step_id = step.id
-
-    def on_tool_end(self, output, **kwargs):
-        """Record tool result."""
-        import asyncio
-
-        if not self.current_step_id:
-            return
-
-        asyncio.get_event_loop().run_until_complete(
-            self.memory_client.reasoning.add_tool_call(
-                step_id=self.current_step_id,
-                tool_name=kwargs.get("name", "unknown"),
-                arguments={},
-                result={"output": str(output)[:500]},
-                success=True,
-            )
-        )
-
-    def on_chain_end(self, outputs, **kwargs):
-        """Complete trace when chain finishes."""
-        import asyncio
-
-        if not self.trace_id:
-            return
-
-        asyncio.get_event_loop().run_until_complete(
-            self.memory_client.reasoning.complete_trace(
-                trace_id=self.trace_id,
-                outcome="success",
-                result={"output": str(outputs)[:500]},
-            )
-        )
-
-    def on_chain_error(self, error, **kwargs):
-        """Record chain failure."""
-        import asyncio
-
-        if not self.trace_id:
-            return
-
-        asyncio.get_event_loop().run_until_complete(
-            self.memory_client.reasoning.complete_trace(
-                trace_id=self.trace_id,
-                outcome="failure",
-                error=str(error),
-            )
-        )
-
-
-# Usage
-callback = ReasoningTraceCallback(memory_client, user_id)
-
-result = agent.invoke(
-    {"input": "Find running shoes", "user_id": user_id},
-    config={"callbacks": [callback]},
-)
+async with MemoryClient(settings) as client:
+    history = Neo4jAgentMemory(
+        memory_client=client,
+        session_id="user-123",
+        include_reasoning=False,  # no trace search on NAMS
+    )
 ----
 
-== Best Practices
+== Best practices
 
-=== 1. Use Session-Based History
-
-Create unique sessions for conversation isolation:
+=== Use one session per conversation
 
 [source,python]
 ----
-# Good: Unique session per conversation
-session_id = f"user-{user_id}-{datetime.now().strftime('%Y%m%d%H%M%S')}"
+from datetime import datetime, timezone
 
-# Avoid: Shared session for all users
-session_id = "global"  # Don't do this
+# Good: unique, attributable session
+session_id = f"user-{user_id}-{datetime.now(timezone.utc):%Y%m%d%H%M%S}"
+
+# Avoid: one session shared by every user
+session_id = "global"
 ----
 
-=== 2. Handle Async Properly
+For a policy rather than an ad-hoc string, use `MemoryIntegration` with a
+`SessionStrategy` (`PER_CONVERSATION`, `PER_DAY`, `PERSISTENT`) — see
+xref:reference/api/adapters.adoc[Adapters reference].
 
-Use async versions when running in async context:
+=== Stay on the async path
+
+Every adapter's async surface talks to Neo4j directly; the sync surface exists
+only for genuinely synchronous callers and refuses to run inside an event loop.
+Use `ainvoke` / `astream` on agents and chains, and the `a*` methods on the
+adapters.
+
+=== Cap what you inject
 
 [source,python]
 ----
-# In async context
-history = AsyncNeo4jChatMessageHistory(memory_client, session_id)
-messages = await history.aget_messages()
-
-# In sync context
-history = Neo4jChatMessageHistory(memory_client, session_id)
-messages = history.messages
+Neo4jMemoryMiddleware(client, session_id=session_id, max_items=5)
+Neo4jAgentMemory(memory_client=client, session_id=session_id, max_messages=10)
+Neo4jMemoryRetriever(memory_client=client, session_id=session_id, k=5)
 ----
 
-=== 3. Limit Memory Size
+Memory competes with the rest of the prompt for context; fewer, better items
+usually beat more.
 
-Prevent context from growing too large:
+=== Do not let memory break the agent
+
+The middleware already degrades on unsupported layers, but storage errors
+propagate. Wrap the run if a memory outage must not take the agent down:
 
 [source,python]
 ----
-from langchain.memory import ConversationBufferWindowMemory
+import logging
 
-# Keep only last k messages in context
-memory = ConversationBufferWindowMemory(
-    chat_memory=message_history,
-    k=10,  # Last 10 messages
-    return_messages=True,
-)
+logger = logging.getLogger(__name__)
+
+try:
+    result = await agent.ainvoke({"messages": [("user", question)]})
+except Exception:
+    logger.warning("memory-backed agent run failed; retrying without memory")
+    plain = create_agent(model, tools=tools, system_prompt=system_prompt)
+    result = await plain.ainvoke({"messages": [("user", question)]})
 ----
 
-=== 4. Add Error Handling
+[#legacy]
+== Legacy: pre-1.0 LangChain
 
-Gracefully handle memory failures:
+If you are maintaining an application built on LangChain 0.x, the classes the
+earlier version of this guide used now live in the `langchain-classic`
+distribution:
 
-[source,python]
-----
-class RobustNeo4jChatMessageHistory(BaseChatMessageHistory):
-    def add_message(self, message: BaseMessage) -> None:
-        try:
-            # Attempt to save
-            asyncio.get_event_loop().run_until_complete(
-                self.memory_client.short_term.add_message(...)
-            )
-        except Exception as e:
-            # Log but don't fail the chain
-            logger.warning(f"Failed to save message to memory: {e}")
-----
+[cols="1,1", options="header"]
+|===
+| Pre-1.0 import | 1.x location
+
+| `langchain_core.memory.BaseMemory` | removed
+| `langchain.memory.ConversationBufferMemory` | `langchain_classic.memory.ConversationBufferMemory`
+| `langchain.memory.ConversationBufferWindowMemory` | `langchain_classic.memory.ConversationBufferWindowMemory`
+| `langchain.chains.ConversationChain` | `langchain_classic.chains.ConversationChain`
+| `langchain.agents.AgentExecutor` | `langchain_classic.agents.AgentExecutor`
+| `langchain.agents.create_openai_functions_agent` | `langchain_classic.agents.create_openai_functions_agent`
+|===
+
+`Neo4jAgentMemory` can still back a classic `ConversationBufferMemory` through
+its `chat_memory=` argument, because that argument takes a
+`BaseChatMessageHistory` — which is exactly what `Neo4jAgentMemory` now is. New
+code should use <<agent,middleware>> or `RunnableWithMessageHistory` instead.
 
 == See Also
 
 * xref:how-to/integrations/pydantic-ai.adoc[Use with PydanticAI]
 * xref:how-to/integrations/llamaindex.adoc[Use with LlamaIndex]
 * xref:how-to/messages.adoc[Store and Search Messages]
-* https://python.langchain.com/docs/[LangChain Documentation]
+* xref:how-to/audit-reasoning.adoc[Audit Reasoning]
+* https://docs.langchain.com/oss/python/langchain/middleware[LangChain middleware documentation]
+* https://docs.langchain.com/oss/python/langchain/agents[LangChain agents documentation]

--- a/docs/modules/ROOT/pages/how-to/integrations/microsoft-agent.adoc
+++ b/docs/modules/ROOT/pages/how-to/integrations/microsoft-agent.adoc
@@ -6,7 +6,15 @@ This guide explains how to use Neo4j Agent Memory with Microsoft Agent Framework
 
 [NOTE]
 ====
-This integration targets Microsoft Agent Framework v1.0.0b260212. The framework has reached GA; check the https://github.com/microsoft/agent-framework[Microsoft Agent Framework releases] for the latest version and any API changes.
+This integration targets the Microsoft Agent Framework 1.x GA line (`>=1.13,<2`), verified against 1.18.0. Check the https://github.com/microsoft/agent-framework[Microsoft Agent Framework releases] for the latest version.
+
+Upgrading from the `1.0.0b260212` public preview? The GA line renamed the two provider base classes (`BaseContextProvider` -> `ContextProvider`, `BaseHistoryProvider` -> `HistoryProvider`), so the preview pin no longer imports. The library handles the rename internally; your own code only needs the dependency bump. The `before_run` / `after_run` hook signatures are unchanged.
+====
+
+[TIP]
+====
+A runnable full-stack example lives in the repository at
+https://github.com/neo4j-labs/agent-memory/tree/main/examples/microsoft_agent_retail_assistant[examples/microsoft_agent_retail_assistant] — a FastAPI retail shopping assistant using `Neo4jMicrosoftMemory`, `create_memory_tools` and the GDS recommendation path over a Neo4j product graph.
 ====
 
 == Overview
@@ -34,8 +42,17 @@ pip install neo4j-agent-memory[microsoft-agent]
 
 This installs:
 
-* `agent-framework>=1.0.0b` - Microsoft Agent Framework
+* `agent-framework-core>=1.13,<2` — the distribution that ships the `agent_framework` package this integration imports
 * Required Neo4j dependencies
+
+Add the chat client you intend to use — the extra deliberately does not pull every provider:
+
+[source,bash]
+----
+pip install agent-framework-azure-ai   # Azure OpenAI clients
+pip install agent-framework-openai     # OpenAI clients
+pip install agent-framework            # everything (the meta-package)
+----
 
 == Pass-through your Agent Framework client
 
@@ -43,6 +60,8 @@ The Microsoft Agent Framework wraps Azure OpenAI and OpenAI clients. `llm_provid
 
 [source,python]
 ----
+import os
+
 from agent_framework.azure import AzureOpenAIResponsesClient
 
 from neo4j_agent_memory import MemoryClient, MemorySettings
@@ -51,7 +70,7 @@ from neo4j_agent_memory.integrations.microsoft_agent import (
 )
 
 chat_client = AzureOpenAIResponsesClient(
-    deployment_name="gpt-4o-mini-prod",
+    deployment_name=os.getenv("AZURE_OPENAI_DEPLOYMENT", "gpt-5-mini"),
     api_key="...",
 )
 
@@ -72,9 +91,12 @@ The `Neo4jContextProvider` automatically injects relevant memory context before 
 
 [source,python]
 ----
+import os
+
+from agent_framework.azure import AzureOpenAIResponsesClient
+
 from neo4j_agent_memory import MemoryClient, MemorySettings
 from neo4j_agent_memory.integrations.microsoft_agent import Neo4jContextProvider
-from agent_framework.azure import AzureOpenAIResponsesClient
 
 settings = MemorySettings(
     neo4j={"uri": "bolt://localhost:7687", "username": "neo4j", "password": "password"},
@@ -92,7 +114,7 @@ async with MemoryClient(settings) as client:
     )
 
     # Create agent with memory
-    chat_client = AzureOpenAIResponsesClient(model="gpt-4")
+    chat_client = AzureOpenAIResponsesClient(model=os.getenv("OPENAI_MODEL", "gpt-5-mini"))
     agent = chat_client.as_agent(
         name="assistant",
         instructions="You are a helpful assistant.",
@@ -390,6 +412,8 @@ Here's a complete shopping assistant example. With callable `FunctionTool` insta
 [source,python]
 ----
 import asyncio
+import os
+
 from agent_framework import Message
 from agent_framework.azure import AzureOpenAIResponsesClient
 
@@ -425,7 +449,7 @@ async def main():
         )
 
         # Create chat client
-        chat_client = AzureOpenAIResponsesClient(model="gpt-4")
+        chat_client = AzureOpenAIResponsesClient(model=os.getenv("OPENAI_MODEL", "gpt-5-mini"))
 
         # Create memory tools bound to the memory instance
         tools = create_memory_tools(memory, include_gds_tools=True)
@@ -480,10 +504,10 @@ if __name__ == "__main__":
 
 This integration targets:
 
-* **Package**: `agent-framework`
-* **Version**: `1.0.0b260212`
-* **Status**: Public Preview
-* **GA Target**: Q1 2026
+* **Package**: `agent-framework-core` (pulled by the `[microsoft-agent]` extra; also installed by the `agent-framework` meta-package)
+* **Version range**: `>=1.13,<2`
+* **Verified against**: 1.18.0
+* **Status**: GA
 
 === Version Matrix
 
@@ -491,9 +515,13 @@ This integration targets:
 |===
 | neo4j-agent-memory | agent-framework | Status
 
-| 0.1.x
-| 1.0.0b260212
+| 0.6.x
+| >=1.13,<2 (GA)
 | Current
+
+| 0.1.x - 0.5.x
+| 1.0.0b260212 (preview)
+| Superseded — does not import on the GA line
 |===
 
 === APIs Used
@@ -502,17 +530,23 @@ This integration targets:
 |===
 | API | Import Path
 
-| `BaseContextProvider`
-| `agent_framework.BaseContextProvider`
+| `ContextProvider`
+| `agent_framework.ContextProvider`
 
-| `BaseHistoryProvider`
-| `agent_framework.BaseHistoryProvider`
+| `HistoryProvider`
+| `agent_framework.HistoryProvider`
+
+| `SessionContext`, `AgentSession`, `SupportsAgentRun`
+| `agent_framework`
 
 | `Message`
 | `agent_framework.Message`
 
+| `FunctionTool`, `tool`
+| `agent_framework`
+
 | `AzureOpenAIResponsesClient`
-| `agent_framework.azure.AzureOpenAIResponsesClient`
+| `agent_framework.azure.AzureOpenAIResponsesClient` (separate distribution)
 |===
 
 === Breaking Change Detection
@@ -533,7 +567,18 @@ Install the Microsoft Agent Framework package:
 ----
 pip install neo4j-agent-memory[microsoft-agent]
 # or
-pip install agent-framework>=1.0.0b
+pip install "agent-framework-core>=1.13,<2"
+----
+
+=== ImportError: cannot import name 'BaseContextProvider'
+
+You are on an older `neo4j-agent-memory` (0.5.x or earlier) together with a GA
+`agent-framework`. The GA line renamed that class to `ContextProvider`.
+Upgrade the library:
+
+[source,bash]
+----
+pip install -U "neo4j-agent-memory[microsoft-agent]"
 ----
 
 === GDS Not Available Warning

--- a/docs/modules/ROOT/pages/how-to/integrations/pydantic-ai.adoc
+++ b/docs/modules/ROOT/pages/how-to/integrations/pydantic-ai.adoc
@@ -8,6 +8,20 @@
 
 How to integrate neo4j-agent-memory with PydanticAI agents to build memory-enabled applications with a persistent context graph.
 
+[NOTE]
+====
+**Supported PydanticAI range: 2.x** (`pydantic-ai-slim>=2.0,<3`, installed by
+the `[pydantic-ai]` extra). Every snippet on this page uses the 2.x API:
+`output_type=` (not `result_type=`), `result.output` (not `result.data`),
+`instructions` (not `system_prompt`), and the current model classes
+`OpenAIChatModel` / `AnthropicModel` / `GoogleModel` (`OpenAIModel` and
+`GeminiModel` were removed).
+
+In 2.x the `"openai:"` model-string prefix selects the Responses API and
+`"openai-chat:"` selects Chat Completions, so these examples build a model
+instance instead — it is unambiguous and reusable.
+====
+
 == Overview
 
 PydanticAI is a Python agent framework that provides type-safe tools, dependency injection, and structured outputs. Integrating with neo4j-agent-memory adds persistent memory capabilities, enabling agents to remember past interactions and build knowledge over time.
@@ -49,18 +63,23 @@ a|
 == Prerequisites
 
 * Python 3.10+
-* `neo4j-agent-memory` and `pydantic-ai` installed
+* `neo4j-agent-memory` and PydanticAI 2.x installed
 * Neo4j database running
 * OpenAI API key (or other LLM provider)
 
 [source,bash]
 ----
-pip install neo4j-agent-memory pydantic-ai
+pip install "neo4j-agent-memory[pydantic-ai]"
 ----
+
+The extra installs `pydantic-ai-slim[openai]>=2.0,<3` — the same
+`pydantic_ai` import package as the `pydantic-ai` meta-package, minus the ~20
+provider SDKs this adapter never imports. Installing it alongside `[mcp]`
+(FastMCP 4) is fine: both resolve to the same `fastmcp-slim` 4.x distribution.
 
 == Pass-through your PydanticAI model
 
-PydanticAI models expose `model_name` and a provider-specific class (`OpenAIModel`, `AnthropicModel`, `GeminiModel`, …). `llm_provider_from_pydantic_ai` converts a configured model directly into an `LLMProvider` so the same model is used by both your agent and the memory client:
+PydanticAI models expose `model_name` and a provider-specific class (`OpenAIChatModel`, `AnthropicModel`, `GoogleModel`, …). `llm_provider_from_pydantic_ai` converts a configured model directly into an `LLMProvider` so the same model is used by both your agent and the memory client:
 
 [source,python]
 ----
@@ -73,7 +92,7 @@ from neo4j_agent_memory.integrations.pydantic_ai import (
 )
 
 # One model, used by both the agent and memory.
-model = AnthropicModel("claude-3-5-sonnet-latest")
+model = AnthropicModel("claude-sonnet-4-5")
 agent = Agent(model, deps_type=AgentDeps)
 
 settings = MemorySettings(
@@ -83,9 +102,97 @@ settings = MemorySettings(
 )
 ----
 
-The helper introspects the model — class name `AnthropicModel` triggers the `anthropic/` prefix, `model_name` becomes the model id. `OpenAIModel` resolves to `OpenAIProvider`, and so on.
+The helper introspects the model — class name `AnthropicModel` triggers the `anthropic/` prefix, `model_name` becomes the model id. `OpenAIChatModel` resolves to the OpenAI provider, and so on.
 
 For the equivalent pattern across other integrations, see xref:how-to/migrate-to-providers.adoc[Migrate to Pluggable Providers — Pattern 5].
+
+[#shipped-adapters]
+== Shortcut: the shipped adapters
+
+Before hand-rolling a dependency class and tools, reach for the three adapters the
+package already ships. They cover the common case in a dozen lines:
+
+`MemoryDependency`:: a ready-made `deps_type` with `get_context()`,
+`save_interaction()`, `add_preference()` and `search_preferences()`.
+`create_memory_tools()`:: plain `async def` tools — `search_memory`,
+`save_preference`, `recall_preferences` — that PydanticAI 2.x accepts directly in
+`Agent(tools=...)`. On the hosted backend, `nams_memory_tools()` returns the same
+three plus the NAMS Platinum tools (entity feedback, history, provenance, Cypher).
+`record_agent_trace()`:: turns a finished `AgentRunResult` into a reasoning trace —
+one step per tool call, with a `ToolCall` node attached and the run's token usage in
+the trace outcome.
+
+[source,python]
+----
+import os
+
+from pydantic_ai import Agent, RunContext
+from pydantic_ai.models.openai import OpenAIChatModel
+
+from neo4j_agent_memory import MemoryClient
+from neo4j_agent_memory.config.settings import BoltSettings
+from neo4j_agent_memory.integrations.pydantic_ai import (
+    MemoryDependency,
+    create_memory_tools,
+    llm_provider_from_pydantic_ai,
+    record_agent_trace,
+)
+
+SESSION_ID = "pydantic-ai-demo"
+
+model = OpenAIChatModel(os.getenv("OPENAI_MODEL", "gpt-5-mini"))
+
+# BoltSettings pins the backend: plain MemorySettings flips to the hosted NAMS
+# backend whenever MEMORY_API_KEY happens to be exported.
+settings = BoltSettings(
+    neo4j={"password": "password"},
+    embedding="openai/text-embedding-3-small",
+    llm=llm_provider_from_pydantic_ai(model),
+)
+
+USER_INPUT = "Find me a good restaurant for dinner tonight."
+
+
+async def main() -> None:
+    async with MemoryClient(settings) as memory:
+        tools = create_memory_tools(memory)
+        agent = Agent(model, deps_type=MemoryDependency, tools=tools, output_type=str)
+
+        @agent.instructions
+        async def memory_instructions(ctx: RunContext[MemoryDependency]) -> str:
+            # Re-rendered for every model request; `ctx.prompt` is this run's user
+            # message, so the retrieved context is turn-specific.
+            context = await ctx.deps.get_context(str(ctx.prompt))
+            base = "You are a restaurant recommendation assistant."
+            return f"{base}\n\nContext from memory:\n{context}" if context else base
+
+        deps = MemoryDependency(client=memory, session_id=SESSION_ID)
+        result = await agent.run(USER_INPUT, deps=deps)
+        print(result.output)  # 2.x: `.output`, not `.data`
+
+        # Short-term memory: persist both sides so the next turn sees this one.
+        await deps.save_interaction(USER_INPUT, str(result.output))
+
+        # Reasoning memory: record the run, then read it back.
+        trace = await record_agent_trace(
+            memory.reasoning,
+            session_id=SESSION_ID,
+            result=result,
+            task="Find restaurant recommendation",
+        )
+        stored = await memory.reasoning.get_trace_with_steps(trace.id)
+        tool_calls = sum(len(step.tool_calls) for step in stored.steps)
+        print(f"{len(stored.steps)} step(s), {tool_calls} tool call(s)")
+----
+
+`examples/pydantic_ai_agent.py` is this flow as a runnable script, with a second
+turn that proves the agent sees the first. It runs without an API key by swapping
+in `pydantic_ai.models.test.TestModel` and a local sentence-transformers embedder,
+so the graph writes and the trace read-back are real while the model is stubbed.
+
+The rest of this page builds the same capabilities by hand, which is what you want
+when the dependency needs extra fields (a `user_id`, a current trace id) or the
+tools need to expose domain queries the adapters do not.
 
 == Basic Integration
 
@@ -111,12 +218,15 @@ class AgentDeps:
 
 [source,python]
 ----
+import os
+
 from pydantic_ai import Agent, RunContext
+from pydantic_ai.models.openai import OpenAIChatModel
 
 agent = Agent(
-    "openai:gpt-4o",
+    OpenAIChatModel(os.getenv("OPENAI_MODEL", "gpt-5-mini")),
     deps_type=AgentDeps,
-    system_prompt="""
+    instructions="""
     You are a helpful shopping assistant. Use the available tools to:
     1. Search for products matching customer requests
     2. Retrieve customer preferences to personalize recommendations
@@ -193,15 +303,17 @@ async def search_entities(
     ])
 ----
 
-=== Dynamic System Prompt with Memory
+=== Dynamic Instructions with Memory
 
-Inject memory context into the system prompt:
+Inject memory context with the `instructions` hook — the PydanticAI 2.x
+replacement for `system_prompt`. It is re-rendered on every model request,
+so the context stays current within a run:
 
 [source,python]
 ----
-@agent.system_prompt
+@agent.instructions
 async def add_memory_context(ctx: RunContext[AgentDeps]) -> str:
-    """Dynamically add memory context to system prompt."""
+    """Dynamically add memory context to the agent instructions."""
     parts = []
 
     # Add user preferences
@@ -272,11 +384,11 @@ async def main():
     await memory_client.short_term.add_message(
         session_id=session_id,
         role="assistant",
-        content=result.data,
+        content=result.output,
         metadata={"user_id": user_id},
     )
 
-    print(result.data)
+    print(result.output)
 
 if __name__ == "__main__":
     import asyncio
@@ -292,8 +404,10 @@ A complete example of a memory-enabled shopping assistant:
 from dataclasses import dataclass, field
 from datetime import datetime
 import json
+import os
 
 from pydantic_ai import Agent, RunContext
+from pydantic_ai.models.openai import OpenAIChatModel
 from pydantic import BaseModel
 from neo4j_agent_memory import MemoryClient, MemorySettings
 
@@ -320,10 +434,10 @@ class ShoppingDeps:
 # --- Agent Definition ---
 
 shopping_agent = Agent(
-    "openai:gpt-4o",
+    OpenAIChatModel(os.getenv("OPENAI_MODEL", "gpt-5-mini")),
     deps_type=ShoppingDeps,
-    result_type=ProductRecommendation,
-    system_prompt="""
+    output_type=ProductRecommendation,
+    instructions="""
     You are a personal shopping assistant for an online retailer.
 
     Your goals:
@@ -467,9 +581,9 @@ async def get_similar_recommendations(
 
 # --- System Prompt Enhancement ---
 
-@shopping_agent.system_prompt
+@shopping_agent.instructions
 async def inject_customer_context(ctx: RunContext[ShoppingDeps]) -> str:
-    """Inject customer context into system prompt."""
+    """Inject customer context into the agent instructions."""
 
     # Get preferences
     prefs = await ctx.deps.memory_client.long_term.get_preferences(
@@ -538,9 +652,9 @@ async def run_shopping_assistant():
 
             # Format response
             response = f"Here are my recommendations:\n\n"
-            for i, product in enumerate(result.data.products, 1):
+            for i, product in enumerate(result.output.products, 1):
                 response += f"{i}. {product['name']} - ${product.get('price', 'N/A')}\n"
-            response += f"\n{result.data.reasoning}"
+            response += f"\n{result.output.reasoning}"
 
             print(f"\nAssistant: {response}\n")
 
@@ -556,8 +670,8 @@ async def run_shopping_assistant():
                 trace_id=trace.id,
                 outcome="success",
                 result={
-                    "products": result.data.products,
-                    "personalization": result.data.personalization_used,
+                    "products": result.output.products,
+                    "personalization": result.output.personalization_used,
                 },
             )
 
@@ -582,8 +696,11 @@ Example for a financial services use case:
 
 [source,python]
 ----
+import os
 from dataclasses import dataclass
+
 from pydantic_ai import Agent, RunContext
+from pydantic_ai.models.openai import OpenAIChatModel
 from pydantic import BaseModel
 from neo4j_agent_memory import MemoryClient, MemorySettings
 
@@ -606,10 +723,10 @@ class AdvisoryDeps:
 
 
 advisory_agent = Agent(
-    "openai:gpt-4o",
+    OpenAIChatModel(os.getenv("OPENAI_MODEL", "gpt-5-mini")),
     deps_type=AdvisoryDeps,
-    result_type=InvestmentRecommendation,
-    system_prompt="""
+    output_type=InvestmentRecommendation,
+    instructions="""
     You are a financial advisory assistant helping wealth managers serve their clients.
 
     Important guidelines:
@@ -735,7 +852,7 @@ async def record_compliance_note(
     return f"Recorded compliance note: {category}"
 
 
-@advisory_agent.system_prompt
+@advisory_agent.instructions
 async def inject_client_context(ctx: RunContext[AdvisoryDeps]) -> str:
     """Inject client investment profile into system prompt."""
 
@@ -794,7 +911,7 @@ result = await agent.run(user_input, deps=deps)
 await memory_client.short_term.add_message(
     session_id=session_id,
     role="assistant",
-    content=result.data,
+    content=result.output,
 )
 ----
 
@@ -814,7 +931,7 @@ try:
     await memory_client.reasoning.complete_trace(
         trace_id=trace.id,
         outcome="success",
-        result={"response": result.data},
+        result={"response": result.output},
     )
 except Exception as e:
     await memory_client.reasoning.complete_trace(
@@ -825,13 +942,13 @@ except Exception as e:
     raise
 ----
 
-=== 4. Leverage Dynamic System Prompts
+=== 4. Leverage Dynamic Instructions
 
 Inject relevant context automatically:
 
 [source,python]
 ----
-@agent.system_prompt
+@agent.instructions
 async def dynamic_context(ctx: RunContext[AgentDeps]) -> str:
     # Only fetch what's relevant to current query
     if "preference" in ctx.deps.current_query.lower():
@@ -842,6 +959,7 @@ async def dynamic_context(ctx: RunContext[AgentDeps]) -> str:
 
 == See Also
 
+* `examples/pydantic_ai_agent.py` — the <<shipped-adapters,adapter flow>> above as a runnable script
 * xref:how-to/integrations/langchain.adoc[Use with LangChain]
 * xref:how-to/reasoning-traces.adoc[Record and Query Reasoning Traces]
 * xref:tutorials/conversation-memory.adoc[Tutorial: Add Conversation Memory]

--- a/docs/modules/ROOT/pages/how-to/typescript/integrations-overview.adoc
+++ b/docs/modules/ROOT/pages/how-to/typescript/integrations-overview.adoc
@@ -7,28 +7,33 @@ Pick yours below.
 == Vercel AI SDK (TypeScript)
 
 The `agentMemoryMiddleware` injects three-tier context (reflections +
-observations + recent messages) into every model call and persists the
-assistant's response.
+observations + recent messages) into every model call and persists both the
+user's input and the assistant's response — streamed or not. It implements
+specification v4 (`ai` 7.x / `@ai-sdk/provider` 4.x).
 
 [source,ts]
 ----
-import { generateText } from "ai";
+import { generateText, wrapLanguageModel } from "ai";
+import { openai } from "@ai-sdk/openai";
 import { MemoryClient } from "@neo4j-labs/agent-memory";
 import { agentMemoryMiddleware } from "@neo4j-labs/agent-memory/middleware/vercel-ai";
 
 const client = new MemoryClient({ endpoint: "https://memory.neo4jlabs.com/v1", apiKey });
 
-const result = await generateText({
-  model: openai("gpt-4o"),
-  experimental_middleware: agentMemoryMiddleware(client, {
+const model = wrapLanguageModel({
+  model: openai(process.env.OPENAI_MODEL ?? "gpt-5-mini"),
+  middleware: agentMemoryMiddleware(client, {
     conversationId: "conv-uuid",
     userId: "alice@example.com",
     includeContext: true,
     persistResponses: true,
   }),
-  messages: [{ role: "user", content: "What did we decide?" }],
 });
+
+const result = await generateText({ model, prompt: "What did we decide?" });
 ----
+
+See link:vercel-ai.adoc[How-to: integrate with the Vercel AI SDK].
 
 == LangChain JS (TypeScript)
 
@@ -51,15 +56,17 @@ const docs = await retriever.invoke("Find entities about Acme Corp");
 
 == Mastra (TypeScript)
 
-`Neo4jMastraMemory` wraps `MemoryClient` as a Mastra `Memory` provider.
+`Neo4jMastraMemory` is a thin thread-and-message-history adapter in Mastra's
+vocabulary. It is not a Mastra `Memory` or storage adapter — drive it alongside
+your agent; see link:mastra.adoc[How-to: store Mastra threads in NAMS].
 
 [source,ts]
 ----
 import { Neo4jMastraMemory } from "@neo4j-labs/agent-memory/integrations/mastra";
-import { Agent } from "@mastra/core/agent";
 
 const memory = new Neo4jMastraMemory(client);
-const agent = new Agent({ name: "scout", memory });
+const thread = await memory.createThread({ resourceId: "alice", title: "Scouting" });
+await memory.saveMessage({ threadId: thread.id, role: "user", content: "Hi" });
 ----
 
 == Strands Agents (TypeScript)

--- a/docs/modules/ROOT/pages/how-to/typescript/langchain.adoc
+++ b/docs/modules/ROOT/pages/how-to/typescript/langchain.adoc
@@ -3,73 +3,160 @@
 :source-highlighter: rouge
 
 The `@neo4j-labs/agent-memory/integrations/langchain` subpath exposes
-two duck-typed adapters that fit common LangChain JS shapes:
+two framework-free adapters over `MemoryClient`:
 
-* `Neo4jChatMessageHistory` — slots into `RunnableWithMessageHistory`
-  wherever a `BaseChatMessageHistory` is expected.
-* `Neo4jEntityRetriever` — slots into retriever chains wherever a
-  `BaseRetriever`-shaped object is expected.
+* `Neo4jChatMessageHistory` — read and write a conversation's messages
+  (`getMessages`, `addMessage`, `addUserMessage`, `addAIChatMessage`,
+  `clear`).
+* `Neo4jEntityRetriever` — entity look-up that returns
+  `{ pageContent, metadata }` documents (`invoke`,
+  `getRelevantDocuments`).
+
+Neither imports `@langchain/core`, so the SDK installs without it. They
+are *shapes you adapt*, not subclasses: `Neo4jChatMessageHistory` does
+not extend `BaseChatMessageHistory` and does not implement
+`addMessages`, so it cannot be dropped into
+`RunnableWithMessageHistory` — that class calls `addMessages()` on the
+history it is given. In LangChain JS v1 the idiom to reach for is
+`createAgent()` with middleware anyway, which is what the runnable
+example below does.
 
 A runnable example lives at
-link:https://github.com/neo4j-labs/agent-memory/tree/main/typescript/examples/langchain[`clients/typescript/examples/langchain`].
+link:https://github.com/neo4j-labs/agent-memory/tree/main/typescript/examples/langchain[`typescript/examples/langchain`]
+— a two-turn `createAgent()` agent with no checkpointer, plus a mocked
+test that runs without an API key.
 
-== Why duck-typed
+== Bridging the adapters to `@langchain/core`
 
-LangChain JS evolves quickly and the published interfaces shift between
-minor versions. Importing concrete base classes from `@langchain/core`
-would bind us to a specific version; duck-typing lets these adapters
-slot in regardless.
-
-The cost: type information about the LangChain interfaces is not
-imported. If you want stronger types in your own app, cast at the call
-site:
+Three small functions cover the whole gap. No casts are needed.
 
 [source,typescript]
 ----
-import type { BaseChatMessageHistory } from "@langchain/core/chat_history";
-import { Neo4jChatMessageHistory } from "@neo4j-labs/agent-memory/integrations/langchain";
+import { AIMessage, HumanMessage, SystemMessage, Document, type BaseMessage } from "langchain";
 
-const history: BaseChatMessageHistory =
-  new Neo4jChatMessageHistory(memory, conv.id) as unknown as BaseChatMessageHistory;
+interface AdapterMessage {
+  type: "human" | "ai" | "system";
+  content: string;
+}
+
+function toLangChainMessage(message: AdapterMessage): BaseMessage {
+  if (message.type === "ai") return new AIMessage(message.content);
+  if (message.type === "system") return new SystemMessage(message.content);
+  return new HumanMessage(message.content);
+}
+
+function fromLangChainMessage(message: BaseMessage): AdapterMessage | null {
+  const content = message.text.trim();
+  if (content === "") return null;
+  if (AIMessage.isInstance(message)) {
+    // An assistant turn that only requests a tool call is not an utterance.
+    if ((message.tool_calls?.length ?? 0) > 0) return null;
+    return { type: "ai", content };
+  }
+  if (message.getType() === "human") return { type: "human", content };
+  return null;
+}
+
+function toLangChainDocument(doc: { pageContent: string; metadata: Record<string, unknown> }) {
+  return new Document(doc);
+}
 ----
 
-== Chat message history
+== Memory middleware for `createAgent`
+
+`wrapModelCall` injects graph memory into the system message;
+`afterAgent` persists the turn through the history adapter. Because the
+graph holds the history, the agent needs no checkpointer — invoke it
+with only the new user message.
 
 [source,typescript]
 ----
-import { RunnableWithMessageHistory } from "@langchain/core/runnables";
+import { MemoryClient } from "@neo4j-labs/agent-memory";
 import { Neo4jChatMessageHistory } from "@neo4j-labs/agent-memory/integrations/langchain";
+import { ChatOpenAI } from "@langchain/openai";
+import { HumanMessage, SystemMessage, createAgent, createMiddleware } from "langchain";
 
-const chain = baseChain.pipe(...);
+const memory = new MemoryClient();                    // reads MEMORY_API_KEY
+const conversationId = (await memory.shortTerm.createConversation({ userId })).id;
+const history = new Neo4jChatMessageHistory(memory, conversationId);
 
-const memoryChain = new RunnableWithMessageHistory({
-  runnable: chain,
-  getMessageHistory: (sessionId) => new Neo4jChatMessageHistory(memory, sessionId),
-  inputMessagesKey: "input",
-  historyMessagesKey: "history",
+const namsMemory = createMiddleware({
+  name: "NamsMemoryMiddleware",
+  wrapModelCall: async (request, handler) => {
+    const ctx = await memory.shortTerm.getContext(conversationId);
+    const recalled = [
+      ...ctx.reflections.map((r) => `- ${r.content}`),
+      ...ctx.recentMessages.map((m) => `- ${m.role}: ${m.content}`),
+    ].join("\n");
+    if (recalled === "") return handler(request);
+    return handler({
+      ...request,
+      systemMessage: new SystemMessage(`${request.systemMessage.text}\n\n## Memory\n${recalled}`),
+    });
+  },
+  afterAgent: async (state) => {
+    for (const message of state.messages) {
+      const stored = fromLangChainMessage(message);
+      if (stored) await history.addMessage(stored);     // de-duplicate by message id
+    }
+  },
 });
 
-await memoryChain.invoke(
-  { input: "Hello!" },
-  { configurable: { sessionId: conv.id } },
-);
+const agent = createAgent({
+  model: new ChatOpenAI({ model: process.env.OPENAI_MODEL ?? "gpt-5-mini" }),
+  systemPrompt: "You are a concise assistant with a long memory.",
+  middleware: [namsMemory],
+});
+
+const result = await agent.invoke({ messages: [new HumanMessage("Hello!")] });
 ----
 
-== Entity retriever
+== Entity retriever as a tool
+
+`Neo4jEntityRetriever` takes `{ type, topK }` (not `limit`), and returns
+`pageContent` of the form `"<name> — <description>"` with `metadata`
+carrying `id`, `type`, `confidence`, `sourceStage` and `canonicalName`.
 
 [source,typescript]
 ----
 import { Neo4jEntityRetriever } from "@neo4j-labs/agent-memory/integrations/langchain";
+import { tool } from "langchain";
+import { z } from "zod";
 
-const retriever = new Neo4jEntityRetriever(memory, { limit: 5 });
-const docs = await retriever.invoke("Neo4j graph database");
-// docs[i].pageContent === entity.description
-// docs[i].metadata.name === entity.name
+const retriever = new Neo4jEntityRetriever(memory, { topK: 5 });
+
+const searchMemoryEntities = tool(
+  async ({ query }) => {
+    const docs = await retriever.invoke(query);
+    if (docs.length === 0) return "No entities in memory match that query.";
+    return docs.map((d) => `- ${d.pageContent} (id=${String(d.metadata.id)})`).join("\n");
+  },
+  {
+    name: "search_memory_entities",
+    description: "Search long-term memory for entities the user discussed before.",
+    schema: z.object({ query: z.string() }),
+  },
+);
+----
+
+NAMS extracts entities in a background pipeline, so a write is not
+immediately searchable. Await consistency explicitly rather than
+sleeping:
+
+[source,typescript]
+----
+const ready = await memory.longTerm.waitForExtraction({
+  query: "graph database",
+  expectedNames: ["Neo4j"],
+  timeoutMs: 20_000,
+});
+if (!ready) console.warn("extraction has not caught up yet");
 ----
 
 == Version compatibility
 
-These adapters are tested against LangChain JS 0.2+ shapes. We will not
-break the adapter signatures across minor releases without a CHANGELOG
-callout, but upstream interface drift can still surface — if you hit it,
-please file an issue with the LangChain JS version you're on.
+The adapters carry no LangChain dependency, so they cannot break on a
+LangChain release — but they also gain nothing from one. The bridge
+functions above are verified against `langchain` 1.5 and
+`@langchain/core` 1.2. If you hit drift, please file an issue with the
+LangChain JS version you are on.

--- a/docs/modules/ROOT/pages/how-to/typescript/mastra.adoc
+++ b/docs/modules/ROOT/pages/how-to/typescript/mastra.adoc
@@ -1,16 +1,26 @@
-= How to: integrate with Mastra
+= How to: store Mastra threads in NAMS
 :toc: left
 :source-highlighter: rouge
 
 The `@neo4j-labs/agent-memory/integrations/mastra` subpath exports
-`Neo4jMastraMemory` — a duck-typed Mastra memory provider backed by a
-`MemoryClient`. Hand it to `new Agent({ memory })` and your agent gets
-graph-backed conversation history and entity memory.
+`Neo4jMastraMemory` — a **thin thread-and-message-history adapter** that speaks
+Mastra's vocabulary (`resourceId`, thread, message) against a `MemoryClient`.
 
 A runnable example lives at
-link:https://github.com/neo4j-labs/agent-memory/tree/main/typescript/examples/mastra[`clients/typescript/examples/mastra`].
+link:https://github.com/neo4j-labs/agent-memory/tree/main/typescript/examples/mastra[`typescript/examples/mastra`].
+
+[IMPORTANT]
+====
+This is **not** a Mastra `Memory` implementation and **not** a Mastra storage
+adapter. It cannot be passed to `new Agent({ memory })` or
+`new Memory({ storage })`. See <<Why not a storage adapter yet>>.
+====
 
 == Wiring
+
+Drive the adapter alongside your Mastra agent. The agent is constructed as
+usual — the adapter never goes in the `memory` slot — and the graph holds the
+history:
 
 [source,typescript]
 ----
@@ -18,32 +28,121 @@ import { Agent } from "@mastra/core/agent";
 import { MemoryClient } from "@neo4j-labs/agent-memory";
 import { Neo4jMastraMemory } from "@neo4j-labs/agent-memory/integrations/mastra";
 
-const memory = new Neo4jMastraMemory(new MemoryClient());
+const client = new MemoryClient();             // reads MEMORY_API_KEY
+const memory = new Neo4jMastraMemory(client);  // thread + message history
 
 const agent = new Agent({
+  id: "scout",
   name: "scout",
   instructions: "You help users plan trips.",
-  memory,
+  model: "openai/gpt-5-mini",
+  // NOT `memory` — see the IMPORTANT note above.
 });
+
+const thread = await memory.createThread({
+  resourceId: "alice",             // Mastra's resource → NAMS userId
+  title: "Trip planning",
+});
+----
+
+Per request, replay the thread out of the graph and write the turn back. Mastra
+takes role-discriminated messages, so annotate the one-line bridge rather than
+mapping inline — an unannotated `{ role: m.role, ... }` does not type-check
+against `MessageListItem`:
+
+[source,typescript]
+----
+import type { MastraMemoryMessage } from "@neo4j-labs/agent-memory/integrations/mastra";
+
+type InputMessage =
+  | { role: "system"; content: string }
+  | { role: "user"; content: string }
+  | { role: "assistant"; content: string };
+
+const toMastraMessages = (history: MastraMemoryMessage[]): InputMessage[] =>
+  history.map((m) => ({ role: m.role, content: m.content }));
+
+const history = await memory.getMessages(thread.id, { limit: 20 });
+
+const result = await agent.generate([
+  ...toMastraMessages(history),
+  { role: "user", content: userInput },
+]);
+
+await memory.saveMessage({ threadId: thread.id, role: "user", content: userInput });
+await memory.saveMessage({
+  threadId: thread.id,
+  role: "assistant",
+  content: result.text,
+});
+----
+
+There is no in-process buffer: reuse the same thread id across requests and
+processes and a restarted server picks the thread up where it left off.
+
+Everything written this way is a real NAMS conversation, so entity extraction,
+three-tier context and Cypher queries all apply to it — which is the reason to
+mirror turns here rather than leave them in Mastra's own store:
+
+[source,typescript]
+----
+const context = await client.shortTerm.getContext(thread.id);
+const hits = await client.shortTerm.searchMessages("where is the trip to", {
+  sessionId: thread.id,
+});
+
+// Preferences are scoped to the resource, not the thread, so a second thread
+// for "alice" recalls what the first one learned.
+const second = await memory.createThread({ resourceId: "alice", title: "Follow-up" });
+const recalled = await client.longTerm.searchPreferences("trip style", { limit: 3 });
 ----
 
 == What the adapter implements
 
 * `createThread({ resourceId, title?, metadata? })` — wraps
-  `createConversation`. `resourceId` becomes the `userId`.
+  `createConversation`. `resourceId` becomes the `userId`; `title` is folded into
+  conversation metadata as `mastraTitle` (and omitted entirely when absent).
+* `getThreadById(threadId)` — wraps `getConversationMetadata` and reads the
+  title back.
 * `getMessages(threadId, { limit? })` — wraps `getConversation`.
 * `saveMessage({ threadId, role, content, metadata? })` — wraps
   `addMessage`.
-* `deleteThread(threadId)` — wraps `deleteConversation`.
+* `deleteThread(threadId)` — wraps `deleteConversation`, falling back to
+  `clearSession` on transports that have no delete.
 
-Bridge transports (TCK conformance servers, local reference) don't
-implement `createConversation`; in that case `createThread` synthesizes
-a thread id from the supplied `resourceId`.
+A transport with no `createConversation` (a TCK conformance server, the local
+reference adapter) makes `createThread` synthesize a session id of the form
+`{resourceId}:{uuid}`. It is per-thread, not per-resource: a resource owns many
+threads, and reusing the `resourceId` would collapse them into one.
 
-== Versioning
+[[Why not a storage adapter yet]]
+== Why not a storage adapter yet
 
-Mastra's interfaces are still evolving. We duck-type rather than
-importing `@mastra/core` so this adapter doesn't pin you to a specific
-version. If your Mastra version expects shapes the adapter doesn't
-produce, file an issue with the Mastra version pinned in your
-`package.json`.
+Mastra 1.x takes a custom backend as a **storage adapter**: a
+`MastraCompositeStore` whose `memory` domain extends the abstract
+`MemoryStorage` class from `@mastra/core/storage`. That contract is nine abstract
+methods over `MastraDBMessage` and `StorageListMessagesInput` —
+`getThreadById`, `saveThread`, `updateThread`, `deleteThread`, `listThreads`,
+`listMessages`, `listMessagesById`, `saveMessages`, `updateMessages` — plus
+resource-scoped working memory.
+
+Two of those (`listMessagesById`, `updateMessages`) have no equivalent on the
+NAMS API today, so a half-implemented domain would fail inside Mastra's own
+recall paths rather than at wiring time. Until the API covers them, this adapter
+stays explicitly outside Mastra's extension points.
+`typescript/test/unit/mastra.test.ts` pins that gap against the installed
+`@mastra/core` typings, so a rename on either side fails a test instead of
+quietly making this page wrong.
+
+Track the full storage adapter in
+link:https://github.com/neo4j-labs/agent-memory/issues[the issue tracker]; if you
+need it, say which Mastra recall features you depend on.
+
+== Compatibility
+
+Verified against `@neo4j-labs/agent-memory` 0.5.0-dev, `@mastra/core` 1.66,
+`@mastra/memory` 1.29, Node.js 22 — 2026-09. The published adapter imports
+nothing from Mastra (`import type` only), so it adds no dependency to your
+project; `@mastra/core` is a devDependency of this repository and a real
+dependency of `typescript/examples/mastra`, so both the gap above and the wiring
+snippets are type-checked against the installed Mastra typings in CI.

--- a/docs/modules/ROOT/pages/how-to/typescript/mcp.adoc
+++ b/docs/modules/ROOT/pages/how-to/typescript/mcp.adoc
@@ -2,41 +2,115 @@
 :toc: left
 :source-highlighter: rouge
 
-The `@neo4j-labs/agent-memory/mcp` subpath ships the 12 standard
-neo4j-agent-memory tool definitions plus a dispatcher. Use it to register
-the same tool surface on your own MCP server, or to programmatically
-invoke tools against a `MemoryClient`.
+The `@neo4j-labs/agent-memory/mcp` subpath ships 12 neo4j-agent-memory tool
+definitions plus a dispatcher, and `@neo4j-labs/agent-memory/mcp/register`
+registers them on a high-level `McpServer` in one call. Use either to stand up
+your own MCP server, or to invoke tools programmatically against a
+`MemoryClient`.
 
 A runnable example lives at
-link:https://github.com/neo4j-labs/agent-memory/tree/main/typescript/examples/mcp[`clients/typescript/examples/mcp`].
+link:https://github.com/neo4j-labs/agent-memory/tree/main/typescript/examples/mcp[`typescript/examples/mcp`].
 
 == When to self-host MCP
 
-Most users don't need to. The hosted service already exposes the same 12
-tools at `https://memory.neo4jlabs.com/mcp`. Reach for self-hosting when
-you want to add a logging layer, filter or rewrite tool calls, or run an
-MCP server inside a corporate boundary.
+Most users don't need to. The hosted NAMS MCP server at
+`mcp.memory.neo4jlabs.com` exposes a much larger, scope-gated surface
+(ontology, Skills, administration) and supports OAuth — see
+xref:reference/nams-mcp.adoc[Reference: the hosted NAMS MCP server].
+
+What this subpath gives you is the 12-tool subset that maps one-to-one onto this
+client's methods, which is what you want when you need to wrap, log or filter
+tool calls, expose a restricted surface, or run an MCP server inside a boundary
+that cannot reach the hosted server.
 
 == The 12 tools
 
 [options="header"]
 |===
-| Tool | Wraps
-| `memory_create_conversation` | `shortTerm.createConversation`
-| `memory_add_messages` | `shortTerm.addMessage` (bulk-aware)
-| `memory_get_context` | `shortTerm.getContext`
-| `memory_search_messages` | `shortTerm.searchMessages`
-| `memory_search_entities` | `longTerm.searchEntities`
-| `memory_get_entity` | `longTerm.getEntity`
-| `memory_add_entity` | `longTerm.addEntity`
-| `memory_get_entity_history` | `longTerm.getEntityHistory`
-| `memory_record_step` | `reasoning.recordStep`
-| `memory_record_tool_call` | `reasoning.recordToolCall`
-| `memory_get_trace` | `reasoning.getTraceByConversation`
-| `memory_explain_decision` | `reasoning.explainStep`
+| Tool | Wraps | Annotations
+| `memory_create_conversation` | `shortTerm.createConversation` | write
+| `memory_add_messages` | `shortTerm.addMessage` (bulk-aware) | write
+| `memory_get_context` | `shortTerm.getContext` | read-only, idempotent
+| `memory_search_messages` | `shortTerm.searchMessages` | read-only, idempotent
+| `memory_search_entities` | `longTerm.searchEntities` | read-only, idempotent
+| `memory_get_entity` | `longTerm.getEntity` | read-only, idempotent
+| `memory_add_entity` | `longTerm.addEntity` | write
+| `memory_get_entity_history` | `longTerm.getEntityHistory` | read-only, idempotent
+| `memory_record_step` | `reasoning.recordStep` | write
+| `memory_record_tool_call` | `reasoning.recordToolCall` | write
+| `memory_get_trace` | `reasoning.getTraceByConversation` | read-only, idempotent
+| `memory_explain_decision` | `reasoning.explainStep` | read-only, idempotent
 |===
 
-== Registering with an MCP server
+No memory tool is marked destructive. The read/write split is exported as
+`READ_ONLY_MEMORY_TOOLS` and `memoryToolAnnotations(name)` so a server can apply
+the same policy to tools it adds.
+
+== Registering on an `McpServer` (recommended)
+
+`McpServer.registerTool` validates arguments, which means its `inputSchema` must
+be a Zod shape rather than the JSON Schema the low-level API takes.
+`registerMemoryTools` carries that Zod half and does the registration:
+
+[source,typescript]
+----
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { MemoryClient, VERSION } from "@neo4j-labs/agent-memory";
+import { registerMemoryTools } from "@neo4j-labs/agent-memory/mcp/register";
+
+const memory = new MemoryClient();
+const server = new McpServer({ name: "my-memory-server", version: VERSION });
+
+registerMemoryTools(server, memory, {
+  // optional: expose a subset
+  only: process.env.MCP_TOOLS?.split(","),
+  // optional: one audit line per call — tool name and argument *keys* only
+  onCall: ({ tool, argKeys, durationMs, ok }) =>
+    console.error(`[mcp] ${tool} keys=${argKeys.join(",")} ${durationMs}ms ok=${ok}`),
+});
+
+await server.connect(new StdioServerTransport());
+----
+
+Keep diagnostics on `stderr`: with the stdio transport, `stdout` is the
+protocol channel.
+
+A dispatch failure comes back as a tool result with `isError: true` and the
+message as text — the MCP convention — rather than as a thrown protocol error,
+so the model can see what went wrong. Malformed arguments are rejected by the
+server's own schema validation before the dispatcher runs.
+
+Tool results are one JSON `text` block. No `outputSchema` is declared: several
+tools resolve to arrays, which `structuredContent` cannot carry without
+re-shaping the payload.
+
+== Streamable HTTP
+
+The same registration works over HTTP — only the transport changes:
+
+[source,typescript]
+----
+import { StreamableHTTPServerTransport }
+  from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+
+const transport = new StreamableHTTPServerTransport({
+  sessionIdGenerator: () => crypto.randomUUID(),
+});
+await server.connect(transport);
+
+// In your HTTP handler, forward POST / GET / DELETE on the MCP route:
+//   await transport.handleRequest(req, res, body);
+----
+
+Use Streamable HTTP when the client is not co-located with the server (a
+container, a sidecar, a network boundary). Put authentication in front of the
+route — the transport does not authenticate callers for you.
+
+== Registering with the low-level `Server`
+
+If you already use the low-level API, `createMemoryTools()` emits JSON Schema
+plus annotations directly:
 
 [source,typescript]
 ----
@@ -53,17 +127,27 @@ const server = new Server({ name: "...", version: "..." }, { capabilities: { too
 
 server.setRequestHandler(ListToolsRequestSchema, async () => ({
   tools: tools.map((t) => ({
-    name: t.name, description: t.description, inputSchema: t.inputSchema,
+    name: t.name,
+    description: t.description,
+    inputSchema: t.inputSchema,
+    annotations: t.annotations,
   })),
 }));
 
 server.setRequestHandler(CallToolRequestSchema, async (req) => {
-  const result = await handleMemoryToolCall(
-    memory, req.params.name, (req.params.arguments ?? {}) as Record<string, unknown>,
-  );
-  return { content: [{ type: "text", text: JSON.stringify(result) }] };
+  try {
+    const result = await handleMemoryToolCall(
+      memory, req.params.name, (req.params.arguments ?? {}) as Record<string, unknown>,
+    );
+    return { content: [{ type: "text", text: JSON.stringify(result) }] };
+  } catch (e) {
+    return { isError: true, content: [{ type: "text", text: String(e) }] };
+  }
 });
 ----
+
+This path does not validate arguments — the dispatcher casts them — so prefer
+`registerMemoryTools` for anything a model drives.
 
 == Programmatic dispatch
 
@@ -83,6 +167,15 @@ Argument keys use snake_case (matching the JSON schema published by
 
 == Deprecated tool names
 
-A few `memory.<verb>` aliases from earlier drafts are still accepted and
-forward to the new names with a warning. Migrate to the
-`memory_<noun>_<verb>` form when you can.
+Five `memory.<verb>` aliases from v0.1 are still accepted and forward to the new
+names with a warning: `memory.addMessage`, `memory.getConversation`,
+`memory.searchMessages`, `memory.addEntity`, `memory.searchEntities`. They are
+scheduled for removal in 1.0 — migrate to the `memory_<noun>_<verb>` form.
+
+== Compatibility
+
+Verified against `@neo4j-labs/agent-memory` 0.5.0-dev,
+`@modelcontextprotocol/sdk` 1.30, `zod` 4.6, Node.js 22 — 2026-09.
+`@modelcontextprotocol/sdk` and `zod` are optional peer dependencies; they are
+required only by the `./mcp/register` subpath (the MCP SDK already depends on
+`zod`).

--- a/docs/modules/ROOT/pages/how-to/typescript/strands.adoc
+++ b/docs/modules/ROOT/pages/how-to/typescript/strands.adoc
@@ -35,7 +35,7 @@ In Strands' own vocabulary: the session storage restores sessions, the
 memory store feeds the agent loop.
 
 A runnable example lives at
-link:https://github.com/neo4j-labs/agent-memory/tree/main/typescript/examples/strands[`clients/typescript/examples/strands`].
+link:https://github.com/neo4j-labs/agent-memory/tree/main/typescript/examples/strands[`typescript/examples/strands`].
 
 == Quick Start
 
@@ -183,11 +183,16 @@ import { MemoryClient } from "@neo4j-labs/agent-memory";
 import { connectMemoryToAgent } from "@neo4j-labs/agent-memory/integrations/strands";
 
 const memory = new MemoryClient();
-const conv = await memory.shortTerm.createConversation({ userId: "alice" });
+
+// Resume rather than restart: both session storage and context injection are
+// conversation-scoped, so recall across runs needs the same conversation id.
+const userId = "alice";
+const previous = (await memory.shortTerm.listConversations({ userId, limit: 1 }))[0];
+const conv = previous ?? (await memory.shortTerm.createConversation({ userId }));
 
 const agent = new Agent({
   ...await connectMemoryToAgent(memory, { conversationId: conv.id }),
-  model: new OpenAIModel({ modelId: "gpt-4o-mini" }),
+  model: new OpenAIModel({ modelId: process.env.OPENAI_MODEL ?? "gpt-5-mini" }),
   tools: [/* ... */],
 });
 
@@ -197,6 +202,18 @@ await agent.invoke("Tell me about graph databases.");
 The factory returns `{ sessionManager, conversationManager }` — spread it
 into `new Agent({...})`. Reasoning hooks attach automatically when the
 conversation manager's `initAgent` runs.
+
+[NOTE]
+====
+The spread needs **one resolved copy** of `@strands-agents/sdk` in the
+dependency tree. Strands' `ConversationManager` carries protected fields, so two
+copies (the usual outcome of a symlinked local checkout — `npm link`, or a
+`file:` dependency installed with the default `install-links=false`) make the
+same class nominally distinct and TypeScript rejects the config. Installing
+`@neo4j-labs/agent-memory` from npm gives you one copy; a local checkout needs
+`install-links=true` (see `typescript/examples/strands/.npmrc`) or an npm
+workspace.
+====
 
 == Individual pieces (advanced)
 
@@ -302,13 +319,28 @@ in. An auth failure surfaces as `AuthenticationError` from
 
 == Version compatibility
 
-We test against `@strands-agents/sdk@^1.2.0`. Strands' v1 API is stable
-under semver — the integration should track v1 minor releases without
-adjustment. We will not break the integration API across minor releases
-of `@neo4j-labs/agent-memory` without a CHANGELOG callout.
+Verified against `@strands-agents/sdk` 1.17 (declared floor: `>=1.16 <2`) and
+Node.js 22, with `@neo4j-labs/agent-memory` 0.5.0-dev — 2026-09. Strands' v1 API
+is stable under semver, and `typescript/test/unit/strands/type-compatibility.test.ts`
+asserts each of our classes still satisfies the interface it implements, so an
+`npm install` that reshapes one of them fails a test rather than drifting
+silently. We will not break the integration API across minor releases of
+`@neo4j-labs/agent-memory` without a CHANGELOG callout.
 
 `Neo4jMemoryStore` needs `@strands-agents/sdk >= 1.6.0`, the release that
 introduced `MemoryManager`/`MemoryStore`.
+
+=== A note on `SnapshotStorage` vs the unified `Storage`
+
+Strands 1.16 introduced a unified `Storage` interface (`write`/`read`/`delete`/
+`list` over opaque `Uint8Array` values) and marked the snapshot-shaped
+`{ snapshot: SnapshotStorage }` form of `SessionManagerConfig.storage`
+deprecated. `Neo4jSessionStorage` deliberately stays on the snapshot form,
+which Strands still accepts: a byte-blob backend would reduce a NAMS
+conversation to one opaque value, losing entity extraction, message search and
+graph traversal over the transcript — the reasons to persist a session into a
+graph at all. If Strands removes the snapshot form, the integration will move to
+a unified `Storage` that keeps the hybrid message mapping behind it.
 
 == See also
 

--- a/docs/modules/ROOT/pages/how-to/typescript/vercel-ai.adoc
+++ b/docs/modules/ROOT/pages/how-to/typescript/vercel-ai.adoc
@@ -2,28 +2,53 @@
 :toc: left
 :source-highlighter: rouge
 
-The TypeScript client ships a `LanguageModelV1`-shaped middleware that
-auto-injects context and persists messages around any Vercel AI SDK call.
-This page covers the wiring; a runnable example lives at
-link:https://github.com/neo4j-labs/agent-memory/tree/main/typescript/examples/vercel-ai[`clients/typescript/examples/vercel-ai`].
+The TypeScript client ships a language-model middleware that auto-injects
+context and persists messages around any Vercel AI SDK call. It implements
+specification **v4** (`LanguageModelV4Middleware` from `@ai-sdk/provider` 4.x),
+which is the provider specification `ai` 7.x uses. This page covers the wiring;
+a runnable example lives at
+link:https://github.com/neo4j-labs/agent-memory/tree/main/typescript/examples/vercel-ai[`typescript/examples/vercel-ai`].
+
+[NOTE]
+====
+`ai` 7 requires Node.js 22 or newer, and so does this client.
+====
+
+[TIP]
+====
+This page covers the low-level middleware. For a provider wrapper, ready-made
+memory tools and a Next.js route handler built on the same service, see
+link:https://github.com/neo4j-labs/agent-memory/tree/main/typescript/packages/vercel-ai-provider[`@neo4j-labs/nams-ai-provider`],
+which uses the same NAMS backend at a higher level of abstraction.
+====
 
 == What the middleware does
 
 For every model invocation:
 
 1. Fetches three-tier context for the conversation (reflections,
-   observations, recent messages) and prepends it to the prompt.
-2. Persists the user's input message before generation.
-3. Persists the assistant's response after generation.
+   observations, recent messages) and prepends it to the prompt —
+   reflections and observations as one `system` message, recent messages
+   replayed as `user`/`assistant` turns with `{ type: "text" }` parts.
+2. Persists the user's input message before generation. A multi-part user
+   message (text interleaved with files) is flattened to its text parts.
+3. Persists the assistant's response after generation — for `generateText`
+   via `wrapGenerate`, and for `streamText` via `wrapStream`, which
+   accumulates the text deltas and writes once the stream finishes.
 
 If three-tier context is unavailable (bridge transport, or a service
-error), the middleware falls back to flat conversation history.
+error), the middleware falls back to flat conversation history. Every
+persistence failure is non-fatal: the model call still returns.
+
+In a tool-calling loop `transformParams` runs once per step with the same user
+turn still last in the prompt; the middleware writes that turn once, not once
+per step.
 
 == Basic wiring
 
 [source,typescript]
 ----
-import { generateText, experimental_wrapLanguageModel as wrapModel } from "ai";
+import { generateText, wrapLanguageModel } from "ai";
 import { openai } from "@ai-sdk/openai";
 import { MemoryClient } from "@neo4j-labs/agent-memory";
 import { agentMemoryMiddleware } from "@neo4j-labs/agent-memory/middleware/vercel-ai";
@@ -31,14 +56,14 @@ import { agentMemoryMiddleware } from "@neo4j-labs/agent-memory/middleware/verce
 const memory = new MemoryClient();
 const conv = await memory.shortTerm.createConversation({ userId: "alice" });
 
-const model = wrapModel({
-  model: openai("gpt-4o-mini"),
+const model = wrapLanguageModel({
+  model: openai(process.env.OPENAI_MODEL ?? "gpt-5-mini"),
   middleware: agentMemoryMiddleware(memory, { conversationId: conv.id }),
 });
 
 const { text } = await generateText({
   model,
-  messages: [{ role: "user", content: "Hello!" }],
+  prompt: "Hello!",
 });
 ----
 
@@ -60,11 +85,57 @@ agentMemoryMiddleware(client, {
 when the id is derived from request state (e.g., from `req.user.id` in a
 Next.js route handler).
 
+== Resuming instead of always creating
+
+Memory is only visible across sessions if the next process reaches for the same
+conversation. Resolve the id before wiring the middleware — `createConversation`
+on every run gives every run an empty graph:
+
+[source,typescript]
+----
+const userId = process.env.DEMO_USER_ID ?? "alice";
+
+// Prefer an explicit id, else the newest conversation for this user, else create.
+const requested = process.env.CONVERSATION_ID;
+const existing = requested
+  ? await memory.shortTerm.getConversationMetadata(requested)
+  : (await memory.shortTerm.listConversations({ userId }))[0];
+
+const conv =
+  existing ??
+  (await memory.shortTerm.createConversation({ userId, metadata: { source: "my-app" } }));
+
+console.log(existing ? `Resumed ${conv.id}` : `Created ${conv.id}`);
+----
+
+In a server, the id normally comes from the request (a thread id in your own
+schema); the env-var form above is what a script uses.
+
 == Streaming
 
-The same middleware works with `streamText` because Vercel AI handles
-streaming via the wrapped model — the middleware's `wrapGenerate` is
-called once the stream completes.
+`streamText` is persisted too. `wrapStream` pipes the provider's stream
+through a transform that accumulates every `text-delta` and writes one
+assistant message when the `finish` part arrives (or when the consumer
+cancels early), so nothing is lost and the consumer sees every part
+unchanged:
+
+[source,typescript]
+----
+const { textStream } = streamText({ model, prompt: "Explain graph memory." });
+for await (const chunk of textStream) process.stdout.write(chunk);
+// the assembled response is now a Message node on the conversation
+----
+
+The write is fire-and-forget — the stream is never held open waiting on
+the memory service.
+
+== Types
+
+`agentMemoryMiddleware` returns `LanguageModelV4Middleware`, so
+`wrapLanguageModel` accepts it with no cast. `@ai-sdk/provider` is an
+optional peer dependency of this package: anything that has `ai` 7
+installed already has it, and a project that does not use this middleware
+does not need it.
 
 == Edge runtimes
 
@@ -82,3 +153,8 @@ export default {
 ----
 
 See link:edge-runtime.adoc[How-to: deploy to edge runtimes] for details.
+
+== Compatibility
+
+Verified against `@neo4j-labs/agent-memory` 0.5.0-dev, `ai` 7.0,
+`@ai-sdk/provider` 4.0, Node.js 22 — 2026-09.

--- a/docs/modules/ROOT/pages/reference/api/adapters.adoc
+++ b/docs/modules/ROOT/pages/reference/api/adapters.adoc
@@ -199,6 +199,8 @@ VertexAIEmbeddingProvider(
 * Implements `EmbeddingProvider`.
 * Wraps the existing `embeddings.vertex_ai.VertexAIEmbedder`.
 * `task_type` is one of `RETRIEVAL_QUERY`, `RETRIEVAL_DOCUMENT`, `SEMANTIC_SIMILARITY`, `CLASSIFICATION`, `CLUSTERING`.
+* Pass the current model id, `"vertex_ai/gemini-embedding-001"`. Retired ids (`text-embedding-004`, `textembedding-gecko*`) raise `EmbeddingError` when the underlying embedder is constructed.
+* The underlying embedder truncates output to 768 dimensions by default, so leave `dimensions` unset (it resolves to 768) or pass `dimensions=768`. For 1536- or 3072-dimension vectors, construct `VertexAIEmbedder(output_dimensionality=...)` directly and pass it as `embedder=` to `MemoryClient` — this adapter does not forward `output_dimensionality` yet.
 
 Vertex AI as an *LLM* provider routes through LiteLLM — there is no native `VertexAIProvider` because the existing Vertex AI embedder predates the Protocol and is well-tested for embeddings only.
 

--- a/docs/modules/ROOT/pages/reference/cli.adoc
+++ b/docs/modules/ROOT/pages/reference/cli.adoc
@@ -296,9 +296,9 @@ neo4j-agent-memory mcp serve [OPTIONS]
 | `--user`                | `neo4j`               | Neo4j username (env: `NEO4J_USER`).
 | `--password`            | _required_            | Neo4j password (env: `NEO4J_PASSWORD`).
 | `--database`            | `neo4j`               | Neo4j database name (env: `NEO4J_DATABASE`).
-| `--transport`           | `stdio`               | MCP transport (`stdio`, `sse`, or `http`).
-| `--host`                | `127.0.0.1`           | Host for network transports.
-| `--port`                | `8080`                | Port for network transports.
+| `--transport`           | `stdio`               | MCP transport: `stdio` or `http` (Streamable HTTP; `streamable-http` is a synonym). `sse` is deprecated and serves Streamable HTTP with a warning.
+| `--host`                | `127.0.0.1`           | Host for the HTTP transport (`0.0.0.0` to expose it).
+| `--port`                | `8080`                | Port for the HTTP transport.
 | `--profile`             | `extended`            | Tool profile: `core` (6 tools) or `extended` (16 tools).
 | `--session-strategy`    | `per_conversation`    | `per_conversation`, `per_day`, or `persistent`.
 | `--user-id`             | _none_                | User ID for `per_day`/`persistent` strategies (env: `MCP_USER_ID`).
@@ -336,7 +336,20 @@ neo4j-agent-memory mcp serve \
   --profile core \
   --session-strategy per_day \
   --user-id alice
+
+# Streamable HTTP, for a networked deployment (Cloud Run, Kubernetes).
+# The MCP endpoint is POST/GET http://<host>:8080/mcp/
+neo4j-agent-memory mcp serve \
+  --password mypw \
+  --transport http \
+  --host 0.0.0.0 \
+  --port 8080
 ----
+
+NOTE: `--transport sse` is deprecated. The MCP specification replaced the legacy
+HTTP+SSE transport with Streamable HTTP; the flag still starts a server but logs
+a warning and serves Streamable HTTP at `/mcp/`. See
+xref:reference/mcp-tools.adoc#_transports[Transports].
 
 == Environment Variables
 

--- a/docs/modules/ROOT/pages/reference/configuration.adoc
+++ b/docs/modules/ROOT/pages/reference/configuration.adoc
@@ -198,7 +198,7 @@ OPENAI_API_KEY=sk-...
 |`model`
 |str
 |`text-embedding-3-small`
-|Model name
+|Model name. When `provider=VERTEX_AI` and `model` is not set, it defaults to `gemini-embedding-001` (and `dimensions` to 768).
 
 |`api_key`
 |SecretStr
@@ -235,6 +235,11 @@ OPENAI_API_KEY=sk-...
 |`RETRIEVAL_DOCUMENT`
 |Vertex AI task type
 
+|`output_dimensionality`
+|int \| None
+|None (768 when `provider=VERTEX_AI`)
+|Vertex AI truncation target. `gemini-embedding-001` emits 3072 dimensions natively and can be truncated to 1536 or 768.
+
 |`aws_region`
 |str
 |None
@@ -261,8 +266,8 @@ OPENAI_API_KEY=sk-...
 |Runs locally
 
 |`VERTEX_AI`
-|`text-embedding-004`, `textembedding-gecko@003`
-|Requires GCP project. Install with `pip install neo4j-agent-memory[vertex-ai]`
+|`gemini-embedding-001` (default), `text-embedding-005`, `text-multilingual-embedding-002`
+|Requires GCP project. Install with `pip install neo4j-agent-memory[vertex-ai]`. `text-embedding-004` (retired 2026-01-14) and `textembedding-gecko*` (retired 2025-04-09) raise an error.
 
 |`BEDROCK`
 |`amazon.titan-embed-text-v2:0`, `amazon.titan-embed-text-v1`, `cohere.embed-english-v3`, `cohere.embed-multilingual-v3`

--- a/docs/modules/ROOT/pages/reference/environment-variables.adoc
+++ b/docs/modules/ROOT/pages/reference/environment-variables.adoc
@@ -76,7 +76,7 @@ These are equivalent to the matching `--llm` / `--embedding` flags on `neo4j-age
 | `NAM_EMBEDDING__MODEL`
 | string
 | `text-embedding-3-small`
-| Embedding model name
+| Embedding model name. Unset with `PROVIDER=vertex_ai` it defaults to `gemini-embedding-001`
 
 | `NAM_EMBEDDING__API_KEY`
 | string
@@ -107,6 +107,16 @@ These are equivalent to the matching `--llm` / `--embedding` flags on `neo4j-age
 | string
 | `us-central1`
 | GCP region (for Vertex AI)
+
+| `NAM_EMBEDDING__TASK_TYPE`
+| string
+| `RETRIEVAL_DOCUMENT`
+| Vertex AI task type
+
+| `NAM_EMBEDDING__OUTPUT_DIMENSIONALITY`
+| int
+| _none_ (`768` for Vertex AI)
+| Vertex AI truncation target (`gemini-embedding-001` is 3072 natively)
 
 | `NAM_EMBEDDING__AWS_REGION`
 | string

--- a/docs/modules/ROOT/pages/reference/mcp-tools.adoc
+++ b/docs/modules/ROOT/pages/reference/mcp-tools.adoc
@@ -430,6 +430,43 @@ The server sends behavioral instructions during MCP initialization that teach Cl
 * To use POLE+O entity types and `UPPER_SNAKE_CASE` relationship types
 * (Extended) To record reasoning traces for complex tasks
 
+== Transports
+
+The server is built on FastMCP 4 (MCP Python SDK 2) and serves two transports:
+
+[cols="1,3", options="header"]
+|===
+| Transport | When to use
+
+| `stdio` (default)
+| Local hosts that launch the server as a child process: Claude Desktop, Claude Code, Cursor. The host owns stdin/stdout, so nothing else may write to them -- the FastMCP startup banner is suppressed on this transport for that reason.
+
+| `http`
+| Streamable HTTP, the network transport in the current MCP spec. Use it for Cloud Run, Kubernetes, or any deployment where several clients share one server. `streamable-http` is accepted as an explicit spelling of the same thing.
+|===
+
+[source,bash]
+----
+# local, for a desktop host
+neo4j-agent-memory mcp serve --password "$NEO4J_PASSWORD"
+
+# networked, Streamable HTTP on all interfaces
+neo4j-agent-memory mcp serve --transport http --host 0.0.0.0 --port 8080 \
+  --password "$NEO4J_PASSWORD"
+----
+
+[WARNING]
+====
+`--transport sse` is **deprecated**. The MCP specification replaced the legacy
+HTTP+SSE transport with Streamable HTTP, and FastMCP 4 deprecated it in turn.
+The flag is still accepted so existing launch configurations keep starting, but
+it logs a warning and serves Streamable HTTP. Switch to `--transport http`.
+
+The endpoint path also changed with it: Streamable HTTP serves a single
+`POST`/`GET` endpoint at `/mcp/`, not the old `/sse` + `/messages` pair. Update
+client URLs alongside the flag.
+====
+
 == CLI Reference
 
 [source,bash]
@@ -459,15 +496,15 @@ neo4j-agent-memory mcp serve [OPTIONS]
 
 | `--transport`
 | `stdio`
-| Transport: `stdio`, `sse`, or `http`.
+| Transport: `stdio` or `http` (Streamable HTTP). `streamable-http` is a synonym for `http`. `sse` is deprecated -- it is still accepted so existing launch configurations keep starting, but it logs a warning and serves Streamable HTTP.
 
 | `--host`
 | `127.0.0.1`
-| Host for SSE/HTTP transports.
+| Host for the HTTP transport. Use `0.0.0.0` to expose the server outside the container.
 
 | `--port`
 | `8080`
-| Port for SSE/HTTP transports.
+| Port for the HTTP transport.
 
 | `--profile`
 | `extended`
@@ -495,3 +532,9 @@ neo4j-agent-memory mcp serve [OPTIONS]
 * xref:how-to/typescript/mcp.adoc[Wire the same tools into the TypeScript SDK]
 * xref:reference/rest-api.adoc[NAMS REST API] - HTTP surface backing the MCP tools
 * link:https://github.com/neo4j-labs/agent-memory-tck/blob/main/docs/reference/mcp-tools.adoc[MCP tools spec in the TCK] - Cross-language behavioral contract
+
+== Runnable example
+
+link:https://github.com/neo4j-labs/agent-memory/tree/main/examples/claude-code-team-memory[`examples/claude-code-team-memory/`]
+wires this server (both profiles) and the hosted NAMS MCP server side by side in
+Claude Code, Claude Desktop and Cursor, with no agent code.

--- a/docs/modules/ROOT/pages/reference/typescript-api.adoc
+++ b/docs/modules/ROOT/pages/reference/typescript-api.adoc
@@ -438,7 +438,7 @@ TypeDoc: link:{attachmentsdir}/api/typescript/classes/index.MemoryError.html[`Me
 
 == Subpath exports
 
-The package exposes six subpath exports beyond the root. Each is independently importable to keep tree-shaking honest on edge runtimes.
+The package exposes seven subpath exports beyond the root. Each is independently importable to keep tree-shaking honest on edge runtimes.
 
 [cols="2,3,3", options="header"]
 |===
@@ -450,11 +450,15 @@ The package exposes six subpath exports beyond the root. Each is independently i
 
 |`@neo4j-labs/agent-memory/middleware/vercel-ai`
 |`agentMemoryMiddleware`, `AgentMemoryLanguageModelMiddleware`
-|Wire memory into a Vercel AI SDK `generateText` / `streamText` call. See xref:how-to/typescript/vercel-ai.adoc[Vercel AI SDK middleware].
+|Wire memory into a Vercel AI SDK `generateText` / `streamText` call. Implements specification v4 (`ai` 7.x). See xref:how-to/typescript/vercel-ai.adoc[Vercel AI SDK middleware].
 
 |`@neo4j-labs/agent-memory/mcp`
-|`createMemoryTools`, `handleMemoryToolCall`, `McpToolDefinition`
-|Register the 12 standard memory tools with an MCP server. See xref:how-to/typescript/mcp.adoc[MCP tools].
+|`createMemoryTools`, `handleMemoryToolCall`, `McpToolDefinition`, `McpToolAnnotations`, `READ_ONLY_MEMORY_TOOLS`, `memoryToolAnnotations`
+|The 12-tool memory surface as JSON Schema plus a dispatcher, for the low-level MCP `Server` API. See xref:how-to/typescript/mcp.adoc[MCP tools].
+
+|`@neo4j-labs/agent-memory/mcp/register`
+|`registerMemoryTools`, `memoryToolShapes`, `MemoryToolCallAudit`
+|Register the same 12 tools on a high-level `McpServer` (Zod input schemas, annotations, optional allow-list and audit hook). Requires the optional `zod` peer.
 
 |`@neo4j-labs/agent-memory/integrations/langchain`
 |`Neo4jChatMessageHistory`, `Neo4jEntityRetriever`
@@ -462,10 +466,10 @@ The package exposes six subpath exports beyond the root. Each is independently i
 
 |`@neo4j-labs/agent-memory/integrations/mastra`
 |`Neo4jMastraMemory`
-|Mastra agent framework. See xref:how-to/typescript/mastra.adoc[Mastra].
+|A thin thread-and-message-history adapter in Mastra's vocabulary — not a Mastra `Memory` or storage adapter. See xref:how-to/typescript/mastra.adoc[Mastra].
 
 |`@neo4j-labs/agent-memory/integrations/strands`
-|`Neo4jSessionStorage`, `Neo4jConversationManager`, `registerReasoningHooks`, `connectMemoryToAgent`
+|`Neo4jSessionStorage`, `Neo4jConversationManager`, `registerReasoningHooks`, `connectMemoryToAgent`, `Neo4jMemoryStore`
 |AWS Strands Agents SDK (JS). See xref:how-to/typescript/strands.adoc[Strands].
 
 |`@neo4j-labs/agent-memory/testing`

--- a/docs/modules/ROOT/pages/tutorials/mcp-server.adoc
+++ b/docs/modules/ROOT/pages/tutorials/mcp-server.adoc
@@ -147,6 +147,35 @@ Claude will call `memory_search` and find your stored preference for Italian foo
 
 Claude will call `memory_get_entity` (if using extended profile) or `memory_search` to find the entity and any related context.
 
+== Running the Server Remotely
+
+Claude Desktop launches the server as a child process and talks to it over
+`stdio`, which is what every step above uses. If you want one server shared by
+several clients -- a team deployment, or a Cloud Run service -- start it on the
+Streamable HTTP transport instead:
+
+[source,bash]
+----
+neo4j-agent-memory mcp serve \
+  --transport http \
+  --host 0.0.0.0 \
+  --port 8080 \
+  --password test-password
+----
+
+The MCP endpoint is then `POST`/`GET` at `/mcp/` on that host and port, and
+clients connect to the URL rather than spawning a process.
+
+[NOTE]
+====
+Streamable HTTP is the network transport in the current MCP specification, and
+FastMCP 4 -- which this server is built on -- deprecated the older HTTP+SSE
+transport. `--transport sse` is still accepted so existing launch configurations
+keep starting, but it warns and serves Streamable HTTP. If you are migrating a
+config, change `sse` to `http` and point the client at `/mcp/` instead of
+`/sse`.
+====
+
 == Programmatic Server Usage
 
 You can also start the MCP server from Python code:
@@ -194,3 +223,9 @@ By default, the server starts with the **extended** profile (16 tools). For simp
 ----
 
 See the xref:reference/mcp-tools.adoc[MCP Tools Reference] for the complete list of tools in each profile.
+
+== Runnable example
+
+link:https://github.com/neo4j-labs/agent-memory/tree/main/examples/claude-code-team-memory[`examples/claude-code-team-memory/`]
+turns this tutorial into a team setup: per-developer keys, a seeded shared
+workspace, and a `doctor.py` that validates every editor config offline.

--- a/docs/modules/ROOT/pages/tutorials/microsoft-agent-memory.adoc
+++ b/docs/modules/ROOT/pages/tutorials/microsoft-agent-memory.adoc
@@ -6,7 +6,9 @@ This tutorial guides you through building a shopping assistant that remembers cu
 
 [NOTE]
 ====
-This tutorial targets Microsoft Agent Framework v1.0.0b260212. The framework has reached GA; check the https://github.com/microsoft/agent-framework[Microsoft Agent Framework releases] for the latest version and any API changes.
+This tutorial targets the Microsoft Agent Framework 1.x GA line (`>=1.13,<2`), verified against 1.18.0. Check the https://github.com/microsoft/agent-framework[Microsoft Agent Framework releases] for the latest version.
+
+If you are coming from the `1.0.0b260212` public preview, note that the GA line renamed the provider base classes (`BaseContextProvider` -> `ContextProvider`, `BaseHistoryProvider` -> `HistoryProvider`). The library handles the rename for you; you only need the dependency bump.
 ====
 
 == What You'll Build
@@ -30,7 +32,13 @@ A retail shopping assistant that:
 [source,bash]
 ----
 pip install neo4j-agent-memory[microsoft-agent,openai]
+pip install agent-framework-azure-ai   # the chat client this tutorial uses
 ----
+
+The `[microsoft-agent]` extra installs `agent-framework-core`, which ships the
+`agent_framework` package the integration imports. Chat clients live in separate
+distributions, so install the one you plan to use (or `agent-framework`, the
+meta-package that bundles them all).
 
 == Step 2: Set Up Neo4j
 
@@ -121,6 +129,7 @@ Create a file `agent.py`. All tools — both memory tools and product tools — 
 """Shopping assistant agent."""
 
 import json
+import os
 from typing import Annotated
 
 from agent_framework import Agent, FunctionTool, Message, tool
@@ -176,7 +185,10 @@ def get_product_tools(memory: Neo4jMicrosoftMemory) -> list[FunctionTool]:
         LIMIT 5
         """
 
-        result = await client.graph.execute_read(cypher, params)
+        # client.query.cypher() is the portable read-only accessor; it works on
+        # both the bolt and hosted (NAMS) backends. client.graph.execute_read()
+        # is deprecated and bolt-only.
+        result = await client.query.cypher(cypher, params)
         products = [dict(r) for r in result]
         return json.dumps({"products": products, "count": len(products)})
 
@@ -185,7 +197,7 @@ def get_product_tools(memory: Neo4jMicrosoftMemory) -> list[FunctionTool]:
 
 async def create_agent(memory: Neo4jMicrosoftMemory) -> Agent:
     """Create the shopping assistant agent."""
-    chat_client = AzureOpenAIResponsesClient(model="gpt-4")
+    chat_client = AzureOpenAIResponsesClient(model=os.getenv("OPENAI_MODEL", "gpt-5-mini"))
 
     # Create memory tools bound to the memory instance
     memory_tools = create_memory_tools(memory, include_gds_tools=bool(memory.gds))

--- a/docs/modules/ROOT/pages/tutorials/strands-agent-quickstart.adoc
+++ b/docs/modules/ROOT/pages/tutorials/strands-agent-quickstart.adoc
@@ -47,7 +47,8 @@ This installs:
 
 * `neo4j-agent-memory` - The core memory library
 * `boto3` - AWS SDK for Bedrock access
-* `strands-agents` - AWS Strands Agents SDK
+* `strands-agents` - AWS Strands Agents SDK (`>=1.52,<2`; tested against 1.52
+  and 1.55.1)
 
 == Step 2: Configure Credentials
 
@@ -62,6 +63,12 @@ NEO4J_PASSWORD=your-password
 
 # AWS Configuration (uses default credentials if not set)
 AWS_REGION=us-east-1
+
+# Optional: pin the Bedrock ids instead of the library defaults.
+# Verify with: aws bedrock list-inference-profiles
+# BEDROCK_MODEL_ID=us.anthropic.claude-sonnet-4-6
+# BEDROCK_INFERENCE_PROFILE_PREFIX=us
+# BEDROCK_EMBEDDING_MODEL_ID=amazon.titan-embed-text-v2:0
 ----
 
 [TIP]
@@ -84,7 +91,10 @@ Create a file called `agent.py`:
 import os
 from dotenv import load_dotenv
 from strands import Agent
-from neo4j_agent_memory.integrations.strands import context_graph_tools
+from neo4j_agent_memory.integrations.strands import (
+    bedrock_llm_model,
+    context_graph_tools,
+)
 
 # Load environment variables
 load_dotenv()
@@ -98,9 +108,14 @@ tools = context_graph_tools(
     aws_region=os.environ.get("AWS_REGION", "us-east-1"),
 )
 
-# Create the agent with memory tools
+# Create the agent with memory tools.
+# bedrock_llm_model() resolves a cross-region inference-profile id
+# (us.anthropic.claude-sonnet-4-6 by default) — current Claude models on
+# Bedrock are not invocable by their bare foundation-model id. Override with
+# BEDROCK_MODEL_ID, or swap just the region prefix with
+# BEDROCK_INFERENCE_PROFILE_PREFIX=eu.
 agent = Agent(
-    model="anthropic.claude-sonnet-4-20250514-v1:0",
+    model=bedrock_llm_model(),
     tools=tools,
     system_prompt="""You are a helpful assistant with persistent memory.
 
@@ -163,6 +178,54 @@ as a software engineer. How can I help you today?
 You: What company do I work for?
 Assistant: Based on my memory, you work at Acme Corp as a software engineer!
 ----
+
+[TIP]
+====
+The tools above are *pull-based*: the agent decides when to read and write
+memory. If you also want every turn persisted and restored without the model
+having to ask, attach a session manager — one extra argument, and the
+conversation survives process restarts:
+
+[source,python]
+----
+from pydantic import SecretStr
+
+from neo4j_agent_memory import MemorySettings, Neo4jConfig
+from neo4j_agent_memory.integrations.strands import (
+    Neo4jRetrievalConfig,
+    Neo4jSessionManager,
+    bedrock_llm_model,
+)
+
+# Pinning backend="bolt" keeps a stray MEMORY_API_KEY from redirecting
+# writes to the hosted service; drop it (or use .for_nams()) for NAMS.
+manager = Neo4jSessionManager(
+    "tutorial-session",
+    settings=MemorySettings(
+        backend="bolt",
+        neo4j=Neo4jConfig(
+            uri=os.environ["NEO4J_URI"],
+            username=os.environ.get("NEO4J_USER", "neo4j"),
+            password=SecretStr(os.environ["NEO4J_PASSWORD"]),
+        ),
+    ),
+    # min_score is a Neo4j vector-index score ((1 + cosine) / 2), so 0.5
+    # means "orthogonal"; 0.75 is the equivalent of cosine 0.5.
+    retrieval_config=Neo4jRetrievalConfig(top_k=5, min_score=0.75),
+)
+
+agent = Agent(
+    model=bedrock_llm_model(),
+    tools=tools,
+    session_manager=manager,
+)
+----
+
+See xref:how-to/integrations/aws-strands.adoc#_session_manager_push_based[Session Manager (Push-Based)]
+for the constructor reference and limitations, and the
+`examples/strands-session-manager/` example for a runnable demo that needs no
+API key.
+====
 
 == Step 5: Explore the Knowledge Graph
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,13 @@ classifiers = [
 ]
 
 dependencies = [
-    "neo4j>=5.20.0",
+    # Neo4j driver 5.20+ or 6.x. The floor stays at 5.20 deliberately: the graph
+    # layer only uses the async driver surface that is identical on both majors
+    # (`AsyncGraphDatabase.driver`, `session.run`, `Result.data()`, `.single()`,
+    # `neo4j.time.DateTime.to_native()`, `neo4j.spatial.Point`), so pinning 6.x
+    # would strand deployments still on the 5.x line for no gain. Capped below 7
+    # because a major bump is free to reshape that surface.
+    "neo4j>=5.20,<7",
     "pydantic>=2.0.0",
     "pydantic-settings>=2.0.0",
     "typing-extensions>=4.4",  # PEP 696 TypeVar defaults on Python < 3.13
@@ -53,20 +59,64 @@ dependencies = [
 #   - Universal fallback: [litellm] — covers every other provider
 #   - Optional power-user: [instructor] — for users who already use Instructor
 # LLM + embedding providers
-openai = ["openai>=1.0.0"]
-anthropic = ["anthropic>=0.20.0"]
-sentence-transformers = ["sentence-transformers>=2.2.0"]
-vertex-ai = ["google-cloud-aiplatform>=1.38.0"]
+#
+# OpenAI SDK 2.x or 3.x. Both majors expose every surface the two adapters bind
+# to — `AsyncOpenAI(api_key=, base_url=, organization=, timeout=, max_retries=,
+# default_headers=)`, `chat.completions.create(... response_format=json_schema,
+# max_tokens=, stop=, timeout=)`, `embeddings.create(... dimensions=)`, and the
+# `AuthenticationError` / `RateLimitError` / `APITimeoutError` / `BadRequestError`
+# / `APIConnectionError` / `APIStatusError` classes the exception translator
+# imports — verified against 2.54 and 3.13. The floor is 2.0 rather than 3.0
+# because openai 3.x moved its HTTP layer to the separate `httpx2` distribution
+# and no longer installs `httpx`; `[nams]` declares `httpx` itself and the two
+# distributions ship different top-level packages (`httpx` vs `httpx2`), so they
+# coexist in one environment. Note that the committed lock resolves openai 2.x:
+# litellm and crewai both cap it at `<3`.
+openai = ["openai>=2.0,<4"]
+# Anthropic SDK 1.x. 1.0 is the floor because the whole 1.x line dropped
+# `temperature` / `top_p` / `top_k` from `messages.create()` (a `TypeError` now,
+# matching the API, which rejects sampling parameters on current models) — the
+# adapter no longer sends them. Everything else it uses is unchanged:
+# `AsyncAnthropic(api_key=, base_url=, timeout=, max_retries=)`,
+# `messages.create(... system=, stop_sequences=, tools=, tool_choice=)`, the
+# text/tool_use content blocks, the `Usage` cache fields, and the exception
+# classes. 1.x is also built on `httpx2` rather than `httpx` (see above).
+anthropic = ["anthropic>=1.0,<2"]
+# sentence-transformers 3.x-6.x. The floor is 3.0 (2.x predates the
+# `device=`-keyword constructor contract); verified on 6.0, which reorganized the
+# package internals but keeps the three call sites this library uses
+# (`SentenceTransformer(name, device=...)`, `encode(texts, convert_to_numpy=True)`,
+# `get_sentence_embedding_dimension()`) — `encode()`'s first parameter was renamed
+# `sentences` -> `inputs` but is passed positionally here, and a
+# `@deprecated_kwargs` shim covers the keyword form.
+sentence-transformers = ["sentence-transformers>=3.0,<7"]
+# Vertex AI via google-cloud-aiplatform 2.x, which removed
+# `vertexai.language_models` and requires `google-genai` — the backend the
+# embedder falls back to (`genai.Client(vertexai=True, ...)` +
+# `models.embed_content(..., EmbedContentConfig(task_type=,
+# output_dimensionality=))`, verified on google-genai 2.22). google-genai is
+# declared explicitly because the embedder imports it directly. The 1.x
+# `TextEmbeddingModel` path is still in the code for deployments that pin an
+# older aiplatform, but it is no longer what a fresh install resolves.
+vertex-ai = ["google-cloud-aiplatform>=2.0,<3", "google-genai>=1.66"]
 bedrock = ["boto3>=1.26.0"]
-litellm = ["litellm>=1.50.0,<2.0"]
-instructor = ["instructor>=1.7.0"]
+litellm = ["litellm>=1.50,<2"]
+instructor = ["instructor>=1.7,<2"]
 
 # Cloud provider bundles
-google = ["google-cloud-aiplatform>=1.38.0"]
+google = ["google-cloud-aiplatform>=2.0,<3", "google-genai>=1.66"]
 aws = ["boto3>=1.26.0"]
 
-# AWS Strands Agents SDK
-strands = ["strands-agents>=1.44.0", "boto3>=1.26.0"]
+# AWS Strands Agents SDK 1.x. The floor is 1.52 because that is the oldest
+# release carrying every surface the two adapters bind to: the `SessionManager`
+# base class with multi-agent *and* bidirectional hooks (`sync_multi_agent`,
+# `initialize_bidi_agent`, `append_bidi_message`, `sync_bidi_agent`, registered
+# unconditionally in `strands.session.session_manager`), and the `strands.memory`
+# package (`MemoryStore`, `MemoryManager`, `AddMessagesContext`,
+# `ExtractionConfig`) that `Neo4jMemoryStore` implements. Capped at the next
+# major: `SessionManager` and `MemoryStore` are both pre-2.0 contracts that a
+# major bump is free to reshape.
+strands = ["strands-agents>=1.52,<2", "boto3>=1.26.0"]
 
 # Entity extraction
 spacy = ["spacy>=3.7.0"]
@@ -94,18 +144,74 @@ observability = [
 ]
 
 # Framework integrations
-langchain = ["langchain-core>=0.2.0"]
-llamaindex = ["llama-index-core>=0.10.0"]
-pydantic-ai = ["pydantic-ai>=0.1.0"]
-crewai = ["crewai>=0.50.0"]
-openai-agents = ["openai>=1.0.0"]
-microsoft-agent = ["agent-framework>=1.0.0b260212"]
+# LangChain 1.x. `[langchain]` carries only `langchain-core`, which is what the
+# two ABC-backed adapters need: `Neo4jAgentMemory` implements
+# `langchain_core.chat_history.BaseChatMessageHistory` and
+# `Neo4jMemoryRetriever` implements `langchain_core.retrievers.BaseRetriever`.
+# The floor is 1.0 because langchain-core 1.x removed `langchain_core.memory`
+# (the pre-v1 `BaseMemory` contract the old adapter imitated) — adapters written
+# against the 0.x shape do not belong on the 1.x line, and a floor spanning both
+# protects nobody.
+langchain = ["langchain-core>=1.0,<2"]
+# `create_agent` middleware lives in the `langchain` distribution (which pulls
+# langgraph), so `Neo4jMemoryMiddleware` gets its own extra rather than making
+# every user of the memory/retriever adapters install a graph runtime.
+langchain-agents = ["langchain-core>=1.0,<2", "langchain>=1.0,<2"]
+# LlamaIndex 0.14.x. `llama-index-core` has no 1.0 release yet, so the cap is
+# `<1` and the floor is the current minor: `Neo4jLlamaIndexMemory` subclasses
+# `llama_index.core.memory.BaseMemory` and implements the
+# `get`/`put`/`set`/`reset`/`get_all` + `aget`/`aput`/`aset`/`areset`/`aget_all`
+# pair plus `from_defaults`, which is the 0.12+ shape of that ABC.
+llamaindex = ["llama-index-core>=0.14,<1"]
+# PydanticAI 2.x. We depend on the `pydantic-ai-slim` distribution (same
+# `pydantic_ai` import package) rather than the `pydantic-ai` meta-package,
+# which pulls ~20 provider SDKs this adapter never imports. Historically the
+# `-slim` suffix was also load-bearing because the meta-package's
+# `pydantic-ai-slim[mcp]` -> `fastmcp-slim>=3` collided with the `fastmcp<3`
+# distribution used by the [mcp] extra; now that [mcp] is on fastmcp 4 (which
+# is itself a thin wrapper over `fastmcp-slim==4.x`) that collision is gone and
+# the suffix is purely about install weight.
+pydantic-ai = ["pydantic-ai-slim[openai]>=2.0,<3"]
+# CrewAI 1.x. `Neo4jCrewMemory` subclasses `crewai.memory.memory.Memory`, which
+# is a Pydantic model on the 1.x line; the 0.x floor predates that module layout.
+crewai = ["crewai>=1.0,<2"]
+# OpenAI Agents SDK. This extra deliberately carries only the `openai` SDK, not
+# the `openai-agents` distribution: the adapter (`Neo4jOpenAIMemory`,
+# `record_agent_trace`) never imports the `agents` package — it gates on
+# `import openai` and speaks plain chat-completion dicts, so an agent built with
+# any version of the Agents SDK can use it. Pulling `openai-agents` in would also
+# force `openai>=3` (its own floor) and make the `[all]` bundle unresolvable,
+# since litellm and crewai cap openai at `<3`.
+openai-agents = ["openai>=2.0,<4"]
+# Microsoft Agent Framework 1.x (GA). The adapter targets the GA provider
+# contract: `ContextProvider` / `HistoryProvider`, which replaced the
+# `BaseContextProvider` / `BaseHistoryProvider` names the 1.0.0b2 preview
+# exported (the keyword-only `before_run` / `after_run` signatures are
+# unchanged). We depend on `agent-framework-core`, not the `agent-framework`
+# meta-package: at GA the meta-package resolves to `agent-framework-core[all]`,
+# which drags in ~30 provider distributions (anthropic, bedrock, gemini,
+# mistral, ollama, redis, devui's fastapi/uvicorn, powerfx, ...) that this
+# adapter never imports. Everything it does import — `ContextProvider`,
+# `HistoryProvider`, `AgentSession`, `SessionContext`, `SupportsAgentRun`,
+# `FunctionTool`, `tool`, `Message` — is exported from the top-level
+# `agent_framework` package shipped by -core. Applications add their own chat
+# client (`agent-framework-openai`, `agent-framework-azure-ai`, or the
+# `agent-framework` meta-package) alongside this extra.
+microsoft-agent = ["agent-framework-core>=1.13,<2"]
 
-# MCP server
-mcp = ["fastmcp>=2.0.0,<3"]
+# MCP server. FastMCP 4.x (MCP Python SDK 2.x): keyword-only server
+# construction, `ctx.lifespan_context`, and Streamable HTTP as the network
+# transport (`transport="http"`). The legacy HTTP+SSE transport is still
+# reachable but deprecated upstream; the CLI maps `--transport sse` onto
+# streamable HTTP with a warning.
+mcp = ["fastmcp>=4.0,<5"]
 
-# Google ADK
-google-adk = ["google-adk>=0.1.0"]
+# Google ADK 2.x (GA). The adapter targets the 2.x BaseMemoryService
+# contract (keyword-only `search_memory`, `SearchMemoryResponse` of
+# `MemoryEntry(content=google.genai.types.Content(...), author, timestamp)`).
+# google-genai is pinned explicitly because the adapter builds `types.Content`
+# objects itself rather than relying on google-adk's transitive floor.
+google-adk = ["google-adk>=2.0,<3", "google-genai>=1.0"]
 
 # Hosted NAMS (Neo4j Agent Memory Service) backend
 nams = ["httpx>=0.27.0"]
@@ -148,10 +254,22 @@ dev = [
     "pre-commit>=3.6.0",
     "testcontainers[neo4j]>=4.0.0",
     "beautifulsoup4>=4.12.0",
-    "fastmcp>=2.0.0,<3",
+    "fastmcp>=4.0,<5",
     # NAMS HTTP-transport tests (Phase 2+)
     "httpx>=0.27.0",
     "respx>=0.21.0",
+    # examples/_env.py reads examples/.env through python-dotenv and degrades to a
+    # hand-rolled parser without it. Declared so the example smoke tests exercise
+    # the real path rather than the fallback (it was only ever present
+    # transitively via pydantic-settings).
+    "python-dotenv>=1.0",
+    # TODO: add `langchain-openai>=1.0,<2` here so CI exercises the
+    # `llm_provider_from_langchain` branch of examples/langchain_agent.py
+    # (requested by the LangChain example's review pass). It must land in the
+    # same commit that deletes the now-redundant
+    # `# type: ignore[import-not-found]` on examples/langchain_agent.py:105 —
+    # once the package is installed mypy resolves the import and `make
+    # typecheck` fails with `unused-ignore`.
 ]
 
 docs = [
@@ -222,10 +340,11 @@ plugins = ["pydantic.mypy"]
 # covered by typeshed's types-PyYAML, now a declared dev dependency so clean CI
 # resolves it (it was previously only ambiently present, which made the mypy
 # error count non-reproducible). Confirmed that gliner 0.2.24 ships no
-# py.typed marker; it is suppressed via the override below. google.adk.* also
-# ships no type information; since it is used at a typed boundary in only two
-# files (the ADK MemoryService), it is suppressed per-module here rather than
-# shipping local stubs. nest_asyncio (used only by the llamaindex integration)
+# py.typed marker; it is suppressed via the override below. google.adk 2.x and
+# google.genai *do* ship py.typed, but both are optional extras, so the
+# per-module overrides below stay: they keep `mypy src` clean in environments
+# where the [google-adk] extra is not installed (the ADK MemoryService imports
+# them at a typed boundary). nest_asyncio (used only by the llamaindex integration)
 # is likewise suppressed per-module below. The remaining dep that genuinely
 # ships no type information is glirel; its import diagnostics are intentionally
 # left in the budget and will be addressed later (local stubs vs. per-module
@@ -237,6 +356,10 @@ ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
 module = "google.adk.*"
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = "google.genai.*"
 ignore_missing_imports = true
 
 [[tool.mypy.overrides]]

--- a/src/neo4j_agent_memory/cli/main.py
+++ b/src/neo4j_agent_memory/cli/main.py
@@ -737,20 +737,24 @@ def mcp() -> None:
 )
 @click.option(
     "--transport",
-    type=click.Choice(["stdio", "sse", "http"]),
+    type=click.Choice(["stdio", "http", "streamable-http", "sse"]),
     default="stdio",
-    help="MCP transport type (default: stdio).",
+    help=(
+        "MCP transport (default: stdio). 'http' is Streamable HTTP; "
+        "'streamable-http' is a synonym. 'sse' is deprecated and serves "
+        "Streamable HTTP with a warning."
+    ),
 )
 @click.option(
     "--host",
     default="127.0.0.1",
-    help="Host for network transports.",
+    help="Host to bind for --transport http (use 0.0.0.0 to expose it).",
 )
 @click.option(
     "--port",
     type=int,
     default=8080,
-    help="Port for network transports.",
+    help="Port to bind for --transport http. The MCP endpoint is /mcp/.",
 )
 @click.option(
     "--profile",
@@ -873,7 +877,7 @@ def mcp_serve(
 
     The server exposes memory tools, resources, and prompts via the
     Model Context Protocol. Use stdio transport for Claude Desktop
-    or SSE/HTTP for network deployments.
+    and Streamable HTTP for network deployments.
 
     \b
     Examples:
@@ -881,13 +885,20 @@ def mcp_serve(
         neo4j-agent-memory mcp serve --password mypassword
 
     \b
-        # Start with SSE transport on port 8080
-        neo4j-agent-memory mcp serve --transport sse --port 8080
+        # Start with Streamable HTTP on port 8080
+        neo4j-agent-memory mcp serve --transport http --port 8080
 
     \b
         # Start with core profile (fewer tools, less context overhead)
         neo4j-agent-memory mcp serve --profile core
     """
+    if transport == "sse":
+        error_console.print(
+            "[yellow]Warning:[/yellow] --transport sse is deprecated. The MCP spec "
+            "replaced HTTP+SSE with Streamable HTTP; serving Streamable HTTP "
+            "instead. Use --transport http."
+        )
+
     # Resolve backend: explicit --backend wins; otherwise infer from env.
     resolved_backend = backend or ("nams" if api_key else "bolt")
 

--- a/src/neo4j_agent_memory/config/settings.py
+++ b/src/neo4j_agent_memory/config/settings.py
@@ -10,6 +10,13 @@ from pydantic import BaseModel, ConfigDict, Field, SecretStr, model_validator
 from pydantic_settings import BaseSettings, PydanticBaseSettingsSource, SettingsConfigDict
 from pydantic_settings.sources import DotEnvSettingsSource
 
+from neo4j_agent_memory.embeddings.vertex_models import (
+    VERTEX_DEFAULT_EMBEDDING_MODEL,
+    VERTEX_DEFAULT_OUTPUT_DIMENSIONALITY,
+    VERTEX_EMBEDDING_MODELS,
+    VERTEX_RETIRED_EMBEDDING_MODELS,
+)
+
 # Strict config shared by every child config model. Misspelled fields raise
 # at construction time instead of being silently dropped.
 _STRICT_CONFIG = ConfigDict(extra="forbid")
@@ -109,7 +116,13 @@ class Neo4jConfig(BaseModel):
 
 
 class EmbeddingConfig(BaseModel):
-    """Embedding provider configuration."""
+    """Embedding provider configuration.
+
+    When ``provider`` is :attr:`EmbeddingProvider.VERTEX_AI` and ``model`` is
+    left at its default, the model defaults to ``gemini-embedding-001`` and
+    ``dimensions`` to 768 (see :data:`VERTEX_DEFAULT_EMBEDDING_MODEL`).
+    Retired Vertex AI model ids are rejected at construction time.
+    """
 
     model_config = _STRICT_CONFIG
 
@@ -129,9 +142,47 @@ class EmbeddingConfig(BaseModel):
         default="RETRIEVAL_DOCUMENT",
         description="Vertex AI task type (RETRIEVAL_QUERY, RETRIEVAL_DOCUMENT, etc.)",
     )
+    output_dimensionality: int | None = Field(
+        default=None,
+        ge=1,
+        description=(
+            "Vertex AI output dimensionality. gemini-embedding-001 emits 3072 "
+            "dimensions natively and can be truncated to 1536 or 768. Defaults "
+            "to 768 for Vertex AI so existing vector indexes keep working; pass "
+            "an explicit value to override."
+        ),
+    )
     # AWS Bedrock specific
     aws_region: str | None = Field(default=None, description="AWS region for Bedrock")
     aws_profile: str | None = Field(default=None, description="AWS credentials profile name")
+
+    @model_validator(mode="after")
+    def _apply_vertex_ai_defaults(self) -> EmbeddingConfig:
+        """Fill Vertex AI defaults and reject retired Vertex AI model ids."""
+        if self.provider != EmbeddingProvider.VERTEX_AI:
+            return self
+
+        if self.model in VERTEX_RETIRED_EMBEDDING_MODELS:
+            shutdown = VERTEX_RETIRED_EMBEDDING_MODELS[self.model]
+            raise ValueError(
+                f"Vertex AI embedding model {self.model!r} was retired by Google on "
+                f"{shutdown} and no longer serves requests. Use one of: "
+                f"{', '.join(VERTEX_EMBEDDING_MODELS)} "
+                f"(default: {VERTEX_DEFAULT_EMBEDDING_MODEL})."
+            )
+
+        # The ``model``/``dimensions`` defaults describe OpenAI; translate them
+        # to the Vertex AI equivalents when the caller did not set them.
+        fields_set = self.model_fields_set
+        if "model" not in fields_set:
+            self.model = VERTEX_DEFAULT_EMBEDDING_MODEL
+        if "output_dimensionality" not in fields_set:
+            self.output_dimensionality = VERTEX_DEFAULT_OUTPUT_DIMENSIONALITY
+        if "dimensions" not in fields_set:
+            self.dimensions = self.output_dimensionality or VERTEX_EMBEDDING_MODELS.get(
+                self.model, VERTEX_DEFAULT_OUTPUT_DIMENSIONALITY
+            )
+        return self
 
 
 class LLMConfig(BaseModel):

--- a/src/neo4j_agent_memory/core/protocols.py
+++ b/src/neo4j_agent_memory/core/protocols.py
@@ -321,11 +321,34 @@ class LongTermProtocol(Protocol):
         """
         ...
 
-    async def wait_for_extraction(self) -> bool:
+    async def wait_for_extraction(
+        self,
+        *,
+        query: str | None = None,
+        expected_names: list[str] | None = None,
+        min_results: int = 1,
+        predicate: Callable[[list[Entity]], bool] | None = None,
+        timeout: float = 30.0,
+        interval: float = 1.0,
+        session_id: str | None = None,
+        **kwargs: Any,
+    ) -> bool:
         """Wait for any pending asynchronous entity extraction to complete.
 
         Returns True once extraction has settled (or immediately if there
         is nothing to await).
+
+        Every parameter is optional and keyword-only so that portable code
+        can pass the NAMS readiness arguments through ``client.long_term``
+        on either backend. On bolt, extraction is synchronous and the call
+        returns ``True`` immediately, ignoring all arguments. On NAMS they
+        select the readiness signal: ``session_id`` (alias
+        ``conversation_id``, accepted via ``**kwargs``) polls the
+        conversation's extraction status, while ``query`` /
+        ``expected_names`` / ``min_results`` / ``predicate`` confirm the
+        extracted entities are searchable. ``timeout`` and ``interval``
+        bound the polling. See
+        :meth:`neo4j_agent_memory.nams.long_term.NamsLongTermMemory.wait_for_extraction`.
         """
         ...
 

--- a/src/neo4j_agent_memory/embeddings/sentence_transformers.py
+++ b/src/neo4j_agent_memory/embeddings/sentence_transformers.py
@@ -23,6 +23,23 @@ MODEL_DIMENSIONS = {
 }
 
 
+def _embedding_dimension(model: object) -> int | None:
+    """Read a loaded model's embedding width across sentence-transformers majors.
+
+    sentence-transformers 6.0 renamed ``get_sentence_embedding_dimension()`` to
+    ``get_embedding_dimension()``; the old name still works but is deprecated and
+    will go away. The declared floor is 3.0, so both names have to be tolerated —
+    and neither may be referenced statically, or the deprecated-attribute
+    diagnostic fires on whichever name is older than the installed version.
+    """
+    for attribute in ("get_embedding_dimension", "get_sentence_embedding_dimension"):
+        getter = getattr(model, attribute, None)
+        if callable(getter):
+            dimension = getter()
+            return int(dimension) if dimension is not None else None
+    return None
+
+
 class SentenceTransformerEmbedder(BaseEmbedder):
     """Local sentence-transformers embedding provider."""
 
@@ -55,8 +72,7 @@ class SentenceTransformerEmbedder(BaseEmbedder):
                     "Install with: pip install neo4j-agent-memory[sentence-transformers]"
                 )
             self._model = SentenceTransformer(self._model_name, device=self._device)
-            # Get actual dimensions from model
-            self._dimensions = self._model.get_sentence_embedding_dimension()
+            self._dimensions = _embedding_dimension(self._model)
         return self._model
 
     @property

--- a/src/neo4j_agent_memory/embeddings/vertex_ai.py
+++ b/src/neo4j_agent_memory/embeddings/vertex_ai.py
@@ -1,9 +1,25 @@
 """Vertex AI embedding provider.
 
-Supports Google Cloud's Vertex AI text embedding models including:
-- text-embedding-004 (768 dimensions, recommended)
-- textembedding-gecko@003 (768 dimensions)
-- textembedding-gecko-multilingual@001 (768 dimensions)
+Supported Google Cloud Vertex AI text embedding models:
+
+- ``gemini-embedding-001`` — default, 3072 native dimensions, truncatable
+  (Matryoshka) to 1536 or 768 via ``output_dimensionality``.
+- ``text-embedding-005`` — 768 dimensions, English/code.
+- ``text-multilingual-embedding-002`` — 768 dimensions, multilingual.
+
+Retired model ids (``text-embedding-004``, ``textembedding-gecko*``) raise
+:class:`~neo4j_agent_memory.core.exceptions.EmbeddingError` with the
+replacement named; see :data:`RETIRED_VERTEX_MODELS`.
+
+.. note::
+   ``output_dimensionality`` defaults to 768 rather than the model's native
+   3072 so that Neo4j vector indexes created against the previous default
+   (``text-embedding-004``, 768 dimensions) keep working unchanged. Vector
+   index dimensionality is fixed at creation time, so raising it means
+   dropping and recreating the indexes and re-embedding every node. Pass
+   ``output_dimensionality=None`` for the model's native dimensionality (the
+   highest retrieval quality) on a fresh database, or 1536 as a middle
+   ground.
 """
 
 from __future__ import annotations
@@ -13,22 +29,39 @@ from typing import TYPE_CHECKING, Any
 
 from neo4j_agent_memory.core.exceptions import EmbeddingError
 from neo4j_agent_memory.embeddings.base import BaseEmbedder
+from neo4j_agent_memory.embeddings.vertex_models import (
+    VERTEX_DEFAULT_EMBEDDING_MODEL,
+    VERTEX_DEFAULT_OUTPUT_DIMENSIONALITY,
+    VERTEX_EMBEDDING_MODELS,
+    VERTEX_MAX_BATCH_SIZE,
+    VERTEX_MODEL_MAX_BATCH,
+    VERTEX_RETIRED_EMBEDDING_MODELS,
+)
 
 if TYPE_CHECKING:
-    from vertexai.language_models import TextEmbeddingModel
+    from collections.abc import Sequence
 
 
-# Model dimensions mapping
-VERTEX_MODEL_DIMENSIONS = {
-    "text-embedding-004": 768,
-    "textembedding-gecko@003": 768,
-    "textembedding-gecko@002": 768,
-    "textembedding-gecko@001": 768,
-    "textembedding-gecko-multilingual@001": 768,
-}
+# Backwards-compatible aliases for the model tables, which now live in
+# :mod:`neo4j_agent_memory.embeddings.vertex_models`.
+DEFAULT_VERTEX_MODEL = VERTEX_DEFAULT_EMBEDDING_MODEL
+DEFAULT_OUTPUT_DIMENSIONALITY = VERTEX_DEFAULT_OUTPUT_DIMENSIONALITY
+VERTEX_MODEL_DIMENSIONS = VERTEX_EMBEDDING_MODELS
+RETIRED_VERTEX_MODELS = VERTEX_RETIRED_EMBEDDING_MODELS
+DEFAULT_BATCH_SIZE = VERTEX_MAX_BATCH_SIZE
 
-# Default batch size (Vertex AI supports up to 250 texts per request)
-DEFAULT_BATCH_SIZE = 250
+
+def _reject_retired_model(model: str) -> None:
+    """Raise :class:`EmbeddingError` if ``model`` is a retired Vertex AI id."""
+    shutdown = RETIRED_VERTEX_MODELS.get(model)
+    if shutdown is None:
+        return
+    supported = ", ".join(sorted(VERTEX_MODEL_DIMENSIONS))
+    raise EmbeddingError(
+        f"Vertex AI embedding model {model!r} was retired by Google on {shutdown} "
+        f"and no longer serves requests. Use one of: {supported} "
+        f"(default: {DEFAULT_VERTEX_MODEL})."
+    )
 
 
 class VertexAIEmbedder(BaseEmbedder):
@@ -42,12 +75,12 @@ class VertexAIEmbedder(BaseEmbedder):
 
         # Using Application Default Credentials
         embedder = VertexAIEmbedder(
-            model="text-embedding-004",
+            model="gemini-embedding-001",
             project_id="my-gcp-project",
             location="us-central1",
         )
 
-        # Generate embedding
+        # Generate embedding (768 dimensions by default)
         embedding = await embedder.embed("Hello, world!")
 
         # Batch embedding
@@ -57,52 +90,88 @@ class VertexAIEmbedder(BaseEmbedder):
             "Third text",
         ])
 
+        # Full native dimensionality (3072) on a fresh database
+        embedder = VertexAIEmbedder(output_dimensionality=None)
+
     Note:
         Requires the `google-cloud-aiplatform` package. Install with:
         ``pip install neo4j-agent-memory[vertex-ai]``
 
+        On ``google-cloud-aiplatform`` 1.x the legacy
+        ``vertexai.language_models`` path is used; on 2.x, where that module
+        was removed, the embedder falls back to the ``google-genai`` client
+        (``pip install google-genai``). The public surface is identical.
+
     Attributes:
-        dimensions: The embedding vector dimensions (768 for most models).
+        dimensions: The embedding vector dimensions actually produced.
     """
 
     def __init__(
         self,
-        model: str = "text-embedding-004",
+        model: str = DEFAULT_VERTEX_MODEL,
         *,
         project_id: str | None = None,
         location: str = "us-central1",
         credentials: Any | None = None,
         batch_size: int = DEFAULT_BATCH_SIZE,
         task_type: str = "RETRIEVAL_DOCUMENT",
+        output_dimensionality: int | None = DEFAULT_OUTPUT_DIMENSIONALITY,
     ):
         """Initialize Vertex AI embedder.
 
         Args:
-            model: Vertex AI embedding model name. Defaults to "text-embedding-004".
+            model: Vertex AI embedding model name. Defaults to
+                ``"gemini-embedding-001"``. Retired ids raise
+                :class:`EmbeddingError`.
             project_id: GCP project ID. If not provided, uses the default project
                 from Application Default Credentials (ADC).
             location: GCP region for Vertex AI. Defaults to "us-central1".
             credentials: Optional Google Cloud credentials object. If not provided,
                 uses Application Default Credentials.
-            batch_size: Maximum texts per API call. Defaults to 250 (Vertex AI limit).
+            batch_size: Maximum texts per API call. Defaults to 250 (Vertex AI
+                limit), further capped per model -- ``gemini-embedding-001``
+                accepts one text per request.
             task_type: The type of task for which embeddings are generated.
                 Options: RETRIEVAL_QUERY, RETRIEVAL_DOCUMENT, SEMANTIC_SIMILARITY,
                 CLASSIFICATION, CLUSTERING. Defaults to "RETRIEVAL_DOCUMENT".
+            output_dimensionality: Truncate embeddings to this many dimensions.
+                Defaults to 768 so Neo4j vector indexes sized for the previous
+                ``text-embedding-004`` default keep working. Pass ``None`` for
+                the model's native dimensionality.
+
+        Raises:
+            EmbeddingError: If ``model`` is retired, or
+                ``output_dimensionality`` is not a positive int.
         """
+        _reject_retired_model(model)
+        if output_dimensionality is not None and output_dimensionality < 1:
+            raise EmbeddingError(
+                f"output_dimensionality must be a positive int or None, "
+                f"got {output_dimensionality!r}."
+            )
+
         self._model = model
         self._project_id = project_id
         self._location = location
         self._credentials = credentials
-        self._batch_size = min(batch_size, DEFAULT_BATCH_SIZE)
         self._task_type = task_type
-        self._embedding_model: TextEmbeddingModel | None = None
+        self._output_dimensionality = output_dimensionality
+        # The client object is either a legacy ``TextEmbeddingModel`` (1.x) or a
+        # ``google.genai.Client`` (2.x fallback); ``_backend`` says which.
+        self._embedding_model: Any = None
+        self._backend: str | None = None
         self._init_lock = asyncio.Lock()
 
-        # Determine dimensions from model name
-        self._dimensions = VERTEX_MODEL_DIMENSIONS.get(model, 768)
+        model_cap = VERTEX_MODEL_MAX_BATCH.get(model, DEFAULT_BATCH_SIZE)
+        self._batch_size = max(1, min(batch_size, model_cap))
 
-    def _ensure_initialized(self) -> TextEmbeddingModel:
-        """Ensure Vertex AI is initialized and return the embedding model.
+        # Dimensions actually produced: the truncation target when set,
+        # otherwise the model's native size.
+        native = VERTEX_MODEL_DIMENSIONS.get(model, DEFAULT_OUTPUT_DIMENSIONALITY)
+        self._dimensions = output_dimensionality if output_dimensionality is not None else native
+
+    def _ensure_initialized(self) -> Any:
+        """Ensure Vertex AI is initialized and return the embedding client.
 
         Note: For thread-safe async initialization, use _ensure_initialized_async instead.
         """
@@ -113,10 +182,9 @@ class VertexAIEmbedder(BaseEmbedder):
             import vertexai
             from vertexai.language_models import TextEmbeddingModel
         except ImportError:
-            raise EmbeddingError(
-                "Vertex AI package not installed. Install with: "
-                "pip install neo4j-agent-memory[vertex-ai]"
-            )
+            # google-cloud-aiplatform 2.x removed ``vertexai.language_models``;
+            # fall back to the google-genai client when it is available.
+            return self._ensure_initialized_genai()
 
         try:
             # Initialize Vertex AI (note: sets global state in vertexai library)
@@ -128,13 +196,36 @@ class VertexAIEmbedder(BaseEmbedder):
 
             # Load the embedding model
             self._embedding_model = TextEmbeddingModel.from_pretrained(self._model)
+            self._backend = "vertexai"
 
             return self._embedding_model
 
         except Exception as e:
             raise EmbeddingError(f"Failed to initialize Vertex AI: {e}") from e
 
-    async def _ensure_initialized_async(self) -> TextEmbeddingModel:
+    def _ensure_initialized_genai(self) -> Any:
+        """Initialize the ``google-genai`` Vertex AI client (aiplatform 2.x path)."""
+        try:
+            from google import genai
+        except ImportError:
+            raise EmbeddingError(
+                "Vertex AI package not installed. Install with: "
+                "pip install neo4j-agent-memory[vertex-ai]"
+            ) from None
+
+        try:
+            self._embedding_model = genai.Client(
+                vertexai=True,
+                project=self._project_id,
+                location=self._location,
+                credentials=self._credentials,
+            )
+            self._backend = "genai"
+            return self._embedding_model
+        except Exception as e:
+            raise EmbeddingError(f"Failed to initialize Vertex AI: {e}") from e
+
+    async def _ensure_initialized_async(self) -> Any:
         """Thread-safe async initialization."""
         if self._embedding_model is not None:
             return self._embedding_model
@@ -161,6 +252,40 @@ class VertexAIEmbedder(BaseEmbedder):
         """Return the embedding dimensions."""
         return self._dimensions
 
+    @property
+    def output_dimensionality(self) -> int | None:
+        """Return the configured truncation target, or ``None`` for native size."""
+        return self._output_dimensionality
+
+    def _embed_sync(self, client: Any, texts: Sequence[str]) -> list[list[float]]:
+        """Embed ``texts`` with a single API call (runs on a worker thread)."""
+        if self._backend == "genai":
+            from google.genai.types import EmbedContentConfig
+
+            config = EmbedContentConfig(
+                task_type=self._task_type,
+                output_dimensionality=self._output_dimensionality,
+            )
+            response = client.models.embed_content(
+                model=self._model,
+                contents=list(texts),
+                config=config,
+            )
+            return [list(e.values) for e in response.embeddings]
+
+        from vertexai.language_models import TextEmbeddingInput
+
+        inputs: list[str | TextEmbeddingInput] = [
+            TextEmbeddingInput(t, task_type=self._task_type) for t in texts
+        ]
+        if self._output_dimensionality is not None:
+            embeddings = client.get_embeddings(
+                inputs, output_dimensionality=self._output_dimensionality
+            )
+        else:
+            embeddings = client.get_embeddings(inputs)
+        return [list(e.values) for e in embeddings]
+
     async def embed(self, text: str) -> list[float]:
         """Generate embedding for a single text.
 
@@ -173,16 +298,11 @@ class VertexAIEmbedder(BaseEmbedder):
         Raises:
             EmbeddingError: If embedding generation fails.
         """
-        model = await self._ensure_initialized_async()
+        client = await self._ensure_initialized_async()
 
         try:
-            from vertexai.language_models import TextEmbeddingInput
-
-            input_obj = TextEmbeddingInput(text, task_type=self._task_type)
-            # Use the wider element type to satisfy to_thread's invariant Callable parameter.
-            inputs_single: list[str | TextEmbeddingInput] = [input_obj]
-            embeddings = await asyncio.to_thread(model.get_embeddings, inputs_single)
-            return embeddings[0].values
+            vectors = await asyncio.to_thread(self._embed_sync, client, [text])
+            return vectors[0]
 
         except EmbeddingError:
             raise
@@ -204,22 +324,15 @@ class VertexAIEmbedder(BaseEmbedder):
         if not texts:
             return []
 
-        model = await self._ensure_initialized_async()
+        client = await self._ensure_initialized_async()
         all_embeddings: list[list[float]] = []
 
         try:
-            from vertexai.language_models import TextEmbeddingInput
-
-            # Process in batches (Vertex AI limit is 250 per request)
+            # Process in batches (Vertex AI limit is 250 per request, 1 for
+            # gemini-embedding-001).
             for i in range(0, len(texts), self._batch_size):
                 batch = texts[i : i + self._batch_size]
-                # Annotate as the wider type that get_embeddings accepts (str | TextEmbeddingInput)
-                # to satisfy to_thread's invariant Callable parameter type.
-                inputs: list[str | TextEmbeddingInput] = [
-                    TextEmbeddingInput(t, task_type=self._task_type) for t in batch
-                ]
-                embeddings = await asyncio.to_thread(model.get_embeddings, inputs)
-                all_embeddings.extend([e.values for e in embeddings])
+                all_embeddings.extend(await asyncio.to_thread(self._embed_sync, client, batch))
 
             return all_embeddings
 

--- a/src/neo4j_agent_memory/embeddings/vertex_models.py
+++ b/src/neo4j_agent_memory/embeddings/vertex_models.py
@@ -1,0 +1,57 @@
+"""Vertex AI embedding model facts (single source of truth).
+
+Kept free of intra-package imports so both
+:mod:`neo4j_agent_memory.embeddings.vertex_ai` and
+:mod:`neo4j_agent_memory.config.settings` can depend on it.
+
+Google retired ``text-embedding-004`` on 2026-01-14 and the
+``textembedding-gecko*`` family on 2025-04-09; the current generation is
+``gemini-embedding-001`` (3072 native dimensions, Matryoshka-truncatable to
+1536 or 768), plus the task-specific ``text-embedding-005`` and
+``text-multilingual-embedding-002`` (768 each).
+"""
+
+from __future__ import annotations
+
+# Default Vertex AI embedding model.
+VERTEX_DEFAULT_EMBEDDING_MODEL = "gemini-embedding-001"
+
+# Default truncation target. 768 matches the dimensionality of the previous
+# default (``text-embedding-004``) so Neo4j vector indexes -- whose
+# dimensionality is fixed at creation time -- keep working unchanged.
+VERTEX_DEFAULT_OUTPUT_DIMENSIONALITY = 768
+
+# Supported models mapped to their native (untruncated) output dimensions.
+VERTEX_EMBEDDING_MODELS: dict[str, int] = {
+    "gemini-embedding-001": 3072,
+    "text-embedding-005": 768,
+    "text-multilingual-embedding-002": 768,
+}
+
+# Retired model ids mapped to the date Google stopped serving them. Used to
+# fail fast with a message naming the replacement instead of surfacing a 404.
+VERTEX_RETIRED_EMBEDDING_MODELS: dict[str, str] = {
+    "text-embedding-004": "2026-01-14",
+    "textembedding-gecko": "2025-04-09",
+    "textembedding-gecko@001": "2025-04-09",
+    "textembedding-gecko@002": "2025-04-09",
+    "textembedding-gecko@003": "2025-04-09",
+    "textembedding-gecko-multilingual@001": "2025-04-09",
+}
+
+# Per-model cap on texts per request. ``gemini-embedding-001`` accepts a
+# single input per request; the other models accept up to 250.
+VERTEX_MAX_BATCH_SIZE = 250
+VERTEX_MODEL_MAX_BATCH: dict[str, int] = {
+    "gemini-embedding-001": 1,
+}
+
+
+__all__ = [
+    "VERTEX_DEFAULT_EMBEDDING_MODEL",
+    "VERTEX_DEFAULT_OUTPUT_DIMENSIONALITY",
+    "VERTEX_EMBEDDING_MODELS",
+    "VERTEX_MAX_BATCH_SIZE",
+    "VERTEX_MODEL_MAX_BATCH",
+    "VERTEX_RETIRED_EMBEDDING_MODELS",
+]

--- a/src/neo4j_agent_memory/enrichment/background.py
+++ b/src/neo4j_agent_memory/enrichment/background.py
@@ -271,14 +271,23 @@ class BackgroundEnrichmentService:
         if not attrs:
             return
 
-        # Build the update query
-        # Store enrichment attributes in the entity's metadata JSON
+        # Build the update query.
+        #
+        # The headline fields are written as node properties so Cypher can
+        # filter and return them (``MemoryClient.get_locations`` selects
+        # ``e.enriched_description`` and ``e.wikipedia_url`` directly), and the
+        # full result is kept in the ``enrichment_data`` JSON blob. Both are
+        # folded back into ``Entity.metadata`` by
+        # ``LongTermMemory._parse_entity``.
         query = """
         MATCH (e:Entity {id: $id})
         SET e.enriched_description = $enriched_description,
             e.enriched_at = datetime(),
             e.enrichment_provider = $provider,
-            e.enrichment_data = $enrichment_data
+            e.enrichment_data = $enrichment_data,
+            e.wikipedia_url = coalesce($wikipedia_url, e.wikipedia_url),
+            e.wikidata_id = coalesce($wikidata_id, e.wikidata_id),
+            e.image_url = coalesce($image_url, e.image_url)
         RETURN e
         """
 
@@ -303,6 +312,9 @@ class BackgroundEnrichmentService:
             "enriched_description": result.description,
             "provider": result.provider,
             "enrichment_data": json.dumps(enrichment_data),
+            "wikipedia_url": result.wikipedia_url,
+            "wikidata_id": result.wikidata_id,
+            "image_url": result.image_url,
         }
 
         await self._client.execute_write(query, params)

--- a/src/neo4j_agent_memory/integrations/google_adk/memory_service.py
+++ b/src/neo4j_agent_memory/integrations/google_adk/memory_service.py
@@ -1,21 +1,54 @@
-"""Google ADK MemoryService implementation backed by Neo4j.
+"""Google ADK ``BaseMemoryService`` implementation backed by Neo4j.
 
-Provides a Neo4j-backed implementation of the Google ADK MemoryService
-interface for persistent agent memory.
+Targets the **google-adk 2.x** memory contract
+(``google.adk.memory.base_memory_service``):
+
+============================================  =========================================
+ADK 2.x method                                 Implemented here
+============================================  =========================================
+``add_session_to_memory(session)``             ingests ``session.events`` (or a dict /
+                                               list of messages) into short-term memory
+``add_events_to_memory(*, app_name, user_id,   ingests an incremental slice of events —
+events, session_id, custom_metadata)``         used by ``Context.add_events_to_memory()``
+``add_memory(*, app_name, user_id, memories,   writes explicit ADK ``MemoryEntry`` items;
+custom_metadata)``                             also keeps the 0.5.0 convenience form
+                                               ``add_memory(content=..., memory_type=...)``
+``search_memory(*, app_name, user_id, query)``  hybrid message + entity + preference
+                                               recall, returned as a
+                                               ``SearchMemoryResponse``
+============================================  =========================================
+
+``SearchMemoryResponse.memories`` holds ADK ``MemoryEntry`` objects whose
+``content`` is a ``google.genai.types.Content`` — so ``load_memory`` and
+``preload_memory`` render them directly. ``author`` carries the source
+(message role, or ``"entity"`` / ``"preference"`` for long-term recall),
+``timestamp`` the ISO-8601 creation time, and ``custom_metadata`` the memory
+type and similarity score that the library's own ``MemoryEntry`` dataclass
+exposes.
+
+The ADK base class is imported lazily: ``google-adk`` is an optional extra
+(``pip install "neo4j-agent-memory[google-adk]"``), so when it is absent the
+module falls back to local stand-ins with the same attribute shape and the
+service still works against plain dict sessions.
 """
 
 from __future__ import annotations
 
 import logging
+from collections.abc import Mapping, Sequence
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
-    # google.adk ships no py.typed marker, so its exports resolve to Any.
-    # Alias the ADK base to ``object`` for static analysis (strict mode
-    # forbids subclassing Any) and import the response type for annotations.
-    # The runtime import / fallback lives in the ``else`` branch, which the
-    # type checkers treat as unreachable — so neither sees a redefinition.
+    # ``_ADKBase`` is aliased to ``object`` for static analysis: the real base
+    # is an ABC that only exists when the optional extra is installed, and this
+    # class deliberately widens two of its signatures (``query`` stays
+    # positional-or-keyword, and ``add_memory`` keeps the 0.5.0 convenience
+    # form which returns an entry). Runtime conformance is asserted in
+    # ``tests/unit/integrations/test_google_adk.py``.
     from google.adk.memory.base_memory_service import SearchMemoryResponse
+    from google.adk.memory.memory_entry import MemoryEntry as ADKMemoryEntry
+    from google.genai.types import Content as ADKContent
+    from google.genai.types import Part as ADKPart
 
     _ADKBase = object
 else:
@@ -24,37 +57,54 @@ else:
             BaseMemoryService as _ADKBase,
         )
         from google.adk.memory.base_memory_service import SearchMemoryResponse
-    except ImportError:
+        from google.adk.memory.memory_entry import MemoryEntry as ADKMemoryEntry
+        from google.genai.types import Content as ADKContent
+        from google.genai.types import Part as ADKPart
+    except ImportError:  # pragma: no cover - exercised in no-ADK environments
         _ADKBase = object
 
+        class ADKPart:
+            """Stand-in for ``google.genai.types.Part`` (text parts only)."""
+
+            def __init__(self, text: str | None = None, **_: Any) -> None:
+                self.text = text
+
+        class ADKContent:
+            """Stand-in for ``google.genai.types.Content``."""
+
+            def __init__(
+                self,
+                role: str | None = None,
+                parts: list[Any] | None = None,
+                **_: Any,
+            ) -> None:
+                self.role = role
+                self.parts = list(parts or [])
+
+        class ADKMemoryEntry:
+            """Stand-in for ``google.adk.memory.MemoryEntry`` (ADK 2.x shape)."""
+
+            def __init__(
+                self,
+                *,
+                content: Any,
+                custom_metadata: dict[str, Any] | None = None,
+                id: str | None = None,  # mirrors the ADK field name
+                author: str | None = None,
+                timestamp: str | None = None,
+                **_: Any,
+            ) -> None:
+                self.content = content
+                self.custom_metadata = custom_metadata or {}
+                self.id = id
+                self.author = author
+                self.timestamp = timestamp
+
         class SearchMemoryResponse:
-            """Exact replica of ADK's response objects for CI environments."""
+            """Stand-in for ``google.adk.memory.SearchMemoryResponse``."""
 
-            def __init__(self, memories: list[dict[str, Any]] | None = None, **kwargs: Any) -> None:
-                self.memories: list[Any] = []
-                for m in memories or []:
-                    if isinstance(m, dict):
-
-                        class MockPart:
-                            def __init__(self, text: str) -> None:
-                                self.text = text
-
-                        class MockContent:
-                            def __init__(self, role: str, parts: list[dict[str, Any]]) -> None:
-                                self.role = role
-                                self.parts = [MockPart(p.get("text", "")) for p in parts]
-
-                        class MockEntry:
-                            def __init__(self, data: dict[str, Any]) -> None:
-                                self.id = data.get("id")
-                                c_data = data.get("content", {})
-                                self.content = MockContent(
-                                    c_data.get("role", "user"), c_data.get("parts", [])
-                                )
-
-                        self.memories.append(MockEntry(m))
-                    else:
-                        self.memories.append(m)
+            def __init__(self, memories: Sequence[Any] | None = None, **_: Any) -> None:
+                self.memories: list[Any] = list(memories or [])
 
 
 from neo4j_agent_memory.integrations.google_adk.types import (
@@ -71,40 +121,135 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+#: Roles accepted by ``google.genai.types.Content``. Everything the library
+#: stores that is not a user turn is surfaced to the model as ``"model"``.
+_USER_ROLE = "user"
+_MODEL_ROLE = "model"
+
+
+def _content_role(author: str | None) -> str:
+    """Map a library role/author onto a google-genai ``Content.role``."""
+    return _USER_ROLE if (author or "").lower() == _USER_ROLE else _MODEL_ROLE
+
+
+def _message_role(author: str | None) -> str:
+    """Map an ADK event ``author`` onto a library ``MessageRole`` value.
+
+    ADK authors are ``"user"`` for user turns and the **agent name** for model
+    turns (``"memory_demo"``, ``"supervisor"``, …), while the library validates
+    roles against ``MessageRole`` (user / assistant / system / tool). Anything
+    that is not a known role is an agent, so it is stored as ``"assistant"``
+    and the original author is preserved in the message metadata — without
+    this, every agent-authored event is rejected on write.
+    """
+    role = (author or _USER_ROLE).lower()
+    if role in {"user", "assistant", "system", "tool"}:
+        return role
+    # ``"model"`` and agent names alike are assistant turns.
+    return "assistant"
+
+
+def _iso_timestamp(value: Any) -> str | None:
+    """Render a timestamp as the ISO-8601 string ADK's ``MemoryEntry`` wants.
+
+    Accepts ``datetime`` as well as ``neo4j.time.DateTime`` (both expose
+    ``isoformat()``) and yields ``None`` for anything else, since ADK validates
+    the field as ``Optional[str]``.
+    """
+    isoformat = getattr(value, "isoformat", None)
+    if callable(isoformat):
+        rendered = isoformat()
+        if isinstance(rendered, str):
+            return rendered
+    return None
+
+
+def _adk_author(entry: MemoryEntry) -> str:
+    """Derive the ADK ``author`` for a library memory entry.
+
+    Messages keep their role (``user`` / ``assistant`` / an agent name);
+    long-term recall is attributed to its memory type so ``preload_memory``
+    renders ``entity: Acme Corp: ...`` rather than an anonymous line.
+    """
+    if entry.memory_type == "message":
+        metadata = entry.metadata or {}
+        # ``adk_author`` preserves the ADK agent name for model turns.
+        author = metadata.get("adk_author") or metadata.get("role")
+        return str(author) if author else _USER_ROLE
+    return entry.memory_type
+
+
+def to_adk_memory_entry(entry: MemoryEntry) -> ADKMemoryEntry:
+    """Convert a library :class:`MemoryEntry` into an ADK 2.x ``MemoryEntry``.
+
+    Args:
+        entry: The library-side entry produced by the ``*_to_memory_entry``
+            converters in :mod:`neo4j_agent_memory.integrations.google_adk.types`.
+
+    Returns:
+        An ADK ``MemoryEntry`` with ``content`` as a ``types.Content``,
+        ``author``, ISO-8601 ``timestamp``, ``id`` and ``custom_metadata``.
+    """
+    author = _adk_author(entry)
+    custom_metadata: dict[str, Any] = {"memory_type": entry.memory_type}
+    if entry.score is not None:
+        custom_metadata["score"] = entry.score
+    for key in ("session_id", "category", "type"):
+        value = (entry.metadata or {}).get(key)
+        if value is not None:
+            custom_metadata[key] = value
+
+    return ADKMemoryEntry(
+        content=ADKContent(
+            role=_content_role(author),
+            parts=[ADKPart(text=str(entry.content))],
+        ),
+        author=author,
+        timestamp=_iso_timestamp(entry.timestamp),
+        id=str(entry.id) if entry.id else None,
+        custom_metadata=custom_metadata,
+    )
+
 
 class Neo4jMemoryService(_ADKBase):
     """Neo4j-backed memory service for Google ADK agents.
 
-    Implements the ADK MemoryService interface to provide:
-    - Session memory persistence
-    - Semantic memory search
-    - Entity/fact storage
+    Implements the google-adk 2.x ``BaseMemoryService`` interface to provide:
 
-    .. warning::
-        Google ADK is in preview. The MemoryService interface may change
-        before GA release.
+    - session / event ingestion into short-term memory (with entity extraction)
+    - hybrid semantic search across messages, entities and preferences
+    - direct memory writes (ADK ``MemoryEntry`` items or the convenience form)
 
     Example:
+        from google.adk.agents import LlmAgent
+        from google.adk.runners import Runner
+        from google.adk.sessions import InMemorySessionService
+        from google.adk.tools import load_memory
+
         from neo4j_agent_memory import MemoryClient, MemorySettings
         from neo4j_agent_memory.integrations.google_adk import Neo4jMemoryService
 
-        settings = MemorySettings(...)
-        async with MemoryClient(settings) as client:
-            memory_service = Neo4jMemoryService(
-                memory_client=client,
-                user_id="user-123",
+        async with MemoryClient(MemorySettings()) as client:
+            memory_service = Neo4jMemoryService(memory_client=client, user_id="user-123")
+            runner = Runner(
+                app_name="memory-demo",
+                agent=LlmAgent(name="demo", model="gemini-2.5-flash", tools=[load_memory]),
+                session_service=InMemorySessionService(),
+                memory_service=memory_service,
             )
-
-            # Store a session
+            # ... run a turn, then persist it:
             await memory_service.add_session_to_memory(session)
 
-            # Search memories
-            results = await memory_service.search_memory("project deadline")
+            response = await memory_service.search_memory(
+                app_name="memory-demo", user_id="user-123", query="project deadline"
+            )
+            for entry in response.memories:
+                print(entry.author, "".join(p.text or "" for p in entry.content.parts))
 
     Attributes:
         user_id: Optional user identifier for personalization.
-        include_entities: Whether to extract and search entities.
-        include_preferences: Whether to extract and search preferences.
+        include_entities: Whether to search entities.
+        include_preferences: Whether to search preferences.
     """
 
     def __init__(
@@ -153,11 +298,11 @@ class Neo4jMemoryService(_ADKBase):
         session_id: str | None = None,
         **kwargs: Any,
     ) -> None:
-        """Store session messages and extract entities.
+        """Store a session's messages and extract entities.
 
-        This method stores all messages from a session into the Neo4j
-        memory store. If entity extraction is enabled, it will also
-        extract entities from the messages.
+        ADK 2.x calls this with a single positional ``Session`` whose
+        ``events`` carry the turn history. Dicts and plain message lists are
+        also accepted so the adapter is usable without the ADK installed.
 
         Args:
             session: The ADK Session object or dict with messages.
@@ -173,32 +318,42 @@ class Neo4jMemoryService(_ADKBase):
             else:
                 session_id = "default"
 
-        # Remember the active session so search_memory() can scope to it
-        # (NAMS message search is conversation-scoped — issue #130).
-        self._current_session_id = session_id
-
-        # Extract messages from session
         messages = self._extract_messages(session)
+        await self._store_messages(session_id, messages)
 
-        if not messages:
-            logger.debug(f"No messages to store for session {session_id}")
-            return
+    async def add_events_to_memory(
+        self,
+        *,
+        app_name: str | None = None,
+        user_id: str | None = None,
+        events: Sequence[Any] = (),
+        session_id: str | None = None,
+        custom_metadata: Mapping[str, Any] | None = None,
+        **kwargs: Any,
+    ) -> None:
+        """Store an incremental slice of ADK events (ADK 2.x).
 
-        # Store each message
-        for msg in messages:
-            try:
-                await self._client.short_term.add_message(
-                    session_id=session_id,
-                    role=msg.role,
-                    content=msg.content,
-                    metadata=msg.metadata,
-                    extract_entities=self._extract_on_store,
-                    generate_embedding=True,
-                )
-            except Exception as e:
-                logger.warning(f"Error storing message: {e}")
+        ``Context.add_events_to_memory(events=...)`` routes here when an agent
+        wants to persist only the latest turn instead of re-ingesting the whole
+        session. Events are treated as a delta: each text-bearing event becomes
+        one message on the resolved session.
 
-        logger.debug(f"Stored {len(messages)} messages for session {session_id}")
+        Args:
+            app_name: ADK application name (accepted for contract parity).
+            user_id: ADK user id (accepted for contract parity).
+            events: The events to ingest.
+            session_id: Session scope; falls back to the last session written.
+            custom_metadata: Portable metadata merged into each message's
+                ``metadata`` map.
+            **kwargs: Additional arguments (for API compatibility).
+        """
+        scope = session_id or self._current_session_id or "default"
+        messages = self._extract_messages_from_events(events)
+        if custom_metadata:
+            extra = dict(custom_metadata)
+            for msg in messages:
+                msg.metadata = {**(msg.metadata or {}), **extra}
+        await self._store_messages(scope, messages)
 
     async def search_memory(
         self,
@@ -215,16 +370,23 @@ class Neo4jMemoryService(_ADKBase):
         Performs hybrid vector + graph search across messages, entities,
         and preferences to find relevant memories.
 
+        ADK 2.x always calls this with keyword arguments
+        (``app_name=``, ``user_id=``, ``query=``); ``query`` stays
+        positional-or-keyword so 0.5.0 callers keep working.
+
         Args:
             query: The search query.
-            app_name: Optional app name filter (not used currently).
-            user_id: Optional user ID filter (not used currently).
+            app_name: ADK application name (accepted for contract parity).
+            user_id: ADK user id (accepted for contract parity; tenant scoping
+                is not wired yet — see the multi-tenancy how-to).
             limit: Maximum number of results.
             threshold: Minimum similarity threshold.
-            **kwargs: Additional arguments (for API compatibility).
+            **kwargs: Additional arguments — ``session_id`` scopes the message
+                search explicitly.
 
         Returns:
-            List of MemoryEntry objects matching the query.
+            A ``SearchMemoryResponse`` whose ``memories`` are ADK
+            ``MemoryEntry`` objects (``content`` is a ``types.Content``).
         """
         results: list[MemoryEntry] = []
 
@@ -285,19 +447,10 @@ class Neo4jMemoryService(_ADKBase):
 
         # Sort by score (descending) and limit
         results.sort(key=lambda x: x.score or 0, reverse=True)
-        adk_memories = []
-        for r in results[:limit]:
-            adk_memories.append(
-                {
-                    "id": str(getattr(r, "id", "default")),
-                    "content": {
-                        "role": getattr(r, "role", "user") or "user",
-                        "parts": [{"text": str(getattr(r, "content", ""))}],
-                    },
-                }
-            )
 
-        return SearchMemoryResponse(memories=adk_memories)
+        return SearchMemoryResponse(
+            memories=[to_adk_memory_entry(entry) for entry in results[:limit]]
+        )
 
     async def get_memories_for_session(
         self,
@@ -308,7 +461,9 @@ class Neo4jMemoryService(_ADKBase):
     ) -> list[MemoryEntry]:
         """Get memories relevant to a session.
 
-        Retrieves conversation history and related memories for a session.
+        Retrieves conversation history for a session. This is a library
+        convenience (not part of the ADK contract), so it returns the library's
+        own :class:`MemoryEntry` dataclass rather than ADK entries.
 
         Args:
             session_id: The session ID to get memories for.
@@ -337,8 +492,12 @@ class Neo4jMemoryService(_ADKBase):
 
     async def add_memory(
         self,
-        content: str,
+        content: str | None = None,
         *,
+        memories: Sequence[Any] | None = None,
+        app_name: str | None = None,
+        user_id: str | None = None,
+        custom_metadata: Mapping[str, Any] | None = None,
         memory_type: str = "message",
         session_id: str = "default",
         role: str = "user",
@@ -346,12 +505,24 @@ class Neo4jMemoryService(_ADKBase):
         metadata: dict[str, Any] | None = None,
         **kwargs: Any,
     ) -> MemoryEntry | None:
-        """Add a single memory entry.
+        """Write memory directly, in either the ADK 2.x or the convenience form.
 
-        Convenience method for adding individual memories.
+        ADK 2.x form — ``add_memory(app_name=..., user_id=..., memories=[...])``
+        with ADK ``MemoryEntry`` items (what ``Context.add_memory()`` sends).
+        Each entry's text parts are stored as one message, authored by
+        ``entry.author``, and ``None`` is returned.
+
+        Convenience form (kept from 0.5.0) — ``add_memory(content="...",
+        memory_type="message" | "preference", ...)``, which returns the created
+        library :class:`MemoryEntry`.
 
         Args:
-            content: The memory content.
+            content: The memory content (convenience form).
+            memories: ADK ``MemoryEntry`` items (ADK 2.x form).
+            app_name: ADK application name (accepted for contract parity).
+            user_id: ADK user id (accepted for contract parity).
+            custom_metadata: Portable metadata merged into each message's
+                ``metadata`` map (ADK 2.x form).
             memory_type: Type of memory ("message", "preference").
             session_id: Session ID for messages.
             role: Message role (for message type).
@@ -360,8 +531,38 @@ class Neo4jMemoryService(_ADKBase):
             **kwargs: Additional arguments.
 
         Returns:
-            The created MemoryEntry or None on error.
+            The created MemoryEntry for the convenience form, otherwise None.
         """
+        if memories is not None:
+            # The ADK form carries no session id, so fall back to the session
+            # last written to; an explicit session_id= still wins.
+            scope = (
+                session_id if session_id != "default" else (self._current_session_id or session_id)
+            )
+            extra = dict(custom_metadata) if custom_metadata else {}
+            session_messages: list[SessionMessage] = []
+            for entry in memories:
+                text = self._extract_text_from_content(getattr(entry, "content", None))
+                if not text:
+                    continue
+                author = str(getattr(entry, "author", None) or role)
+                entry_metadata = dict(extra)
+                if author != _message_role(author):
+                    entry_metadata["adk_author"] = author
+                session_messages.append(
+                    SessionMessage(
+                        role=_message_role(author),
+                        content=text,
+                        metadata=entry_metadata or None,
+                    )
+                )
+            await self._store_messages(scope, session_messages)
+            return None
+
+        if content is None:
+            logger.warning("add_memory: no content and no memories provided")
+            return None
+
         try:
             if memory_type == "message":
                 self._current_session_id = session_id
@@ -405,17 +606,54 @@ class Neo4jMemoryService(_ADKBase):
         except Exception as e:
             logger.error(f"Error clearing session: {e}")
 
+    async def _store_messages(self, session_id: str, messages: list[SessionMessage]) -> None:
+        """Write extracted session messages to short-term memory.
+
+        Remembers the session so ``search_memory()`` can scope to it (NAMS
+        message search is conversation-scoped — issue #130).
+        """
+        self._current_session_id = session_id
+
+        if not messages:
+            logger.debug(f"No messages to store for session {session_id}")
+            return
+
+        failures = 0
+        for msg in messages:
+            try:
+                await self._client.short_term.add_message(
+                    session_id=session_id,
+                    role=msg.role,
+                    content=msg.content,
+                    metadata=msg.metadata,
+                    extract_entities=self._extract_on_store,
+                    generate_embedding=True,
+                )
+            except Exception as e:
+                failures += 1
+                logger.error(f"Error storing message for session {session_id}: {e}")
+
+        stored = len(messages) - failures
+        if failures:
+            logger.error(
+                f"Stored {stored}/{len(messages)} messages for session "
+                f"{session_id} ({failures} failed)"
+            )
+        else:
+            logger.debug(f"Stored {stored} messages for session {session_id}")
+
     @staticmethod
     def _extract_text_from_content(content: Any) -> str:
         """Extract plain text from ADK Content/Parts objects or strings.
 
-        ADK v1.x uses google.genai.types.Content objects with a `.parts` list,
-        where each Part may carry `.text`, `.function_call`, `.function_response`,
-        etc. We ingest **only** the text parts. Tool events (function calls /
-        responses) carry no `.text`, so they yield an empty string and the
-        caller skips them — they must never be ``str()``-ified into the entity
-        pipeline, where the JSON noise breaks server-side extraction and yields
-        empty knowledge graphs (issue #130, defect 2).
+        ADK uses ``google.genai.types.Content`` objects with a ``.parts`` list,
+        where each Part may carry ``.text``, ``.function_call``,
+        ``.function_response``, etc. We ingest **only** the text parts. Tool
+        events (function calls / responses) carry no ``.text``, so they yield an
+        empty string and the caller skips them — they must never be
+        ``str()``-ified into the entity pipeline, where the JSON noise breaks
+        server-side extraction and yields empty knowledge graphs (issue #130,
+        defect 2).
 
         Args:
             content: A string, Content object, or other content type.
@@ -429,13 +667,44 @@ class Neo4jMemoryService(_ADKBase):
         texts = [part.text for part in parts if getattr(part, "text", None)]
         return "\n".join(texts)
 
+    def _extract_messages_from_events(self, events: Sequence[Any]) -> list[SessionMessage]:
+        """Convert ADK ``Event`` objects into :class:`SessionMessage` values.
+
+        ADK events carry ``.content`` (a ``types.Content``) and ``.author``
+        instead of a role. Events with no text part (tool calls / responses)
+        are skipped — see :meth:`_extract_text_from_content`.
+        """
+        messages: list[SessionMessage] = []
+        for event in events:
+            content = getattr(event, "content", None)
+            if content is None:
+                continue
+            text = self._extract_text_from_content(content)
+            if not text:
+                continue
+            author = getattr(event, "author", None)
+            metadata = dict(getattr(event, "metadata", None) or {})
+            if author and author != _message_role(author):
+                # Keep the real ADK author (usually the agent name) alongside
+                # the coarse MessageRole the library stores.
+                metadata["adk_author"] = str(author)
+            messages.append(
+                SessionMessage(
+                    role=_message_role(author),
+                    content=text,
+                    timestamp=getattr(event, "timestamp", None),
+                    metadata=metadata or None,
+                )
+            )
+        return messages
+
     def _extract_messages(self, session: Any) -> list[SessionMessage]:
         """Extract messages from various session formats.
 
         Supports:
-        - ADK v1.x Session objects (session.events with Event.content/author)
-        - ADK Session objects with session.messages
-        - Plain dicts with "messages" key
+        - ADK Session objects (``session.events`` with ``Event.content``/``.author``)
+        - ADK Session objects with ``session.messages``
+        - Plain dicts with a "messages" key
         - Lists of message dicts
 
         Args:
@@ -446,26 +715,9 @@ class Neo4jMemoryService(_ADKBase):
         """
         messages: list[SessionMessage] = []
 
-        # Handle ADK v1.x Session with events (Event has .content and .author)
+        # Handle ADK Session with events (Event has .content and .author)
         if hasattr(session, "events"):
-            for event in session.events:
-                content = getattr(event, "content", None)
-                if content is None:
-                    continue
-                text = self._extract_text_from_content(content)
-                if not text:
-                    continue
-                # ADK v1.x uses .author instead of .role
-                author = getattr(event, "author", None)
-                role = str(author) if author else "user"
-                messages.append(
-                    SessionMessage(
-                        role=role,
-                        content=text,
-                        timestamp=getattr(event, "timestamp", None),
-                        metadata=getattr(event, "metadata", None),
-                    )
-                )
+            messages.extend(self._extract_messages_from_events(session.events))
 
         # Handle ADK Session objects with messages attribute
         elif hasattr(session, "messages"):

--- a/src/neo4j_agent_memory/integrations/langchain/__init__.py
+++ b/src/neo4j_agent_memory/integrations/langchain/__init__.py
@@ -1,4 +1,28 @@
-"""LangChain integration for neo4j-agent-memory."""
+"""LangChain 1.x integration for neo4j-agent-memory.
+
+Three adapters, each implementing a contract that exists in the installed
+LangChain, plus a pass-through helper:
+
+``Neo4jAgentMemory``
+    ``langchain_core.chat_history.BaseChatMessageHistory`` — drop it into
+    ``RunnableWithMessageHistory`` (or call its context-assembly methods
+    directly). Needs ``langchain-core``: ``pip install
+    neo4j-agent-memory[langchain]``.
+``Neo4jMemoryRetriever``
+    ``langchain_core.retrievers.BaseRetriever`` over all three memory layers.
+    Needs ``langchain-core``.
+``Neo4jMemoryMiddleware``
+    ``langchain.agents.middleware.AgentMiddleware`` for
+    :func:`langchain.agents.create_agent`. Needs the ``langchain``
+    distribution: ``pip install neo4j-agent-memory[langchain-agents]``.
+``llm_provider_from_langchain``
+    Reuse an already-configured LangChain chat model for memory's own LLM work.
+    No LangChain import required.
+
+Nothing here targets ``langchain_core.memory.BaseMemory`` or
+``langchain.chains.ConversationChain``: langchain-core 1.x dropped the former
+and moved the latter to ``langchain-classic``.
+"""
 
 from __future__ import annotations
 
@@ -7,10 +31,14 @@ from typing import TYPE_CHECKING, Any
 from neo4j_agent_memory.integrations._passthrough import (
     llm_provider_from_framework_model as _passthrough,
 )
-from neo4j_agent_memory.integrations.langchain.memory import Neo4jAgentMemory
 
 if TYPE_CHECKING:
     from neo4j_agent_memory.llm import LLMProvider
+
+#: Minimum langchain-core the adapters are written against (1.x ABCs).
+LANGCHAIN_CORE_MIN_VERSION = "1.0"
+#: Minimum `langchain` distribution for `Neo4jMemoryMiddleware`.
+LANGCHAIN_MIN_VERSION = "1.0"
 
 
 def llm_provider_from_langchain(model: Any) -> LLMProvider:
@@ -18,12 +46,14 @@ def llm_provider_from_langchain(model: Any) -> LLMProvider:
 
     Lets users pass through their already-configured LangChain model::
 
-        from langchain_anthropic import ChatAnthropic
+        import os
+
+        from langchain_openai import ChatOpenAI
         from neo4j_agent_memory.integrations.langchain import (
             llm_provider_from_langchain,
         )
 
-        chat = ChatAnthropic(model_name="claude-3-5-sonnet-latest")
+        chat = ChatOpenAI(model=os.getenv("OPENAI_MODEL", "gpt-5-mini"))
         provider = llm_provider_from_langchain(chat)
         # Wire provider into MemorySettings(llm=provider) or
         # MemoryClient(... llm_provider=provider)
@@ -37,17 +67,23 @@ def llm_provider_from_langchain(model: Any) -> LLMProvider:
     return _passthrough(model)
 
 
-try:
+__all__ = [
+    "LANGCHAIN_CORE_MIN_VERSION",
+    "LANGCHAIN_MIN_VERSION",
+    "llm_provider_from_langchain",
+]
+
+try:  # langchain-core: the chat-history and retriever adapters
+    from neo4j_agent_memory.integrations.langchain.memory import Neo4jAgentMemory
     from neo4j_agent_memory.integrations.langchain.retriever import Neo4jMemoryRetriever
 
-    __all__ = [
-        "Neo4jAgentMemory",
-        "Neo4jMemoryRetriever",
-        "llm_provider_from_langchain",
-    ]
-except ImportError:
-    # langchain_core not installed for retriever
-    __all__ = [
-        "Neo4jAgentMemory",
-        "llm_provider_from_langchain",
-    ]
+    __all__ += ["Neo4jAgentMemory", "Neo4jMemoryRetriever"]
+except ImportError:  # pragma: no cover - depends on the installed extras
+    pass
+
+try:  # `langchain` (create_agent + middleware): the agent middleware
+    from neo4j_agent_memory.integrations.langchain.middleware import Neo4jMemoryMiddleware
+
+    __all__ += ["Neo4jMemoryMiddleware"]
+except ImportError:  # pragma: no cover - depends on the installed extras
+    pass

--- a/src/neo4j_agent_memory/integrations/langchain/memory.py
+++ b/src/neo4j_agent_memory/integrations/langchain/memory.py
@@ -1,74 +1,217 @@
-"""LangChain memory integration."""
+"""LangChain chat-message-history adapter backed by Neo4j Agent Memory.
 
-from collections.abc import Coroutine
+``Neo4jAgentMemory`` implements :class:`langchain_core.chat_history.BaseChatMessageHistory`
+— a live langchain-core 1.x abstract base class — so it plugs into
+:class:`~langchain_core.runnables.history.RunnableWithMessageHistory` and anything
+else that accepts a chat history object.
+
+It used to imitate the pre-v1 ``langchain_core.memory.BaseMemory`` protocol
+(``memory_variables`` / ``load_memory_variables`` / ``save_context``). That module
+no longer exists in langchain-core 1.x, so the class was retargeted onto
+``BaseChatMessageHistory``. The old context-assembly surface is kept — it is
+useful for hand-rolled prompts and for
+:class:`~neo4j_agent_memory.integrations.langchain.middleware.Neo4jMemoryMiddleware`
+— but its async methods are now public (``aload_memory_variables`` /
+``asave_context``); the underscore-prefixed names remain as deprecated aliases
+for one release.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Coroutine, Sequence
 from typing import TYPE_CHECKING, Any, TypeVar
 
-from pydantic import BaseModel, ConfigDict
+from langchain_core.chat_history import BaseChatMessageHistory
+from langchain_core.messages import (
+    AIMessage,
+    BaseMessage,
+    ChatMessage,
+    HumanMessage,
+    SystemMessage,
+)
+
+from neo4j_agent_memory.core.exceptions import NotSupportedError
 
 if TYPE_CHECKING:
+    from neo4j_agent_memory import MemoryClient
+    from neo4j_agent_memory.memory.long_term import Preference
     from neo4j_agent_memory.memory.reasoning import ReasoningTrace
     from neo4j_agent_memory.memory.short_term import Message
 
+logger = logging.getLogger(__name__)
+
 _T = TypeVar("_T")
 
+#: LangChain message ``type`` -> neo4j-agent-memory ``MessageRole`` value.
+_LC_TYPE_TO_ROLE: dict[str, str] = {
+    "human": "user",
+    "ai": "assistant",
+    "system": "system",
+    "tool": "tool",
+}
 
-class Neo4jAgentMemory(BaseModel):
-    """
-    LangChain memory that uses Neo4j Agent Memory.
 
-    Provides:
-    - Conversation history (short-term)
-    - User facts and preferences (long-term)
-    - Similar past task traces (reasoning)
+def _memory_message_to_langchain(message: Message) -> BaseMessage:
+    """Convert a library :class:`Message` into a LangChain message."""
+    role = message.role.value if hasattr(message.role, "value") else str(message.role)
+    message_id = str(message.id)
+    if role == "user":
+        return HumanMessage(content=message.content, id=message_id)
+    if role == "assistant":
+        return AIMessage(content=message.content, id=message_id)
+    if role == "system":
+        return SystemMessage(content=message.content, id=message_id)
+    # "tool" and any future role: ChatMessage keeps the role verbatim without
+    # inventing a tool_call_id that memory never stored.
+    return ChatMessage(content=message.content, role=role, id=message_id)
 
-    Example:
-        from neo4j_agent_memory import MemoryClient, MemorySettings
+
+def _langchain_message_to_role(message: BaseMessage) -> str:
+    """Map a LangChain message onto a library ``MessageRole`` value."""
+    if isinstance(message, ChatMessage):
+        return message.role
+    return _LC_TYPE_TO_ROLE.get(message.type, "user")
+
+
+class Neo4jAgentMemory(BaseChatMessageHistory):
+    """Neo4j-backed LangChain chat message history, plus memory context assembly.
+
+    Implements ``langchain_core.chat_history.BaseChatMessageHistory``. The async
+    surface (``aget_messages`` / ``aadd_messages`` / ``aclear``) talks to Neo4j
+    Agent Memory directly; the sync surface only works outside a running event
+    loop (the underlying driver is async), and raises a pointed ``RuntimeError``
+    otherwise rather than deadlocking on the caller's loop.
+
+    Example — wiring it into a LangChain runnable::
+
+        from langchain_core.runnables.history import RunnableWithMessageHistory
+        from neo4j_agent_memory import MemoryClient
         from neo4j_agent_memory.integrations.langchain import Neo4jAgentMemory
 
         async with MemoryClient(settings) as client:
-            memory = Neo4jAgentMemory(
-                memory_client=client,
-                session_id="user-123"
+            chain_with_history = RunnableWithMessageHistory(
+                chain,
+                lambda session_id: Neo4jAgentMemory(
+                    memory_client=client, session_id=session_id
+                ),
+                input_messages_key="input",
+                history_messages_key="history",
             )
-            # Use with LangChain agent
+            await chain_with_history.ainvoke(
+                {"input": "Where should I eat?"},
+                config={"configurable": {"session_id": "user-123"}},
+            )
+
+    Attributes:
+        memory_client: A connected :class:`~neo4j_agent_memory.MemoryClient`.
+        session_id: Conversation/session identifier to read and write.
+        include_short_term: Include conversation history in ``aload_memory_variables``.
+        include_long_term: Include entities/preferences in ``aload_memory_variables``.
+        include_reasoning: Include similar past traces in ``aload_memory_variables``.
+        max_messages: Message cap for history reads.
+        max_preferences: Item cap for long-term lookups.
+        max_traces: Trace cap for reasoning lookups.
+        extract_entities: Run entity extraction on messages written through the adapter.
+        generate_embeddings: Generate embeddings for messages written through the adapter.
     """
 
-    memory_client: Any  # MemoryClient - using Any to avoid pydantic issues
-    session_id: str
-    include_short_term: bool = True
-    include_long_term: bool = True
-    include_reasoning: bool = True
-    max_messages: int = 10
-    max_preferences: int = 5
-    max_traces: int = 3
+    def __init__(
+        self,
+        memory_client: MemoryClient,
+        session_id: str,
+        *,
+        include_short_term: bool = True,
+        include_long_term: bool = True,
+        include_reasoning: bool = True,
+        max_messages: int = 10,
+        max_preferences: int = 5,
+        max_traces: int = 3,
+        extract_entities: bool = True,
+        generate_embeddings: bool = True,
+    ) -> None:
+        """Initialize the adapter. See the class docstring for attribute meanings."""
+        self.memory_client = memory_client
+        self.session_id = session_id
+        self.include_short_term = include_short_term
+        self.include_long_term = include_long_term
+        self.include_reasoning = include_reasoning
+        self.max_messages = max_messages
+        self.max_preferences = max_preferences
+        self.max_traces = max_traces
+        self.extract_entities = extract_entities
+        self.generate_embeddings = generate_embeddings
 
-    model_config = ConfigDict(arbitrary_types_allowed=True)
+    # ------------------------------------------------------------------ sync
+    @staticmethod
+    def _run_sync(coro: Coroutine[Any, Any, _T], *, async_alternative: str) -> _T:
+        """Run ``coro`` to completion, refusing to block a running event loop.
 
-    def _run_async(self, coro: Coroutine[Any, Any, _T]) -> _T:
+        Neo4j Agent Memory is async all the way down and its driver is bound to
+        the loop that created it. Scheduling onto the caller's own running loop
+        and then blocking on the result (the adapter's pre-1.x behaviour)
+        deadlocks, so from async code we raise and name the coroutine to await.
         """
-        Run an async coroutine from sync context.
-
-        Handles the case where we're already in an async context by
-        scheduling the coroutine on the existing event loop.
-        """
-        import asyncio
-
         try:
-            loop = asyncio.get_running_loop()
+            asyncio.get_running_loop()
         except RuntimeError:
-            loop = None
-
-        if loop is not None and loop.is_running():
-            # We're in an async context - schedule on the existing loop
-            future = asyncio.run_coroutine_threadsafe(coro, loop)
-            return future.result(timeout=30)
-        else:
-            # Not in async context - create a new loop
             return asyncio.run(coro)
 
+        coro.close()
+        msg = (
+            "Neo4jAgentMemory's synchronous API cannot be used from inside a "
+            f"running event loop. Await {async_alternative} instead."
+        )
+        raise RuntimeError(msg)
+
+    # -------------------------------------------- BaseChatMessageHistory API
+    @property
+    def messages(self) -> list[BaseMessage]:  # type: ignore[override]  # ty: ignore[unused-ignore-comment]  # BaseChatMessageHistory declares `messages` as a plain attribute; a read-only property is the documented way to implement it
+        """Conversation history as LangChain messages (sync; see :meth:`aget_messages`)."""
+        return self._run_sync(self.aget_messages(), async_alternative="aget_messages()")
+
+    async def aget_messages(self) -> list[BaseMessage]:
+        """Return this session's messages as LangChain messages, oldest first."""
+        conversation = await self.memory_client.short_term.get_conversation(
+            self.session_id, limit=self.max_messages
+        )
+        return [_memory_message_to_langchain(m) for m in conversation.messages]
+
+    def add_messages(self, messages: Sequence[BaseMessage]) -> None:
+        """Persist ``messages`` (sync; see :meth:`aadd_messages`)."""
+        self._run_sync(self.aadd_messages(messages), async_alternative="aadd_messages(messages)")
+
+    async def aadd_messages(self, messages: Sequence[BaseMessage]) -> None:
+        """Persist ``messages`` to short-term memory, in order.
+
+        Messages with no text content (for example an ``AIMessage`` that only
+        carries tool calls) are skipped — memory stores text.
+        """
+        for message in messages:
+            content = message.text
+            if not content:
+                continue
+            await self.memory_client.short_term.add_message(
+                self.session_id,
+                _langchain_message_to_role(message),
+                content,
+                extract_entities=self.extract_entities,
+                generate_embedding=self.generate_embeddings,
+            )
+
+    def clear(self) -> None:
+        """Clear this session's history (sync; see :meth:`aclear`)."""
+        self._run_sync(self.aclear(), async_alternative="aclear()")
+
+    async def aclear(self) -> None:
+        """Clear all short-term memory for this session."""
+        await self.memory_client.short_term.clear_session(self.session_id)
+
+    # ------------------------------------------------- context assembly API
     @property
     def memory_variables(self) -> list[str]:
-        """Return memory variables."""
+        """Names of the keys :meth:`aload_memory_variables` returns."""
         variables = []
         if self.include_short_term:
             variables.append("history")
@@ -79,15 +222,26 @@ class Neo4jAgentMemory(BaseModel):
         return variables
 
     def load_memory_variables(self, inputs: dict[str, Any]) -> dict[str, Any]:
-        """
-        Load memory context for the current input.
+        """Assemble memory context (sync; see :meth:`aload_memory_variables`)."""
+        return self._run_sync(
+            self.aload_memory_variables(inputs),
+            async_alternative="aload_memory_variables(inputs)",
+        )
 
-        This is a sync wrapper that handles async execution properly.
-        """
-        return self._run_async(self._load_memory_variables_async(inputs))
+    async def aload_memory_variables(self, inputs: dict[str, Any]) -> dict[str, Any]:
+        """Assemble memory context for the current input.
 
-    async def _load_memory_variables_async(self, inputs: dict[str, Any]) -> dict[str, Any]:
-        """Async implementation of load_memory_variables."""
+        Backend tolerance: preference search and similar-trace search are
+        bolt-only (NAMS raises :class:`NotSupportedError`). Those keys come back
+        empty on the hosted backend instead of raising, and ``context`` falls
+        back to entity search when ``long_term.get_context`` yields nothing.
+
+        Args:
+            inputs: Chain inputs; ``inputs["input"]`` is used as the search query.
+
+        Returns:
+            A dict whose keys are :attr:`memory_variables`.
+        """
         query = inputs.get("input", "")
         result: dict[str, Any] = {}
 
@@ -98,59 +252,105 @@ class Neo4jAgentMemory(BaseModel):
             result["history"] = self._format_messages(conv.messages)
 
         if self.include_long_term:
-            context = await self.memory_client.long_term.get_context(
-                query, max_items=self.max_preferences
-            )
-            result["context"] = context
-
-            prefs = await self.memory_client.long_term.search_preferences(
-                query, limit=self.max_preferences
-            )
-            result["preferences"] = [
-                {"category": p.category, "preference": p.preference} for p in prefs
-            ]
+            result["context"] = await self._load_long_term_context(query)
+            result["preferences"] = await self._load_preferences(query)
 
         if self.include_reasoning:
-            traces = await self.memory_client.reasoning.get_similar_traces(
-                query, limit=self.max_traces
-            )
-            result["similar_tasks"] = self._format_traces(traces)
+            result["similar_tasks"] = self._format_traces(await self._load_traces(query))
 
         return result
 
     def save_context(self, inputs: dict[str, Any], outputs: dict[str, str]) -> None:
-        """
-        Save the current interaction to memory.
+        """Persist one exchange (sync; see :meth:`asave_context`)."""
+        self._run_sync(
+            self.asave_context(inputs, outputs),
+            async_alternative="asave_context(inputs, outputs)",
+        )
 
-        This is a sync wrapper that handles async execution properly.
-        """
-        self._run_async(self._save_context_async(inputs, outputs))
-
-    async def _save_context_async(self, inputs: dict[str, Any], outputs: dict[str, str]) -> None:
-        """Async implementation of save_context."""
+    async def asave_context(self, inputs: dict[str, Any], outputs: dict[str, str]) -> None:
+        """Persist one user/assistant exchange to short-term memory."""
         user_input = inputs.get("input", "")
         assistant_output = outputs.get("output", "")
 
         if user_input:
-            await self.memory_client.short_term.add_message(self.session_id, "user", user_input)
+            await self.memory_client.short_term.add_message(
+                self.session_id,
+                "user",
+                user_input,
+                extract_entities=self.extract_entities,
+                generate_embedding=self.generate_embeddings,
+            )
 
         if assistant_output:
             await self.memory_client.short_term.add_message(
-                self.session_id, "assistant", assistant_output
+                self.session_id,
+                "assistant",
+                assistant_output,
+                extract_entities=self.extract_entities,
+                generate_embedding=self.generate_embeddings,
             )
 
-    def clear(self) -> None:
-        """Clear conversation history for this session."""
-        self._run_async(self.memory_client.short_term.clear_session(self.session_id))
+    # Deprecated one-release aliases for the old private coroutines. Callers
+    # that reached into the underscore names (there was no public async surface
+    # before 0.6) keep working; prefer the public names above.
+    _load_memory_variables_async = aload_memory_variables
+    _save_context_async = asave_context
 
-    def _format_messages(self, messages: list["Message"]) -> str:
-        """Format messages for context."""
+    # ----------------------------------------------------------- internals
+    async def _load_long_term_context(self, query: str) -> str:
+        """Long-term context, falling back to entity search on NAMS."""
+        try:
+            context: str = await self.memory_client.long_term.get_context(
+                query, max_items=self.max_preferences
+            )
+        except NotSupportedError:
+            context = ""
+        if context:
+            return context
+
+        # NAMS has no long-term context endpoint (it returns ""), but entity
+        # search is supported — assemble an equivalent block from it.
+        try:
+            entities = await self.memory_client.long_term.search_entities(
+                query, limit=self.max_preferences
+            )
+        except NotSupportedError:
+            return ""
         lines = []
-        for msg in messages:
-            lines.append(f"{msg.role.value}: {msg.content}")
+        for entity in entities:
+            line = f"- {entity.display_name} ({entity.full_type})"
+            if entity.description:
+                line += f": {entity.description}"
+            lines.append(line)
         return "\n".join(lines)
 
-    def _format_traces(self, traces: list["ReasoningTrace"]) -> str:
+    async def _load_preferences(self, query: str) -> list[dict[str, str]]:
+        """Preference lookups are bolt-only; return [] where unsupported."""
+        try:
+            prefs: list[Preference] = await self.memory_client.long_term.search_preferences(
+                query, limit=self.max_preferences
+            )
+        except NotSupportedError:
+            logger.debug("search_preferences unsupported on this backend; returning []")
+            return []
+        return [{"category": p.category, "preference": p.preference} for p in prefs]
+
+    async def _load_traces(self, query: str) -> list[ReasoningTrace]:
+        """Similar-trace search is bolt-only; return [] where unsupported."""
+        try:
+            traces: list[ReasoningTrace] = await self.memory_client.reasoning.get_similar_traces(
+                query, limit=self.max_traces
+            )
+        except NotSupportedError:
+            logger.debug("get_similar_traces unsupported on this backend; returning []")
+            return []
+        return traces
+
+    def _format_messages(self, messages: list[Message]) -> str:
+        """Format messages for context."""
+        return "\n".join(f"{msg.role.value}: {msg.content}" for msg in messages)
+
+    def _format_traces(self, traces: list[ReasoningTrace]) -> str:
         """Format reasoning traces for context."""
         lines = []
         for trace in traces:

--- a/src/neo4j_agent_memory/integrations/langchain/middleware.py
+++ b/src/neo4j_agent_memory/integrations/langchain/middleware.py
@@ -1,0 +1,217 @@
+"""``create_agent`` middleware that gives a LangChain 1.x agent Neo4j memory.
+
+LangChain 1.x replaced the pre-v1 ``BaseMemory``/``ConversationChain`` story with
+agent middleware: :func:`langchain.agents.create_agent` accepts a list of
+:class:`~langchain.agents.middleware.AgentMiddleware` objects whose hooks run
+around every model call. :class:`Neo4jMemoryMiddleware` is that hook set for
+Neo4j Agent Memory — it reads memory before the model runs and writes the turn
+back after.
+
+Requires the ``langchain`` distribution (``pip install
+neo4j-agent-memory[langchain-agents]``), not just ``langchain-core``; importing
+this module without it raises ``ImportError``, and
+``neo4j_agent_memory.integrations.langchain`` simply omits
+``Neo4jMemoryMiddleware`` from its exports in that case.
+
+Example::
+
+    from langchain.agents import create_agent
+    from neo4j_agent_memory import MemoryClient
+    from neo4j_agent_memory.integrations.langchain import Neo4jMemoryMiddleware
+
+    async with MemoryClient(settings) as client:
+        agent = create_agent(
+            model,
+            tools=[...],
+            middleware=[Neo4jMemoryMiddleware(client, session_id="user-123")],
+        )
+        result = await agent.ainvoke({"messages": [("user", "Where should I eat?")]})
+
+Only the async hooks are implemented, because Neo4j Agent Memory is async all
+the way down. Invoke the agent with ``ainvoke``/``astream``; the sync hooks
+raise a pointed error rather than silently skipping memory.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections import OrderedDict
+from collections.abc import Sequence
+from typing import TYPE_CHECKING, Any
+
+from langchain.agents.middleware import AgentMiddleware, AgentState
+from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
+
+from neo4j_agent_memory.core.exceptions import NotSupportedError
+from neo4j_agent_memory.integrations.langchain.memory import _langchain_message_to_role
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+
+    from langchain.agents.middleware import ModelRequest, ModelResponse
+    from langchain_core.messages import BaseMessage
+    from langgraph.runtime import Runtime
+
+    from neo4j_agent_memory import MemoryClient
+
+logger = logging.getLogger(__name__)
+
+_SYNC_HINT = (
+    "Neo4jMemoryMiddleware only implements the async hooks because Neo4j Agent "
+    "Memory is async. Invoke the agent with `await agent.ainvoke(...)` or "
+    "`agent.astream(...)`."
+)
+
+#: How many LangChain message ids to remember per middleware instance so a
+#: multi-turn tool loop does not persist the same message on every model call.
+_SEEN_IDS_MAXLEN = 2048
+
+
+class Neo4jMemoryMiddleware(AgentMiddleware[AgentState[Any], Any, Any]):
+    """Inject Neo4j Agent Memory context into an agent and persist its turns.
+
+    Hooks:
+        * ``abefore_model`` — persists any new user messages, so the turn is
+          recorded even if the model call then fails.
+        * ``awrap_model_call`` — appends a memory block to the request's system
+          message. This is the injection point LangChain's own middleware uses
+          (see ``TodoListMiddleware``); it leaves agent state untouched, so the
+          memory block never accumulates in the thread's message list.
+        * ``aafter_model`` — persists the assistant's reply.
+
+    Args:
+        memory_client: A connected :class:`~neo4j_agent_memory.MemoryClient`.
+        session_id: Session/conversation id to read and write.
+        include_short_term: Include conversation history in the injected block.
+        include_long_term: Include entities/facts/preferences in the injected block.
+        include_reasoning: Include similar past traces in the injected block.
+        max_items: Per-layer item cap for the context lookup.
+        store_messages: Persist user and assistant messages as they flow through.
+        extract_entities: Run entity extraction on persisted messages.
+        context_header: Heading placed above the injected memory block.
+    """
+
+    def __init__(
+        self,
+        memory_client: MemoryClient,
+        session_id: str,
+        *,
+        include_short_term: bool = True,
+        include_long_term: bool = True,
+        include_reasoning: bool = True,
+        max_items: int = 10,
+        store_messages: bool = True,
+        extract_entities: bool = True,
+        context_header: str = "# Memory",
+    ) -> None:
+        """Initialize the middleware. See the class docstring for argument meanings."""
+        super().__init__()
+        self.memory_client = memory_client
+        self.session_id = session_id
+        self.include_short_term = include_short_term
+        self.include_long_term = include_long_term
+        self.include_reasoning = include_reasoning
+        self.max_items = max_items
+        self.store_messages = store_messages
+        self.extract_entities = extract_entities
+        self.context_header = context_header
+        # No extra tools registered by this middleware.
+        self.tools = []
+        # Message ids already written to memory. `aafter_model` runs once per
+        # model call, and a tool-calling agent calls the model repeatedly with
+        # the same history, so without this the first user message would be
+        # stored again on every loop iteration.
+        self._persisted: OrderedDict[str, None] = OrderedDict()
+
+    # ------------------------------------------------------------- persisting
+    def _mark_persisted(self, message_id: str) -> None:
+        self._persisted[message_id] = None
+        while len(self._persisted) > _SEEN_IDS_MAXLEN:
+            self._persisted.popitem(last=False)
+
+    def _unpersisted(
+        self, messages: Sequence[BaseMessage], kinds: tuple[type[BaseMessage], ...]
+    ) -> list[BaseMessage]:
+        """Messages of ``kinds`` with text content that memory has not seen yet."""
+        pending = []
+        for message in messages:
+            if not isinstance(message, kinds) or not message.text:
+                continue
+            key = message.id or f"{message.type}:{message.text}"
+            if key in self._persisted:
+                continue
+            self._mark_persisted(key)
+            pending.append(message)
+        return pending
+
+    async def _store(self, messages: Sequence[BaseMessage]) -> None:
+        for message in messages:
+            await self.memory_client.short_term.add_message(
+                self.session_id,
+                _langchain_message_to_role(message),
+                message.text,
+                extract_entities=self.extract_entities,
+            )
+
+    # ------------------------------------------------------------- LC hooks
+    async def abefore_model(
+        self, state: AgentState[Any], runtime: Runtime[Any]
+    ) -> dict[str, Any] | None:
+        """Persist any user messages the agent has not stored yet."""
+        if self.store_messages:
+            await self._store(self._unpersisted(state["messages"], (HumanMessage,)))
+        return None
+
+    def before_model(self, state: AgentState[Any], runtime: Runtime[Any]) -> dict[str, Any] | None:
+        """Sync hook — not supported; see :data:`_SYNC_HINT`."""
+        raise NotImplementedError(_SYNC_HINT)
+
+    async def aafter_model(
+        self, state: AgentState[Any], runtime: Runtime[Any]
+    ) -> dict[str, Any] | None:
+        """Persist the assistant's reply."""
+        if self.store_messages:
+            await self._store(self._unpersisted(state["messages"], (AIMessage,)))
+        return None
+
+    def after_model(self, state: AgentState[Any], runtime: Runtime[Any]) -> dict[str, Any] | None:
+        """Sync hook — not supported; see :data:`_SYNC_HINT`."""
+        raise NotImplementedError(_SYNC_HINT)
+
+    async def awrap_model_call(
+        self,
+        request: ModelRequest[Any],
+        handler: Callable[[ModelRequest[Any]], Awaitable[ModelResponse[Any]]],
+    ) -> ModelResponse[Any]:
+        """Append the memory block to the system message, then call the model."""
+        block = await self._memory_block(request.messages)
+        if not block:
+            return await handler(request)
+
+        if request.system_message is not None:
+            content = f"{request.system_message.text}\n\n{block}"
+        else:
+            content = block
+        return await handler(request.override(system_message=SystemMessage(content=content)))
+
+    async def _memory_block(self, messages: Sequence[BaseMessage]) -> str:
+        """Assemble the memory context for the most recent user message."""
+        query = next(
+            (m.text for m in reversed(messages) if isinstance(m, HumanMessage) and m.text),
+            "",
+        )
+        try:
+            context = await self.memory_client.get_context(
+                query,
+                session_id=self.session_id,
+                include_short_term=self.include_short_term,
+                include_long_term=self.include_long_term,
+                include_reasoning=self.include_reasoning,
+                max_items=self.max_items,
+            )
+        except NotSupportedError:
+            logger.debug("get_context unsupported on this backend; skipping injection")
+            return ""
+        if not context:
+            return ""
+        return f"{self.context_header}\n{context}"

--- a/src/neo4j_agent_memory/integrations/langchain/retriever.py
+++ b/src/neo4j_agent_memory/integrations/langchain/retriever.py
@@ -1,156 +1,238 @@
-"""LangChain retriever integration."""
+"""LangChain retriever backed by Neo4j Agent Memory.
 
+``Neo4jMemoryRetriever`` is a real :class:`langchain_core.retrievers.BaseRetriever`,
+so ``invoke`` / ``ainvoke`` / ``batch`` and the LangSmith callbacks all work as
+LangChain users expect.
+
+The async hook is ``_aget_relevant_documents`` — the name LangChain actually
+calls. Before 0.6 the coroutine was named ``_get_relevant_documents_async``,
+which LangChain never sees: ``BaseRetriever.__init_subclass__`` synthesised an
+``_aget_relevant_documents`` that ran the *sync* path in a worker thread, so
+``await retriever.ainvoke(...)`` ended up calling ``asyncio.run()`` on a fresh
+loop against a Neo4j driver bound to the caller's loop. The old name is kept as
+a deprecated alias for one release.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
 from typing import TYPE_CHECKING, Any
 
+from langchain_core.callbacks import (
+    AsyncCallbackManagerForRetrieverRun,
+    CallbackManagerForRetrieverRun,
+)
+from langchain_core.documents import Document
+from langchain_core.retrievers import BaseRetriever
+from pydantic import ConfigDict
+
+from neo4j_agent_memory.core.exceptions import NotSupportedError
+
 if TYPE_CHECKING:
-    pass
+    from neo4j_agent_memory.memory.long_term import Entity, Preference
+    from neo4j_agent_memory.memory.reasoning import ReasoningTrace
+    from neo4j_agent_memory.memory.short_term import Message
 
-try:
-    from langchain_core.callbacks import CallbackManagerForRetrieverRun
-    from langchain_core.documents import Document
-    from langchain_core.retrievers import BaseRetriever
+logger = logging.getLogger(__name__)
 
-    class Neo4jMemoryRetriever(BaseRetriever):
+
+class Neo4jMemoryRetriever(BaseRetriever):
+    """LangChain retriever that searches across all memory types.
+
+    Example::
+
+        from neo4j_agent_memory import MemoryClient
+        from neo4j_agent_memory.integrations.langchain import Neo4jMemoryRetriever
+
+        async with MemoryClient(settings) as client:
+            retriever = Neo4jMemoryRetriever(
+                memory_client=client, session_id="user-123"
+            )
+            docs = await retriever.ainvoke("Italian restaurants")
+
+    Attributes:
+        memory_client: A connected :class:`~neo4j_agent_memory.MemoryClient`.
+        session_id: Optional session scope for message search. Required on the
+            hosted NAMS backend, whose message search is conversation-scoped.
+        search_short_term: Search conversation messages.
+        search_long_term: Search entities and preferences.
+        search_reasoning: Search reasoning traces.
+        k: Maximum documents to return.
+        threshold: Minimum similarity for a hit.
+    """
+
+    memory_client: Any
+    session_id: str | None = None
+    search_short_term: bool = True
+    search_long_term: bool = True
+    search_reasoning: bool = True
+    k: int = 10
+    threshold: float = 0.7
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    def _get_relevant_documents(
+        self,
+        query: str,
+        *,
+        run_manager: CallbackManagerForRetrieverRun | None = None,
+    ) -> list[Document]:
+        """Sync retrieval. Only usable outside a running event loop.
+
+        Neo4j Agent Memory is async and its driver is loop-bound, so rather than
+        spawning a thread with its own loop (which races the caller's driver) we
+        refuse and point at ``ainvoke``.
         """
-        LangChain retriever that searches across all memory types.
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            return asyncio.run(self._retrieve(query))
 
-        Example:
-            from neo4j_agent_memory import MemoryClient, MemorySettings
-            from neo4j_agent_memory.integrations.langchain import Neo4jMemoryRetriever
+        msg = (
+            "Neo4jMemoryRetriever.invoke() cannot be used from inside a running "
+            "event loop. Use `await retriever.ainvoke(query)` instead."
+        )
+        raise RuntimeError(msg)
 
-            async with MemoryClient(settings) as client:
-                retriever = Neo4jMemoryRetriever(memory_client=client)
-                docs = retriever.invoke("Italian restaurants")
-        """
+    async def _aget_relevant_documents(
+        self,
+        query: str,
+        *,
+        run_manager: AsyncCallbackManagerForRetrieverRun | None = None,
+    ) -> list[Document]:
+        """Async retrieval hook — the one LangChain's ``ainvoke`` calls."""
+        return await self._retrieve(query)
 
-        memory_client: Any  # MemoryClient
-        search_short_term: bool = True
-        search_long_term: bool = True
-        search_reasoning: bool = True
-        k: int = 10
-        threshold: float = 0.7
+    async def _retrieve(self, query: str) -> list[Document]:
+        """Search every enabled memory layer and merge the hits by similarity."""
+        documents: list[Document] = []
 
-        class Config:
-            """Pydantic configuration."""
+        if self.search_short_term:
+            documents.extend(await self._search_messages(query))
 
-            arbitrary_types_allowed = True
+        if self.search_long_term:
+            documents.extend(await self._search_entities(query))
+            documents.extend(await self._search_preferences(query))
 
-        def _get_relevant_documents(
-            self,
-            query: str,
-            *,
-            run_manager: CallbackManagerForRetrieverRun | None = None,
-        ) -> list[Document]:
-            """
-            Retrieve relevant memory documents.
+        if self.search_reasoning:
+            documents.extend(await self._search_traces(query))
 
-            This is a sync wrapper that creates an event loop if needed.
-            """
-            import asyncio
+        documents.sort(key=lambda d: d.metadata.get("similarity", 0), reverse=True)
+        return documents[: self.k]
 
-            try:
-                loop = asyncio.get_running_loop()
-            except RuntimeError:
-                loop = None
+    # Deprecated one-release alias for the pre-0.6 coroutine name.
+    _get_relevant_documents_async = _retrieve
 
-            if loop is not None:
-                import concurrent.futures
+    # ----------------------------------------------------------- per-layer
+    async def _search_messages(self, query: str) -> list[Document]:
+        try:
+            messages: list[Message] = await self.memory_client.short_term.search_messages(
+                query,
+                session_id=self.session_id,
+                limit=self.k,
+                threshold=self.threshold,
+            )
+        except NotSupportedError:
+            logger.debug("search_messages unsupported on this backend; skipping")
+            return []
+        except ValueError:
+            # NAMS message search is conversation-scoped and rejects a missing
+            # session id. Skip the layer rather than failing the whole retrieval.
+            logger.warning(
+                "Message search needs a session_id on this backend; "
+                "pass session_id= to Neo4jMemoryRetriever to include messages."
+            )
+            return []
+        return [
+            Document(
+                page_content=msg.content,
+                metadata={
+                    "type": "message",
+                    "role": msg.role.value,
+                    "id": str(msg.id),
+                    "similarity": msg.metadata.get("similarity", 0),
+                },
+            )
+            for msg in messages
+        ]
 
-                with concurrent.futures.ThreadPoolExecutor() as executor:
-                    coro = self._get_relevant_documents_async(query)
-                    future = executor.submit(lambda: asyncio.run(coro))
-                    return future.result()
-            else:
-                return asyncio.run(self._get_relevant_documents_async(query))
-
-        async def _get_relevant_documents_async(self, query: str) -> list[Document]:
-            """Async implementation of _get_relevant_documents."""
-            documents = []
-
-            if self.search_short_term:
-                messages = await self.memory_client.short_term.search_messages(
-                    query, limit=self.k, threshold=self.threshold
+    async def _search_entities(self, query: str) -> list[Document]:
+        try:
+            entities: list[Entity] = await self.memory_client.long_term.search_entities(
+                query, limit=self.k, threshold=self.threshold
+            )
+        except NotSupportedError:
+            logger.debug("search_entities unsupported on this backend; skipping")
+            return []
+        documents = []
+        for entity in entities:
+            content = entity.display_name
+            if entity.description:
+                content += f": {entity.description}"
+            # entity.type may be a string or an enum
+            entity_type = entity.type.value if hasattr(entity.type, "value") else str(entity.type)
+            documents.append(
+                Document(
+                    page_content=content,
+                    metadata={
+                        "type": "entity",
+                        "entity_type": entity_type,
+                        "id": str(entity.id),
+                        "similarity": entity.metadata.get("similarity", 0),
+                    },
                 )
-                for msg in messages:
-                    documents.append(
-                        Document(
-                            page_content=msg.content,
-                            metadata={
-                                "type": "message",
-                                "role": msg.role.value,
-                                "id": str(msg.id),
-                                "similarity": msg.metadata.get("similarity", 0),
-                            },
-                        )
-                    )
+            )
+        return documents
 
-            if self.search_long_term:
-                entities = await self.memory_client.long_term.search_entities(
-                    query, limit=self.k, threshold=self.threshold
+    async def _search_preferences(self, query: str) -> list[Document]:
+        try:
+            preferences: list[Preference] = await self.memory_client.long_term.search_preferences(
+                query, limit=self.k, threshold=self.threshold
+            )
+        except NotSupportedError:
+            logger.debug("search_preferences unsupported on this backend; skipping")
+            return []
+        documents = []
+        for pref in preferences:
+            content = f"[{pref.category}] {pref.preference}"
+            if pref.context:
+                content += f" (context: {pref.context})"
+            documents.append(
+                Document(
+                    page_content=content,
+                    metadata={
+                        "type": "preference",
+                        "category": pref.category,
+                        "id": str(pref.id),
+                        "similarity": pref.metadata.get("similarity", 0),
+                    },
                 )
-                for entity in entities:
-                    content = f"{entity.display_name}"
-                    if entity.description:
-                        content += f": {entity.description}"
-                    # entity.type may be a string or enum
-                    entity_type = (
-                        entity.type.value if hasattr(entity.type, "value") else str(entity.type)
-                    )
-                    documents.append(
-                        Document(
-                            page_content=content,
-                            metadata={
-                                "type": "entity",
-                                "entity_type": entity_type,
-                                "id": str(entity.id),
-                                "similarity": entity.metadata.get("similarity", 0),
-                            },
-                        )
-                    )
+            )
+        return documents
 
-                preferences = await self.memory_client.long_term.search_preferences(
-                    query, limit=self.k, threshold=self.threshold
+    async def _search_traces(self, query: str) -> list[Document]:
+        try:
+            traces: list[ReasoningTrace] = await self.memory_client.reasoning.get_similar_traces(
+                query, limit=max(1, self.k // 2), threshold=self.threshold
+            )
+        except NotSupportedError:
+            logger.debug("get_similar_traces unsupported on this backend; skipping")
+            return []
+        documents = []
+        for trace in traces:
+            content = f"Task: {trace.task}"
+            if trace.outcome:
+                content += f"\nOutcome: {trace.outcome}"
+            documents.append(
+                Document(
+                    page_content=content,
+                    metadata={
+                        "type": "trace",
+                        "success": trace.success,
+                        "id": str(trace.id),
+                        "similarity": trace.metadata.get("similarity", 0),
+                    },
                 )
-                for pref in preferences:
-                    content = f"[{pref.category}] {pref.preference}"
-                    if pref.context:
-                        content += f" (context: {pref.context})"
-                    documents.append(
-                        Document(
-                            page_content=content,
-                            metadata={
-                                "type": "preference",
-                                "category": pref.category,
-                                "id": str(pref.id),
-                                "similarity": pref.metadata.get("similarity", 0),
-                            },
-                        )
-                    )
-
-            if self.search_reasoning:
-                traces = await self.memory_client.reasoning.get_similar_traces(
-                    query, limit=self.k // 2, threshold=self.threshold
-                )
-                for trace in traces:
-                    content = f"Task: {trace.task}"
-                    if trace.outcome:
-                        content += f"\nOutcome: {trace.outcome}"
-                    documents.append(
-                        Document(
-                            page_content=content,
-                            metadata={
-                                "type": "trace",
-                                "success": trace.success,
-                                "id": str(trace.id),
-                                "similarity": trace.metadata.get("similarity", 0),
-                            },
-                        )
-                    )
-
-            # Sort by similarity
-            documents.sort(key=lambda d: d.metadata.get("similarity", 0), reverse=True)
-            return documents[: self.k]
-
-except ImportError:
-    # LangChain not installed
-    pass
+            )
+        return documents

--- a/src/neo4j_agent_memory/integrations/microsoft_agent/__init__.py
+++ b/src/neo4j_agent_memory/integrations/microsoft_agent/__init__.py
@@ -4,6 +4,12 @@ This module provides memory integration for Microsoft's Agent Framework,
 enabling persistent conversation history, entity knowledge, graph-enhanced
 context retrieval, and reasoning trace recording.
 
+Requires the Microsoft Agent Framework 1.x GA line. Install the adapter's
+dependency with ``pip install neo4j-agent-memory[microsoft-agent]`` (which
+pulls ``agent-framework-core``) plus whichever chat client you use — e.g.
+``agent-framework-openai``, ``agent-framework-azure-ai``, or the
+``agent-framework`` meta-package.
+
 Example:
     from neo4j_agent_memory import MemoryClient, MemorySettings
     from neo4j_agent_memory.integrations.microsoft_agent import (
@@ -52,9 +58,15 @@ from neo4j_agent_memory.integrations._passthrough import (
 if TYPE_CHECKING:
     from neo4j_agent_memory.llm import LLMProvider
 
-# Target API version - document for compatibility tracking
-MICROSOFT_AGENT_FRAMEWORK_VERSION = "1.0.0b260212"
-MICROSOFT_AGENT_FRAMEWORK_MIN_VERSION = "1.0.0b260212"
+# Target API version - document for compatibility tracking.
+#
+# The 1.x GA line renamed the two provider base classes this adapter extends
+# (`BaseContextProvider` -> `ContextProvider`, `BaseHistoryProvider` ->
+# `HistoryProvider`); the keyword-only `before_run` / `after_run` signatures are
+# unchanged from the 1.0.0b2 preview. 1.13 is the floor because it is the first
+# GA release carrying the renamed names that we pin against in `pyproject.toml`.
+MICROSOFT_AGENT_FRAMEWORK_VERSION = "1.18.0"
+MICROSOFT_AGENT_FRAMEWORK_MIN_VERSION = "1.13.0"
 
 
 def llm_provider_from_microsoft_agent(model: Any) -> LLMProvider:
@@ -102,7 +114,8 @@ except ImportError as e:
     import warnings
 
     warnings.warn(
-        f"Microsoft Agent Framework integration requires the 'agent-framework' package. "
+        f"Microsoft Agent Framework integration requires the 'agent-framework-core' "
+        f"package at version {MICROSOFT_AGENT_FRAMEWORK_MIN_VERSION} or newer. "
         f"Install with: pip install neo4j-agent-memory[microsoft-agent] "
         f"(Import error: {e})",
         ImportWarning,

--- a/src/neo4j_agent_memory/integrations/microsoft_agent/chat_store.py
+++ b/src/neo4j_agent_memory/integrations/microsoft_agent/chat_store.py
@@ -1,4 +1,4 @@
-"""Microsoft Agent Framework BaseHistoryProvider implementation.
+"""Microsoft Agent Framework HistoryProvider implementation.
 
 Provides Neo4j-backed persistent chat history storage for
 Microsoft Agent Framework agents.
@@ -18,13 +18,13 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 try:
-    from agent_framework import BaseHistoryProvider, Message
+    from agent_framework import HistoryProvider, Message
 
-    class Neo4jChatMessageStore(BaseHistoryProvider):
+    class Neo4jChatMessageStore(HistoryProvider):
         """
         Neo4j-backed implementation of chat history storage.
 
-        Extends BaseHistoryProvider to integrate directly into the agent's
+        Extends HistoryProvider to integrate directly into the agent's
         context provider pipeline. The agent automatically loads history
         before invocation and saves after via before_run/after_run.
 
@@ -103,15 +103,23 @@ try:
             """Get the underlying memory client."""
             return self._client
 
-        async def get_messages(self, session_id: str | None = None, **kwargs: Any) -> list[Message]:
+        async def get_messages(
+            self,
+            session_id: str | None = None,
+            *,
+            state: dict[str, Any] | None = None,
+            **kwargs: Any,
+        ) -> list[Message]:
             """
             Retrieve messages from Neo4j in chronological order.
 
-            Called by BaseHistoryProvider.before_run() to load conversation
+            Called by HistoryProvider.before_run() to load conversation
             history before agent invocation.
 
             Args:
                 session_id: Session ID (uses self._session_id if None).
+                state: Provider-scoped session state supplied by the framework.
+                    Unused — history lives in Neo4j, not in session state.
                 **kwargs: Additional arguments.
 
             Returns:
@@ -136,17 +144,21 @@ try:
             self,
             session_id: str | None,
             messages: Sequence[Message],
+            *,
+            state: dict[str, Any] | None = None,
             **kwargs: Any,
         ) -> None:
             """
             Save messages to Neo4j storage.
 
-            Called by BaseHistoryProvider.after_run() to persist messages
+            Called by HistoryProvider.after_run() to persist messages
             after agent invocation.
 
             Args:
                 session_id: Session ID (uses self._session_id if None).
                 messages: Sequence of Message objects to store.
+                state: Provider-scoped session state supplied by the framework.
+                    Unused — history lives in Neo4j, not in session state.
                 **kwargs: Additional arguments.
             """
             if not messages:

--- a/src/neo4j_agent_memory/integrations/microsoft_agent/context_provider.py
+++ b/src/neo4j_agent_memory/integrations/microsoft_agent/context_provider.py
@@ -1,4 +1,4 @@
-"""Microsoft Agent Framework BaseContextProvider implementation.
+"""Microsoft Agent Framework ContextProvider implementation.
 
 Provides Neo4j-backed context injection and memory extraction for
 Microsoft Agent Framework agents.
@@ -30,15 +30,15 @@ logger = logging.getLogger(__name__)
 try:
     from agent_framework import (
         AgentSession,
-        BaseContextProvider,
+        ContextProvider,
         Message,
         SessionContext,
         SupportsAgentRun,
     )
 
-    class Neo4jContextProvider(BaseContextProvider):
+    class Neo4jContextProvider(ContextProvider):
         """
-        Microsoft Agent Framework BaseContextProvider backed by Neo4j Agent Memory.
+        Microsoft Agent Framework ContextProvider backed by Neo4j Agent Memory.
 
         Provides automatic context injection before agent invocation and memory
         extraction after agent responses. Supports all three memory types:

--- a/src/neo4j_agent_memory/integrations/microsoft_agent/memory.py
+++ b/src/neo4j_agent_memory/integrations/microsoft_agent/memory.py
@@ -1,6 +1,6 @@
 """Microsoft Agent Framework unified memory interface.
 
-Provides a convenience class that combines BaseContextProvider and BaseHistoryProvider
+Provides a convenience class that combines ContextProvider and HistoryProvider
 for easy integration with Microsoft Agent Framework agents.
 """
 
@@ -31,7 +31,7 @@ try:
         """
         Unified memory interface for Microsoft Agent Framework.
 
-        Combines BaseContextProvider and BaseHistoryProvider functionality into
+        Combines ContextProvider and HistoryProvider functionality into
         a single convenient interface. Provides direct access to all three
         memory types (short-term, long-term, reasoning) and GDS algorithms.
 

--- a/src/neo4j_agent_memory/integrations/microsoft_agent/tools.py
+++ b/src/neo4j_agent_memory/integrations/microsoft_agent/tools.py
@@ -35,8 +35,9 @@ try:
         during streaming. No manual ``execute_memory_tool()`` dispatch needed.
 
         .. note::
-            Tool format follows Microsoft Agent Framework conventions.
-            May need updates for GA release.
+            Tool format follows Microsoft Agent Framework conventions
+            (``@tool``-decorated callables returning ``FunctionTool``), as
+            shipped on the 1.x GA line.
 
         Args:
             memory: The Neo4jMicrosoftMemory instance.

--- a/src/neo4j_agent_memory/integrations/microsoft_agent/tracing.py
+++ b/src/neo4j_agent_memory/integrations/microsoft_agent/tracing.py
@@ -37,8 +37,8 @@ try:
         that can be retrieved for similar future tasks.
 
         .. note::
-            Microsoft Agent Framework API - may change before GA.
-            Currently targets v1.0.0b260212.
+            Targets the Microsoft Agent Framework 1.x GA line
+            (``agent-framework-core>=1.13,<2``).
 
         Args:
             memory: The Neo4jMicrosoftMemory instance.

--- a/src/neo4j_agent_memory/integrations/pydantic_ai/__init__.py
+++ b/src/neo4j_agent_memory/integrations/pydantic_ai/__init__.py
@@ -16,15 +16,22 @@ def llm_provider_from_pydantic_ai(model: Any) -> LLMProvider:
     """Translate a Pydantic AI ``Model`` into an :class:`LLMProvider`.
 
     Pydantic AI Models expose ``model_name``; class names like
-    ``OpenAIModel`` / ``AnthropicModel`` provide the provider prefix::
+    ``OpenAIChatModel`` / ``AnthropicModel`` / ``GoogleModel`` (the 2.x
+    names — ``OpenAIModel`` and ``GeminiModel`` are gone) provide the
+    provider prefix::
 
-        from pydantic_ai.models.anthropic import AnthropicModel
+        import os
+
+        from pydantic_ai.models.openai import OpenAIChatModel
         from neo4j_agent_memory.integrations.pydantic_ai import (
             llm_provider_from_pydantic_ai,
         )
 
-        model = AnthropicModel("claude-3-5-sonnet-latest")
+        model = OpenAIChatModel(os.getenv("OPENAI_MODEL", "gpt-5-mini"))
         provider = llm_provider_from_pydantic_ai(model)
+
+    The same model instance can then back both the agent and memory's
+    entity extraction, so you configure credentials once.
     """
     return _passthrough(model)
 

--- a/src/neo4j_agent_memory/integrations/pydantic_ai/memory.py
+++ b/src/neo4j_agent_memory/integrations/pydantic_ai/memory.py
@@ -1,8 +1,23 @@
-"""Pydantic AI integration for neo4j-agent-memory."""
+"""Pydantic AI integration for neo4j-agent-memory.
+
+Targets PydanticAI 2.x (``pydantic-ai-slim>=2.0,<3``, installed by the
+``[pydantic-ai]`` extra). The 2.x shapes used here:
+
+* ``AgentRunResult.output`` — ``.data`` was removed.
+* ``AgentRunResult.usage`` / ``.response`` — properties, not methods.
+* Plain ``async def`` tools (no leading ``RunContext``) are still valid
+  ``Agent(tools=...)`` members, so :func:`create_memory_tools` returns
+  plain callables; wrap them in a
+  :class:`pydantic_ai.toolsets.FunctionToolset` when you want to pass
+  them via ``toolsets=``.
+* ``@agent.instructions`` is the preferred dynamic-prompt hook.
+"""
 
 from collections.abc import Callable
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, TypeVar
+
+from neo4j_agent_memory.schema.models import TraceOutcome
 
 if TYPE_CHECKING:
     from pydantic_ai.agent import AgentRunResult
@@ -22,24 +37,29 @@ class MemoryDependency:
     memory capabilities.
 
     Example:
-        from pydantic_ai import Agent
+        import os
+
+        from pydantic_ai import Agent, RunContext
+        from pydantic_ai.models.openai import OpenAIChatModel
+
         from neo4j_agent_memory import MemoryClient, MemorySettings
         from neo4j_agent_memory.integrations.pydantic_ai import MemoryDependency
 
-        agent = Agent(
-            'openai:gpt-4o',
-            deps_type=MemoryDependency,
-            system_prompt=dynamic_system_prompt,
-        )
+        model = OpenAIChatModel(os.getenv("OPENAI_MODEL", "gpt-5-mini"))
+        agent = Agent(model, deps_type=MemoryDependency)
 
-        async def dynamic_system_prompt(ctx: RunContext[MemoryDependency]) -> str:
-            memory = ctx.deps
-            context = await memory.get_context(ctx.messages[-1].content)
+        # ``instructions`` is the PydanticAI 2.x dynamic-prompt hook;
+        # ``ctx.prompt`` is the user message for this run.
+        @agent.instructions
+        async def memory_context(ctx: RunContext[MemoryDependency]) -> str:
+            context = await ctx.deps.get_context(str(ctx.prompt))
             return f"You are a helpful assistant.\\n\\nContext:\\n{context}"
 
         async with MemoryClient(settings) as client:
             deps = MemoryDependency(client=client, session_id="user-123")
             result = await agent.run("Find me a restaurant", deps=deps)
+            print(result.output)
+            await deps.save_interaction("Find me a restaurant", str(result.output))
     """
 
     client: "MemoryClient"
@@ -137,13 +157,27 @@ def create_memory_tools(memory: "MemoryClient") -> list[Callable[..., Any]]:
     - save_preference: Save a user preference
     - recall_preferences: Get user preferences for a topic
 
+    The tools are plain ``async def`` functions without a leading
+    ``RunContext`` parameter — PydanticAI 2.x accepts those directly in
+    ``Agent(tools=...)``. Pass them as a toolset instead when you want
+    one named, reusable bundle.
+
     Example:
         from pydantic_ai import Agent
+        from pydantic_ai.models.openai import OpenAIChatModel
+        from pydantic_ai.toolsets import FunctionToolset
+
         from neo4j_agent_memory.integrations.pydantic_ai import create_memory_tools
 
         async with MemoryClient(settings) as client:
             tools = create_memory_tools(client)
-            agent = Agent('openai:gpt-4o', tools=tools)
+
+            # Either register them directly ...
+            agent = Agent(OpenAIChatModel("gpt-5-mini"), tools=tools)
+
+            # ... or bundle them as a 2.x toolset.
+            memory_toolset = FunctionToolset(tools, id="memory")
+            agent = Agent(OpenAIChatModel("gpt-5-mini"), toolsets=[memory_toolset])
     """
 
     async def search_memory(
@@ -237,16 +271,18 @@ async def record_agent_trace(
     generate_embeddings: bool = False,
 ) -> "ReasoningTrace":
     """
-    Record a reasoning trace from a PydanticAI RunResult.
+    Record a reasoning trace from a PydanticAI ``AgentRunResult``.
 
     This function extracts tool calls and their results from a completed
     PydanticAI agent run and records them as a reasoning trace in reasoning
-    memory.
+    memory. The trace is completed with a :class:`TraceOutcome` whose
+    metrics carry the run's token usage (``AgentRunResult.usage`` is a
+    property in PydanticAI 2.x).
 
     Args:
         reasoning_memory: The reasoning memory instance to record to
         session_id: Session ID for the trace
-        result: The RunResult from a PydanticAI agent run
+        result: The ``AgentRunResult`` from a PydanticAI agent run
         task: Optional task description (defaults to extracting from messages)
         include_tool_calls: Whether to record individual tool calls
         generate_embeddings: Whether to generate embeddings for steps
@@ -256,9 +292,11 @@ async def record_agent_trace(
 
     Example:
         from pydantic_ai import Agent
+        from pydantic_ai.models.openai import OpenAIChatModel
+
         from neo4j_agent_memory.integrations.pydantic_ai import record_agent_trace
 
-        agent = Agent('openai:gpt-4o')
+        agent = Agent(OpenAIChatModel("gpt-5-mini"))
         result = await agent.run("Find restaurants near me")
 
         # Record the trace
@@ -301,7 +339,7 @@ async def record_agent_trace(
         task=task,
         metadata={
             "source": "pydantic_ai",
-            "model": getattr(result, "model", None),
+            "model": _run_model_name(result),
         },
     )
 
@@ -362,16 +400,47 @@ async def record_agent_trace(
                 error=str(tool_result) if is_error else None,
             )
 
-    # Complete the trace with the final output
-    final_output = str(result.data) if hasattr(result, "data") else None
+    # Complete the trace with the final output. PydanticAI 2.x exposes the
+    # run output as ``result.output`` (``.data`` was removed in 1.0) and the
+    # run usage as a property.
+    output = getattr(result, "output", None)
+    final_output = str(output) if output is not None else None
     completed_trace = await reasoning_memory.complete_trace(
         trace.id,
-        outcome=final_output[:1000] if final_output else "Completed",
-        success=True,
+        outcome=TraceOutcome(
+            success=True,
+            summary=final_output[:1000] if final_output else "Completed",
+            metrics=_usage_metrics(result),
+        ),
         generate_step_embeddings=generate_embeddings,
     )
 
     return completed_trace
+
+
+def _run_model_name(result: Any) -> str | None:
+    """Model name for a finished run.
+
+    ``AgentRunResult.response`` (PydanticAI 2.x) is the final
+    ``ModelResponse``; it raises when the history holds no response.
+    """
+    try:
+        return str(result.response.model_name)
+    except Exception:
+        return None
+
+
+def _usage_metrics(result: Any) -> dict[str, float]:
+    """Token/request counters from ``AgentRunResult.usage`` (a 2.x property)."""
+    usage = getattr(result, "usage", None)
+    if usage is None:
+        return {}
+    metrics: dict[str, float] = {}
+    for field in ("input_tokens", "output_tokens", "requests", "tool_calls"):
+        value = getattr(usage, field, None)
+        if isinstance(value, (int, float)):
+            metrics[field] = float(value)
+    return metrics
 
 
 def _format_tool_result(result: Any) -> str:
@@ -431,12 +500,17 @@ def nams_memory_tools(memory: "MemoryClient") -> list[Callable[..., Any]]:
     Example::
 
         from pydantic_ai import Agent
+        from pydantic_ai.models.openai import OpenAIChatModel
+
         from neo4j_agent_memory.integrations.pydantic_ai import (
             nams_memory_tools,
         )
 
         async with MemoryClient(MemorySettings(backend="nams", ...)) as c:
-            agent = Agent("openai:gpt-4o", tools=nams_memory_tools(c))
+            agent = Agent(
+                OpenAIChatModel("gpt-5-mini"),
+                tools=nams_memory_tools(c),
+            )
 
     Returns the base tools followed by the four Platinum tools.
     """

--- a/src/neo4j_agent_memory/integrations/strands/__init__.py
+++ b/src/neo4j_agent_memory/integrations/strands/__init__.py
@@ -6,7 +6,10 @@ memory and knowledge graph operations.
 
 Example:
     from strands import Agent
-    from neo4j_agent_memory.integrations.strands import context_graph_tools
+    from neo4j_agent_memory.integrations.strands import (
+        bedrock_llm_model,
+        context_graph_tools,
+    )
 
     tools = context_graph_tools(
         neo4j_uri=os.environ["NEO4J_URI"],
@@ -15,7 +18,7 @@ Example:
     )
 
     agent = Agent(
-        model="anthropic.claude-sonnet-4-20250514-v1:0",
+        model=bedrock_llm_model(),  # us.anthropic.claude-sonnet-4-6 by default
         tools=tools,
     )
 
@@ -37,10 +40,11 @@ if TYPE_CHECKING:
 def llm_provider_from_strands(model: Any) -> LLMProvider:
     """Translate a Strands Agents model into an :class:`LLMProvider`.
 
-    Strands typically uses Bedrock model identifier strings (e.g.
-    ``"anthropic.claude-sonnet-4-20250514-v1:0"``). Strings without a
-    provider prefix are routed to the ``bedrock/`` provider; objects are
-    introspected via the shared helper.
+    Strands typically uses Bedrock model identifier strings — for current
+    Claude models, a cross-region inference-profile id such as
+    ``"us.anthropic.claude-sonnet-4-6"``. Strings without a ``provider/``
+    prefix are routed to the ``bedrock/`` provider; objects are introspected
+    via the shared helper.
     """
     if isinstance(model, str):
         from neo4j_agent_memory.llm import from_provider
@@ -55,9 +59,12 @@ def llm_provider_from_strands(model: Any) -> LLMProvider:
 
 try:
     from neo4j_agent_memory.integrations.strands.config import (
+        BEDROCK_CLAUDE_BASE_MODELS,
         BEDROCK_EMBEDDING_MODELS,
         BEDROCK_LLM_MODELS,
         StrandsConfig,
+        bedrock_embedding_model,
+        bedrock_llm_model,
     )
     from neo4j_agent_memory.integrations.strands.memory_store import (
         Neo4jMemoryStore,
@@ -78,8 +85,11 @@ try:
         "nams_context_graph_tools",
         "clear_client_cache",
         "StrandsConfig",
+        "BEDROCK_CLAUDE_BASE_MODELS",
         "BEDROCK_EMBEDDING_MODELS",
         "BEDROCK_LLM_MODELS",
+        "bedrock_embedding_model",
+        "bedrock_llm_model",
         "llm_provider_from_strands",
         "Neo4jSessionManager",
         "Neo4jRetrievalConfig",

--- a/src/neo4j_agent_memory/integrations/strands/config.py
+++ b/src/neo4j_agent_memory/integrations/strands/config.py
@@ -209,18 +209,105 @@ def build_nams_settings(
 
 # ---------------------------------------------------------------------------
 # Default Bedrock models for different use cases
+#
+# Model ids rot. Both maps below are *defaults*, not a catalogue: resolve them
+# through `bedrock_llm_model()` / `bedrock_embedding_model()` so a deployment can
+# override the id from the environment without a library release.
+#
+# Verification source for the Claude ids: the Bedrock section of
+# `strands.models._defaults._CONTEXT_WINDOW_LIMITS` plus
+# `strands.models.bedrock.DEFAULT_BEDROCK_MODEL_ID`, read from the
+# strands-agents release this package pins (1.55.1). Those are the ids the SDK
+# we hand them to treats as known-good. What a *specific AWS account and
+# region* can invoke is narrower and not checkable from here — confirm with
+# `aws bedrock list-inference-profiles` / `aws bedrock list-foundation-models`
+# before relying on a default.
 # ---------------------------------------------------------------------------
 
-# Default Bedrock models for different use cases
+#: Env var overriding the resolved Bedrock LLM id (see `bedrock_llm_model`).
+BEDROCK_MODEL_ID_ENV = "BEDROCK_MODEL_ID"
+
+#: Env var overriding the resolved Bedrock embedding id.
+BEDROCK_EMBEDDING_MODEL_ID_ENV = "BEDROCK_EMBEDDING_MODEL_ID"
+
+#: Env var overriding the cross-region inference-profile prefix.
+BEDROCK_INFERENCE_PROFILE_PREFIX_ENV = "BEDROCK_INFERENCE_PROFILE_PREFIX"
+
+#: Cross-region inference-profile prefix applied to the Claude ids below.
+#: Current-generation Claude models on Bedrock are invoked through a
+#: cross-region inference profile — a ``<prefix>.anthropic.…`` id — rather than
+#: the bare foundation-model id. Valid prefixes are region-dependent ("us",
+#: "eu", "apac", "global"); strands' own default model id uses "global".
+DEFAULT_BEDROCK_INFERENCE_PROFILE_PREFIX = "us"
+
+#: Unprefixed Claude ids by family alias. Keys are stable; values track the
+#: current generation and are expected to change between releases.
+BEDROCK_CLAUDE_BASE_MODELS = {
+    # strands' own DEFAULT_BEDROCK_MODEL_ID family, hence the safest default.
+    "claude-sonnet": "anthropic.claude-sonnet-4-6",
+    "claude-opus": "anthropic.claude-opus-5",
+    "claude-haiku": "anthropic.claude-haiku-4-5-20251001-v1:0",
+}
+
+#: Bedrock embedding ids by alias. Only the payload shapes
+#: ``neo4j_agent_memory.embeddings.bedrock.BedrockEmbedder`` knows how to build
+#: are listed — Titan text and Cohere embed v3. Amazon's Nova multimodal
+#: embedding models use a different request/response body and are deliberately
+#: absent: listing one here would hand callers an id the embedder cannot drive.
 BEDROCK_EMBEDDING_MODELS = {
     "titan-v2": "amazon.titan-embed-text-v2:0",  # Recommended, 1024 dimensions
-    "titan-v1": "amazon.titan-embed-text-v1",  # 1536 dimensions
+    "titan-v1": "amazon.titan-embed-text-v1",  # Legacy (v1 generation), 1536 dimensions
     "cohere-english": "cohere.embed-english-v3",  # 1024 dimensions
     "cohere-multilingual": "cohere.embed-multilingual-v3",  # 1024 dimensions
 }
 
+#: Default Bedrock LLM ids, inference-profile-prefixed with
+#: ``DEFAULT_BEDROCK_INFERENCE_PROFILE_PREFIX``. Prefer `bedrock_llm_model()`,
+#: which honours the environment overrides above.
 BEDROCK_LLM_MODELS = {
-    "claude-sonnet": "anthropic.claude-sonnet-4-20250514-v1:0",
-    "claude-haiku": "anthropic.claude-3-haiku-20240307-v1:0",
-    "claude-opus": "anthropic.claude-3-opus-20240229-v1:0",
+    alias: f"{DEFAULT_BEDROCK_INFERENCE_PROFILE_PREFIX}.{base}"
+    for alias, base in BEDROCK_CLAUDE_BASE_MODELS.items()
 }
+
+
+def bedrock_llm_model(alias: str = "claude-sonnet") -> str:
+    """Resolve a Bedrock Claude inference-profile id.
+
+    Precedence: ``BEDROCK_MODEL_ID`` (used verbatim, prefix included), then the
+    ``BEDROCK_INFERENCE_PROFILE_PREFIX``-prefixed default for ``alias``.
+
+    Args:
+        alias: Key in :data:`BEDROCK_CLAUDE_BASE_MODELS`.
+
+    Raises:
+        KeyError: If ``alias`` is unknown and no ``BEDROCK_MODEL_ID`` is set.
+    """
+    override = os.environ.get(BEDROCK_MODEL_ID_ENV)
+    if override:
+        return override
+    base = BEDROCK_CLAUDE_BASE_MODELS[alias]
+    prefix = (
+        os.environ.get(BEDROCK_INFERENCE_PROFILE_PREFIX_ENV)
+        or DEFAULT_BEDROCK_INFERENCE_PROFILE_PREFIX
+    )
+    return f"{prefix}.{base}"
+
+
+def bedrock_embedding_model(alias: str = "titan-v2") -> str:
+    """Resolve a Bedrock embedding model id.
+
+    Precedence: ``BEDROCK_EMBEDDING_MODEL_ID``, then the default for ``alias``.
+    Embedding models are not invoked through inference profiles, so no prefix is
+    applied.
+
+    Args:
+        alias: Key in :data:`BEDROCK_EMBEDDING_MODELS`.
+
+    Raises:
+        KeyError: If ``alias`` is unknown and no ``BEDROCK_EMBEDDING_MODEL_ID``
+            is set.
+    """
+    override = os.environ.get(BEDROCK_EMBEDDING_MODEL_ID_ENV)
+    if override:
+        return override
+    return BEDROCK_EMBEDDING_MODELS[alias]

--- a/src/neo4j_agent_memory/integrations/strands/memory_store.py
+++ b/src/neo4j_agent_memory/integrations/strands/memory_store.py
@@ -22,7 +22,7 @@ try:
     )
 except ImportError as import_error:  # pragma: no cover - exercised via package __init__
     raise ImportError(
-        "strands-agents>=1.44.0 is required for the Strands memory store. "
+        "strands-agents>=1.52 is required for the Strands memory store. "
         "Install with: pip install 'neo4j-agent-memory[strands]'"
     ) from import_error
 

--- a/src/neo4j_agent_memory/integrations/strands/session_manager.py
+++ b/src/neo4j_agent_memory/integrations/strands/session_manager.py
@@ -76,6 +76,17 @@ class Neo4jSessionManager(SessionManager):
     Provide exactly one of ``memory_client`` (bolt or NAMS; left open on
     close unless we connected it) or ``settings`` (a client is
     constructed and owned by the manager).
+
+    Single-``Agent`` scope. The base class registers multi-agent
+    (``MultiAgentInitializedEvent`` / ``AfterNodeCallEvent`` /
+    ``AfterMultiAgentInvocationEvent``) and bidirectional-agent hooks
+    unconditionally, and its implementations of them raise
+    ``NotImplementedError`` naming this class — so attaching this manager to a
+    Strands Graph/Swarm or a ``BidiAgent`` fails at the first dispatch. Those
+    topologies want one of Strands' own repository-backed managers
+    (``FileSessionManager`` / ``S3SessionManager`` / ``RepositorySessionManager``);
+    the "shared brain" pattern this manager is built for is N independent
+    ``Agent`` instances, each with its own manager, over one graph.
     """
 
     def __init__(
@@ -284,6 +295,14 @@ class Neo4jSessionManager(SessionManager):
         so external AfterInvocationEvent hooks observe the final turn while it is
         still un-persisted; hooks that need the persisted message should read it
         on the next turn instead.
+
+        Both orderings hold *within one ``HookOrder`` priority group*: since
+        strands 1.5x, ``HookRegistry.add_callback`` takes a keyword-only
+        ``order`` and sorts by it first (lower runs first), preserving —
+        or, for reverse-dispatch events, inverting — registration order only
+        inside a group. Every callback registered here uses the default
+        priority, so a hook deliberately registered at ``HookOrder.SDK_FIRST``
+        or ``SDK_LAST`` can still straddle our flush.
         """
         super().register_hooks(registry, **kwargs)
         registry.add_callback(AfterInvocationEvent, self._on_after_invocation)

--- a/src/neo4j_agent_memory/integrations/strands/tools.py
+++ b/src/neo4j_agent_memory/integrations/strands/tools.py
@@ -6,7 +6,10 @@ semantic memory, entity retrieval, and knowledge graph operations.
 
 Example:
     from strands import Agent
-    from neo4j_agent_memory.integrations.strands import context_graph_tools
+    from neo4j_agent_memory.integrations.strands import (
+        bedrock_llm_model,
+        context_graph_tools,
+    )
 
     tools = context_graph_tools(
         neo4j_uri=os.environ["NEO4J_URI"],
@@ -16,7 +19,7 @@ Example:
     )
 
     agent = Agent(
-        model="anthropic.claude-sonnet-4-20250514-v1:0",
+        model=bedrock_llm_model(),
         tools=tools,
     )
 """
@@ -704,7 +707,10 @@ def context_graph_tools(
 
     Example:
         from strands import Agent
-        from neo4j_agent_memory.integrations.strands import context_graph_tools
+        from neo4j_agent_memory.integrations.strands import (
+            bedrock_llm_model,
+            context_graph_tools,
+        )
 
         tools = context_graph_tools(
             neo4j_uri="neo4j+s://xxx.databases.neo4j.io",
@@ -714,7 +720,7 @@ def context_graph_tools(
         )
 
         agent = Agent(
-            model="anthropic.claude-sonnet-4-20250514-v1:0",
+            model=bedrock_llm_model(),
             tools=tools,
         )
 
@@ -996,11 +1002,12 @@ def nams_context_graph_tools(
 
         from strands import Agent
         from neo4j_agent_memory.integrations.strands import (
+            bedrock_llm_model,
             nams_context_graph_tools,
         )
 
         tools = nams_context_graph_tools()  # picks up MEMORY_API_KEY from env
-        agent = Agent(model="anthropic.claude-sonnet-4-20250514-v1:0", tools=tools)
+        agent = Agent(model=bedrock_llm_model(), tools=tools)
     """
     from neo4j_agent_memory.integrations.strands.config import resolve_nams_connection
 

--- a/src/neo4j_agent_memory/llm/adapters/anthropic.py
+++ b/src/neo4j_agent_memory/llm/adapters/anthropic.py
@@ -12,6 +12,14 @@ Preferred over LiteLLM for ``anthropic/*`` models because:
 Falls back to :func:`~neo4j_agent_memory.llm.structured.schema_aligned_extract`
 if the tool-use response is malformed.
 
+.. note::
+   The Anthropic SDK 1.x removed ``temperature`` / ``top_p`` / ``top_k`` from
+   ``messages.create()`` (passing one is a :class:`TypeError`), mirroring the
+   API, which rejects sampling parameters on current Claude models. This adapter
+   therefore accepts ``temperature`` for protocol compatibility but does not
+   send it; a non-default value is logged once. Use Anthropic's
+   ``output_config.effort`` knob for the equivalent control.
+
 Install with::
 
     pip install 'neo4j-agent-memory[anthropic]'
@@ -47,6 +55,27 @@ T = TypeVar("T", bound=BaseModel)
 
 
 _DEFAULT_MAX_TOKENS = 4096
+
+_sampling_warning_emitted = False
+
+
+def _note_dropped_temperature(temperature: float) -> None:
+    """Log once when a caller asks for a temperature Anthropic no longer accepts.
+
+    ``messages.create()`` has no ``temperature`` parameter on the anthropic 1.x
+    line, and the API rejects sampling parameters outright on current Claude
+    models, so the value cannot be forwarded. Silence would hide the difference
+    between what the caller asked for and what was sent, so say it once.
+    """
+    global _sampling_warning_emitted
+    if temperature == 0.0 or _sampling_warning_emitted:
+        return
+    _sampling_warning_emitted = True
+    logger.warning(
+        "Anthropic no longer accepts sampling parameters (temperature=%s ignored); "
+        "current Claude models reject them. Use output_config.effort instead.",
+        temperature,
+    )
 
 
 def _strip_provider_prefix(model: str) -> str:
@@ -148,7 +177,7 @@ class AnthropicProvider:
         from neo4j_agent_memory.llm.adapters.anthropic import AnthropicProvider
 
         provider = AnthropicProvider(
-            "anthropic/claude-3-5-sonnet-latest",
+            "anthropic/claude-opus-5",
             api_key="sk-ant-...",
             cache_system=True,  # opt-in prompt caching
         )
@@ -227,12 +256,12 @@ class AnthropicProvider:
         timeout: float | None = None,
     ) -> Completion:
         client = self._ensure_client()
+        _note_dropped_temperature(temperature)
         system, anth_messages = _split_system_message(messages)
         kwargs: dict[str, Any] = {
             "model": self._bare_model,
             "messages": anth_messages,
             "max_tokens": max_tokens if max_tokens is not None else self._default_max_tokens,
-            "temperature": temperature,
         }
         system_param = self._build_system_param(system)
         if system_param is not None:
@@ -281,6 +310,7 @@ class AnthropicProvider:
         :func:`schema_aligned_extract` on tool-use failure.
         """
         client = self._ensure_client()
+        _note_dropped_temperature(temperature)
         system, anth_messages = _split_system_message(messages)
         schema = response_model.model_json_schema()
 
@@ -296,7 +326,6 @@ class AnthropicProvider:
             "model": self._bare_model,
             "messages": anth_messages,
             "max_tokens": self._default_max_tokens,
-            "temperature": temperature,
             "tools": [tool_spec],
             "tool_choice": {"type": "tool", "name": "submit_extraction"},
         }

--- a/src/neo4j_agent_memory/mcp/_common.py
+++ b/src/neo4j_agent_memory/mcp/_common.py
@@ -13,13 +13,22 @@ if TYPE_CHECKING:
 
 
 def _lifespan_context(ctx: Context) -> dict[str, Any]:
-    """Return the lifespan context dict, raising RuntimeError if unavailable."""
-    rc = ctx.request_context
-    if rc is None:
-        raise RuntimeError("MCP request context is not available (no active session)")
-    # rc.lifespan_context is typed as the generic LifespanContextT which resolves to
-    # Any in the FastMCP Context property — cast to dict[str, Any] at this boundary.
-    return cast(dict[str, Any], rc.lifespan_context)
+    """Return the lifespan context dict, raising RuntimeError if unavailable.
+
+    FastMCP 4 exposes the lifespan result directly as ``Context.lifespan_context``
+    (it reads the owning server's cached lifespan result rather than the MCP
+    session's, which matters once this server is mounted under another one).
+    It returns an empty dict when no lifespan ran, which for this server means
+    the tools have nothing to talk to — surface that as a RuntimeError rather
+    than a KeyError deeper in the call.
+    """
+    context: dict[str, Any] = ctx.lifespan_context
+    if not context:
+        raise RuntimeError(
+            "MCP lifespan context is not available (the server was created "
+            "without settings, or no session is active)"
+        )
+    return context
 
 
 def get_client(ctx: Context) -> MemoryClient:

--- a/src/neo4j_agent_memory/mcp/_prompts.py
+++ b/src/neo4j_agent_memory/mcp/_prompts.py
@@ -13,7 +13,6 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from fastmcp.prompts import Message
-from mcp.types import PromptMessage
 
 if TYPE_CHECKING:
     from fastmcp import FastMCP
@@ -35,7 +34,7 @@ def _register_core_prompts(mcp: FastMCP) -> None:
     """Register the core prompt (memory-conversation)."""
 
     @mcp.prompt(name="memory-conversation")
-    def memory_conversation(session_id: str = "") -> list[PromptMessage]:
+    def memory_conversation(session_id: str = "") -> list[Message]:
         """Initialize a memory-aware conversation.
 
         Loads context from memory and instructs Claude on how to use
@@ -71,7 +70,7 @@ def _register_extended_prompts(mcp: FastMCP) -> None:
     """Register extended prompts (memory-reasoning, memory-review)."""
 
     @mcp.prompt(name="memory-reasoning")
-    def memory_reasoning(task: str) -> list[PromptMessage]:
+    def memory_reasoning(task: str) -> list[Message]:
         """Record a reasoning trace for a complex task.
 
         Guides Claude through structured reasoning with step-by-step
@@ -100,7 +99,7 @@ def _register_extended_prompts(mcp: FastMCP) -> None:
         ]
 
     @mcp.prompt(name="memory-review")
-    def memory_review() -> list[PromptMessage]:
+    def memory_review() -> list[Message]:
         """Review stored knowledge and flag contradictions.
 
         Summarizes everything stored in memory: entities, preferences,

--- a/src/neo4j_agent_memory/mcp/_tools.py
+++ b/src/neo4j_agent_memory/mcp/_tools.py
@@ -31,17 +31,22 @@ logger = logging.getLogger(__name__)
 
 
 # ── Tool annotations ──────────────────────────────────────────────────
+#
+# MCP Python SDK 2 (which FastMCP 4 builds on) renamed the ``ToolAnnotations``
+# fields to snake_case. FastMCP still accepts the legacy camelCase spelling via
+# a compatibility shim that can be switched off, so these dicts use the native
+# names. They are serialised back to the wire's camelCase by the SDK.
 
 READ_ANNOTATIONS = {
-    "readOnlyHint": True,
-    "destructiveHint": False,
-    "idempotentHint": True,
+    "read_only_hint": True,
+    "destructive_hint": False,
+    "idempotent_hint": True,
 }
 
 WRITE_ANNOTATIONS = {
-    "readOnlyHint": False,
-    "destructiveHint": False,
-    "idempotentHint": False,
+    "read_only_hint": False,
+    "destructive_hint": False,
+    "idempotent_hint": False,
 }
 
 

--- a/src/neo4j_agent_memory/mcp/server.py
+++ b/src/neo4j_agent_memory/mcp/server.py
@@ -1,11 +1,22 @@
 """MCP Server implementation for Neo4j Agent Memory.
 
-Provides a Model Context Protocol server using FastMCP that exposes
-memory capabilities as tools, resources, and prompts for AI platforms.
+Provides a Model Context Protocol server using FastMCP 4 (MCP Python SDK 2)
+that exposes memory capabilities as tools, resources, and prompts for AI
+platforms.
 
 Supports two tool profiles:
 - Core (6 tools): Essential read/write cycle
 - Extended (16 tools): Full surface with reasoning, entities, graph export
+
+Transports:
+- ``stdio`` — the default; what Claude Desktop, Claude Code, and Cursor use.
+- ``http`` — Streamable HTTP, the single network transport in the current MCP
+  spec. ``streamable-http`` is accepted as an explicit spelling of the same
+  thing.
+- ``sse`` — the legacy HTTP+SSE transport, deprecated in the MCP spec and in
+  FastMCP. Requesting it here logs a warning and serves Streamable HTTP
+  instead; it remains accepted only so existing launch configurations keep
+  starting.
 """
 
 from __future__ import annotations
@@ -21,6 +32,46 @@ if TYPE_CHECKING:
     from neo4j_agent_memory import MemoryClient
 
 logger = logging.getLogger(__name__)
+
+#: Transport names accepted by :func:`run_server` and the ``mcp serve`` CLI.
+TRANSPORTS = ("stdio", "http", "streamable-http", "sse")
+
+#: Transport names that are accepted but no longer serve what they name.
+DEPRECATED_TRANSPORTS = {"sse"}
+
+
+def normalize_transport(transport: str) -> str:
+    """Map a requested transport name onto what FastMCP 4 should actually run.
+
+    ``streamable-http`` and the deprecated ``sse`` both collapse onto ``http``
+    (Streamable HTTP). Requesting ``sse`` logs a deprecation warning: the MCP
+    spec replaced the HTTP+SSE transport with Streamable HTTP, and serving the
+    old one would leave clients on a transport that is going away.
+
+    Args:
+        transport: Requested transport name.
+
+    Returns:
+        Either ``"stdio"`` or ``"http"``.
+
+    Raises:
+        ValueError: If the name is not one of :data:`TRANSPORTS`.
+    """
+    if transport not in TRANSPORTS:
+        raise ValueError(
+            f"Unknown transport {transport!r}. Choose one of: {', '.join(TRANSPORTS)}."
+        )
+    if transport in DEPRECATED_TRANSPORTS:
+        logger.warning(
+            "Transport 'sse' is deprecated (the MCP spec replaced HTTP+SSE with "
+            "Streamable HTTP); serving Streamable HTTP instead. Use "
+            "--transport http."
+        )
+        return "http"
+    if transport == "streamable-http":
+        return "http"
+    return transport
+
 
 try:
     from fastmcp import FastMCP
@@ -102,7 +153,7 @@ try:
                     }
 
         mcp = FastMCP(
-            server_name,
+            name=server_name,
             instructions=get_instructions(profile),
             lifespan=lifespan,
         )
@@ -195,7 +246,7 @@ try:
                 }
 
             self._mcp = FastMCP(
-                server_name,
+                name=server_name,
                 instructions=get_instructions(profile),
                 lifespan=_preconnected_lifespan,
             )
@@ -212,17 +263,36 @@ try:
             register_prompts(self._mcp, profile=profile)
 
         async def run(self) -> None:
-            """Run the MCP server using stdio transport."""
-            await self._mcp.run_async(transport="stdio")
+            """Run the MCP server using stdio transport.
 
-        async def run_sse(self, host: str = "127.0.0.1", port: int = 8080) -> None:
-            """Run the MCP server using SSE transport.
+            The FastMCP startup banner is suppressed: on stdio the host owns
+            stderr, and the banner (which in 4.x also carries a third-party
+            deploy link) only shows up as noise in its logs.
+            """
+            await self._mcp.run_async(transport="stdio", show_banner=False)
+
+        async def run_http(self, host: str = "127.0.0.1", port: int = 8080) -> None:
+            """Run the MCP server using Streamable HTTP transport.
 
             Args:
                 host: Host to bind to.
                 port: Port to listen on.
             """
-            await self._mcp.run_async(transport="sse", host=host, port=port)
+            await self._mcp.run_async(transport="http", host=host, port=port)
+
+        async def run_sse(self, host: str = "127.0.0.1", port: int = 8080) -> None:
+            """Run the MCP server over HTTP. Deprecated alias for :meth:`run_http`.
+
+            The MCP spec replaced the HTTP+SSE transport with Streamable HTTP, so
+            this serves Streamable HTTP and logs a warning rather than starting
+            the legacy transport.
+
+            Args:
+                host: Host to bind to.
+                port: Port to listen on.
+            """
+            normalize_transport("sse")
+            await self.run_http(host=host, port=port)
 
     async def run_server(
         neo4j_uri: str,
@@ -255,7 +325,9 @@ try:
             neo4j_user: Neo4j username.
             neo4j_password: Neo4j password.
             neo4j_database: Neo4j database name.
-            transport: Transport type (stdio, sse, or http).
+            transport: Transport type — ``stdio`` (default), ``http`` /
+                ``streamable-http``, or the deprecated ``sse`` (which serves
+                Streamable HTTP with a warning). See :func:`normalize_transport`.
             host: Host for network transports.
             port: Port for network transports.
             profile: Tool profile ('core' or 'extended').
@@ -331,12 +403,13 @@ try:
             auto_preferences=auto_preferences,
         )
 
-        if transport == "sse":
-            await server.run_async(transport="sse", host=host, port=port)  # ty: ignore[possibly-missing-attribute]  # run_async exists on FastMCP; ty unifies with the ImportError-fallback stubs
-        elif transport == "http":
-            await server.run_async(transport="http", host=host, port=port)  # ty: ignore[possibly-missing-attribute]  # same
+        resolved_transport = normalize_transport(transport)
+        if resolved_transport == "http":
+            await server.run_async(transport="http", host=host, port=port)  # ty: ignore[possibly-missing-attribute]  # run_async exists on FastMCP; ty unifies with the ImportError-fallback stubs
         else:
-            await server.run_async(transport="stdio")  # ty: ignore[possibly-missing-attribute]  # same
+            # show_banner=False: on stdio the MCP host owns stderr, and FastMCP's
+            # startup banner is only noise in its logs.
+            await server.run_async(transport="stdio", show_banner=False)  # ty: ignore[possibly-missing-attribute]  # same
 
 except ImportError:
     # FastMCP not installed — these stubs have different signatures from the real
@@ -395,9 +468,13 @@ def main() -> None:
     )
     parser.add_argument(
         "--transport",
-        choices=["stdio", "sse", "http"],
+        choices=list(TRANSPORTS),
         default="stdio",
-        help="MCP transport type",
+        help=(
+            "MCP transport type: stdio (default) or http (Streamable HTTP). "
+            "'streamable-http' is a synonym for 'http'; 'sse' is deprecated "
+            "and serves Streamable HTTP."
+        ),
     )
     parser.add_argument(
         "--host",

--- a/src/neo4j_agent_memory/memory/long_term.py
+++ b/src/neo4j_agent_memory/memory/long_term.py
@@ -144,6 +144,69 @@ def _deserialize_metadata(metadata_str: str | None) -> dict[str, Any]:
         return {}
 
 
+# Node properties written by ``BackgroundEnrichmentService._update_entity``.
+# They live on the node (not inside the metadata JSON) so Cypher can filter on
+# them; ``_enrichment_metadata`` folds them back into ``Entity.metadata`` so the
+# Python API surfaces them too.
+_ENRICHMENT_NODE_PROPERTIES = (
+    "enriched_description",
+    "enriched_summary",
+    "wikipedia_url",
+    "wikidata_id",
+    "image_url",
+    "enrichment_provider",
+)
+
+# Keys inside the ``enrichment_data`` JSON blob that are renamed on the way out,
+# so ``Entity.metadata`` uses the same names as
+# ``EnrichmentResult.to_entity_attributes()``.
+_ENRICHMENT_DATA_RENAMES = {
+    "description": "enriched_description",
+    "summary": "enriched_summary",
+    "metadata": "enrichment_metadata",
+    "confidence": "enrichment_confidence",
+    "retrieved_at": "enriched_at",
+}
+
+
+def _enrichment_metadata(data: dict[str, Any]) -> dict[str, Any]:
+    """Extract enrichment fields from an entity node into a metadata dict.
+
+    Background enrichment writes its results as node properties plus an
+    ``enrichment_data`` JSON blob (see
+    :meth:`neo4j_agent_memory.enrichment.background.BackgroundEnrichmentService._update_entity`).
+    Without this, every enrichment field was dropped when the node was parsed
+    into an :class:`Entity`, so ``entity.metadata["wikipedia_url"]`` was always
+    missing even after a successful enrichment.
+    """
+    extracted: dict[str, Any] = {}
+
+    raw = data.get("enrichment_data")
+    if isinstance(raw, str):
+        try:
+            parsed = json.loads(raw)
+        except (json.JSONDecodeError, TypeError):
+            parsed = None
+        if isinstance(parsed, dict):
+            for raw_key, value in parsed.items():
+                if value is None:
+                    continue
+                key = str(raw_key)
+                extracted[_ENRICHMENT_DATA_RENAMES.get(key, key)] = value
+
+    # Node properties win over the JSON blob: they are what Cypher reads.
+    for prop in _ENRICHMENT_NODE_PROPERTIES:
+        value = data.get(prop)
+        if value is not None:
+            extracted[prop] = value
+
+    enriched_at = data.get("enriched_at")
+    if enriched_at is not None:
+        extracted["enriched_at"] = _to_python_datetime(enriched_at).isoformat()
+
+    return extracted
+
+
 def _to_python_datetime(neo4j_datetime: Any) -> datetime:
     """Convert Neo4j DateTime to Python datetime."""
     if neo4j_datetime is None:
@@ -2092,6 +2155,9 @@ class LongTermMemory(BaseMemory[Entity], LongTermProtocol):
         metadata = _deserialize_metadata(data.get("metadata"))
         attributes = metadata.pop("attributes", {})
         aliases = metadata.pop("aliases", [])
+        # Surface background-enrichment results (stored as node properties)
+        # through ``entity.metadata`` — see CLAUDE.md implementation note 22.
+        metadata.update(_enrichment_metadata(data))
 
         return Entity(
             id=UUID(data["id"]),

--- a/src/neo4j_agent_memory/resolution/exact.py
+++ b/src/neo4j_agent_memory/resolution/exact.py
@@ -31,14 +31,20 @@ class ExactMatchResolver(BaseResolver):
         *,
         existing_entities: list[str] | None = None,
     ) -> ResolvedEntity:
-        """Resolve entity using exact matching."""
+        """Resolve entity using exact matching.
+
+        ``match_type`` is ``"exact"`` only when a candidate actually matched;
+        the two non-matching paths report ``"none"`` (the same sentinel
+        :class:`~neo4j_agent_memory.resolution.composite.CompositeResolver`
+        uses), so callers can read the field instead of re-comparing names.
+        """
         if not existing_entities:
             return ResolvedEntity(
                 original_name=entity_name,
                 canonical_name=entity_name,
                 entity_type=entity_type,
                 confidence=1.0,
-                match_type="exact",
+                match_type="none",
             )
 
         normalized = self._normalize(entity_name) if not self._case_sensitive else entity_name
@@ -63,7 +69,7 @@ class ExactMatchResolver(BaseResolver):
             canonical_name=entity_name,
             entity_type=entity_type,
             confidence=1.0,
-            match_type="exact",
+            match_type="none",
         )
 
     async def find_matches(

--- a/tests/examples/test_google_cloud_integration.py
+++ b/tests/examples/test_google_cloud_integration.py
@@ -110,7 +110,7 @@ class TestGoogleCloudIntegrationImports:
         from neo4j_agent_memory.embeddings.vertex_ai import VertexAIEmbedder
 
         embedder = VertexAIEmbedder()
-        assert embedder.model == "text-embedding-004"
+        assert embedder.model == "gemini-embedding-001"
         assert embedder.task_type == "RETRIEVAL_DOCUMENT"
         assert embedder.dimensions == 768
 

--- a/tests/integration/nams/test_framework_smoke.py
+++ b/tests/integration/nams/test_framework_smoke.py
@@ -55,7 +55,7 @@ async def test_langchain_smoke(nams_client: MemoryClient, nams_session: str) -> 
     marker = _marker()
 
     async def store() -> None:
-        await memory._save_context_async(
+        await memory.asave_context(
             {"input": f"{marker} founded Acme Corporation in Paris."},
             {"output": "Noted."},
         )

--- a/tests/integration/test_crewai_integration.py
+++ b/tests/integration/test_crewai_integration.py
@@ -10,9 +10,12 @@ import pytest
 
 from neo4j_agent_memory.memory.short_term import MessageRole
 
-# Check if CrewAI is available
+# Check if CrewAI is available. Import the base class from the same module path
+# the adapter uses (`crewai.memory.memory`): crewai 1.x no longer re-exports
+# `Memory` from the `crewai.memory` package, so probing the package would skip
+# every test below even with crewai installed.
 try:
-    from crewai.memory import Memory
+    from crewai.memory.memory import Memory
 
     CREWAI_AVAILABLE = True
 except ImportError:

--- a/tests/integration/test_entity_resolution.py
+++ b/tests/integration/test_entity_resolution.py
@@ -255,8 +255,10 @@ class TestEntityResolutionEdgeCases:
         )
 
         assert result.canonical_name == "Brand New Entity"
-        # When no existing entities, returns itself as canonical with "exact" match type
-        assert result.match_type == "exact"
+        # With no existing entities there is nothing to match: the entity is its
+        # own canonical form and the match type is "none" (only a real hit
+        # reports "exact").
+        assert result.match_type == "none"
 
     @pytest.mark.asyncio
     async def test_resolution_special_characters(self, memory_client):

--- a/tests/integration/test_google_adk_integration.py
+++ b/tests/integration/test_google_adk_integration.py
@@ -297,3 +297,84 @@ class TestGoogleADKMemoryServiceIntegration:
 
         session_memories = await memory_service.get_memories_for_session(session_id)
         assert len(session_memories) == 2
+
+
+@pytest.mark.integration
+class TestGoogleADK2xSessionIngestion:
+    """End-to-end ingestion of a real google-adk 2.x ``Session``."""
+
+    @pytest.mark.asyncio
+    async def test_adk_session_events_round_trip(self, memory_client, session_id):
+        """Events in, ADK MemoryEntry objects out (the load_memory path)."""
+        pytest.importorskip("google.adk", reason="requires the [google-adk] extra")
+
+        from google.adk.events.event import Event
+        from google.adk.memory.base_memory_service import SearchMemoryResponse
+        from google.adk.sessions.session import Session
+        from google.adk.tools import _memory_entry_utils
+        from google.genai import types
+
+        from neo4j_agent_memory.integrations.google_adk import Neo4jMemoryService
+
+        memory_service = Neo4jMemoryService(
+            memory_client=memory_client,
+            user_id="adk-2x-user",
+            include_entities=False,
+            include_preferences=False,
+            extract_on_store=False,
+        )
+
+        session = Session(
+            id=session_id,
+            app_name="memory-demo",
+            user_id="adk-2x-user",
+            events=[
+                Event(
+                    author="user",
+                    content=types.Content(
+                        role="user",
+                        parts=[types.Part(text="Project Alpha ships next Friday.")],
+                    ),
+                ),
+                Event(
+                    author="memory_demo",
+                    content=types.Content(
+                        role="model",
+                        parts=[types.Part(text="Noted: Project Alpha ships next Friday.")],
+                    ),
+                ),
+                # Tool-only event — must not be ingested (#130, defect 2).
+                Event(
+                    author="memory_demo",
+                    content=types.Content(
+                        role="model",
+                        parts=[
+                            types.Part(
+                                function_call=types.FunctionCall(
+                                    name="load_memory", args={"query": "Project Alpha"}
+                                )
+                            )
+                        ],
+                    ),
+                ),
+            ],
+        )
+
+        await memory_service.add_session_to_memory(session)
+
+        conversation = await memory_client.short_term.get_conversation(session_id)
+        assert len(conversation.messages) == 2
+
+        response = await memory_service.search_memory(
+            app_name="memory-demo",
+            user_id="adk-2x-user",
+            query="Project Alpha deadline",
+        )
+
+        assert isinstance(response, SearchMemoryResponse)
+        assert response.memories
+        texts = [_memory_entry_utils.extract_text(entry) for entry in response.memories]
+        assert any("Project Alpha" in text for text in texts)
+        # author/timestamp are what preload_memory renders.
+        assert all(entry.author for entry in response.memories)
+        assert all(entry.custom_metadata["memory_type"] == "message" for entry in response.memories)

--- a/tests/integration/test_langchain_integration.py
+++ b/tests/integration/test_langchain_integration.py
@@ -1,22 +1,31 @@
-"""Integration tests for LangChain integration."""
+"""Integration tests for the LangChain 1.x integration (needs Neo4j).
+
+These drive the adapters against a real database. The LangChain contracts they
+rely on — ``BaseChatMessageHistory``, ``BaseRetriever``, ``AgentMiddleware`` —
+are asserted in ``tests/unit/integrations/test_langchain.py``; here we only care
+that the Cypher round-trips work.
+"""
 
 import pytest
 
-from neo4j_agent_memory.memory.short_term import MessageRole
-
-# Check if langchain is available
+LANGCHAIN_CORE_AVAILABLE = True
 try:
-    from langchain_core.memory import BaseMemory
+    from langchain_core.messages import AIMessage, HumanMessage
+except ImportError:  # pragma: no cover - depends on installed extras
+    LANGCHAIN_CORE_AVAILABLE = False
 
-    LANGCHAIN_AVAILABLE = True
-except ImportError:
-    LANGCHAIN_AVAILABLE = False
+LANGCHAIN_AGENTS_AVAILABLE = True
+try:
+    from langchain.agents import create_agent
+    from langchain_core.language_models.fake_chat_models import GenericFakeChatModel
+except ImportError:  # pragma: no cover - depends on installed extras
+    LANGCHAIN_AGENTS_AVAILABLE = False
 
 
 @pytest.mark.integration
-@pytest.mark.skipif(not LANGCHAIN_AVAILABLE, reason="LangChain not installed")
+@pytest.mark.skipif(not LANGCHAIN_CORE_AVAILABLE, reason="langchain-core not installed")
 class TestNeo4jAgentMemory:
-    """Test Neo4jAgentMemory LangChain integration."""
+    """Test Neo4jAgentMemory against a live Neo4j."""
 
     @pytest.mark.asyncio
     async def test_memory_initialization(self, memory_client, session_id):
@@ -29,8 +38,8 @@ class TestNeo4jAgentMemory:
         )
 
         assert memory.session_id == session_id
-        assert memory.include_episodic is True
-        assert memory.include_semantic is True
+        assert memory.include_short_term is True
+        assert memory.include_long_term is True
         assert memory.include_reasoning is True
 
     @pytest.mark.asyncio
@@ -38,10 +47,7 @@ class TestNeo4jAgentMemory:
         """Test memory_variables property."""
         from neo4j_agent_memory.integrations.langchain import Neo4jAgentMemory
 
-        memory = Neo4jAgentMemory(
-            memory_client=memory_client,
-            session_id=session_id,
-        )
+        memory = Neo4jAgentMemory(memory_client=memory_client, session_id=session_id)
 
         variables = memory.memory_variables
         assert "history" in variables
@@ -51,13 +57,13 @@ class TestNeo4jAgentMemory:
 
     @pytest.mark.asyncio
     async def test_memory_variables_filtered(self, memory_client, session_id):
-        """Test memory_variables with filters."""
+        """Test memory_variables with layers disabled."""
         from neo4j_agent_memory.integrations.langchain import Neo4jAgentMemory
 
         memory = Neo4jAgentMemory(
             memory_client=memory_client,
             session_id=session_id,
-            include_episodic=False,
+            include_short_term=False,
             include_reasoning=False,
         )
 
@@ -74,30 +80,47 @@ class TestNeo4jAgentMemory:
         memory = Neo4jAgentMemory(
             memory_client=memory_client,
             session_id=session_id,
-            include_semantic=False,
+            include_long_term=False,
             include_reasoning=False,
         )
 
-        # Save context
-        memory.save_context(
+        await memory.asave_context(
             {"input": "Hello, I am John"},
             {"output": "Hello John! How can I help you today?"},
         )
 
-        # Load context
-        variables = memory.load_memory_variables({"input": "What is my name?"})
+        variables = await memory.aload_memory_variables({"input": "What is my name?"})
 
         assert "history" in variables
         assert "John" in variables["history"]
         assert "Hello" in variables["history"]
 
     @pytest.mark.asyncio
-    async def test_load_memory_with_semantic(self, memory_client, session_id):
-        """Test loading memory with semantic context."""
+    async def test_chat_message_history_round_trip(self, memory_client, session_id):
+        """aadd_messages / aget_messages / aclear against Neo4j."""
         from neo4j_agent_memory.integrations.langchain import Neo4jAgentMemory
-        from neo4j_agent_memory.memory.long_term import EntityType
 
-        # Add some semantic data
+        memory = Neo4jAgentMemory(memory_client=memory_client, session_id=session_id)
+
+        await memory.aadd_messages(
+            [
+                HumanMessage(content="My name is Alice"),
+                AIMessage(content="Nice to meet you, Alice!"),
+            ]
+        )
+
+        messages = await memory.aget_messages()
+        assert [type(m) for m in messages] == [HumanMessage, AIMessage]
+        assert messages[0].text == "My name is Alice"
+
+        await memory.aclear()
+        assert await memory.aget_messages() == []
+
+    @pytest.mark.asyncio
+    async def test_load_memory_with_long_term(self, memory_client, session_id):
+        """Test loading memory with long-term context."""
+        from neo4j_agent_memory.integrations.langchain import Neo4jAgentMemory
+
         await memory_client.long_term.add_preference(
             category="food",
             preference="I love Italian food",
@@ -105,7 +128,7 @@ class TestNeo4jAgentMemory:
         )
         await memory_client.long_term.add_entity(
             name="Italian Restaurant",
-            entity_type=EntityType.CONCEPT,
+            entity_type="ORGANIZATION",
             resolve=False,
             generate_embedding=True,
         )
@@ -113,22 +136,63 @@ class TestNeo4jAgentMemory:
         memory = Neo4jAgentMemory(
             memory_client=memory_client,
             session_id=session_id,
-            include_episodic=False,
+            include_short_term=False,
             include_reasoning=False,
         )
 
-        variables = memory.load_memory_variables({"input": "food recommendations"})
+        variables = await memory.aload_memory_variables({"input": "food recommendations"})
 
         assert "context" in variables
-        assert "preferences" in variables
-        # Preferences should be a list
         assert isinstance(variables["preferences"], list)
+
+    @pytest.mark.asyncio
+    async def test_empty_conversation_history(self, memory_client, session_id):
+        """Test loading memory with no conversation history."""
+        from neo4j_agent_memory.integrations.langchain import Neo4jAgentMemory
+
+        memory = Neo4jAgentMemory(
+            memory_client=memory_client,
+            session_id=session_id,
+            include_long_term=False,
+            include_reasoning=False,
+        )
+
+        variables = await memory.aload_memory_variables({"input": "Hello"})
+
+        assert isinstance(variables["history"], str)
+
+    @pytest.mark.asyncio
+    async def test_multiple_save_contexts(self, memory_client, session_id):
+        """Test saving multiple contexts in sequence."""
+        from neo4j_agent_memory.integrations.langchain import Neo4jAgentMemory
+
+        memory = Neo4jAgentMemory(
+            memory_client=memory_client,
+            session_id=session_id,
+            include_long_term=False,
+            include_reasoning=False,
+            max_messages=20,
+        )
+
+        exchanges = [
+            ("Hello", "Hi there!"),
+            ("My name is Alice", "Nice to meet you, Alice!"),
+            ("What time is it?", "I don't have access to the current time."),
+        ]
+
+        for user_input, assistant_output in exchanges:
+            await memory.asave_context({"input": user_input}, {"output": assistant_output})
+
+        variables = await memory.aload_memory_variables({"input": "recap"})
+
+        assert "Alice" in variables["history"]
+        assert "Hello" in variables["history"]
 
 
 @pytest.mark.integration
-@pytest.mark.skipif(not LANGCHAIN_AVAILABLE, reason="LangChain not installed")
+@pytest.mark.skipif(not LANGCHAIN_CORE_AVAILABLE, reason="langchain-core not installed")
 class TestNeo4jMemoryRetriever:
-    """Test Neo4jMemoryRetriever LangChain integration."""
+    """Test Neo4jMemoryRetriever against a live Neo4j."""
 
     @pytest.mark.asyncio
     async def test_retriever_initialization(self, memory_client, session_id):
@@ -143,11 +207,11 @@ class TestNeo4jMemoryRetriever:
         assert retriever.session_id == session_id
 
     @pytest.mark.asyncio
-    async def test_retriever_get_relevant_documents(self, memory_client, session_id):
-        """Test retrieving relevant documents."""
+    async def test_retriever_ainvoke(self, memory_client, session_id):
+        """Test retrieving documents through LangChain's async entry point."""
         from neo4j_agent_memory.integrations.langchain import Neo4jMemoryRetriever
+        from neo4j_agent_memory.memory.short_term import MessageRole
 
-        # Add some data
         await memory_client.short_term.add_message(
             session_id,
             MessageRole.USER,
@@ -168,62 +232,44 @@ class TestNeo4jMemoryRetriever:
             session_id=session_id,
         )
 
-        # Get relevant documents
-        docs = retriever.get_relevant_documents("outdoor activities")
+        docs = await retriever.ainvoke("outdoor activities")
 
         assert isinstance(docs, list)
 
 
 @pytest.mark.integration
-@pytest.mark.skipif(not LANGCHAIN_AVAILABLE, reason="LangChain not installed")
-class TestLangChainIntegrationEdgeCases:
-    """Test edge cases for LangChain integration."""
+@pytest.mark.skipif(
+    not LANGCHAIN_AGENTS_AVAILABLE,
+    reason="the `langchain` distribution is not installed",
+)
+class TestNeo4jMemoryMiddleware:
+    """Test Neo4jMemoryMiddleware inside create_agent against a live Neo4j."""
 
     @pytest.mark.asyncio
-    async def test_empty_conversation_history(self, memory_client, session_id):
-        """Test loading memory with no conversation history."""
-        from neo4j_agent_memory.integrations.langchain import Neo4jAgentMemory
+    async def test_agent_turn_is_persisted(self, memory_client, session_id):
+        """One agent turn with a fake model writes both messages to Neo4j."""
+        from neo4j_agent_memory.integrations.langchain import Neo4jMemoryMiddleware
 
-        memory = Neo4jAgentMemory(
-            memory_client=memory_client,
-            session_id=session_id,
-            include_semantic=False,
-            include_reasoning=False,
+        model = GenericFakeChatModel(messages=iter([AIMessage(content="Try Thai Kitchen.")]))
+        agent = create_agent(
+            model,
+            tools=[],
+            system_prompt="You are helpful.",
+            middleware=[
+                Neo4jMemoryMiddleware(
+                    memory_client,
+                    session_id=session_id,
+                    extract_entities=False,
+                )
+            ],
         )
 
-        variables = memory.load_memory_variables({"input": "Hello"})
+        result = await agent.ainvoke({"messages": [("user", "Where should I eat?")]})
 
-        assert "history" in variables
-        # Empty history should be an empty string or contain no messages
-        assert isinstance(variables["history"], str)
-
-    @pytest.mark.asyncio
-    async def test_multiple_save_contexts(self, memory_client, session_id):
-        """Test saving multiple contexts in sequence."""
-        from neo4j_agent_memory.integrations.langchain import Neo4jAgentMemory
-
-        memory = Neo4jAgentMemory(
-            memory_client=memory_client,
-            session_id=session_id,
-            include_semantic=False,
-            include_reasoning=False,
-        )
-
-        # Save multiple exchanges
-        exchanges = [
-            ("Hello", "Hi there!"),
-            ("My name is Alice", "Nice to meet you, Alice!"),
-            ("What time is it?", "I don't have access to the current time."),
+        assert result["messages"][-1].content == "Try Thai Kitchen."
+        conversation = await memory_client.short_term.get_conversation(session_id)
+        stored = [(m.role.value, m.content) for m in conversation.messages]
+        assert stored == [
+            ("user", "Where should I eat?"),
+            ("assistant", "Try Thai Kitchen."),
         ]
-
-        for user_input, assistant_output in exchanges:
-            memory.save_context(
-                {"input": user_input},
-                {"output": assistant_output},
-            )
-
-        # Load and verify
-        variables = memory.load_memory_variables({"input": "recap"})
-
-        assert "Alice" in variables["history"]
-        assert "Hello" in variables["history"]

--- a/tests/integration/test_microsoft_agent_integration.py
+++ b/tests/integration/test_microsoft_agent_integration.py
@@ -894,3 +894,129 @@ class TestEdgeCases:
         # Verify cleared
         conv = await memory.get_conversation()
         assert len(conv) == 0
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(not AGENT_FRAMEWORK_AVAILABLE, reason="Microsoft Agent Framework not installed")
+class TestAgentLoopWiring:
+    """Drive a real ``Agent`` run loop over the Neo4j providers.
+
+    Every other test in this file calls ``before_run`` / ``after_run`` by hand,
+    which is why the 1.x GA rename of ``BaseContextProvider`` ->
+    ``ContextProvider`` went unnoticed: the providers were never handed to an
+    actual agent. These tests assemble the pipeline the way the docs tell users
+    to (``chat_client.as_agent(context_providers=[...])``) against a fake chat
+    client, so a future change to the provider protocol fails here.
+    """
+
+    @staticmethod
+    def _echo_client(reply="Canned reply"):
+        """Build a minimal non-streaming chat client that returns ``reply``."""
+        from agent_framework import BaseChatClient, ChatResponse, Message
+
+        class EchoChatClient(BaseChatClient):
+            """Records what the agent sent it and answers with a canned message."""
+
+            def __init__(self):
+                super().__init__()
+                self.seen_messages = []
+                self.seen_instructions = ""
+
+            def _inner_get_response(self, *, messages, stream, options, **kwargs):
+                self.seen_messages = list(messages)
+                # Provider instructions reach the client through the options
+                # mapping (``Agent`` merges ``SessionContext.instructions`` into
+                # ``chat_options["instructions"]``), not as a system message.
+                self.seen_instructions = options.get("instructions") or ""
+
+                async def _respond():
+                    return ChatResponse(
+                        messages=[Message("assistant", [reply])],
+                        finish_reason="stop",
+                    )
+
+                return _respond()
+
+        return EchoChatClient()
+
+    @pytest.mark.asyncio
+    async def test_context_provider_persists_a_full_turn(self, memory_client, session_id):
+        """One agent.run() writes both the user and assistant message to Neo4j."""
+        from neo4j_agent_memory.integrations.microsoft_agent import Neo4jContextProvider
+
+        provider = Neo4jContextProvider(
+            memory_client=memory_client,
+            session_id=session_id,
+            extract_entities=False,
+            include_reasoning=False,
+        )
+        client = self._echo_client("Hello back")
+        agent = client.as_agent(instructions="Be terse.", context_providers=[provider])
+
+        response = await agent.run("Remember that I like graph databases")
+
+        assert response.text == "Hello back"
+
+        conv = await memory_client.short_term.get_conversation(session_id=session_id)
+        roles = [m.role.value if hasattr(m.role, "value") else str(m.role) for m in conv.messages]
+        contents = [m.content for m in conv.messages]
+        assert roles == ["user", "assistant"]
+        assert contents == ["Remember that I like graph databases", "Hello back"]
+
+    @pytest.mark.asyncio
+    async def test_context_provider_injects_stored_memory(self, memory_client, session_id):
+        """Memory stored before the run reaches the model as instructions."""
+        from neo4j_agent_memory.integrations.microsoft_agent import Neo4jContextProvider
+
+        await memory_client.short_term.add_message(
+            session_id=session_id,
+            role="user",
+            content="I am shopping for a birthday gift for my sister",
+            extract_entities=False,
+            generate_embedding=False,
+        )
+
+        provider = Neo4jContextProvider(
+            memory_client=memory_client,
+            session_id=session_id,
+            extract_entities=False,
+            include_long_term=False,
+            include_reasoning=False,
+        )
+        client = self._echo_client()
+        agent = client.as_agent(context_providers=[provider])
+
+        await agent.run("Any suggestions?")
+
+        assert "Recent Conversation" in client.seen_instructions
+        assert "birthday gift for my sister" in client.seen_instructions
+
+    @pytest.mark.asyncio
+    async def test_chat_store_loads_history_into_the_next_run(self, memory_client, session_id):
+        """The history provider replays earlier turns on the following run."""
+        from neo4j_agent_memory.integrations.microsoft_agent import Neo4jChatMessageStore
+
+        store = Neo4jChatMessageStore(
+            memory_client=memory_client,
+            session_id=session_id,
+            generate_embeddings=False,
+        )
+        client = self._echo_client("Noted")
+        agent = client.as_agent(context_providers=[store])
+
+        await agent.run("First question")
+        await agent.run("Second question")
+
+        # The second run must have replayed turn one before the new input.
+        texts = [m.text for m in client.seen_messages]
+        assert "First question" in texts
+        assert "Noted" in texts
+        assert texts[-1] == "Second question"
+
+        conv = await memory_client.short_term.get_conversation(session_id=session_id)
+        assert [m.content for m in conv.messages] == [
+            "First question",
+            "Noted",
+            "Second question",
+            "Noted",
+        ]

--- a/tests/integration/test_pydantic_ai_integration.py
+++ b/tests/integration/test_pydantic_ai_integration.py
@@ -150,7 +150,7 @@ class TestMemoryTools:
         )
 
         tools = create_memory_tools(memory_client)
-        search_memory = tools[0]
+        search_memory = next(t for t in tools if t.__name__ == "search_memory")
 
         result = await search_memory("outdoor activities")
 
@@ -162,7 +162,7 @@ class TestMemoryTools:
         from neo4j_agent_memory.integrations.pydantic_ai import create_memory_tools
 
         tools = create_memory_tools(memory_client)
-        save_preference = tools[1]
+        save_preference = next(t for t in tools if t.__name__ == "save_preference")
 
         result = await save_preference(
             category="travel",
@@ -185,7 +185,7 @@ class TestMemoryTools:
         )
 
         tools = create_memory_tools(memory_client)
-        recall_preferences = tools[2]
+        recall_preferences = next(t for t in tools if t.__name__ == "recall_preferences")
 
         result = await recall_preferences("beverages")
 
@@ -197,7 +197,7 @@ class TestMemoryTools:
         from neo4j_agent_memory.integrations.pydantic_ai import create_memory_tools
 
         tools = create_memory_tools(memory_client)
-        search_memory = tools[0]
+        search_memory = next(t for t in tools if t.__name__ == "search_memory")
 
         result = await search_memory("xyz123nonexistent")
 
@@ -209,8 +209,51 @@ class TestMemoryTools:
         from neo4j_agent_memory.integrations.pydantic_ai import create_memory_tools
 
         tools = create_memory_tools(memory_client)
-        recall_preferences = tools[2]
+        recall_preferences = next(t for t in tools if t.__name__ == "recall_preferences")
 
         result = await recall_preferences("xyz123nonexistent")
 
         assert "No preferences found" in result
+
+
+@pytest.mark.integration
+class TestRecordAgentTrace:
+    """Record a PydanticAI 2.x run into reasoning memory and read it back."""
+
+    @pytest.mark.asyncio
+    async def test_trace_round_trip(self, memory_client, session_id):
+        """A TestModel run (no network) becomes a readable reasoning trace."""
+        pytest.importorskip("pydantic_ai")
+        from pydantic_ai import Agent
+        from pydantic_ai.models.test import TestModel
+
+        from neo4j_agent_memory.integrations.pydantic_ai import (
+            create_memory_tools,
+            record_agent_trace,
+        )
+
+        tools = create_memory_tools(memory_client)
+        agent = Agent(TestModel(), tools=tools)
+
+        result = await agent.run("Find me a vegetarian restaurant")
+
+        trace = await record_agent_trace(
+            memory_client.reasoning,
+            session_id=session_id,
+            result=result,
+            task="Find restaurant recommendation",
+        )
+
+        read_back = await memory_client.reasoning.get_trace_with_steps(trace.id)
+
+        assert read_back is not None
+        assert read_back.task == "Find restaurant recommendation"
+        assert read_back.success is True
+        # One step per tool call; TestModel exercises every registered tool.
+        assert len(read_back.steps) == len(tools)
+        tool_names = {
+            call.tool_name for step in read_back.steps for call in (step.tool_calls or [])
+        }
+        assert {"search_memory", "save_preference", "recall_preferences"} <= tool_names
+        # 2.x: the outcome summary comes from ``result.output``.
+        assert read_back.outcome

--- a/tests/integration/test_vertex_ai_integration.py
+++ b/tests/integration/test_vertex_ai_integration.py
@@ -63,7 +63,7 @@ class TestVertexAIEmbedderIntegration:
         from neo4j_agent_memory.embeddings.vertex_ai import VertexAIEmbedder
 
         embedder = VertexAIEmbedder(
-            model="text-embedding-004",
+            model="gemini-embedding-001",
             project_id=GCP_PROJECT,
             location="us-central1",
         )
@@ -80,7 +80,7 @@ class TestVertexAIEmbedderIntegration:
         from neo4j_agent_memory.embeddings.vertex_ai import VertexAIEmbedder
 
         embedder = VertexAIEmbedder(
-            model="text-embedding-004",
+            model="gemini-embedding-001",
             project_id=GCP_PROJECT,
         )
 
@@ -102,7 +102,7 @@ class TestVertexAIEmbedderIntegration:
         from neo4j_agent_memory.embeddings.vertex_ai import VertexAIEmbedder
 
         embedder = VertexAIEmbedder(
-            model="text-embedding-004",
+            model="gemini-embedding-001",
             project_id=GCP_PROJECT,
         )
 
@@ -115,7 +115,7 @@ class TestVertexAIEmbedderIntegration:
         from neo4j_agent_memory.embeddings.vertex_ai import VertexAIEmbedder
 
         embedder = VertexAIEmbedder(
-            model="text-embedding-004",
+            model="gemini-embedding-001",
             project_id=GCP_PROJECT,
             task_type="RETRIEVAL_QUERY",
         )
@@ -130,7 +130,7 @@ class TestVertexAIEmbedderIntegration:
         from neo4j_agent_memory.embeddings.vertex_ai import VertexAIEmbedder
 
         embedder = VertexAIEmbedder(
-            model="text-embedding-004",
+            model="gemini-embedding-001",
             project_id=GCP_PROJECT,
             task_type="SEMANTIC_SIMILARITY",
         )
@@ -156,25 +156,50 @@ class TestVertexAIEmbedderIntegration:
         from neo4j_agent_memory.embeddings.vertex_ai import VertexAIEmbedder
 
         embedder = VertexAIEmbedder(
-            model="text-embedding-004",
+            model="gemini-embedding-001",
             project_id=GCP_PROJECT,
         )
 
         assert embedder.dimensions == 768
 
     @pytest.mark.asyncio
-    async def test_gecko_model(self):
-        """Test with textembedding-gecko model."""
+    async def test_text_embedding_005_model(self):
+        """Test with the task-specific text-embedding-005 model."""
         from neo4j_agent_memory.embeddings.vertex_ai import VertexAIEmbedder
 
         embedder = VertexAIEmbedder(
-            model="textembedding-gecko@003",
+            model="text-embedding-005",
             project_id=GCP_PROJECT,
         )
 
-        embedding = await embedder.embed("Test with gecko model")
+        embedding = await embedder.embed("Test with text-embedding-005")
 
         assert len(embedding) == 768
+
+    @pytest.mark.asyncio
+    async def test_native_dimensionality(self):
+        """gemini-embedding-001 returns 3072 dimensions when untruncated."""
+        from neo4j_agent_memory.embeddings.vertex_ai import VertexAIEmbedder
+
+        embedder = VertexAIEmbedder(
+            model="gemini-embedding-001",
+            project_id=GCP_PROJECT,
+            output_dimensionality=None,
+        )
+
+        embedding = await embedder.embed("Test native dimensionality")
+
+        assert embedder.dimensions == 3072
+        assert len(embedding) == 3072
+
+    @pytest.mark.asyncio
+    async def test_retired_model_rejected(self):
+        """The retired text-embedding-004 id fails fast instead of 404ing."""
+        from neo4j_agent_memory.core.exceptions import EmbeddingError
+        from neo4j_agent_memory.embeddings.vertex_ai import VertexAIEmbedder
+
+        with pytest.raises(EmbeddingError, match="retired"):
+            VertexAIEmbedder(model="text-embedding-004", project_id=GCP_PROJECT)
 
 
 @pytest.mark.integration
@@ -191,7 +216,7 @@ class TestVertexAIWithMemoryClientIntegration:
         from neo4j_agent_memory.memory.short_term import MessageRole
 
         embedder = VertexAIEmbedder(
-            model="text-embedding-004",
+            model="gemini-embedding-001",
             project_id=GCP_PROJECT,
         )
 
@@ -226,7 +251,7 @@ class TestVertexAIWithMemoryClientIntegration:
         from neo4j_agent_memory.memory.short_term import MessageRole
 
         embedder = VertexAIEmbedder(
-            model="text-embedding-004",
+            model="gemini-embedding-001",
             project_id=GCP_PROJECT,
         )
 

--- a/tests/unit/embeddings/test_vertex_ai.py
+++ b/tests/unit/embeddings/test_vertex_ai.py
@@ -1,5 +1,6 @@
 """Unit tests for Vertex AI embedder."""
 
+import sys
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -17,11 +18,14 @@ class TestVertexAIEmbedder:
 
         embedder = VertexAIEmbedder()
 
-        assert embedder._model == "text-embedding-004"
+        assert embedder._model == "gemini-embedding-001"
         assert embedder._location == "us-central1"
         assert embedder._project_id is None
-        assert embedder._batch_size == 250
+        # gemini-embedding-001 accepts one text per request.
+        assert embedder._batch_size == 1
         assert embedder._task_type == "RETRIEVAL_DOCUMENT"
+        # 768 by default so vector indexes sized for text-embedding-004 still fit.
+        assert embedder.output_dimensionality == 768
         assert embedder.dimensions == 768
 
     def test_embedder_initialization_custom(self):
@@ -29,14 +33,14 @@ class TestVertexAIEmbedder:
         from neo4j_agent_memory.embeddings.vertex_ai import VertexAIEmbedder
 
         embedder = VertexAIEmbedder(
-            model="textembedding-gecko@003",
+            model="text-multilingual-embedding-002",
             project_id="my-project",
             location="europe-west1",
             batch_size=100,
             task_type="RETRIEVAL_QUERY",
         )
 
-        assert embedder._model == "textembedding-gecko@003"
+        assert embedder._model == "text-multilingual-embedding-002"
         assert embedder._project_id == "my-project"
         assert embedder._location == "europe-west1"
         assert embedder._batch_size == 100
@@ -47,11 +51,11 @@ class TestVertexAIEmbedder:
         """Test dimensions property returns correct value for known models."""
         from neo4j_agent_memory.embeddings.vertex_ai import VertexAIEmbedder
 
-        # Test various models
+        # Default output_dimensionality (768) applies to every model.
         models_and_dims = [
-            ("text-embedding-004", 768),
-            ("textembedding-gecko@003", 768),
-            ("textembedding-gecko-multilingual@001", 768),
+            ("gemini-embedding-001", 768),
+            ("text-embedding-005", 768),
+            ("text-multilingual-embedding-002", 768),
             ("unknown-model", 768),  # Default fallback
         ]
 
@@ -61,12 +65,62 @@ class TestVertexAIEmbedder:
                 f"Model {model} should have {expected_dims} dimensions"
             )
 
-    def test_batch_size_capped_at_limit(self):
-        """Test batch size is capped at Vertex AI limit."""
+    def test_native_dimensions_when_output_dimensionality_disabled(self):
+        """Passing output_dimensionality=None yields the model's native size."""
         from neo4j_agent_memory.embeddings.vertex_ai import VertexAIEmbedder
 
-        embedder = VertexAIEmbedder(batch_size=500)
+        assert VertexAIEmbedder(output_dimensionality=None).dimensions == 3072
+        assert (
+            VertexAIEmbedder(model="text-embedding-005", output_dimensionality=None).dimensions
+            == 768
+        )
+
+    def test_explicit_output_dimensionality(self):
+        """An explicit truncation target drives the reported dimensions."""
+        from neo4j_agent_memory.embeddings.vertex_ai import VertexAIEmbedder
+
+        embedder = VertexAIEmbedder(output_dimensionality=1536)
+        assert embedder.dimensions == 1536
+        assert embedder.output_dimensionality == 1536
+
+    def test_invalid_output_dimensionality_raises(self):
+        """Non-positive truncation targets are rejected."""
+        from neo4j_agent_memory.core.exceptions import EmbeddingError
+        from neo4j_agent_memory.embeddings.vertex_ai import VertexAIEmbedder
+
+        with pytest.raises(EmbeddingError, match="output_dimensionality"):
+            VertexAIEmbedder(output_dimensionality=0)
+
+    @pytest.mark.parametrize(
+        "model",
+        [
+            "text-embedding-004",
+            "textembedding-gecko@003",
+            "textembedding-gecko-multilingual@001",
+        ],
+    )
+    def test_retired_models_raise(self, model):
+        """Retired Vertex AI model ids fail fast with the replacement named."""
+        from neo4j_agent_memory.core.exceptions import EmbeddingError
+        from neo4j_agent_memory.embeddings.vertex_ai import VertexAIEmbedder
+
+        with pytest.raises(EmbeddingError, match="retired"):
+            VertexAIEmbedder(model=model)
+
+        with pytest.raises(EmbeddingError, match="gemini-embedding-001"):
+            VertexAIEmbedder(model=model)
+
+    def test_batch_size_capped_at_limit(self):
+        """Test batch size is capped at the Vertex AI / per-model limit."""
+        from neo4j_agent_memory.embeddings.vertex_ai import VertexAIEmbedder
+
+        # text-embedding-005 allows the full 250-instance request.
+        embedder = VertexAIEmbedder(model="text-embedding-005", batch_size=500)
         assert embedder._batch_size == 250  # Should be capped
+
+        # gemini-embedding-001 allows one instance per request.
+        embedder = VertexAIEmbedder(batch_size=500)
+        assert embedder._batch_size == 1
 
     @pytest.mark.asyncio
     async def test_embed_single_text(self):
@@ -98,13 +152,41 @@ class TestVertexAIEmbedder:
         # Verify TextEmbeddingInput was used
         call_args = mock_model.get_embeddings.call_args[0][0]
         assert len(call_args) == 1
+        # Verify the truncation target is forwarded to the API
+        assert mock_model.get_embeddings.call_args[1]["output_dimensionality"] == 768
+
+    @pytest.mark.asyncio
+    async def test_embed_omits_output_dimensionality_when_disabled(self):
+        """output_dimensionality=None leaves the API call untruncated."""
+        from neo4j_agent_memory.embeddings.vertex_ai import VertexAIEmbedder
+
+        embedder = VertexAIEmbedder(project_id="test-project", output_dimensionality=None)
+
+        mock_embedding = MagicMock()
+        mock_embedding.values = [0.1] * 3072
+        mock_model = MagicMock()
+        mock_model.get_embeddings.return_value = [mock_embedding]
+
+        with (
+            patch("vertexai.init"),
+            patch(
+                "vertexai.language_models.TextEmbeddingModel.from_pretrained",
+                return_value=mock_model,
+            ),
+            patch("asyncio.to_thread", side_effect=lambda fn, *args: fn(*args)),
+        ):
+            result = await embedder.embed("Hello, world!")
+
+        assert len(result) == 3072
+        assert "output_dimensionality" not in mock_model.get_embeddings.call_args[1]
 
     @pytest.mark.asyncio
     async def test_embed_batch(self):
         """Test batch embedding multiple texts."""
         from neo4j_agent_memory.embeddings.vertex_ai import VertexAIEmbedder
 
-        embedder = VertexAIEmbedder(project_id="test-project")
+        # text-embedding-005 batches all three texts into one request.
+        embedder = VertexAIEmbedder(model="text-embedding-005", project_id="test-project")
 
         # Mock embeddings for 3 texts
         mock_embeddings = []
@@ -131,6 +213,31 @@ class TestVertexAIEmbedder:
         mock_model.get_embeddings.assert_called_once()
 
     @pytest.mark.asyncio
+    async def test_embed_batch_one_request_per_text_for_gemini(self):
+        """gemini-embedding-001 is called once per text (API accepts one input)."""
+        from neo4j_agent_memory.embeddings.vertex_ai import VertexAIEmbedder
+
+        embedder = VertexAIEmbedder(project_id="test-project")
+
+        mock_embedding = MagicMock()
+        mock_embedding.values = [0.1] * 768
+        mock_model = MagicMock()
+        mock_model.get_embeddings.return_value = [mock_embedding]
+
+        with (
+            patch("vertexai.init"),
+            patch(
+                "vertexai.language_models.TextEmbeddingModel.from_pretrained",
+                return_value=mock_model,
+            ),
+            patch("asyncio.to_thread", side_effect=lambda fn, *args: fn(*args)),
+        ):
+            result = await embedder.embed_batch(["Text 1", "Text 2", "Text 3"])
+
+        assert len(result) == 3
+        assert mock_model.get_embeddings.call_count == 3
+
+    @pytest.mark.asyncio
     async def test_embed_batch_empty_list(self):
         """Test batch embedding with empty list returns empty list."""
         from neo4j_agent_memory.embeddings.vertex_ai import VertexAIEmbedder
@@ -144,7 +251,9 @@ class TestVertexAIEmbedder:
         """Test that large batches are chunked correctly."""
         from neo4j_agent_memory.embeddings.vertex_ai import VertexAIEmbedder
 
-        embedder = VertexAIEmbedder(project_id="test-project", batch_size=2)
+        embedder = VertexAIEmbedder(
+            model="text-embedding-005", project_id="test-project", batch_size=2
+        )
 
         mock_embedding = MagicMock()
         mock_embedding.values = [0.1] * 768
@@ -161,7 +270,7 @@ class TestVertexAIEmbedder:
             patch("asyncio.to_thread", side_effect=lambda fn, *args: fn(*args)),
         ):
             # 5 texts with batch_size=2 should result in 3 API calls
-            result = await embedder.embed_batch(["T1", "T2", "T3", "T4", "T5"])
+            await embedder.embed_batch(["T1", "T2", "T3", "T4", "T5"])
 
         # Should have made 3 calls: [T1, T2], [T3, T4], [T5]
         assert mock_model.get_embeddings.call_count == 3
@@ -208,23 +317,98 @@ class TestVertexAIEmbedder:
                 embedder._ensure_initialized()
 
 
+class TestVertexAIGenAIFallback:
+    """The google-genai path used when aiplatform 2.x drops vertexai.language_models."""
+
+    def test_legacy_import_failure_falls_back_to_genai(self):
+        """aiplatform 2.x removed vertexai.language_models; the embedder adapts."""
+        pytest.importorskip("google.genai", reason="google-genai not installed")
+
+        from neo4j_agent_memory.embeddings.vertex_ai import VertexAIEmbedder
+
+        embedder = VertexAIEmbedder(project_id="test-project")
+        mock_client = MagicMock()
+
+        with (
+            patch.dict(sys.modules, {"vertexai.language_models": None}),
+            patch("google.genai.Client", return_value=mock_client),
+        ):
+            client = embedder._ensure_initialized()
+
+        assert client is mock_client
+        assert embedder._backend == "genai"
+
+    @pytest.mark.asyncio
+    async def test_embed_uses_genai_client(self):
+        """On the genai backend, embed() calls models.embed_content."""
+        pytest.importorskip("google.genai", reason="google-genai not installed")
+
+        from neo4j_agent_memory.embeddings.vertex_ai import VertexAIEmbedder
+
+        embedder = VertexAIEmbedder(project_id="test-project")
+
+        mock_embedding = MagicMock()
+        mock_embedding.values = [0.2] * 768
+        mock_response = MagicMock()
+        mock_response.embeddings = [mock_embedding]
+        mock_client = MagicMock()
+        mock_client.models.embed_content.return_value = mock_response
+
+        # Pretend initialization already picked the genai backend.
+        embedder._embedding_model = mock_client
+        embedder._backend = "genai"
+
+        with patch("asyncio.to_thread", side_effect=lambda fn, *args: fn(*args)):
+            result = await embedder.embed("Hello")
+
+        assert result == [0.2] * 768
+        kwargs = mock_client.models.embed_content.call_args[1]
+        assert kwargs["model"] == "gemini-embedding-001"
+        assert kwargs["config"].output_dimensionality == 768
+        assert kwargs["config"].task_type == "RETRIEVAL_DOCUMENT"
+
+    def test_genai_missing_raises_install_hint(self):
+        """Without google-genai the fallback reports the install hint."""
+        import builtins
+
+        from neo4j_agent_memory.core.exceptions import EmbeddingError
+        from neo4j_agent_memory.embeddings.vertex_ai import VertexAIEmbedder
+
+        embedder = VertexAIEmbedder()
+        real_import = builtins.__import__
+
+        def no_genai(name, globals=None, locals=None, fromlist=(), level=0):
+            if name == "google" and fromlist and "genai" in fromlist:
+                raise ImportError("No module named 'google.genai'")
+            return real_import(name, globals, locals, fromlist, level)
+
+        with (
+            patch.object(builtins, "__import__", no_genai),
+            pytest.raises(EmbeddingError, match="Vertex AI package not installed"),
+        ):
+            embedder._ensure_initialized_genai()
+
+
 class TestVertexAIModelDimensions:
     """Tests for model dimension mappings."""
 
     def test_all_known_models_have_dimensions(self):
-        """Test that all known models have dimension mappings."""
+        """Test that all supported models have dimension mappings."""
         from neo4j_agent_memory.embeddings.vertex_ai import VERTEX_MODEL_DIMENSIONS
 
-        expected_models = [
-            "text-embedding-004",
-            "textembedding-gecko@003",
-            "textembedding-gecko@002",
-            "textembedding-gecko@001",
-            "textembedding-gecko-multilingual@001",
-        ]
+        assert VERTEX_MODEL_DIMENSIONS == {
+            "gemini-embedding-001": 3072,
+            "text-embedding-005": 768,
+            "text-multilingual-embedding-002": 768,
+        }
 
-        for model in expected_models:
-            assert model in VERTEX_MODEL_DIMENSIONS, f"Model {model} should have dimension mapping"
-            assert VERTEX_MODEL_DIMENSIONS[model] == 768, (
-                f"Model {model} should have 768 dimensions"
-            )
+    def test_retired_models_are_not_supported(self):
+        """Retired ids are listed as retired, never as supported."""
+        from neo4j_agent_memory.embeddings.vertex_ai import (
+            RETIRED_VERTEX_MODELS,
+            VERTEX_MODEL_DIMENSIONS,
+        )
+
+        assert RETIRED_VERTEX_MODELS["text-embedding-004"] == "2026-01-14"
+        for model in RETIRED_VERTEX_MODELS:
+            assert model not in VERTEX_MODEL_DIMENSIONS

--- a/tests/unit/integrations/test_google_adk.py
+++ b/tests/unit/integrations/test_google_adk.py
@@ -519,3 +519,468 @@ class TestIssue130Regression:
         await service.add_session_to_memory({"id": "tracked", "messages": []})
         await service.search_memory("q", session_id="explicit")
         assert client.short_term.search_messages.await_args.kwargs["session_id"] == "explicit"
+
+
+class TestADK2xContract:
+    """Conformance with the google-adk 2.x ``BaseMemoryService`` contract.
+
+    google-adk is an optional extra, so every test here skips when it is not
+    installed. What is locked in:
+
+    * the service really is a ``BaseMemoryService`` (so ``Runner`` accepts it);
+    * ``search_memory(*, app_name, user_id, query)`` returns a
+      ``SearchMemoryResponse`` of ADK ``MemoryEntry`` objects whose ``content``
+      is a ``google.genai.types.Content`` with ``author``/``timestamp`` set
+      (what ``load_memory`` / ``preload_memory`` render);
+    * the 2.x-only write paths ``add_events_to_memory`` and the
+      ``add_memory(memories=[...])`` form.
+    """
+
+    @pytest.fixture
+    def adk(self):
+        return pytest.importorskip("google.adk", reason="requires the [google-adk] extra")
+
+    @pytest.fixture
+    def client(self):
+        client = MagicMock()
+        client.backend = "bolt"
+        client.short_term = MagicMock()
+        client.long_term = MagicMock()
+        client.short_term.add_message = AsyncMock(return_value=MagicMock())
+        client.short_term.search_messages = AsyncMock(return_value=[])
+        client.long_term.search_entities = AsyncMock(return_value=[])
+        client.long_term.search_preferences = AsyncMock(return_value=[])
+        return client
+
+    @pytest.fixture
+    def service(self, adk, client):
+        from neo4j_agent_memory.integrations.google_adk import Neo4jMemoryService
+
+        return Neo4jMemoryService(memory_client=client, user_id="u-1")
+
+    def test_is_a_base_memory_service(self, service):
+        """Runner(memory_service=...) type-checks against the ADK ABC."""
+        from google.adk.memory import BaseMemoryService
+
+        assert isinstance(service, BaseMemoryService)
+
+    def test_runner_accepts_the_service(self, service):
+        from google.adk.agents import LlmAgent
+        from google.adk.runners import Runner
+        from google.adk.sessions import InMemorySessionService
+        from google.adk.tools import load_memory
+
+        runner = Runner(
+            app_name="memory-demo",
+            agent=LlmAgent(name="memory_demo", model="gemini-2.5-flash", tools=[load_memory]),
+            session_service=InMemorySessionService(),
+            memory_service=service,
+        )
+        assert runner.memory_service is service
+
+    @pytest.mark.asyncio
+    async def test_add_session_to_memory_ingests_adk_session_events(self, service, client):
+        """A real 2.x Session -> one message per text-bearing event."""
+        from google.adk.events.event import Event
+        from google.adk.sessions.session import Session
+        from google.genai import types
+
+        session = Session(
+            id="adk-2x-session",
+            app_name="memory-demo",
+            user_id="u-1",
+            events=[
+                Event(
+                    author="user",
+                    content=types.Content(
+                        role="user", parts=[types.Part(text="My sister is Sarah.")]
+                    ),
+                ),
+                Event(
+                    author="memory_demo",
+                    content=types.Content(
+                        role="model", parts=[types.Part(text="Noted — Sarah is your sister.")]
+                    ),
+                ),
+                # Tool-only event: must be skipped (#130, defect 2).
+                Event(
+                    author="memory_demo",
+                    content=types.Content(
+                        role="model",
+                        parts=[
+                            types.Part(
+                                function_call=types.FunctionCall(
+                                    name="load_memory", args={"query": "sister"}
+                                )
+                            )
+                        ],
+                    ),
+                ),
+            ],
+        )
+
+        await service.add_session_to_memory(session)
+
+        assert client.short_term.add_message.await_count == 2
+        sessions = {c.kwargs["session_id"] for c in client.short_term.add_message.await_args_list}
+        assert sessions == {"adk-2x-session"}
+        # ADK authors the model turn with the *agent name*; the library only
+        # accepts MessageRole values, so it is stored as "assistant" with the
+        # original author kept in metadata.
+        calls = client.short_term.add_message.await_args_list
+        roles = [c.kwargs["role"] for c in calls]
+        assert roles == ["user", "assistant"]
+        assert calls[0].kwargs["metadata"] is None
+        assert calls[1].kwargs["metadata"] == {"adk_author": "memory_demo"}
+
+    @pytest.mark.asyncio
+    async def test_agent_authored_events_are_stored_not_rejected(self, service, client):
+        """Regression: an agent-named author must not reach MessageRole raw.
+
+        ``short_term.add_message`` validates the role against ``MessageRole``,
+        so passing ADK's author through verbatim dropped every model turn.
+        """
+        from google.adk.events.event import Event
+        from google.genai import types
+
+        await service.add_events_to_memory(
+            app_name="memory-demo",
+            user_id="u-1",
+            events=[
+                Event(
+                    author="supervisor",
+                    content=types.Content(role="model", parts=[types.Part(text="Routed to KYC")]),
+                )
+            ],
+            session_id="s-agent",
+        )
+
+        kwargs = client.short_term.add_message.await_args.kwargs
+        assert kwargs["role"] == "assistant"
+        assert kwargs["metadata"]["adk_author"] == "supervisor"
+
+    @pytest.mark.asyncio
+    async def test_agent_author_survives_the_round_trip(self, service, client):
+        """search_memory() re-attributes the entry to the ADK agent name."""
+        msg = SimpleNamespace(
+            id="msg-2",
+            content="Routed to KYC",
+            role=SimpleNamespace(value="assistant"),
+            created_at=None,
+            metadata={"adk_author": "supervisor"},
+            session_id="s-agent",
+        )
+        client.short_term.search_messages = AsyncMock(return_value=[msg])
+
+        response = await service.search_memory(app_name="a", user_id="u-1", query="kyc")
+
+        entry = response.memories[0]
+        assert entry.author == "supervisor"
+        assert entry.content.role == "model"
+
+    @pytest.mark.asyncio
+    async def test_search_memory_keyword_only_adk_call(self, service, client):
+        """ADK calls search_memory(app_name=, user_id=, query=)."""
+        from google.adk.memory.base_memory_service import SearchMemoryResponse
+
+        response = await service.search_memory(app_name="memory-demo", user_id="u-1", query="q")
+
+        assert isinstance(response, SearchMemoryResponse)
+        assert response.memories == []
+        assert client.short_term.search_messages.await_args.kwargs["query"] == "q"
+
+    @pytest.mark.asyncio
+    async def test_search_memory_returns_adk_memory_entries(self, service, client):
+        """Entries carry Content parts plus author/timestamp/custom_metadata."""
+        from google.adk.memory.memory_entry import MemoryEntry as ADKMemoryEntry
+        from google.adk.tools import _memory_entry_utils
+        from google.genai import types
+
+        created = datetime(2026, 9, 10, 12, 0, 0)
+        msg = SimpleNamespace(
+            id="msg-1",
+            content="My sister is Sarah.",
+            role=SimpleNamespace(value="user"),
+            created_at=created,
+            metadata={"similarity": 0.91},
+            session_id="s-1",
+        )
+        pref = SimpleNamespace(
+            id="pref-1",
+            category="scheduling",
+            preference="Prefers morning meetings",
+            context=None,
+            created_at=created,
+        )
+        client.short_term.search_messages = AsyncMock(return_value=[msg])
+        client.long_term.search_preferences = AsyncMock(return_value=[pref])
+
+        response = await service.search_memory(app_name="a", user_id="u-1", query="sister")
+
+        assert all(isinstance(e, ADKMemoryEntry) for e in response.memories)
+        assert all(isinstance(e.content, types.Content) for e in response.memories)
+        # preload_memory/load_memory read the text through this helper.
+        texts = [_memory_entry_utils.extract_text(e) for e in response.memories]
+        assert "My sister is Sarah." in texts
+        assert "[scheduling] Prefers morning meetings" in texts
+
+        by_author = {e.author: e for e in response.memories}
+        assert by_author["user"].content.role == "user"
+        assert by_author["user"].timestamp == created.isoformat()
+        assert by_author["user"].custom_metadata["memory_type"] == "message"
+        assert by_author["user"].custom_metadata["score"] == 0.91
+        # Long-term recall is attributed to its memory type, not a chat role.
+        assert by_author["preference"].content.role == "model"
+        assert by_author["preference"].custom_metadata["category"] == "scheduling"
+
+    @pytest.mark.asyncio
+    async def test_add_events_to_memory_delta(self, service, client):
+        """Context.add_events_to_memory(events=...) ingests just those events."""
+        from google.adk.events.event import Event
+        from google.genai import types
+
+        events = [
+            Event(
+                author="user",
+                content=types.Content(role="user", parts=[types.Part(text="Turn two text")]),
+            ),
+            Event(author="memory_demo", content=None),
+        ]
+
+        await service.add_events_to_memory(
+            app_name="memory-demo",
+            user_id="u-1",
+            events=events,
+            session_id="delta-session",
+            custom_metadata={"turn": 2},
+        )
+
+        client.short_term.add_message.assert_awaited_once()
+        kwargs = client.short_term.add_message.await_args.kwargs
+        assert kwargs["session_id"] == "delta-session"
+        assert kwargs["content"] == "Turn two text"
+        assert kwargs["metadata"] == {"turn": 2}
+
+    @pytest.mark.asyncio
+    async def test_add_memory_adk_form(self, service, client):
+        """add_memory(app_name=, user_id=, memories=[MemoryEntry]) writes messages."""
+        from google.adk.memory.memory_entry import MemoryEntry as ADKMemoryEntry
+        from google.genai import types
+
+        await service.add_session_to_memory({"id": "tracked-session", "messages": []})
+        client.short_term.add_message.reset_mock()
+
+        result = await service.add_memory(
+            app_name="memory-demo",
+            user_id="u-1",
+            memories=[
+                ADKMemoryEntry(
+                    content=types.Content(
+                        role="user", parts=[types.Part(text="Remember the Q3 deadline")]
+                    ),
+                    author="user",
+                ),
+            ],
+        )
+
+        assert result is None  # the ADK form returns nothing
+        kwargs = client.short_term.add_message.await_args.kwargs
+        assert kwargs["session_id"] == "tracked-session"  # falls back to the tracked session
+        assert kwargs["role"] == "user"
+        assert kwargs["content"] == "Remember the Q3 deadline"
+
+    @pytest.mark.asyncio
+    async def test_add_memory_convenience_form_still_returns_an_entry(self, service, client):
+        """The 0.5.0 convenience form is unchanged."""
+        pref = SimpleNamespace(
+            id="pref-1",
+            category="ui",
+            preference="Dark mode",
+            context=None,
+            created_at=None,
+        )
+        client.long_term.add_preference = AsyncMock(return_value=pref)
+
+        entry = await service.add_memory(
+            content="Dark mode", memory_type="preference", category="ui"
+        )
+
+        assert entry is not None
+        assert entry.memory_type == "preference"
+
+    @pytest.mark.asyncio
+    async def test_add_memory_without_content_or_memories_is_a_noop(self, service, client):
+        assert await service.add_memory() is None
+        client.short_term.add_message.assert_not_awaited()
+
+
+class TestWithoutGoogleADKInstalled:
+    """The adapter must import and search without the optional extra.
+
+    ``google-adk`` is optional, so ``memory_service`` falls back to local
+    stand-ins with the same attribute shape (``SearchMemoryResponse.memories``,
+    ``MemoryEntry.content.parts[*].text``, ``author``, ``timestamp``).
+    """
+
+    @pytest.fixture
+    def no_adk_module(self, monkeypatch):
+        import builtins
+        import importlib
+        import sys
+
+        real_import = builtins.__import__
+
+        def fake_import(name, *args, **kwargs):
+            if name.startswith(("google.adk", "google.genai")):
+                raise ImportError(f"blocked for test: {name}")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", fake_import)
+        for name in [
+            m for m in list(sys.modules) if m.startswith("neo4j_agent_memory.integrations")
+        ]:
+            monkeypatch.delitem(sys.modules, name, raising=False)
+
+        return importlib.import_module("neo4j_agent_memory.integrations.google_adk.memory_service")
+
+    def test_falls_back_to_local_stand_ins(self, no_adk_module):
+        assert no_adk_module.SearchMemoryResponse.__module__ == no_adk_module.__name__
+        assert no_adk_module.ADKMemoryEntry.__module__ == no_adk_module.__name__
+
+    @pytest.mark.asyncio
+    async def test_search_still_returns_the_same_shape(self, no_adk_module):
+        client = MagicMock()
+        client.backend = "bolt"
+        client.short_term = MagicMock()
+        client.long_term = MagicMock()
+        client.short_term.search_messages = AsyncMock(
+            return_value=[
+                SimpleNamespace(
+                    id="msg-1",
+                    content="No ADK installed here",
+                    role=SimpleNamespace(value="user"),
+                    created_at=datetime(2026, 9, 10, 12, 0, 0),
+                    metadata=None,
+                    session_id="s-1",
+                )
+            ]
+        )
+        client.long_term.search_entities = AsyncMock(return_value=[])
+        client.long_term.search_preferences = AsyncMock(return_value=[])
+
+        service = no_adk_module.Neo4jMemoryService(memory_client=client)
+        response = await service.search_memory(app_name="a", user_id="u", query="adk")
+
+        entry = response.memories[0]
+        assert entry.content.parts[0].text == "No ADK installed here"
+        assert entry.content.role == "user"
+        assert entry.author == "user"
+        assert entry.timestamp == "2026-09-10T12:00:00"
+        assert entry.custom_metadata["memory_type"] == "message"
+
+
+class TestLoadMemoryToolThroughRunner:
+    """The real ADK 2.x plumbing: Runner -> load_memory -> search_memory.
+
+    Uses a scripted ``BaseLlm`` so no API key or network is needed: turn 1 emits
+    a ``load_memory`` function call, turn 2 answers from the tool result.
+    """
+
+    @pytest.mark.asyncio
+    async def test_load_memory_returns_neo4j_backed_entries(self):
+        pytest.importorskip("google.adk", reason="requires the [google-adk] extra")
+
+        from collections.abc import AsyncGenerator
+
+        from google.adk.agents import LlmAgent
+        from google.adk.models.base_llm import BaseLlm
+        from google.adk.models.llm_request import LlmRequest
+        from google.adk.models.llm_response import LlmResponse
+        from google.adk.runners import Runner
+        from google.adk.sessions import InMemorySessionService
+        from google.adk.tools import load_memory
+        from google.genai import types
+
+        from neo4j_agent_memory.integrations.google_adk import Neo4jMemoryService
+
+        class ScriptedLlm(BaseLlm):
+            turn: int = 0
+
+            async def generate_content_async(
+                self, llm_request: LlmRequest, stream: bool = False
+            ) -> AsyncGenerator[LlmResponse, None]:
+                self.turn += 1
+                if self.turn == 1:
+                    yield LlmResponse(
+                        content=types.Content(
+                            role="model",
+                            parts=[
+                                types.Part(
+                                    function_call=types.FunctionCall(
+                                        name="load_memory", args={"query": "sister"}
+                                    )
+                                )
+                            ],
+                        )
+                    )
+                else:
+                    yield LlmResponse(
+                        content=types.Content(
+                            role="model", parts=[types.Part(text="Your sister is Sarah.")]
+                        )
+                    )
+
+        client = MagicMock()
+        client.backend = "bolt"
+        client.short_term = MagicMock()
+        client.long_term = MagicMock()
+        client.short_term.add_message = AsyncMock(return_value=MagicMock())
+        client.short_term.search_messages = AsyncMock(
+            return_value=[
+                SimpleNamespace(
+                    id="m1",
+                    content="My sister is Sarah.",
+                    role=SimpleNamespace(value="user"),
+                    created_at=None,
+                    metadata=None,
+                    session_id="s1",
+                )
+            ]
+        )
+        client.long_term.search_entities = AsyncMock(return_value=[])
+        client.long_term.search_preferences = AsyncMock(return_value=[])
+
+        session_service = InMemorySessionService()
+        runner = Runner(
+            app_name="probe-app",
+            agent=LlmAgent(name="probe", model=ScriptedLlm(model="scripted"), tools=[load_memory]),
+            session_service=session_service,
+            memory_service=Neo4jMemoryService(memory_client=client, user_id="u1"),
+        )
+        session = await session_service.create_session(app_name="probe-app", user_id="u1")
+
+        tool_results = []
+        texts = []
+        try:
+            async for event in runner.run_async(
+                user_id="u1",
+                session_id=session.id,
+                new_message=types.Content(
+                    role="user", parts=[types.Part(text="Who is my sister?")]
+                ),
+            ):
+                for part in event.content.parts if event.content and event.content.parts else []:
+                    if part.text:
+                        texts.append(part.text)
+                    if part.function_response:
+                        tool_results.append(part.function_response.response)
+        finally:
+            await runner.close()
+
+        client.short_term.search_messages.assert_awaited_once()
+        assert client.short_term.search_messages.await_args.kwargs["query"] == "sister"
+        assert texts == ["Your sister is Sarah."]
+        # load_memory wraps our SearchMemoryResponse.memories in its own model.
+        memories = tool_results[0]["result"].memories
+        assert memories[0].content.parts[0].text == "My sister is Sarah."
+        assert memories[0].author == "user"

--- a/tests/unit/integrations/test_langchain.py
+++ b/tests/unit/integrations/test_langchain.py
@@ -1,0 +1,456 @@
+"""Unit tests for the LangChain 1.x integration.
+
+No network and no Neo4j: the memory client is a mock and the agent run uses
+``GenericFakeChatModel``. These tests pin the 1.x contracts the adapters
+implement, and the backend tolerance the hosted NAMS backend needs:
+
+* ``Neo4jAgentMemory`` is a ``langchain_core.chat_history.BaseChatMessageHistory``
+  with a working async surface (``aget_messages`` / ``aadd_messages`` / ``aclear``)
+* ``Neo4jMemoryRetriever`` is a ``BaseRetriever`` whose ``ainvoke`` runs the real
+  coroutine on the caller's loop (no worker thread, no nested ``asyncio.run``)
+* ``Neo4jMemoryMiddleware`` works inside ``langchain.agents.create_agent``
+* all three degrade instead of raising when a layer is bolt-only
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+
+from neo4j_agent_memory.core.exceptions import NotSupportedError
+
+pytest.importorskip("langchain_core", reason="langchain-core not installed")
+
+from langchain_core.chat_history import BaseChatMessageHistory  # noqa: E402
+from langchain_core.messages import (  # noqa: E402
+    AIMessage,
+    ChatMessage,
+    HumanMessage,
+    SystemMessage,
+)
+from langchain_core.retrievers import BaseRetriever  # noqa: E402
+
+from neo4j_agent_memory.integrations.langchain import (  # noqa: E402
+    Neo4jAgentMemory,
+    Neo4jMemoryRetriever,
+)
+
+
+def _memory_message(role: str, content: str) -> SimpleNamespace:
+    """A stand-in for ``neo4j_agent_memory.memory.short_term.Message``."""
+    return SimpleNamespace(
+        id=uuid4(),
+        role=SimpleNamespace(value=role),
+        content=content,
+        metadata={"similarity": 0.9},
+    )
+
+
+@pytest.fixture
+def mock_client() -> MagicMock:
+    """A mock MemoryClient with every layer the adapters touch stubbed."""
+    client = MagicMock()
+    client.short_term = MagicMock()
+    client.long_term = MagicMock()
+    client.reasoning = MagicMock()
+
+    conversation = SimpleNamespace(
+        messages=[
+            _memory_message("user", "I prefer spicy food"),
+            _memory_message("assistant", "Noted."),
+        ]
+    )
+    client.short_term.get_conversation = AsyncMock(return_value=conversation)
+    client.short_term.add_message = AsyncMock(return_value=_memory_message("user", "x"))
+    client.short_term.clear_session = AsyncMock()
+    client.short_term.search_messages = AsyncMock(
+        return_value=[_memory_message("user", "I love Thai curry")]
+    )
+    client.long_term.get_context = AsyncMock(return_value="- likes spicy food")
+    client.long_term.search_entities = AsyncMock(return_value=[])
+    client.long_term.search_preferences = AsyncMock(
+        return_value=[
+            SimpleNamespace(
+                id=uuid4(),
+                category="food",
+                preference="Loves spicy dishes",
+                context=None,
+                metadata={"similarity": 0.8},
+            )
+        ]
+    )
+    client.reasoning.get_similar_traces = AsyncMock(return_value=[])
+    client.get_context = AsyncMock(return_value="- likes spicy food")
+    return client
+
+
+def _nams_error(method: str) -> NotSupportedError:
+    return NotSupportedError(backend="nams", method=method)
+
+
+class TestAdapterContracts:
+    """The adapters implement ABCs that exist in the installed langchain-core."""
+
+    def test_langchain_core_has_no_memory_module(self) -> None:
+        """langchain-core 1.x removed ``BaseMemory``; nothing may target it."""
+        with pytest.raises(ImportError):
+            __import__("langchain_core.memory")
+
+    def test_chat_history_subclass(self) -> None:
+        assert issubclass(Neo4jAgentMemory, BaseChatMessageHistory)
+
+    def test_retriever_subclass(self) -> None:
+        assert issubclass(Neo4jMemoryRetriever, BaseRetriever)
+
+    def test_retriever_defines_the_async_hook_langchain_calls(self) -> None:
+        """LangChain synthesises ``_aget_relevant_documents`` when absent."""
+        assert (
+            Neo4jMemoryRetriever._aget_relevant_documents
+            is not BaseRetriever._aget_relevant_documents
+        )
+
+
+class TestChatMessageHistory:
+    """``BaseChatMessageHistory`` surface."""
+
+    async def test_aget_messages_maps_roles(self, mock_client: MagicMock) -> None:
+        history = Neo4jAgentMemory(memory_client=mock_client, session_id="s1")
+
+        messages = await history.aget_messages()
+
+        assert [type(m) for m in messages] == [HumanMessage, AIMessage]
+        assert messages[0].text == "I prefer spicy food"
+        mock_client.short_term.get_conversation.assert_awaited_once()
+
+    async def test_aadd_messages_writes_each_role(self, mock_client: MagicMock) -> None:
+        history = Neo4jAgentMemory(memory_client=mock_client, session_id="s1")
+
+        await history.aadd_messages(
+            [
+                HumanMessage(content="hello"),
+                AIMessage(content="hi"),
+                SystemMessage(content="be nice"),
+                ChatMessage(content="tool output", role="tool"),
+            ]
+        )
+
+        roles = [call.args[1] for call in mock_client.short_term.add_message.await_args_list]
+        assert roles == ["user", "assistant", "system", "tool"]
+
+    async def test_aadd_messages_skips_empty_content(self, mock_client: MagicMock) -> None:
+        """A tool-call-only AIMessage has no text to store."""
+        history = Neo4jAgentMemory(memory_client=mock_client, session_id="s1")
+
+        await history.aadd_messages(
+            [AIMessage(content="", tool_calls=[{"name": "f", "args": {}, "id": "1"}])]
+        )
+
+        mock_client.short_term.add_message.assert_not_awaited()
+
+    async def test_aclear_clears_the_session(self, mock_client: MagicMock) -> None:
+        history = Neo4jAgentMemory(memory_client=mock_client, session_id="s1")
+
+        await history.aclear()
+
+        mock_client.short_term.clear_session.assert_awaited_once_with("s1")
+
+    async def test_sync_surface_refuses_to_block_a_running_loop(
+        self, mock_client: MagicMock
+    ) -> None:
+        """The pre-1.x code scheduled onto the caller's loop and then blocked it."""
+        history = Neo4jAgentMemory(memory_client=mock_client, session_id="s1")
+
+        with pytest.raises(RuntimeError, match="aget_messages"):
+            _ = history.messages
+        with pytest.raises(RuntimeError, match="aadd_messages"):
+            history.add_messages([HumanMessage(content="x")])
+        with pytest.raises(RuntimeError, match="aclear"):
+            history.clear()
+
+    def test_sync_surface_works_outside_a_loop(self, mock_client: MagicMock) -> None:
+        history = Neo4jAgentMemory(memory_client=mock_client, session_id="s1")
+
+        assert len(history.messages) == 2
+
+    async def test_works_with_runnable_with_message_history(self, mock_client: MagicMock) -> None:
+        """The point of the retarget: it plugs into a langchain-core runnable."""
+        from langchain_core.runnables import RunnableLambda
+        from langchain_core.runnables.history import RunnableWithMessageHistory
+
+        def _echo(payload: dict[str, Any]) -> AIMessage:
+            history_len = len(payload["history"])
+            return AIMessage(content=f"saw {history_len} remembered messages")
+
+        chain_with_history = RunnableWithMessageHistory(
+            RunnableLambda(_echo),
+            lambda session_id: Neo4jAgentMemory(memory_client=mock_client, session_id=session_id),
+            input_messages_key="input",
+            history_messages_key="history",
+        )
+
+        result = await chain_with_history.ainvoke(
+            {"input": "where should I eat?"},
+            config={"configurable": {"session_id": "s1"}},
+        )
+
+        assert result.content == "saw 2 remembered messages"
+        # The runnable persists both the input and the output turn.
+        assert mock_client.short_term.add_message.await_count == 2
+
+
+class TestContextAssembly:
+    """The ``aload_memory_variables`` / ``asave_context`` helper surface."""
+
+    async def test_public_async_names(self, mock_client: MagicMock) -> None:
+        memory = Neo4jAgentMemory(memory_client=mock_client, session_id="s1")
+
+        variables = await memory.aload_memory_variables({"input": "restaurants"})
+
+        assert set(variables) == set(memory.memory_variables)
+        assert variables["preferences"] == [
+            {"category": "food", "preference": "Loves spicy dishes"}
+        ]
+
+    async def test_deprecated_private_aliases_still_work(self, mock_client: MagicMock) -> None:
+        memory = Neo4jAgentMemory(memory_client=mock_client, session_id="s1")
+
+        variables = await memory._load_memory_variables_async({"input": "restaurants"})
+        await memory._save_context_async({"input": "q"}, {"output": "a"})
+
+        assert "history" in variables
+        assert mock_client.short_term.add_message.await_count == 2
+
+    async def test_asave_context_writes_both_turns(self, mock_client: MagicMock) -> None:
+        memory = Neo4jAgentMemory(memory_client=mock_client, session_id="s1")
+
+        await memory.asave_context({"input": "q"}, {"output": "a"})
+
+        roles = [call.args[1] for call in mock_client.short_term.add_message.await_args_list]
+        assert roles == ["user", "assistant"]
+
+
+class TestNamsTolerance:
+    """Bolt-only layers degrade instead of raising on the hosted backend."""
+
+    async def test_preferences_and_traces_degrade(self, mock_client: MagicMock) -> None:
+        mock_client.long_term.search_preferences.side_effect = _nams_error("search_preferences")
+        mock_client.reasoning.get_similar_traces.side_effect = _nams_error("get_similar_traces")
+        memory = Neo4jAgentMemory(memory_client=mock_client, session_id="s1")
+
+        variables = await memory.aload_memory_variables({"input": "restaurants"})
+
+        assert variables["preferences"] == []
+        assert variables["similar_tasks"] == ""
+
+    async def test_long_term_context_falls_back_to_entity_search(
+        self, mock_client: MagicMock
+    ) -> None:
+        """NAMS returns "" from ``long_term.get_context`` but supports entities."""
+        mock_client.long_term.get_context.return_value = ""
+        mock_client.long_term.search_entities.return_value = [
+            SimpleNamespace(
+                id=uuid4(),
+                display_name="Thai Kitchen",
+                full_type="ORGANIZATION:RESTAURANT",
+                description="Favourite Thai place",
+                type="ORGANIZATION",
+                metadata={},
+            )
+        ]
+        memory = Neo4jAgentMemory(memory_client=mock_client, session_id="s1")
+
+        variables = await memory.aload_memory_variables({"input": "restaurants"})
+
+        assert "Thai Kitchen" in variables["context"]
+
+    async def test_retriever_skips_unsupported_layers(self, mock_client: MagicMock) -> None:
+        mock_client.long_term.search_preferences.side_effect = _nams_error("search_preferences")
+        mock_client.reasoning.get_similar_traces.side_effect = _nams_error("get_similar_traces")
+        retriever = Neo4jMemoryRetriever(memory_client=mock_client, session_id="s1")
+
+        docs = await retriever.ainvoke("spicy food")
+
+        assert [d.metadata["type"] for d in docs] == ["message"]
+
+    async def test_retriever_skips_message_search_without_session_id(
+        self, mock_client: MagicMock
+    ) -> None:
+        """NAMS message search is conversation-scoped and raises ValueError."""
+        mock_client.short_term.search_messages.side_effect = ValueError("session_id required")
+        retriever = Neo4jMemoryRetriever(memory_client=mock_client, search_reasoning=False)
+
+        docs = await retriever.ainvoke("spicy food")
+
+        assert [d.metadata["type"] for d in docs] == ["preference"]
+
+
+class TestRetriever:
+    """``BaseRetriever`` surface."""
+
+    async def test_ainvoke_runs_on_the_callers_loop(self, mock_client: MagicMock) -> None:
+        """Regression: the old adapter ran retrieval in a worker thread's loop."""
+        caller_thread = threading.get_ident()
+        caller_loop = asyncio.get_running_loop()
+        observed: dict[str, Any] = {}
+
+        async def _search(query: str, **kwargs: Any) -> list[Any]:
+            observed["thread"] = threading.get_ident()
+            observed["loop"] = asyncio.get_running_loop()
+            return [_memory_message("user", f"hit for {query}")]
+
+        mock_client.short_term.search_messages = AsyncMock(side_effect=_search)
+        retriever = Neo4jMemoryRetriever(
+            memory_client=mock_client,
+            session_id="s1",
+            search_long_term=False,
+            search_reasoning=False,
+        )
+
+        docs = await retriever.ainvoke("spicy food")
+
+        assert observed["thread"] == caller_thread
+        assert observed["loop"] is caller_loop
+        assert docs[0].page_content == "hit for spicy food"
+
+    async def test_session_id_is_threaded_into_message_search(self, mock_client: MagicMock) -> None:
+        retriever = Neo4jMemoryRetriever(memory_client=mock_client, session_id="s1")
+
+        await retriever.ainvoke("spicy food")
+
+        assert mock_client.short_term.search_messages.await_args.kwargs["session_id"] == "s1"
+
+    async def test_invoke_refuses_to_run_inside_a_loop(self, mock_client: MagicMock) -> None:
+        retriever = Neo4jMemoryRetriever(memory_client=mock_client, session_id="s1")
+
+        with pytest.raises(RuntimeError, match="ainvoke"):
+            retriever.invoke("spicy food")
+
+    async def test_results_are_capped_and_sorted(self, mock_client: MagicMock) -> None:
+        retriever = Neo4jMemoryRetriever(memory_client=mock_client, session_id="s1", k=1)
+
+        docs = await retriever.ainvoke("spicy food")
+
+        assert len(docs) == 1
+        assert docs[0].metadata["similarity"] == 0.9
+
+    async def test_deprecated_private_coroutine_alias(self, mock_client: MagicMock) -> None:
+        retriever = Neo4jMemoryRetriever(memory_client=mock_client, session_id="s1")
+
+        docs = await retriever._get_relevant_documents_async("spicy food")
+
+        assert docs
+
+
+class TestMiddleware:
+    """``Neo4jMemoryMiddleware`` inside ``langchain.agents.create_agent``."""
+
+    @pytest.fixture
+    def middleware_cls(self) -> Any:
+        pytest.importorskip(
+            "langchain.agents.middleware",
+            reason="the `langchain` distribution is not installed "
+            "(pip install neo4j-agent-memory[langchain-agents])",
+        )
+        from neo4j_agent_memory.integrations.langchain import Neo4jMemoryMiddleware
+
+        return Neo4jMemoryMiddleware
+
+    async def test_agent_run_injects_context_and_persists_turns(
+        self, mock_client: MagicMock, middleware_cls: Any
+    ) -> None:
+        from langchain.agents import create_agent
+        from langchain_core.language_models.fake_chat_models import GenericFakeChatModel
+
+        prompts: list[list[Any]] = []
+
+        class _Recording(GenericFakeChatModel):
+            def _generate(self, messages: list[Any], *args: Any, **kwargs: Any) -> Any:
+                prompts.append(list(messages))
+                return super()._generate(messages, *args, **kwargs)
+
+        model = _Recording(messages=iter([AIMessage(content="Try Thai Kitchen.")]))
+        agent = create_agent(
+            model,
+            tools=[],
+            system_prompt="You are helpful.",
+            middleware=[middleware_cls(mock_client, session_id="s1")],
+        )
+
+        result = await agent.ainvoke({"messages": [("user", "Where should I eat?")]})
+
+        assert result["messages"][-1].content == "Try Thai Kitchen."
+        # Memory context reached the model via the system message.
+        assert "likes spicy food" in prompts[0][0].text
+        # Both turns were persisted.
+        stored = [
+            (call.args[1], call.args[2])
+            for call in mock_client.short_term.add_message.await_args_list
+        ]
+        assert stored == [
+            ("user", "Where should I eat?"),
+            ("assistant", "Try Thai Kitchen."),
+        ]
+
+    async def test_messages_are_persisted_once_across_model_calls(
+        self, mock_client: MagicMock, middleware_cls: Any
+    ) -> None:
+        """A tool loop re-sends the same history on every model call."""
+        from langchain.agents.middleware import AgentState
+
+        middleware = middleware_cls(mock_client, session_id="s1")
+        state: AgentState[Any] = {
+            "messages": [HumanMessage(content="hi", id="h1"), AIMessage(content="yo", id="a1")]
+        }
+
+        await middleware.abefore_model(state, None)
+        await middleware.aafter_model(state, None)
+        await middleware.abefore_model(state, None)
+        await middleware.aafter_model(state, None)
+
+        assert mock_client.short_term.add_message.await_count == 2
+
+    async def test_sync_hooks_raise_instead_of_silently_skipping_memory(
+        self, mock_client: MagicMock, middleware_cls: Any
+    ) -> None:
+        middleware = middleware_cls(mock_client, session_id="s1")
+
+        with pytest.raises(NotImplementedError, match="ainvoke"):
+            middleware.before_model({"messages": []}, None)
+        with pytest.raises(NotImplementedError, match="ainvoke"):
+            middleware.after_model({"messages": []}, None)
+
+    async def test_no_injection_when_memory_is_empty(
+        self, mock_client: MagicMock, middleware_cls: Any
+    ) -> None:
+        mock_client.get_context.return_value = ""
+        middleware = middleware_cls(mock_client, session_id="s1")
+        original = SimpleNamespace(
+            messages=[HumanMessage(content="hi")],
+            system_message=SystemMessage(content="base"),
+        )
+        seen: list[Any] = []
+
+        async def _handler(request: Any) -> str:
+            seen.append(request)
+            return "response"
+
+        assert await middleware.awrap_model_call(original, _handler) == "response"
+        assert seen == [original]
+
+    async def test_get_context_unsupported_degrades(
+        self, mock_client: MagicMock, middleware_cls: Any
+    ) -> None:
+        mock_client.get_context.side_effect = _nams_error("get_context")
+        middleware = middleware_cls(mock_client, session_id="s1")
+        original = SimpleNamespace(messages=[HumanMessage(content="hi")], system_message=None)
+
+        async def _handler(request: Any) -> str:
+            return "response"
+
+        assert await middleware.awrap_model_call(original, _handler) == "response"

--- a/tests/unit/integrations/test_microsoft_agent.py
+++ b/tests/unit/integrations/test_microsoft_agent.py
@@ -6,7 +6,11 @@ requiring an actual Neo4j database or Microsoft Agent Framework installation.
 
 from __future__ import annotations
 
+import inspect
 import json
+import re
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as package_version
 from typing import TYPE_CHECKING, Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -14,6 +18,93 @@ import pytest
 
 # Skip all tests if agent_framework is not installed
 pytest.importorskip("agent_framework", reason="Microsoft Agent Framework not installed")
+
+
+def _release_tuple(raw: str) -> tuple[int, ...]:
+    """Parse the release segment of a version into a comparable tuple."""
+    match = re.match(r"\d+(?:\.\d+)*", raw.strip())
+    assert match is not None, f"unparseable version: {raw!r}"
+    return tuple(int(part) for part in match.group(0).split("."))
+
+
+class TestAgentFrameworkGAContract:
+    """Guard the Agent Framework 1.x GA surface the adapter is written against.
+
+    The 1.0.0b2 preview exported ``BaseContextProvider`` / ``BaseHistoryProvider``;
+    the GA line renamed both (keeping the keyword-only ``before_run`` /
+    ``after_run`` signatures). Nothing in the old test suite noticed, because
+    every test imported the adapter classes without ever checking what they
+    extend — the integration simply stopped importing. These tests fail loudly
+    on the next such rename.
+    """
+
+    def test_context_provider_extends_ga_base(self) -> None:
+        """Neo4jContextProvider must extend agent_framework.ContextProvider."""
+        from agent_framework import ContextProvider
+
+        from neo4j_agent_memory.integrations.microsoft_agent import Neo4jContextProvider
+
+        assert issubclass(Neo4jContextProvider, ContextProvider)
+
+    def test_chat_store_extends_ga_history_provider(self) -> None:
+        """Neo4jChatMessageStore must extend agent_framework.HistoryProvider."""
+        from agent_framework import HistoryProvider
+
+        from neo4j_agent_memory.integrations.microsoft_agent import Neo4jChatMessageStore
+
+        assert issubclass(Neo4jChatMessageStore, HistoryProvider)
+
+    @pytest.mark.parametrize("hook", ["before_run", "after_run"])
+    def test_context_hook_signature_matches_base(self, hook: str) -> None:
+        """The provider hooks must keep the framework's keyword-only signature."""
+        from agent_framework import ContextProvider
+
+        from neo4j_agent_memory.integrations.microsoft_agent import Neo4jContextProvider
+
+        base_params = inspect.signature(getattr(ContextProvider, hook)).parameters
+        ours = inspect.signature(getattr(Neo4jContextProvider, hook)).parameters
+
+        assert list(ours) == list(base_params)
+        for name, param in base_params.items():
+            assert ours[name].kind == param.kind
+
+    def test_history_provider_hooks_are_inherited(self) -> None:
+        """The chat store relies on HistoryProvider's before_run/after_run."""
+        from agent_framework import HistoryProvider
+
+        from neo4j_agent_memory.integrations.microsoft_agent import Neo4jChatMessageStore
+
+        assert Neo4jChatMessageStore.before_run is HistoryProvider.before_run
+        assert Neo4jChatMessageStore.after_run is HistoryProvider.after_run
+
+    @pytest.mark.parametrize("method", ["get_messages", "save_messages"])
+    def test_history_methods_accept_state_keyword(self, method: str) -> None:
+        """HistoryProvider calls these with ``state=``; both must accept it."""
+        from neo4j_agent_memory.integrations.microsoft_agent import Neo4jChatMessageStore
+
+        params = inspect.signature(getattr(Neo4jChatMessageStore, method)).parameters
+        assert "state" in params
+        assert params["state"].kind is inspect.Parameter.KEYWORD_ONLY
+
+    def test_installed_framework_satisfies_declared_minimum(self) -> None:
+        """The installed agent-framework must be at least MIN_VERSION."""
+        from neo4j_agent_memory.integrations.microsoft_agent import (
+            MICROSOFT_AGENT_FRAMEWORK_MIN_VERSION,
+        )
+
+        for distribution in ("agent-framework-core", "agent-framework"):
+            try:
+                installed = package_version(distribution)
+            except PackageNotFoundError:
+                continue
+            assert _release_tuple(installed) >= _release_tuple(
+                MICROSOFT_AGENT_FRAMEWORK_MIN_VERSION
+            ), (
+                f"{distribution} {installed} is older than the adapter's declared "
+                f"minimum {MICROSOFT_AGENT_FRAMEWORK_MIN_VERSION}"
+            )
+            return
+        pytest.skip("no agent-framework distribution metadata found")
 
 
 class TestNeo4jContextProvider:
@@ -259,6 +350,67 @@ class TestNeo4jChatMessageStore:
 
         assert len(messages) == 2
         assert all(isinstance(m, Message) for m in messages)
+
+    @pytest.mark.asyncio
+    async def test_before_run_loads_history_into_context(
+        self, chat_store: Any, mock_memory_client: MagicMock
+    ) -> None:
+        """The inherited before_run must load Neo4j history into the context.
+
+        This drives the real ``HistoryProvider.before_run``, which calls
+        ``get_messages(session_id, state=state)`` — so it fails if the
+        framework's loading contract drifts away from our signature.
+        """
+        from agent_framework import SessionContext
+
+        stored = MagicMock()
+        stored.role = MagicMock(value="user")
+        stored.content = "Earlier question"
+        stored.metadata = None
+        mock_conv = MagicMock()
+        mock_conv.messages = [stored]
+        mock_memory_client.short_term.get_conversation = AsyncMock(return_value=mock_conv)
+
+        context = SessionContext(session_id="chat-session-123", input_messages=[])
+
+        await chat_store.before_run(
+            agent=MagicMock(),
+            session=MagicMock(),
+            context=context,
+            state={},
+        )
+
+        loaded = context.get_messages(sources={chat_store.source_id})
+        assert [m.text for m in loaded] == ["Earlier question"]
+
+    @pytest.mark.asyncio
+    async def test_after_run_persists_inputs_and_outputs(
+        self, chat_store: Any, mock_memory_client: MagicMock
+    ) -> None:
+        """The inherited after_run must persist both input and response messages."""
+        from agent_framework import AgentResponse, Message, SessionContext
+
+        mock_memory_client.short_term.add_message = AsyncMock()
+
+        context = SessionContext(
+            session_id="chat-session-123",
+            input_messages=[Message("user", ["Hello"])],
+        )
+        response = MagicMock(spec=AgentResponse)
+        response.messages = [Message("assistant", ["Hi!"])]
+        context._response = response
+
+        await chat_store.after_run(
+            agent=MagicMock(),
+            session=MagicMock(),
+            context=context,
+            state={},
+        )
+
+        roles = [
+            call.kwargs["role"] for call in mock_memory_client.short_term.add_message.call_args_list
+        ]
+        assert roles == ["user", "assistant"]
 
     @pytest.mark.asyncio
     async def test_serialize_deserialize(

--- a/tests/unit/integrations/test_pydantic_ai.py
+++ b/tests/unit/integrations/test_pydantic_ai.py
@@ -1,0 +1,251 @@
+"""Unit tests for the PydanticAI integration against the 2.x API.
+
+These tests never reach the network: agent runs use
+``pydantic_ai.models.test.TestModel`` and the memory client is a mock.
+They pin the PydanticAI 2.x shapes the integration depends on:
+
+* ``AgentRunResult.output`` (``.data`` is gone)
+* ``AgentRunResult.usage`` / ``.response`` as properties
+* plain (no ``RunContext``) tool functions in ``Agent(tools=...)``
+* ``FunctionToolset`` for the ``toolsets=`` registration path
+* ``@agent.instructions`` as the dynamic-prompt hook, with ``ctx.prompt``
+"""
+
+from __future__ import annotations
+
+import inspect
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+
+from neo4j_agent_memory.integrations.pydantic_ai import (
+    MemoryDependency,
+    create_memory_tools,
+    record_agent_trace,
+)
+from neo4j_agent_memory.schema.models import TraceOutcome
+
+pydantic_ai = pytest.importorskip("pydantic_ai", reason="pydantic-ai not installed")
+
+
+@pytest.fixture
+def mock_client() -> MagicMock:
+    """A mock MemoryClient with every layer the tools touch stubbed."""
+    client = MagicMock()
+    client.short_term = MagicMock()
+    client.long_term = MagicMock()
+    client.reasoning = MagicMock()
+    client.get_context = AsyncMock(return_value="remembered: likes Indian food")
+    client.short_term.add_message = AsyncMock()
+    client.short_term.search_messages = AsyncMock(return_value=[])
+    client.long_term.search_entities = AsyncMock(return_value=[])
+    client.long_term.search_preferences = AsyncMock(return_value=[])
+    client.long_term.add_preference = AsyncMock()
+    client.reasoning.get_similar_traces = AsyncMock(return_value=[])
+    return client
+
+
+@pytest.fixture
+def mock_reasoning() -> MagicMock:
+    """A mock ReasoningMemory that records what record_agent_trace writes."""
+    reasoning = MagicMock()
+    trace = MagicMock()
+    trace.id = uuid4()
+    reasoning.start_trace = AsyncMock(return_value=trace)
+
+    def _new_step(*_args: object, **_kwargs: object) -> MagicMock:
+        return MagicMock(id=uuid4())
+
+    reasoning.add_step = AsyncMock(side_effect=_new_step)
+    reasoning.record_tool_call = AsyncMock()
+    reasoning.complete_trace = AsyncMock(return_value=trace)
+    return reasoning
+
+
+class TestPydanticAI2xShapes:
+    """Guard the 2.x identifiers this integration is written against."""
+
+    def test_agent_has_no_result_type_parameter(self) -> None:
+        params = inspect.signature(pydantic_ai.Agent.__init__).parameters
+        assert "output_type" in params
+        assert "result_type" not in params
+        assert "toolsets" in params
+
+    def test_run_result_has_output_not_data(self) -> None:
+        from pydantic_ai.agent import AgentRunResult
+
+        assert "output" in AgentRunResult.__dataclass_fields__
+        assert "data" not in AgentRunResult.__dataclass_fields__
+
+    def test_usage_and_response_are_properties(self) -> None:
+        from pydantic_ai.agent import AgentRunResult
+
+        assert isinstance(AgentRunResult.usage, property)
+        assert isinstance(AgentRunResult.response, property)
+
+    def test_current_model_class_names(self) -> None:
+        from pydantic_ai.models import google, openai
+
+        assert hasattr(openai, "OpenAIChatModel")
+        assert not hasattr(openai, "OpenAIModel")
+        assert hasattr(google, "GoogleModel")
+        assert not hasattr(google, "GeminiModel")
+
+
+class TestCreateMemoryTools:
+    """``create_memory_tools`` returns plain callables usable on 2.x."""
+
+    def test_tool_names(self, mock_client: MagicMock) -> None:
+        names = [t.__name__ for t in create_memory_tools(mock_client)]
+        assert names == ["search_memory", "save_preference", "recall_preferences"]
+
+    def test_tools_take_no_run_context(self, mock_client: MagicMock) -> None:
+        # PydanticAI 2.x accepts both ctx-first and plain tool functions;
+        # these are plain, which is what the docstring promises.
+        for tool in create_memory_tools(mock_client):
+            first = next(iter(inspect.signature(tool).parameters), None)
+            assert first != "ctx"
+
+    async def test_tools_register_and_run_via_tools_kwarg(self, mock_client: MagicMock) -> None:
+        from pydantic_ai import Agent
+        from pydantic_ai.models.test import TestModel
+
+        agent = Agent(TestModel(), tools=create_memory_tools(mock_client))
+        result = await agent.run("what do you remember?")
+
+        called = _tool_names_called(result)
+        assert {"search_memory", "save_preference", "recall_preferences"} <= set(called)
+        mock_client.long_term.add_preference.assert_awaited()
+
+    async def test_tools_register_as_function_toolset(self, mock_client: MagicMock) -> None:
+        from pydantic_ai import Agent
+        from pydantic_ai.models.test import TestModel
+        from pydantic_ai.toolsets import FunctionToolset
+
+        toolset = FunctionToolset(create_memory_tools(mock_client), id="memory")
+        agent = Agent(TestModel(), toolsets=[toolset])
+        result = await agent.run("what do you remember?")
+
+        assert "search_memory" in _tool_names_called(result)
+
+
+class TestMemoryDependency:
+    """The dependency works as ``deps_type`` with the 2.x instructions hook."""
+
+    async def test_instructions_hook_uses_run_prompt(self, mock_client: MagicMock) -> None:
+        from pydantic_ai import Agent, RunContext
+        from pydantic_ai.models.test import TestModel
+
+        agent = Agent(TestModel(), deps_type=MemoryDependency)
+
+        @agent.instructions
+        async def memory_context(ctx: RunContext[MemoryDependency]) -> str:
+            context = await ctx.deps.get_context(str(ctx.prompt))
+            return f"Context:\n{context}"
+
+        deps = MemoryDependency(client=mock_client, session_id="s-1")
+        result = await agent.run("find me a restaurant", deps=deps)
+
+        mock_client.get_context.assert_awaited_once_with("find me a restaurant", session_id="s-1")
+        assert isinstance(result.output, str)
+
+    async def test_save_interaction_persists_both_turns(self, mock_client: MagicMock) -> None:
+        deps = MemoryDependency(client=mock_client, session_id="s-2")
+        await deps.save_interaction("hi", "hello", extract_entities=False)
+
+        assert mock_client.short_term.add_message.await_count == 2
+        roles = [call.args[1] for call in mock_client.short_term.add_message.await_args_list]
+        assert roles == ["user", "assistant"]
+
+
+class TestRecordAgentTrace:
+    """``record_agent_trace`` reads a real 2.x ``AgentRunResult``."""
+
+    async def _run(self, mock_client: MagicMock) -> Any:
+        from pydantic_ai import Agent
+        from pydantic_ai.models.test import TestModel
+
+        agent = Agent(TestModel(), tools=create_memory_tools(mock_client))
+        return await agent.run("find me a restaurant")
+
+    async def test_records_steps_and_tool_calls(
+        self, mock_client: MagicMock, mock_reasoning: MagicMock
+    ) -> None:
+        result = await self._run(mock_client)
+
+        await record_agent_trace(
+            mock_reasoning,
+            session_id="s-3",
+            result=result,
+            task="Find restaurant recommendation",
+        )
+
+        start_kwargs = mock_reasoning.start_trace.await_args.kwargs
+        assert start_kwargs["session_id"] == "s-3"
+        assert start_kwargs["task"] == "Find restaurant recommendation"
+        assert start_kwargs["metadata"]["source"] == "pydantic_ai"
+        # ``result.response.model_name`` — a 2.x property.
+        assert start_kwargs["metadata"]["model"] == "test"
+
+        tools_called = _tool_names_called(result)
+        assert mock_reasoning.add_step.await_count == len(tools_called)
+        assert mock_reasoning.record_tool_call.await_count == len(tools_called)
+        recorded = {
+            call.kwargs["tool_name"] for call in mock_reasoning.record_tool_call.await_args_list
+        }
+        assert recorded == set(tools_called)
+
+    async def test_completes_with_trace_outcome_and_usage_metrics(
+        self, mock_client: MagicMock, mock_reasoning: MagicMock
+    ) -> None:
+        result = await self._run(mock_client)
+
+        await record_agent_trace(mock_reasoning, session_id="s-4", result=result)
+
+        outcome = mock_reasoning.complete_trace.await_args.kwargs["outcome"]
+        assert isinstance(outcome, TraceOutcome)
+        assert outcome.success is True
+        # ``result.output`` — ``.data`` was removed in PydanticAI 1.0.
+        assert outcome.summary == str(result.output)[:1000]
+        # ``result.usage`` is a property in 2.x, so the metrics are populated.
+        assert outcome.metrics["requests"] >= 1
+        assert outcome.metrics["tool_calls"] == float(len(_tool_names_called(result)))
+        assert "input_tokens" in outcome.metrics
+
+    async def test_task_defaults_to_first_user_prompt(
+        self, mock_client: MagicMock, mock_reasoning: MagicMock
+    ) -> None:
+        result = await self._run(mock_client)
+
+        await record_agent_trace(mock_reasoning, session_id="s-5", result=result)
+
+        assert mock_reasoning.start_trace.await_args.kwargs["task"] == "find me a restaurant"
+
+    async def test_include_tool_calls_false_skips_steps(
+        self, mock_client: MagicMock, mock_reasoning: MagicMock
+    ) -> None:
+        result = await self._run(mock_client)
+
+        await record_agent_trace(
+            mock_reasoning,
+            session_id="s-6",
+            result=result,
+            include_tool_calls=False,
+        )
+
+        mock_reasoning.add_step.assert_not_awaited()
+        mock_reasoning.record_tool_call.assert_not_awaited()
+        mock_reasoning.complete_trace.assert_awaited_once()
+
+
+def _tool_names_called(result: Any) -> list[str]:
+    """Tool names invoked during a run, read off the 2.x message history."""
+    from pydantic_ai.messages import ModelResponse, ToolCallPart
+
+    names: list[str] = []
+    for message in result.all_messages():
+        if isinstance(message, ModelResponse):
+            names.extend(part.tool_name for part in message.parts if isinstance(part, ToolCallPart))
+    return names

--- a/tests/unit/integrations/test_strands.py
+++ b/tests/unit/integrations/test_strands.py
@@ -568,3 +568,62 @@ class TestBedrockModels:
         from neo4j_agent_memory.integrations.strands.config import BEDROCK_EMBEDDING_MODELS
 
         assert BEDROCK_EMBEDDING_MODELS["titan-v2"] == "amazon.titan-embed-text-v2:0"
+
+    def test_llm_defaults_are_inference_profile_ids(self) -> None:
+        """Current-generation Claude on Bedrock needs an inference-profile id."""
+        from neo4j_agent_memory.integrations.strands.config import BEDROCK_LLM_MODELS
+
+        for alias, model_id in BEDROCK_LLM_MODELS.items():
+            region_prefix, _, base = model_id.partition(".")
+            assert region_prefix in {"us", "eu", "apac", "global"}, alias
+            assert base.startswith("anthropic."), alias
+
+    def test_no_retired_claude_generations(self) -> None:
+        """Guard against the ids this map used to carry rotting back in."""
+        from neo4j_agent_memory.integrations.strands.config import (
+            BEDROCK_CLAUDE_BASE_MODELS,
+            BEDROCK_LLM_MODELS,
+        )
+
+        for model_id in (*BEDROCK_LLM_MODELS.values(), *BEDROCK_CLAUDE_BASE_MODELS.values()):
+            assert "claude-3-" not in model_id
+            assert "claude-sonnet-4-2025" not in model_id
+
+    def test_bedrock_llm_model_applies_prefix_override(self, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+        """BEDROCK_INFERENCE_PROFILE_PREFIX swaps the cross-region prefix."""
+        from neo4j_agent_memory.integrations.strands.config import (
+            BEDROCK_CLAUDE_BASE_MODELS,
+            bedrock_llm_model,
+        )
+
+        monkeypatch.delenv("BEDROCK_MODEL_ID", raising=False)
+        monkeypatch.setenv("BEDROCK_INFERENCE_PROFILE_PREFIX", "eu")
+
+        assert bedrock_llm_model() == f"eu.{BEDROCK_CLAUDE_BASE_MODELS['claude-sonnet']}"
+
+    def test_bedrock_llm_model_env_override_wins(self, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+        """BEDROCK_MODEL_ID is used verbatim, prefix included."""
+        from neo4j_agent_memory.integrations.strands.config import bedrock_llm_model
+
+        monkeypatch.setenv("BEDROCK_MODEL_ID", "global.anthropic.claude-opus-5")
+        monkeypatch.setenv("BEDROCK_INFERENCE_PROFILE_PREFIX", "eu")
+
+        assert bedrock_llm_model("claude-haiku") == "global.anthropic.claude-opus-5"
+
+    def test_bedrock_embedding_model_resolution(self, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+        """Embedding ids take no inference-profile prefix; env still overrides."""
+        from neo4j_agent_memory.integrations.strands.config import bedrock_embedding_model
+
+        monkeypatch.delenv("BEDROCK_EMBEDDING_MODEL_ID", raising=False)
+        assert bedrock_embedding_model() == "amazon.titan-embed-text-v2:0"
+
+        monkeypatch.setenv("BEDROCK_EMBEDDING_MODEL_ID", "cohere.embed-english-v3")
+        assert bedrock_embedding_model("titan-v2") == "cohere.embed-english-v3"
+
+    def test_embedding_models_are_embedder_supported_shapes(self) -> None:
+        """Only payload shapes BedrockEmbedder can build may be listed."""
+        from neo4j_agent_memory.embeddings.bedrock import BEDROCK_MODEL_DIMENSIONS
+        from neo4j_agent_memory.integrations.strands.config import BEDROCK_EMBEDDING_MODELS
+
+        for model_id in BEDROCK_EMBEDDING_MODELS.values():
+            assert model_id in BEDROCK_MODEL_DIMENSIONS

--- a/tests/unit/integrations/test_strands_memory_protocol.py
+++ b/tests/unit/integrations/test_strands_memory_protocol.py
@@ -1,4 +1,8 @@
-"""The store depends on strands' LTM module, added in strands-agents 1.44.0."""
+"""The store depends on strands' LTM module (`strands.memory`).
+
+It arrived in strands-agents 1.44.0; the `[strands]` extra floors at 1.52, the
+oldest release that also carries the multi-agent/bidi `SessionManager` hooks.
+"""
 
 from __future__ import annotations
 

--- a/tests/unit/integrations/test_strands_session_manager.py
+++ b/tests/unit/integrations/test_strands_session_manager.py
@@ -944,3 +944,88 @@ class TestRestoreLimit:
             assert client.short_term.add_message_calls[0]["content"] == "x"
         finally:
             manager.close()
+
+
+class TestStrandsBaseClassContract:
+    """Pins the strands>=1.52 SessionManager surface this adapter builds on.
+
+    These assert facts about the installed strands-agents, not about our code:
+    they are the tripwire for a strands upgrade that moves the contract out from
+    under Neo4jSessionManager.
+    """
+
+    def test_base_registers_multi_agent_and_bidi_hooks_unconditionally(self) -> None:
+        from strands.experimental.hooks.events import (
+            BidiAfterInvocationEvent,
+            BidiAgentInitializedEvent,
+            BidiMessageAddedEvent,
+        )
+        from strands.hooks.events import (
+            AfterMultiAgentInvocationEvent,
+            AfterNodeCallEvent,
+            MultiAgentInitializedEvent,
+        )
+
+        manager, _ = _make_manager()
+        try:
+            registry = FakeRegistry()
+            manager.register_hooks(registry)
+            event_types = {et for et, _ in registry.callbacks}
+            for event_type in (
+                MultiAgentInitializedEvent,
+                AfterNodeCallEvent,
+                AfterMultiAgentInvocationEvent,
+                BidiAgentInitializedEvent,
+                BidiMessageAddedEvent,
+                BidiAfterInvocationEvent,
+            ):
+                assert event_type in event_types, event_type.__name__
+        finally:
+            manager.close()
+
+    @pytest.mark.parametrize(
+        ("method", "args"),
+        [
+            ("sync_multi_agent", (SimpleNamespace(),)),
+            ("initialize_multi_agent", (SimpleNamespace(),)),
+            ("initialize_bidi_agent", (SimpleNamespace(),)),
+            ("append_bidi_message", ({"role": "user", "content": []}, SimpleNamespace())),
+            ("sync_bidi_agent", (SimpleNamespace(),)),
+        ],
+    )
+    def test_multi_agent_and_bidi_persistence_is_unsupported_and_says_so(
+        self, method: str, args: tuple[object, ...]
+    ) -> None:
+        """Documented limitation: one manager per Agent, no Graph/Swarm/Bidi.
+
+        The inherited implementations raise, and the message names this class —
+        so the adapter needs no override of its own.
+        """
+        manager, _ = _make_manager()
+        try:
+            with pytest.raises(NotImplementedError, match="Neo4jSessionManager"):
+                getattr(manager, method)(*args)
+        finally:
+            manager.close()
+
+    def test_hook_registry_still_takes_our_bare_add_callback_calls(self) -> None:
+        """`order` gained a keyword-only default; positional calls must still work."""
+        import inspect
+
+        from strands.hooks.registry import HookRegistry
+
+        signature = inspect.signature(HookRegistry.add_callback)
+        order = signature.parameters.get("order")
+        assert order is not None
+        assert order.kind is inspect.Parameter.KEYWORD_ONLY
+        assert order.default is not inspect.Parameter.empty
+
+    def test_store_mirrors_strands_default_search_limit(self) -> None:
+        """`_DEFAULT_MAX_SEARCH_RESULTS` copies a strands constant; keep them equal."""
+        from strands.memory.memory_manager import DEFAULT_MAX_SEARCH_RESULTS
+
+        from neo4j_agent_memory.integrations.strands.memory_store import (
+            _DEFAULT_MAX_SEARCH_RESULTS,
+        )
+
+        assert _DEFAULT_MAX_SEARCH_RESULTS == DEFAULT_MAX_SEARCH_RESULTS

--- a/tests/unit/llm/test_foundations.py
+++ b/tests/unit/llm/test_foundations.py
@@ -279,7 +279,7 @@ def test_from_provider_vertex_ai_embedding_hint_suggests_vertex_extra(monkeypatc
 
     monkeypatch.setattr(factory, "_has", lambda _extra: False)
     with pytest.raises(ImportError) as excinfo:
-        from_provider("vertex_ai/text-embedding-004", kind="embedding")
+        from_provider("vertex_ai/gemini-embedding-001", kind="embedding")
     msg = str(excinfo.value)
     assert "vertex-ai" in msg
 

--- a/tests/unit/llm/test_provider_request_shape.py
+++ b/tests/unit/llm/test_provider_request_shape.py
@@ -1,0 +1,308 @@
+"""Request-shape tests for the native OpenAI and Anthropic adapters.
+
+These tests exist because the two SDKs are *generated*: their
+``create()`` methods take explicit keyword parameters and no ``**kwargs``
+catch-all, so a request keyword the installed major no longer declares is a
+``TypeError`` at call time rather than a server-side error. The adapters build
+their request as a ``dict`` and splat it, which a mocked client happily
+accepts — so a mock alone cannot catch that class of drift.
+
+Each test therefore does two things:
+
+1. drives the adapter against a fake client that records the request, and
+2. asserts every recorded keyword is a parameter the *installed* SDK's
+   ``create()`` actually declares.
+
+The notable assertion is the absence of ``temperature`` on the Anthropic path:
+the anthropic 1.x line removed ``temperature`` / ``top_p`` / ``top_k`` from
+``messages.create()`` (mirroring the API, which rejects sampling parameters on
+current Claude models), so the adapter accepts the protocol's ``temperature``
+argument without forwarding it.
+"""
+
+from __future__ import annotations
+
+import inspect
+from typing import Any
+
+import pytest
+from pydantic import BaseModel
+
+from neo4j_agent_memory.llm.types import ChatMessage
+
+
+class _Extraction(BaseModel):
+    value: str
+
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+
+
+class _Recorder:
+    """Collects the kwargs each fake ``create()`` call received."""
+
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+    @property
+    def last(self) -> dict[str, Any]:
+        assert self.calls, "expected the adapter to issue a request"
+        return self.calls[-1]
+
+
+class _Block:
+    def __init__(self, type_: str, **fields: Any) -> None:
+        self.type = type_
+        for key, value in fields.items():
+            setattr(self, key, value)
+
+
+class _AnthropicUsage:
+    input_tokens = 11
+    output_tokens = 7
+    cache_read_input_tokens = 0
+
+
+class _AnthropicResponse:
+    def __init__(self, content: list[_Block]) -> None:
+        self.content = content
+        self.model = "claude-opus-5"
+        self.usage = _AnthropicUsage()
+        self.stop_reason = "end_turn"
+
+    def model_dump(self) -> dict[str, Any]:
+        return {}
+
+
+class _FakeAnthropicMessages:
+    def __init__(self, recorder: _Recorder, content: list[_Block]) -> None:
+        self._recorder = recorder
+        self._content = content
+
+    async def create(self, **kwargs: Any) -> _AnthropicResponse:
+        self._recorder.calls.append(kwargs)
+        return _AnthropicResponse(self._content)
+
+
+class _FakeAnthropicClient:
+    def __init__(self, recorder: _Recorder, content: list[_Block]) -> None:
+        self.messages = _FakeAnthropicMessages(recorder, content)
+
+
+class _OpenAIUsage:
+    prompt_tokens = 5
+    completion_tokens = 3
+    total_tokens = 8
+    prompt_tokens_details = None
+
+
+class _OpenAIChoice:
+    def __init__(self, content: str) -> None:
+        self.message = _Block("message", content=content)
+        self.finish_reason = "stop"
+
+
+class _OpenAIResponse:
+    def __init__(self, content: str) -> None:
+        self.choices = [_OpenAIChoice(content)]
+        self.model = "gpt-5-mini"
+        self.usage = _OpenAIUsage()
+
+    def model_dump(self) -> dict[str, Any]:
+        return {}
+
+
+class _FakeOpenAICompletions:
+    def __init__(self, recorder: _Recorder, content: str) -> None:
+        self._recorder = recorder
+        self._content = content
+
+    async def create(self, **kwargs: Any) -> _OpenAIResponse:
+        self._recorder.calls.append(kwargs)
+        return _OpenAIResponse(self._content)
+
+
+class _FakeOpenAIEmbeddings:
+    def __init__(self, recorder: _Recorder, dimensions: int) -> None:
+        self._recorder = recorder
+        self._dimensions = dimensions
+
+    async def create(self, **kwargs: Any) -> Any:
+        self._recorder.calls.append(kwargs)
+        inputs = kwargs["input"]
+        data = [
+            _Block("embedding", index=i, embedding=[0.1] * self._dimensions)
+            for i in range(len(inputs))
+        ]
+        return _Block("response", data=data)
+
+
+class _FakeOpenAIClient:
+    def __init__(self, recorder: _Recorder, *, content: str = "hi", dimensions: int = 1536) -> None:
+        self.chat = _Block("chat", completions=_FakeOpenAICompletions(recorder, content))
+        self.embeddings = _FakeOpenAIEmbeddings(recorder, dimensions)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _accepted_parameters(method: Any) -> set[str]:
+    """Parameter names the installed SDK method declares."""
+    parameters = inspect.signature(method).parameters
+    return {name for name in parameters if name != "self"}
+
+
+def _assert_kwargs_accepted(sent: dict[str, Any], method: Any) -> None:
+    accepted = _accepted_parameters(method)
+    unknown = sorted(set(sent) - accepted)
+    assert not unknown, (
+        f"adapter sent keyword(s) the installed SDK rejects: {unknown}; "
+        f"accepted: {sorted(accepted)}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Anthropic
+# ---------------------------------------------------------------------------
+
+
+async def test_anthropic_complete_omits_sampling_parameters() -> None:
+    from neo4j_agent_memory.llm.adapters.anthropic import AnthropicProvider
+
+    recorder = _Recorder()
+    provider = AnthropicProvider("anthropic/claude-opus-5", api_key="x")
+    provider._client = _FakeAnthropicClient(recorder, [_Block("text", text="hello")])  # type: ignore[assignment]
+
+    completion = await provider.complete(
+        [ChatMessage(role="system", content="be terse"), ChatMessage(role="user", content="hi")],
+        temperature=0.7,
+        max_tokens=64,
+        stop=["END"],
+    )
+
+    assert completion.content == "hello"
+    sent = recorder.last
+    assert "temperature" not in sent
+    assert "top_p" not in sent
+    assert "top_k" not in sent
+    # The parameters that *are* still supported must survive.
+    assert sent["max_tokens"] == 64
+    assert sent["stop_sequences"] == ["END"]
+    assert sent["system"] == "be terse"
+    assert sent["messages"] == [{"role": "user", "content": "hi"}]
+
+
+async def test_anthropic_structured_omits_sampling_parameters() -> None:
+    from neo4j_agent_memory.llm.adapters.anthropic import AnthropicProvider
+
+    recorder = _Recorder()
+    provider = AnthropicProvider("anthropic/claude-opus-5", api_key="x")
+    provider._client = _FakeAnthropicClient(  # type: ignore[assignment]
+        recorder,
+        [_Block("tool_use", input={"value": "ok"}, name="submit_extraction")],
+    )
+
+    result = await provider.complete_structured(
+        [ChatMessage(role="user", content="extract")],
+        _Extraction,
+        temperature=0.3,
+    )
+
+    assert result.value == "ok"
+    sent = recorder.last
+    assert "temperature" not in sent
+    assert sent["tool_choice"] == {"type": "tool", "name": "submit_extraction"}
+
+
+async def test_anthropic_request_keywords_exist_in_installed_sdk() -> None:
+    anthropic = pytest.importorskip("anthropic")
+    from neo4j_agent_memory.llm.adapters.anthropic import AnthropicProvider
+
+    recorder = _Recorder()
+    provider = AnthropicProvider("anthropic/claude-opus-5", api_key="x", cache_system=True)
+    provider._client = _FakeAnthropicClient(recorder, [_Block("text", text="hello")])  # type: ignore[assignment]
+
+    await provider.complete(
+        [ChatMessage(role="system", content="s"), ChatMessage(role="user", content="u")],
+        stop=["END"],
+        timeout=5.0,
+    )
+
+    _assert_kwargs_accepted(recorder.last, anthropic.AsyncAnthropic(api_key="x").messages.create)
+
+
+def test_anthropic_temperature_warning_is_emitted_once(caplog: pytest.LogCaptureFixture) -> None:
+    from neo4j_agent_memory.llm.adapters import anthropic as adapter
+
+    adapter._sampling_warning_emitted = False
+    try:
+        with caplog.at_level("WARNING", logger=adapter.__name__):
+            adapter._note_dropped_temperature(0.0)
+            assert not caplog.records  # the default value is not worth a warning
+            adapter._note_dropped_temperature(0.9)
+            adapter._note_dropped_temperature(0.9)
+        assert len(caplog.records) == 1
+        assert "sampling parameters" in caplog.records[0].message
+    finally:
+        adapter._sampling_warning_emitted = False
+
+
+# ---------------------------------------------------------------------------
+# OpenAI
+# ---------------------------------------------------------------------------
+
+
+async def test_openai_request_keywords_exist_in_installed_sdk() -> None:
+    openai = pytest.importorskip("openai")
+    from neo4j_agent_memory.llm.adapters.openai import OpenAIProvider
+
+    recorder = _Recorder()
+    provider = OpenAIProvider("openai/gpt-5-mini", api_key="x")
+    provider._client = _FakeOpenAIClient(recorder)  # type: ignore[assignment]
+
+    client = openai.AsyncOpenAI(api_key="x")
+
+    await provider.complete(
+        [ChatMessage(role="user", content="hi")],
+        temperature=0.2,
+        max_tokens=32,
+        stop=["END"],
+        timeout=5.0,
+    )
+    _assert_kwargs_accepted(recorder.last, client.chat.completions.create)
+
+    structured_recorder = _Recorder()
+    structured = OpenAIProvider("openai/gpt-5-mini", api_key="x")
+    structured._client = _FakeOpenAIClient(  # type: ignore[assignment]
+        structured_recorder, content='{"value": "ok"}'
+    )
+    extraction = await structured.complete_structured(
+        [ChatMessage(role="user", content="extract")],
+        _Extraction,
+        temperature=0.0,
+    )
+    assert extraction.value == "ok"
+    sent = structured_recorder.last
+    _assert_kwargs_accepted(sent, client.chat.completions.create)
+    assert sent["response_format"]["type"] == "json_schema"
+    assert sent["response_format"]["json_schema"]["strict"] is True
+
+
+async def test_openai_embedding_request_keywords_exist_in_installed_sdk() -> None:
+    openai = pytest.importorskip("openai")
+    from neo4j_agent_memory.llm.adapters.openai import OpenAIEmbeddingProvider
+
+    recorder = _Recorder()
+    provider = OpenAIEmbeddingProvider("openai/text-embedding-3-small", dimensions=256)
+    provider._client = _FakeOpenAIClient(recorder, dimensions=256)  # type: ignore[assignment]
+
+    vectors = await provider.embed(["a", "b"])
+    assert [len(v) for v in vectors] == [256, 256]
+
+    sent = recorder.last
+    assert sent["dimensions"] == 256
+    _assert_kwargs_accepted(sent, openai.AsyncOpenAI(api_key="x").embeddings.create)

--- a/tests/unit/mcp/test_fastmcp_tools.py
+++ b/tests/unit/mcp/test_fastmcp_tools.py
@@ -102,6 +102,92 @@ class TestToolRegistration:
             assert len(tools) == 16
 
 
+class TestToolAnnotations:
+    """Tool hints must survive the MCP SDK 2 snake_case field rename.
+
+    ``READ_ANNOTATIONS`` / ``WRITE_ANNOTATIONS`` are plain dicts handed to
+    ``@mcp.tool(annotations=...)``; these tests assert they actually land on the
+    advertised ``ToolAnnotations`` rather than being silently dropped by a
+    key-name mismatch.
+    """
+
+    READ_ONLY_TOOLS = {
+        "memory_search",
+        "memory_get_context",
+        "memory_get_conversation",
+        "memory_list_sessions",
+        "memory_get_entity",
+        "memory_export_graph",
+        "memory_get_observations",
+        "graph_query",
+    }
+
+    WRITE_TOOLS = {
+        "memory_store_message",
+        "memory_add_entity",
+        "memory_add_preference",
+        "memory_add_fact",
+        "memory_create_relationship",
+        "memory_start_trace",
+        "memory_record_step",
+        "memory_complete_trace",
+    }
+
+    @pytest.mark.asyncio
+    async def test_every_tool_advertises_annotations(self):
+        server = create_tool_server(make_mock_client(), profile="extended")
+        async with Client(server) as client:
+            tools = await client.list_tools()
+        for tool in tools:
+            assert tool.annotations is not None, f"{tool.name} has no annotations"
+            assert tool.annotations.read_only_hint is not None, tool.name
+            assert tool.annotations.destructive_hint is False, tool.name
+
+    @pytest.mark.asyncio
+    async def test_read_tools_are_read_only_and_idempotent(self):
+        server = create_tool_server(make_mock_client(), profile="extended")
+        async with Client(server) as client:
+            tools = {t.name: t for t in await client.list_tools()}
+        for name in self.READ_ONLY_TOOLS:
+            annotations = tools[name].annotations
+            assert annotations.read_only_hint is True, name
+            assert annotations.idempotent_hint is True, name
+
+    @pytest.mark.asyncio
+    async def test_write_tools_are_not_read_only(self):
+        server = create_tool_server(make_mock_client(), profile="extended")
+        async with Client(server) as client:
+            tools = {t.name: t for t in await client.list_tools()}
+        for name in self.WRITE_TOOLS:
+            annotations = tools[name].annotations
+            assert annotations.read_only_hint is False, name
+            assert annotations.idempotent_hint is False, name
+
+    def test_annotation_dicts_use_sdk2_field_names(self):
+        """The dicts key on the SDK 2 field names, not the legacy camelCase aliases.
+
+        FastMCP 4 still bridges camelCase through a compatibility shim that can be
+        switched off (``fastmcp.settings.mcp_camelcase_compat``), so keying on the
+        native names keeps these hints working either way.
+        """
+        from mcp_types import ToolAnnotations
+
+        from neo4j_agent_memory.mcp._tools import READ_ANNOTATIONS, WRITE_ANNOTATIONS
+
+        fields = set(ToolAnnotations.model_fields)
+        for dictionary in (READ_ANNOTATIONS, WRITE_ANNOTATIONS):
+            assert set(dictionary) <= fields, (
+                f"annotation keys {set(dictionary) - fields} are not ToolAnnotations field names"
+            )
+
+        read = ToolAnnotations.model_validate(READ_ANNOTATIONS)
+        write = ToolAnnotations.model_validate(WRITE_ANNOTATIONS)
+        assert (read.read_only_hint, read.idempotent_hint) == (True, True)
+        assert (write.read_only_hint, write.idempotent_hint) == (False, False)
+        assert read.destructive_hint is False
+        assert write.destructive_hint is False
+
+
 class TestCoreToolParameters:
     """Tests that core tools have correct required parameters."""
 
@@ -118,21 +204,21 @@ class TestCoreToolParameters:
         async with Client(server) as client:
             tools = await client.list_tools()
             tool = next(t for t in tools if t.name == "memory_search")
-            assert "query" in tool.inputSchema.get("required", [])
+            assert "query" in tool.input_schema.get("required", [])
 
     @pytest.mark.asyncio
     async def test_memory_store_message_requires_content(self, server):
         async with Client(server) as client:
             tools = await client.list_tools()
             tool = next(t for t in tools if t.name == "memory_store_message")
-            assert "content" in tool.inputSchema.get("required", [])
+            assert "content" in tool.input_schema.get("required", [])
 
     @pytest.mark.asyncio
     async def test_memory_add_entity_requires_name_and_type(self, server):
         async with Client(server) as client:
             tools = await client.list_tools()
             tool = next(t for t in tools if t.name == "memory_add_entity")
-            required = tool.inputSchema.get("required", [])
+            required = tool.input_schema.get("required", [])
             assert "name" in required
             assert "entity_type" in required
 
@@ -141,7 +227,7 @@ class TestCoreToolParameters:
         async with Client(server) as client:
             tools = await client.list_tools()
             tool = next(t for t in tools if t.name == "memory_add_preference")
-            required = tool.inputSchema.get("required", [])
+            required = tool.input_schema.get("required", [])
             assert "category" in required
             assert "preference" in required
 
@@ -150,7 +236,7 @@ class TestCoreToolParameters:
         async with Client(server) as client:
             tools = await client.list_tools()
             tool = next(t for t in tools if t.name == "memory_add_fact")
-            required = tool.inputSchema.get("required", [])
+            required = tool.input_schema.get("required", [])
             assert "subject" in required
             assert "predicate" in required
             assert "object_value" in required

--- a/tests/unit/mcp/test_mcp_cli.py
+++ b/tests/unit/mcp/test_mcp_cli.py
@@ -61,8 +61,9 @@ class TestMCPServeOptions:
     def test_transport_choices(self, runner):
         result = runner.invoke(cli, ["mcp", "serve", "--help"])
         assert "stdio" in result.output
+        assert "streamable-http" in result.output
+        # Deprecated but still accepted so existing launch configs keep working.
         assert "sse" in result.output
-        assert "http" in result.output
 
     def test_session_strategy_choices(self, runner):
         result = runner.invoke(cli, ["mcp", "serve", "--help"])
@@ -113,5 +114,48 @@ class TestMCPServeExecution:
         result = runner.invoke(
             cli,
             ["mcp", "serve", "--password", "pw", "--session-strategy", "per_day"],
+        )
+        assert result.exit_code == 0
+
+
+class TestDeprecatedSSETransport:
+    """`--transport sse` is accepted but warns and serves Streamable HTTP."""
+
+    @patch("neo4j_agent_memory.cli.main.asyncio")
+    @patch("neo4j_agent_memory.mcp.server.run_server", new_callable=AsyncMock)
+    def test_sse_warns_on_stderr(self, mock_run_server, mock_asyncio, runner):
+        mock_asyncio.run = lambda _coro: None
+
+        result = runner.invoke(
+            cli,
+            ["mcp", "serve", "--password", "pw", "--transport", "sse"],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0
+        assert "deprecated" in result.output.lower()
+        assert "streamable http" in result.output.lower()
+
+    @patch("neo4j_agent_memory.cli.main.asyncio")
+    @patch("neo4j_agent_memory.mcp.server.run_server", new_callable=AsyncMock)
+    def test_http_does_not_warn(self, mock_run_server, mock_asyncio, runner):
+        mock_asyncio.run = lambda _coro: None
+
+        result = runner.invoke(
+            cli,
+            ["mcp", "serve", "--password", "pw", "--transport", "http"],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0
+        assert "deprecated" not in result.output.lower()
+
+    @patch("neo4j_agent_memory.cli.main.asyncio")
+    @patch("neo4j_agent_memory.mcp.server.run_server", new_callable=AsyncMock)
+    def test_streamable_http_is_accepted(self, mock_run_server, mock_asyncio, runner):
+        mock_asyncio.run = lambda _coro: None
+
+        result = runner.invoke(
+            cli,
+            ["mcp", "serve", "--password", "pw", "--transport", "streamable-http"],
+            catch_exceptions=False,
         )
         assert result.exit_code == 0

--- a/tests/unit/mcp/test_mcp_resources.py
+++ b/tests/unit/mcp/test_mcp_resources.py
@@ -23,7 +23,7 @@ class TestResourceRegistration:
         async with Client(server) as client:
             templates = await client.list_resource_templates()
             assert len(templates) == 1
-            assert templates[0].uriTemplate == "memory://context/{session_id}"
+            assert templates[0].uri_template == "memory://context/{session_id}"
 
     @pytest.mark.asyncio
     async def test_extended_profile_resource_templates(self):
@@ -60,7 +60,7 @@ class TestResourceRegistration:
             templates = await client.list_resource_templates()
             for template in templates:
                 assert template.description, (
-                    f"Resource template {template.uriTemplate} has no description"
+                    f"Resource template {template.uri_template} has no description"
                 )
             resources = await client.list_resources()
             for resource in resources:

--- a/tests/unit/mcp/test_mcp_server.py
+++ b/tests/unit/mcp/test_mcp_server.py
@@ -305,3 +305,160 @@ class TestRunServerProviderKwargs:
         nams_config = created_settings[0].kwargs["nams"]
         assert nams_config.kwargs["endpoint"] == "https://memory.example.test/v1"
         assert nams_config.kwargs["api_key"].get_secret_value() == "nams_from_env"
+
+
+class TestTransportNormalization:
+    """Tests for FastMCP 4 transport resolution (Streamable HTTP vs legacy SSE)."""
+
+    def test_stdio_passes_through(self):
+        from neo4j_agent_memory.mcp.server import normalize_transport
+
+        assert normalize_transport("stdio") == "stdio"
+
+    def test_http_passes_through(self):
+        from neo4j_agent_memory.mcp.server import normalize_transport
+
+        assert normalize_transport("http") == "http"
+
+    def test_streamable_http_is_a_synonym_for_http(self):
+        from neo4j_agent_memory.mcp.server import normalize_transport
+
+        assert normalize_transport("streamable-http") == "http"
+
+    def test_sse_maps_to_http_with_a_warning(self, caplog):
+        """`sse` is accepted for compatibility but serves Streamable HTTP."""
+        import logging
+
+        from neo4j_agent_memory.mcp.server import normalize_transport
+
+        with caplog.at_level(logging.WARNING, logger="neo4j_agent_memory.mcp.server"):
+            assert normalize_transport("sse") == "http"
+        assert any("deprecated" in record.message for record in caplog.records)
+
+    def test_unknown_transport_raises(self):
+        from neo4j_agent_memory.mcp.server import normalize_transport
+
+        with pytest.raises(ValueError, match="Unknown transport"):
+            normalize_transport("websocket")
+
+    def test_transports_constant_lists_accepted_names(self):
+        from neo4j_agent_memory.mcp.server import TRANSPORTS
+
+        assert set(TRANSPORTS) == {"stdio", "http", "streamable-http", "sse"}
+
+
+class TestRunServerTransportDispatch:
+    """run_server() must hand FastMCP only the transports FastMCP 4 serves."""
+
+    @pytest.mark.parametrize(
+        ("requested", "expected"),
+        [
+            ("stdio", "stdio"),
+            ("http", "http"),
+            ("streamable-http", "http"),
+            ("sse", "http"),
+        ],
+    )
+    async def test_transport_is_normalized_before_run_async(
+        self, monkeypatch: pytest.MonkeyPatch, requested: str, expected: str
+    ) -> None:
+        import neo4j_agent_memory as nam
+        import neo4j_agent_memory.config.settings as settings_mod
+        import neo4j_agent_memory.mcp.server as server_mod
+
+        fake_server = MagicMock()
+        fake_server.run_async = AsyncMock()
+
+        class _FakeSettings:
+            def __init__(self, **kwargs: object) -> None:
+                self.kwargs = kwargs
+
+        class _FakeNeo4jConfig:
+            def __init__(self, **kwargs: object) -> None:
+                self.kwargs = kwargs
+
+        monkeypatch.setattr(nam, "MemorySettings", _FakeSettings)
+        monkeypatch.setattr(settings_mod, "Neo4jConfig", _FakeNeo4jConfig)
+        monkeypatch.setattr(
+            server_mod, "create_mcp_server", lambda _settings, *_a, **_k: fake_server
+        )
+
+        await server_mod.run_server(
+            neo4j_uri="bolt://localhost:7687",
+            neo4j_user="neo4j",
+            neo4j_password="test-password",
+            transport=requested,
+            host="127.0.0.1",
+            port=8123,
+        )
+
+        kwargs = fake_server.run_async.await_args.kwargs
+        assert kwargs["transport"] == expected
+        if expected == "http":
+            assert kwargs["host"] == "127.0.0.1"
+            assert kwargs["port"] == 8123
+        else:
+            # The host owns stderr on stdio; FastMCP's banner is noise there.
+            assert kwargs["show_banner"] is False
+
+    async def test_unknown_transport_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import neo4j_agent_memory as nam
+        import neo4j_agent_memory.config.settings as settings_mod
+        import neo4j_agent_memory.mcp.server as server_mod
+
+        class _FakeSettings:
+            def __init__(self, **kwargs: object) -> None:
+                self.kwargs = kwargs
+
+        class _FakeNeo4jConfig:
+            def __init__(self, **kwargs: object) -> None:
+                self.kwargs = kwargs
+
+        monkeypatch.setattr(nam, "MemorySettings", _FakeSettings)
+        monkeypatch.setattr(settings_mod, "Neo4jConfig", _FakeNeo4jConfig)
+        monkeypatch.setattr(
+            server_mod, "create_mcp_server", lambda _settings, *_a, **_k: MagicMock()
+        )
+
+        with pytest.raises(ValueError, match="Unknown transport"):
+            await server_mod.run_server(
+                neo4j_uri="bolt://localhost:7687",
+                neo4j_user="neo4j",
+                neo4j_password="test-password",
+                transport="websocket",
+            )
+
+
+class TestPreconnectedServerTransports:
+    """Neo4jMemoryMCPServer exposes run/run_http with run_sse as a shim."""
+
+    @pytest.fixture
+    def server(self):
+        from neo4j_agent_memory.mcp.server import Neo4jMemoryMCPServer
+
+        mock_client = MagicMock()
+        mock_client._settings.backend = "bolt"
+        return Neo4jMemoryMCPServer(mock_client)
+
+    async def test_run_uses_stdio_without_a_banner(self, server):
+        server._mcp.run_async = AsyncMock()
+        await server.run()
+        assert server._mcp.run_async.await_args.kwargs == {
+            "transport": "stdio",
+            "show_banner": False,
+        }
+
+    async def test_run_http_uses_streamable_http(self, server):
+        server._mcp.run_async = AsyncMock()
+        await server.run_http(host="0.0.0.0", port=9000)
+        assert server._mcp.run_async.await_args.kwargs == {
+            "transport": "http",
+            "host": "0.0.0.0",
+            "port": 9000,
+        }
+
+    async def test_run_sse_serves_streamable_http(self, server):
+        server._mcp.run_async = AsyncMock()
+        await server.run_sse(port=9001)
+        assert server._mcp.run_async.await_args.kwargs["transport"] == "http"
+        assert server._mcp.run_async.await_args.kwargs["port"] == 9001

--- a/tests/unit/mcp/test_mcp_tools.py
+++ b/tests/unit/mcp/test_mcp_tools.py
@@ -82,21 +82,21 @@ class TestFastMCPToolRegistration:
         async with Client(core_server) as client:
             tools = await client.list_tools()
             tool = next(t for t in tools if t.name == "memory_search")
-            assert "query" in tool.inputSchema.get("required", [])
+            assert "query" in tool.input_schema.get("required", [])
 
     @pytest.mark.asyncio
     async def test_memory_store_message_schema(self, core_server):
         async with Client(core_server) as client:
             tools = await client.list_tools()
             tool = next(t for t in tools if t.name == "memory_store_message")
-            assert "content" in tool.inputSchema.get("required", [])
+            assert "content" in tool.input_schema.get("required", [])
 
     @pytest.mark.asyncio
     async def test_memory_add_entity_schema(self, core_server):
         async with Client(core_server) as client:
             tools = await client.list_tools()
             tool = next(t for t in tools if t.name == "memory_add_entity")
-            required = tool.inputSchema.get("required", [])
+            required = tool.input_schema.get("required", [])
             assert "name" in required
             assert "entity_type" in required
 
@@ -105,7 +105,7 @@ class TestFastMCPToolRegistration:
         async with Client(extended_server) as client:
             tools = await client.list_tools()
             tool = next(t for t in tools if t.name == "graph_query")
-            assert "query" in tool.inputSchema.get("required", [])
+            assert "query" in tool.input_schema.get("required", [])
 
     @pytest.mark.asyncio
     async def test_graph_query_description_mentions_read_only(self, extended_server):

--- a/tests/unit/test_enrichment_metadata.py
+++ b/tests/unit/test_enrichment_metadata.py
@@ -1,0 +1,212 @@
+"""Enrichment results must reach ``Entity.metadata``.
+
+Background enrichment writes its results as node properties plus an
+``enrichment_data`` JSON blob. Before this was covered, ``_parse_entity``
+dropped every one of those fields, so ``entity.metadata["wikipedia_url"]`` was
+always missing even after a successful enrichment and the enrichment example's
+demo 4 could never report success (see the enrichment-example review, F01).
+
+These tests drive the real writer (``BackgroundEnrichmentService``) with a fake
+provider and a fake Neo4j client, then feed the captured write back through the
+real reader (``LongTermMemory._parse_entity``), so the two halves cannot drift
+apart silently.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from typing import Any
+from unittest.mock import MagicMock
+from uuid import UUID, uuid4
+
+import pytest
+
+from neo4j_agent_memory.enrichment.background import BackgroundEnrichmentService
+from neo4j_agent_memory.enrichment.base import EnrichmentResult, EnrichmentStatus
+from neo4j_agent_memory.memory.long_term import LongTermMemory
+
+ENTITY_ID = UUID("11111111-1111-1111-1111-111111111111")
+
+
+class FakeEnrichmentProvider:
+    """Minimal in-memory provider: no network, deterministic payload."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str]] = []
+
+    @property
+    def name(self) -> str:
+        return "fake"
+
+    @property
+    def supported_entity_types(self) -> list[str]:
+        return ["PERSON", "ORGANIZATION", "LOCATION"]
+
+    def supports_entity_type(self, entity_type: str) -> bool:
+        return entity_type.upper() in self.supported_entity_types
+
+    async def enrich(
+        self,
+        entity_name: str,
+        entity_type: str,
+        *,
+        context: str | None = None,
+        language: str = "en",
+    ) -> EnrichmentResult:
+        self.calls.append((entity_name, entity_type))
+        return EnrichmentResult(
+            entity_name=entity_name,
+            entity_type=entity_type,
+            provider=self.name,
+            status=EnrichmentStatus.SUCCESS,
+            description="Theoretical physicist.",
+            summary="Developed the theory of relativity.",
+            wikipedia_url="https://en.wikipedia.org/wiki/Albert_Einstein",
+            wikidata_id="Q937",
+            image_url="https://example.invalid/einstein.jpg",
+            source_url="https://en.wikipedia.org/wiki/Albert_Einstein",
+            metadata={"birth_year": 1879},
+            retrieved_at=datetime(2026, 9, 10, 12, 0, tzinfo=timezone.utc),
+        )
+
+
+class CapturingClient:
+    """Stand-in for ``Neo4jClient`` that records write calls."""
+
+    def __init__(self) -> None:
+        self.writes: list[tuple[str, dict[str, Any]]] = []
+
+    async def execute_write(self, query: str, params: dict[str, Any]) -> list[Any]:
+        self.writes.append((query, params))
+        return []
+
+
+def _node_from_write(params: dict[str, Any]) -> dict[str, Any]:
+    """Build the entity node a later read would return for this write."""
+    node: dict[str, Any] = {
+        "id": str(ENTITY_ID),
+        "name": "Albert Einstein",
+        "type": "PERSON",
+        "metadata": json.dumps({"aliases": ["Einstein"], "source": "unit-test"}),
+        # ``SET e.enriched_at = datetime()`` — the driver hands back a datetime.
+        "enriched_at": datetime(2026, 9, 10, 12, 0, 1, tzinfo=timezone.utc),
+    }
+    for prop in (
+        "enriched_description",
+        "enrichment_data",
+        "wikipedia_url",
+        "wikidata_id",
+        "image_url",
+    ):
+        node[prop] = params[prop]
+    node["enrichment_provider"] = params["provider"]
+    return node
+
+
+@pytest.fixture
+def long_term() -> LongTermMemory:
+    return LongTermMemory(client=MagicMock())
+
+
+@pytest.mark.asyncio
+async def test_enrichment_write_then_parse_lands_in_entity_metadata(long_term):
+    """The headline fields survive the write → read round trip."""
+    client = CapturingClient()
+    provider = FakeEnrichmentProvider()
+    service = BackgroundEnrichmentService(client, provider)  # type: ignore[arg-type]
+
+    result = await provider.enrich("Albert Einstein", "PERSON")
+    await service._update_entity(ENTITY_ID, result)
+
+    assert len(client.writes) == 1
+    _, params = client.writes[0]
+
+    entity = long_term._parse_entity(_node_from_write(params))
+
+    metadata = entity.metadata
+    assert metadata["enriched_description"] == "Theoretical physicist."
+    assert metadata["wikipedia_url"] == "https://en.wikipedia.org/wiki/Albert_Einstein"
+    assert metadata["wikidata_id"] == "Q937"
+    assert metadata["image_url"] == "https://example.invalid/einstein.jpg"
+    assert metadata["enrichment_provider"] == "fake"
+    assert metadata["enriched_at"].startswith("2026-09-10T12:00:01")
+    # Non-enrichment metadata is preserved, and aliases still get promoted.
+    assert metadata["source"] == "unit-test"
+    assert entity.aliases == ["Einstein"]
+
+
+@pytest.mark.asyncio
+async def test_enrichment_write_sets_node_properties_cypher_reads():
+    """``get_locations`` selects ``e.wikipedia_url``, so the writer must set it."""
+    client = CapturingClient()
+    provider = FakeEnrichmentProvider()
+    service = BackgroundEnrichmentService(client, provider)  # type: ignore[arg-type]
+
+    result = await provider.enrich("Albert Einstein", "PERSON")
+    await service._update_entity(ENTITY_ID, result)
+
+    query, params = client.writes[0]
+    for prop in ("wikipedia_url", "wikidata_id", "image_url", "enriched_description"):
+        assert f"e.{prop}" in query, f"{prop} should be written as a node property"
+    assert params["wikipedia_url"] == "https://en.wikipedia.org/wiki/Albert_Einstein"
+
+
+def test_parse_entity_reads_nested_enrichment_data(long_term):
+    """The JSON blob alone is enough — node properties are a fast path, not the source."""
+    node = {
+        "id": str(uuid4()),
+        "name": "Acme Corporation",
+        "type": "ORGANIZATION",
+        "enrichment_data": json.dumps(
+            {
+                "description": "A fictional company.",
+                "summary": "Makes everything.",
+                "wikipedia_url": "https://en.wikipedia.org/wiki/Acme_Corporation",
+                "wikidata_id": "Q286041",
+                "image_url": "https://example.invalid/acme.png",
+                "confidence": 0.9,
+                "metadata": {"industry": "conglomerate"},
+            }
+        ),
+    }
+
+    entity = long_term._parse_entity(node)
+
+    assert entity.metadata["enriched_description"] == "A fictional company."
+    assert entity.metadata["enriched_summary"] == "Makes everything."
+    assert entity.metadata["wikipedia_url"] == "https://en.wikipedia.org/wiki/Acme_Corporation"
+    assert entity.metadata["wikidata_id"] == "Q286041"
+    assert entity.metadata["image_url"] == "https://example.invalid/acme.png"
+    assert entity.metadata["enrichment_confidence"] == 0.9
+    assert entity.metadata["enrichment_metadata"] == {"industry": "conglomerate"}
+
+
+def test_parse_entity_without_enrichment_has_no_enrichment_keys(long_term):
+    """An un-enriched entity gains nothing — no ``None`` placeholders."""
+    entity = long_term._parse_entity(
+        {
+            "id": str(uuid4()),
+            "name": "Unknown Person",
+            "type": "PERSON",
+            "metadata": None,
+        }
+    )
+
+    assert entity.metadata == {}
+
+
+def test_parse_entity_tolerates_corrupt_enrichment_data(long_term):
+    """A malformed blob must not break entity reads."""
+    entity = long_term._parse_entity(
+        {
+            "id": str(uuid4()),
+            "name": "Broken",
+            "type": "PERSON",
+            "enrichment_data": "{not json",
+            "enriched_description": "still readable",
+        }
+    )
+
+    assert entity.metadata["enriched_description"] == "still readable"
+    assert "wikipedia_url" not in entity.metadata

--- a/tests/unit/test_passthrough.py
+++ b/tests/unit/test_passthrough.py
@@ -249,5 +249,5 @@ def test_strands_wrapper_prefixes_bedrock_for_bare_strings(stub_from_provider):
         llm_provider_from_strands,
     )
 
-    llm_provider_from_strands("anthropic.claude-sonnet-4-20250514-v1:0")
-    assert stub_from_provider[0][0] == "bedrock/anthropic.claude-sonnet-4-20250514-v1:0"
+    llm_provider_from_strands("us.anthropic.claude-sonnet-4-6")
+    assert stub_from_provider[0][0] == "bedrock/us.anthropic.claude-sonnet-4-6"

--- a/tests/unit/test_resolvers.py
+++ b/tests/unit/test_resolvers.py
@@ -42,6 +42,9 @@ class TestExactMatchResolver:
 
         assert result.canonical_name == "Alice Johnson"
         assert result.original_name == "Alice Johnson"
+        # A miss must not claim an exact match, or the field is unreadable:
+        # callers would have to re-compare names to tell hit from miss.
+        assert result.match_type == "none"
 
     @pytest.mark.asyncio
     async def test_empty_existing(self, resolver):
@@ -49,6 +52,15 @@ class TestExactMatchResolver:
         result = await resolver.resolve("John Smith", "PERSON")
 
         assert result.canonical_name == "John Smith"
+        assert result.match_type == "none"
+
+    @pytest.mark.asyncio
+    async def test_empty_existing_list(self, resolver):
+        """An explicitly empty candidate list is also a miss, not an exact match."""
+        result = await resolver.resolve("John Smith", "PERSON", existing_entities=[])
+
+        assert result.canonical_name == "John Smith"
+        assert result.match_type == "none"
 
     @pytest.mark.asyncio
     async def test_find_matches(self, resolver):

--- a/uv.lock
+++ b/uv.lock
@@ -10,335 +10,52 @@ resolution-markers = [
 ]
 
 [[package]]
-name = "a2a-sdk"
-version = "0.3.23"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "google-api-core", version = "2.25.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
-    { name = "google-api-core", version = "2.29.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "httpx" },
-    { name = "httpx-sse" },
-    { name = "protobuf" },
-    { name = "pydantic" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/2d/6a/2fe24e0a85240a651006c12f79bdb37156adc760a96c44bc002ebda77916/a2a_sdk-0.3.23.tar.gz", hash = "sha256:7c46b8572c4633a2b41fced2833e11e62871e8539a5b3c782ba2ba1e33d213c2", size = 255265, upload-time = "2026-02-17T08:34:34.648Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d4/20/77d119f19ab03449d3e6bc0b1f11296d593dae99775c1d891ab1e290e416/a2a_sdk-0.3.23-py3-none-any.whl", hash = "sha256:8c2f01dffbfdd3509eafc15c4684743e6ae75e69a5df5d6f87be214c948e7530", size = 145689, upload-time = "2026-02-17T08:34:33.263Z" },
-]
-
-[[package]]
-name = "ag-ui-protocol"
-version = "0.1.10"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pydantic" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/67/bb/5a5ec893eea5805fb9a3db76a9888c3429710dfb6f24bbb37568f2cf7320/ag_ui_protocol-0.1.10.tar.gz", hash = "sha256:3213991c6b2eb24bb1a8c362ee270c16705a07a4c5962267a083d0959ed894f4", size = 6945, upload-time = "2025-11-06T15:17:17.068Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/8f/78/eb55fabaab41abc53f52c0918a9a8c0f747807e5306273f51120fd695957/ag_ui_protocol-0.1.10-py3-none-any.whl", hash = "sha256:c81e6981f30aabdf97a7ee312bfd4df0cd38e718d9fc10019c7d438128b93ab5", size = 7889, upload-time = "2025-11-06T15:17:15.325Z" },
-]
-
-[[package]]
-name = "agent-framework"
-version = "1.0.0b260212"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "agent-framework-core", extra = ["all"] },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/03/db/e37b6597d706419764e80f7025046d11e5724251f11d6616eda1120bc6e7/agent_framework-1.0.0b260212.tar.gz", hash = "sha256:cb7c5dd7ccbe84198154e71179b5b5f87b196748d181d1d95e7c7711bb3c904d", size = 22496517, upload-time = "2026-02-13T00:38:03.4Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/9b/0e/2b765e2535aba04c50efbca87cca836b0b3fde725f4f92a6f064fc3b8815/agent_framework-1.0.0b260212-py3-none-any.whl", hash = "sha256:bec4fa770c202885aafaa63fdbbe5e3d36b390762cba618902a89647612c336f", size = 5539, upload-time = "2026-02-13T00:38:06.721Z" },
-]
-
-[[package]]
-name = "agent-framework-a2a"
-version = "1.0.0b260212"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "a2a-sdk" },
-    { name = "agent-framework-core" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/22/23/70912248561d75ecee17123d5dfd432ada6f6984436c7ddc9a47c2304f07/agent_framework_a2a-1.0.0b260212.tar.gz", hash = "sha256:2b7dce7dcfdee8e7e0462fe897558f72ba4eb3cde075667af6ff955a03c24cd7", size = 8244, upload-time = "2026-02-13T00:27:29.714Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/73/f1/561bbc6482a70c0596eda2aa011a901997dc11e25644e64f8ae6fb116cc3/agent_framework_a2a-1.0.0b260212-py3-none-any.whl", hash = "sha256:df6ed765b4f00815853d2255d9ba5f7a60ad11dcc46a2bb8808f2e87a780136b", size = 8554, upload-time = "2026-02-13T00:27:16.088Z" },
-]
-
-[[package]]
-name = "agent-framework-ag-ui"
-version = "1.0.0b260212"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "ag-ui-protocol" },
-    { name = "agent-framework-core" },
-    { name = "fastapi" },
-    { name = "uvicorn" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/db/46/b9ba1eb20b99a60811a8104f1500d4a4e987a2614e15f042010c5cb7c49f/agent_framework_ag_ui-1.0.0b260212.tar.gz", hash = "sha256:e7a76ac567eb5bfc341b0036350a5dd6b3b655df6a8a783cb5e74aad52e18f46", size = 100383, upload-time = "2026-02-13T00:38:10.178Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d6/f9/c9abab917250ca07c1ad246216e05c6057cc07ab99045607daef99fdfc1c/agent_framework_ag_ui-1.0.0b260212-py3-none-any.whl", hash = "sha256:5c419bea8b8ca3bfbdb0bc4651199ffce7c94d8d01488f7682d2782dadf6b346", size = 70837, upload-time = "2026-02-13T00:27:26.178Z" },
-]
-
-[[package]]
-name = "agent-framework-anthropic"
-version = "1.0.0b260212"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "agent-framework-core" },
-    { name = "anthropic" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/ff/fb/db7157cd342ed079a467a4080f3d5aadd403b798e25b6c52b638c317f44c/agent_framework_anthropic-1.0.0b260212.tar.gz", hash = "sha256:46adac3ff7cfedbf97d76fafa9c6a461b4ad1b53c075336d300800a283289f21", size = 12977, upload-time = "2026-02-13T00:27:13.58Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f0/1f/0c016c683b922919c5aabb8591fd04cffec7432a224169b029049e90967c/agent_framework_anthropic-1.0.0b260212-py3-none-any.whl", hash = "sha256:8c2a8bb5474b7984994b7e6cf0318f06338765f406c50a3d7336f38ed44c9444", size = 13025, upload-time = "2026-02-13T00:38:15.841Z" },
-]
-
-[[package]]
-name = "agent-framework-azure-ai"
-version = "1.0.0b260212"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "agent-framework-core" },
-    { name = "aiohttp" },
-    { name = "azure-ai-agents" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/0c/de/ad2254deba49e322581a08eef217be847bd17db5d3b93df5ffb98f7d5b27/agent_framework_azure_ai-1.0.0b260212.tar.gz", hash = "sha256:6b717a0d01780977c5fc61cde92ead4ece6c7be31b46caa82157e975e498f1a2", size = 36791, upload-time = "2026-02-13T00:27:20.204Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/99/4e/9a60ac36f50856caf0715b139ddc2175aed7d686405dfde47d4ece3fe6ba/agent_framework_azure_ai-1.0.0b260212-py3-none-any.whl", hash = "sha256:361e6ed3d0c1cd5454e05e47921520a4aedd77d129937fbe5d97b731ecde369b", size = 41253, upload-time = "2026-02-13T00:38:08.481Z" },
-]
-
-[[package]]
-name = "agent-framework-azure-ai-search"
-version = "1.0.0b260212"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "agent-framework-core" },
-    { name = "azure-search-documents" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/f2/5f/b9805751c5fa3d8de37732eb68285a902013e361adba2acfd1d6ac48aab3/agent_framework_azure_ai_search-1.0.0b260212.tar.gz", hash = "sha256:6dea7b8a7624671f3f13322eb50649436f8defc2d16216c2973e0ec8d0d8bd8d", size = 9164, upload-time = "2026-02-13T00:38:05.596Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/9d/30/010b1e8662355735a03479742eaa4381f4332e1b3dfb176f6fa646293581/agent_framework_azure_ai_search-1.0.0b260212-py3-none-any.whl", hash = "sha256:db1b0dfcf5186f821474290699fb77f89a5f23a1181b52a560137650f0d2cf28", size = 9300, upload-time = "2026-02-13T00:38:07.444Z" },
-]
-
-[[package]]
-name = "agent-framework-azurefunctions"
-version = "1.0.0b260212"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "agent-framework-core" },
-    { name = "agent-framework-durabletask" },
-    { name = "azure-functions" },
-    { name = "azure-functions-durable" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/c7/df/472b1df0b10e4c76625e34ca3cf56d591fc387cace20464b466d1387b772/agent_framework_azurefunctions-1.0.0b260212.tar.gz", hash = "sha256:9b816601a2cf679a037d0e07342cc734f6d2665f7ed5b74e16ecdad25760a263", size = 16454, upload-time = "2026-02-13T00:27:27.06Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/bc/7a/8f5479743363816156e8a984cd09a3a584fea6f4e48d1104d2304e83625d/agent_framework_azurefunctions-1.0.0b260212-py3-none-any.whl", hash = "sha256:459c9233d809d8a452bb197ba22c2c5278158094fbcc115a340538f4032cc957", size = 17848, upload-time = "2026-02-13T00:27:17.413Z" },
-]
-
-[[package]]
-name = "agent-framework-chatkit"
-version = "1.0.0b260212"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "agent-framework-core" },
-    { name = "openai-chatkit" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/c0/a6/2b207937b77152cd86579bac79a5d6499cd94868610035ee1fdb77856247/agent_framework_chatkit-1.0.0b260212.tar.gz", hash = "sha256:5cefca05064c4adc3e20bdc05dddb774d6be9cb2bfe99345be93c0b729b743fd", size = 12518, upload-time = "2026-02-13T00:38:15.163Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/be/f1/a7551101b53f4874b633bf472372c80d151b03840de91597ec7195fdf227/agent_framework_chatkit-1.0.0b260212-py3-none-any.whl", hash = "sha256:d6794656eef05c42c850d4988801c99ffede45b91bb056e9ec78076e20a77158", size = 11728, upload-time = "2026-02-13T00:38:21.044Z" },
-]
-
-[[package]]
-name = "agent-framework-copilotstudio"
-version = "1.0.0b260212"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "agent-framework-core" },
-    { name = "microsoft-agents-copilotstudio-client" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/b6/94/f9b3900c7690fe1fa650afd615c4a4fd12cba67529ce37131d185b1fb385/agent_framework_copilotstudio-1.0.0b260212.tar.gz", hash = "sha256:d29fe61d3b5d42ceb11f079a15ed301db4c2303dbcc688987d2f3be9dd696fcf", size = 8404, upload-time = "2026-02-13T00:27:30.968Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d8/ac/3a91b4da6e14308baaacd80b60a5e4c45e0d8942a53816b51c8734d2c3d4/agent_framework_copilotstudio-1.0.0b260212-py3-none-any.whl", hash = "sha256:c7dfe230e64c41c81075be773619e8c980f673792620c78b85e2e181eb621331", size = 8557, upload-time = "2026-02-13T00:38:00.372Z" },
-]
-
-[[package]]
 name = "agent-framework-core"
-version = "1.0.0b260212"
+version = "1.18.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "azure-ai-projects" },
-    { name = "azure-identity" },
-    { name = "mcp", extra = ["ws"] },
-    { name = "openai" },
+    { name = "msgspec" },
     { name = "opentelemetry-api" },
-    { name = "opentelemetry-sdk" },
-    { name = "opentelemetry-semantic-conventions-ai" },
-    { name = "packaging" },
     { name = "pydantic" },
     { name = "python-dotenv" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1f/75/33444ede8faa90ebc0c81a7c362c401c9a29c224d8e4ef3653b018ad32f3/agent_framework_core-1.0.0b260212.tar.gz", hash = "sha256:4490e05f48dff6fe616331e46b4b4432e54a81075475c7087dce91b8c462c8d0", size = 259769, upload-time = "2026-02-13T00:27:18.66Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2e/6e/e0d661f1770bf3a6d70248c5964e684d2bb648b253d53f3dca315f393535/agent_framework_core-1.18.0.tar.gz", hash = "sha256:ef84e1ec570036b81a93a9e924bc4281380f6240ab9bddb8a2db7669282032b0", size = 652594, upload-time = "2026-09-10T09:29:19.938Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d4/b6/6c32def3967496e3688a69fda5bb55066688721c2839bc220de8ca3b306b/agent_framework_core-1.0.0b260212-py3-none-any.whl", hash = "sha256:18fc00c35911bd8a8c49055eda5204dc6dde761cf2379d32b16a91aaf6635dc0", size = 301370, upload-time = "2026-02-13T00:27:32.307Z" },
-]
-
-[package.optional-dependencies]
-all = [
-    { name = "agent-framework-a2a" },
-    { name = "agent-framework-ag-ui" },
-    { name = "agent-framework-anthropic" },
-    { name = "agent-framework-azure-ai" },
-    { name = "agent-framework-azure-ai-search" },
-    { name = "agent-framework-azurefunctions" },
-    { name = "agent-framework-chatkit" },
-    { name = "agent-framework-copilotstudio" },
-    { name = "agent-framework-declarative" },
-    { name = "agent-framework-devui" },
-    { name = "agent-framework-durabletask" },
-    { name = "agent-framework-github-copilot" },
-    { name = "agent-framework-lab" },
-    { name = "agent-framework-mem0" },
-    { name = "agent-framework-ollama" },
-    { name = "agent-framework-orchestrations" },
-    { name = "agent-framework-purview" },
-    { name = "agent-framework-redis" },
+    { url = "https://files.pythonhosted.org/packages/98/a6/10b844bf70bd174d32635e84a5cffa2ada1df1555266e00fc5c3a402d744/agent_framework_core-1.18.0-py3-none-any.whl", hash = "sha256:75f2fac5eed229c62f0665630cf1478eb45204bde41200a4c94dab57d441cc84", size = 712930, upload-time = "2026-09-10T09:28:54.632Z" },
 ]
 
 [[package]]
-name = "agent-framework-declarative"
-version = "1.0.0b260212"
+name = "aiofile"
+version = "3.9.0"
 source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "agent-framework-core" },
-    { name = "powerfx", marker = "python_full_version < '3.14'" },
-    { name = "pyyaml" },
+resolution-markers = [
+    "python_full_version < '3.11'",
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7c/ce/45ff85bee75579a83159d8ba683bb99e18c7cd8e3fc86616f2c52bd02845/agent_framework_declarative-1.0.0b260212.tar.gz", hash = "sha256:c769a1972ecf9b8ed8d5a2d5838a74c6360c51f84b00e62b385ed2a293010a5d", size = 79209, upload-time = "2026-02-13T00:38:17.444Z" }
+dependencies = [
+    { name = "caio", version = "0.9.25", source = { registry = "https://pypi.org/simple" } },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/67/e2/d7cb819de8df6b5c1968a2756c3cb4122d4fa2b8fc768b53b7c9e5edb646/aiofile-3.9.0.tar.gz", hash = "sha256:e5ad718bb148b265b6df1b3752c4d1d83024b93da9bd599df74b9d9ffcf7919b", size = 17943, upload-time = "2024-10-08T10:39:35.846Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/19/61/9933fc6ca91a6ef3af582bb9631c230210591b567c7a7e898029a793a6b8/agent_framework_declarative-1.0.0b260212-py3-none-any.whl", hash = "sha256:34d9d618a0516d7fbcd095322ae4a18bb4d4a073bb9cf6b7e90a68348c2413d2", size = 90175, upload-time = "2026-02-13T00:27:21.43Z" },
+    { url = "https://files.pythonhosted.org/packages/50/25/da1f0b4dd970e52bf5a36c204c107e11a0c6d3ed195eba0bfbc664c312b2/aiofile-3.9.0-py3-none-any.whl", hash = "sha256:ce2f6c1571538cbdfa0143b04e16b208ecb0e9cb4148e528af8a640ed51cc8aa", size = 19539, upload-time = "2024-10-08T10:39:32.955Z" },
 ]
 
 [[package]]
-name = "agent-framework-devui"
-version = "1.0.0b260212"
+name = "aiofile"
+version = "3.12.3"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14'",
+    "python_full_version == '3.13.*'",
+    "python_full_version == '3.12.*'",
+    "python_full_version == '3.11.*'",
+]
 dependencies = [
-    { name = "agent-framework-core" },
-    { name = "fastapi" },
-    { name = "python-dotenv" },
-    { name = "uvicorn", extra = ["standard"] },
+    { name = "caio", version = "0.12.4", source = { registry = "https://pypi.org/simple" } },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2d/bc/cdfb1518cafe7c7fb53198e9b5e5e252d03367cc2ae96538625a223f82f4/agent_framework_devui-1.0.0b260212.tar.gz", hash = "sha256:be448991f78d460d5e5fffc70a2fbf1a24e3e63249bdda3b768986d8182abe88", size = 355894, upload-time = "2026-02-13T00:38:10.895Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/14/31/edb06aabd8f8f0b56d659f30800795f40b93cba96be946ce179f6931e3a5/aiofile-3.12.3.tar.gz", hash = "sha256:caa6aa746b5e47e2165f7abd741b6415e49cf4d44fddc0f61844612cc3924d41", size = 21600, upload-time = "2026-08-04T22:59:27.171Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/03/76/02394e3c109e99c186d194799dad254fe2b110905712ef6f96ff9a151b08/agent_framework_devui-1.0.0b260212-py3-none-any.whl", hash = "sha256:947851c4f5b7cd1455a25bc250a64e98e15e7a4e499aba2f9b22fb5be00d93d6", size = 360599, upload-time = "2026-02-13T00:27:28.127Z" },
-]
-
-[[package]]
-name = "agent-framework-durabletask"
-version = "1.0.0b260212"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "agent-framework-core" },
-    { name = "durabletask" },
-    { name = "durabletask-azuremanaged" },
-    { name = "python-dateutil" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/2f/2f/3747a6346190bbcd37cde269999fee9c5ad60492d3706e8c4ee3019830f4/agent_framework_durabletask-1.0.0b260212.tar.gz", hash = "sha256:dd54fb07410c60c5ad4550f0feaf80a4660bbbb98d137f4f8298a91af0fa9406", size = 30617, upload-time = "2026-02-13T00:27:22.649Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/79/5e/31f877ed9ad8945ef719cdf4728536037146bfbd4580322b4318e7389dc9/agent_framework_durabletask-1.0.0b260212-py3-none-any.whl", hash = "sha256:8a96927c244bae1498fc9cd73782dac3b1efeccff14e64f738feba68d4584733", size = 36413, upload-time = "2026-02-13T00:27:24.934Z" },
-]
-
-[[package]]
-name = "agent-framework-github-copilot"
-version = "1.0.0b260212"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "agent-framework-core" },
-    { name = "github-copilot-sdk", version = "0.1.25", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "github-copilot-sdk", version = "1.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/23/72/920aa1f2fc04273f8eeda2c5bf4258d90d12cd1f35d4720fa429d65fec76/agent_framework_github_copilot-1.0.0b260212.tar.gz", hash = "sha256:5d98c0644f01182662103689f749a24a792aae893f0d4c162ae57a959ebb1121", size = 8449, upload-time = "2026-02-13T00:38:18.862Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/41/9c/bbc9b03b4c4d90945a73ae172b6750b86adbed57d1fcb2749cb0852640da/agent_framework_github_copilot-1.0.0b260212-py3-none-any.whl", hash = "sha256:80854d9623339ba510a498f1c57b03decca7a3a82836d5d8ac576bc92b901d70", size = 9065, upload-time = "2026-02-13T00:27:33.696Z" },
-]
-
-[[package]]
-name = "agent-framework-lab"
-version = "1.0.0b251024"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "agent-framework-core" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/05/c5/be86273cb3545651d0c8112ff9f38ae8fe13b740ce9b65b9be83ff2d70ee/agent_framework_lab-1.0.0b251024.tar.gz", hash = "sha256:4261cb595b6edfd4f30db613c1885c71b3dcfa2088cf29224d4f17b3ff956b2a", size = 23397, upload-time = "2025-10-24T18:13:48.58Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/26/0f/3974b2b1f6bf523ee3ced0886b6afd5ca8bbebd24aa5278ef77db0d3d765/agent_framework_lab-1.0.0b251024-py3-none-any.whl", hash = "sha256:1596408991a92fcacef4bb939305d2b59159517b707f48114105fc0dd46bfee7", size = 26589, upload-time = "2025-10-24T18:13:47.229Z" },
-]
-
-[[package]]
-name = "agent-framework-mem0"
-version = "1.0.0b260212"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "agent-framework-core" },
-    { name = "mem0ai" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/5b/40/a2987a7d4b7a21883b04a4a89c0424c0f72c0568e5060f176bb53ced39c5/agent_framework_mem0-1.0.0b260212.tar.gz", hash = "sha256:ff32dd4fed615e251a11bd4a936734a8390e722214b34f1461f6bf8c077815fa", size = 5190, upload-time = "2026-02-13T00:27:24.191Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/57/db/f2a8adfe16fde1a52658949fb885a10729ec0da32570d5877dcf1d710514/agent_framework_mem0-1.0.0b260212-py3-none-any.whl", hash = "sha256:6eb34e59fd1f9e067bf2ef3c8242e7dee7234a81554cecd2e81db33098f20de3", size = 5531, upload-time = "2026-02-13T00:27:30.291Z" },
-]
-
-[[package]]
-name = "agent-framework-ollama"
-version = "1.0.0b260212"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "agent-framework-core" },
-    { name = "ollama" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/df/b8/16232f3198118de2c1ad3a68c54e42352527b88e0a641ba6ce01b4453b76/agent_framework_ollama-1.0.0b260212.tar.gz", hash = "sha256:fa7e3bcf1082b6417280931516f03e08db5b4bb716736933e93609121f2f0acd", size = 8401, upload-time = "2026-02-13T00:38:14.33Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/13/49/accba004c46d4f0e7b8691a8dfe2d3316d18488a22509d34e66a891dfd75/agent_framework_ollama-1.0.0b260212-py3-none-any.whl", hash = "sha256:936854b0a3ea6a6d4792ba9f833f960465b76ba95aad8f73dd7a5b9a69b275e7", size = 9452, upload-time = "2026-02-13T00:38:18.169Z" },
-]
-
-[[package]]
-name = "agent-framework-orchestrations"
-version = "1.0.0b260212"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "agent-framework-core" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/42/bf/9a1f62bf243157f5ce20e26b1549bdc563334521a1c3155b7eb4093f5b47/agent_framework_orchestrations-1.0.0b260212.tar.gz", hash = "sha256:31c215af8fe7cf954c17306113137df945aabae35e9f3c89052b6983e39516a8", size = 53522, upload-time = "2026-02-13T00:37:58.163Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/2d/87/7af9ea63943555dd133a9aaf3d056de4763cc2e91986763167a2f4dff6e0/agent_framework_orchestrations-1.0.0b260212-py3-none-any.whl", hash = "sha256:c10ed851a33ce46de8ee50f20a08b1db2604ef0a14739a23b42ba1279ddd52d1", size = 59721, upload-time = "2026-02-13T00:37:51.783Z" },
-]
-
-[[package]]
-name = "agent-framework-purview"
-version = "1.0.0b260212"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "agent-framework-core" },
-    { name = "azure-core" },
-    { name = "httpx" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/f8/1a/0fb848870aa661e8949dac17eca6276d127d2990d39994478cadba0324df/agent_framework_purview-1.0.0b260212.tar.gz", hash = "sha256:e5f93128eed1042177e9b61376b80cb169869d349fe0821e80dfba2f7c9027eb", size = 27261, upload-time = "2026-02-13T00:37:58.857Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/1a/0b/1c432a665616c0ec2962ba56751f213c5c97ec1ed6492f173cd2600e7640/agent_framework_purview-1.0.0b260212-py3-none-any.whl", hash = "sha256:7b2ccdffb6311973730c62207723c175fa8b6b7ea09c94206bc19dd9ad88dafc", size = 26731, upload-time = "2026-02-13T00:38:12.451Z" },
-]
-
-[[package]]
-name = "agent-framework-redis"
-version = "1.0.0b260212"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "agent-framework-core" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.4.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "redis" },
-    { name = "redisvl" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/34/df/52ee9681465ae65f51ee128f4b9491537ebecbaab263d2edd03f61813989/agent_framework_redis-1.0.0b260212.tar.gz", hash = "sha256:a5b96b011af8b70c2fd3971735fc6e835ca2f2d2f84b08dd7c0eedc5cb05f507", size = 10311, upload-time = "2026-02-13T00:38:09.549Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d7/19/817e411b075a79ec7a061a0a1609b4691e98cdbb23d7a16f5cbeec4830ff/agent_framework_redis-1.0.0b260212-py3-none-any.whl", hash = "sha256:15f967205fd6c994fa58f355a7f3011d9aa043880facfc20c50172ee459fcaf0", size = 10434, upload-time = "2026-02-13T00:38:20.296Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/79/6e45e778c4c3cab39e0937b007b720c15f76c50c6453d153282d0fcc3588/aiofile-3.12.3-py3-none-any.whl", hash = "sha256:5c1bcc9e929c50834608e8cc1a4cc1d7503eb60c15a535b779fd39e2f372c017", size = 22122, upload-time = "2026-08-04T22:59:25.838Z" },
 ]
 
 [[package]]
@@ -352,7 +69,7 @@ wheels = [
 
 [[package]]
 name = "aiohttp"
-version = "3.13.3"
+version = "3.14.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohappyeyeballs" },
@@ -362,112 +79,129 @@ dependencies = [
     { name = "frozenlist" },
     { name = "multidict" },
     { name = "propcache" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
     { name = "yarl" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/50/42/32cf8e7704ceb4481406eb87161349abb46a57fee3f008ba9cb610968646/aiohttp-3.13.3.tar.gz", hash = "sha256:a949eee43d3782f2daae4f4a2819b2cb9b0c5d3b7f7a927067cc84dafdbb9f88", size = 7844556, upload-time = "2026-01-03T17:33:05.204Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/d9/22ce5786ac0c1653ae8b6c23bded02c1686d11f0dbb45b31ce128e0df985/aiohttp-3.14.3.tar.gz", hash = "sha256:9491196535a88924a60afd5b5f434b5b203b6cc616250878dbdb223a8f7844bc", size = 7971213, upload-time = "2026-07-23T01:57:27.037Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/36/d6/5aec9313ee6ea9c7cde8b891b69f4ff4001416867104580670a31daeba5b/aiohttp-3.13.3-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:d5a372fd5afd301b3a89582817fdcdb6c34124787c70dbcc616f259013e7eef7", size = 738950, upload-time = "2026-01-03T17:29:13.002Z" },
-    { url = "https://files.pythonhosted.org/packages/68/03/8fa90a7e6d11ff20a18837a8e2b5dd23db01aabc475aa9271c8ad33299f5/aiohttp-3.13.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:147e422fd1223005c22b4fe080f5d93ced44460f5f9c105406b753612b587821", size = 496099, upload-time = "2026-01-03T17:29:15.268Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/23/b81f744d402510a8366b74eb420fc0cc1170d0c43daca12d10814df85f10/aiohttp-3.13.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:859bd3f2156e81dd01432f5849fc73e2243d4a487c4fd26609b1299534ee1845", size = 491072, upload-time = "2026-01-03T17:29:16.922Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/e1/56d1d1c0dd334cd203dd97706ce004c1aa24b34a813b0b8daf3383039706/aiohttp-3.13.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dca68018bf48c251ba17c72ed479f4dafe9dbd5a73707ad8d28a38d11f3d42af", size = 1671588, upload-time = "2026-01-03T17:29:18.539Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/34/8d7f962604f4bc2b4e39eb1220dac7d4e4cba91fb9ba0474b4ecd67db165/aiohttp-3.13.3-cp310-cp310-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:fee0c6bc7db1de362252affec009707a17478a00ec69f797d23ca256e36d5940", size = 1640334, upload-time = "2026-01-03T17:29:21.028Z" },
-    { url = "https://files.pythonhosted.org/packages/94/1d/fcccf2c668d87337ddeef9881537baee13c58d8f01f12ba8a24215f2b804/aiohttp-3.13.3-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c048058117fd649334d81b4b526e94bde3ccaddb20463a815ced6ecbb7d11160", size = 1722656, upload-time = "2026-01-03T17:29:22.531Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/98/c6f3b081c4c606bc1e5f2ec102e87d6411c73a9ef3616fea6f2d5c98c062/aiohttp-3.13.3-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:215a685b6fbbfcf71dfe96e3eba7a6f58f10da1dfdf4889c7dd856abe430dca7", size = 1817625, upload-time = "2026-01-03T17:29:24.276Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/c0/cfcc3d2e11b477f86e1af2863f3858c8850d751ce8dc39c4058a072c9e54/aiohttp-3.13.3-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:de2c184bb1fe2cbd2cefba613e9db29a5ab559323f994b6737e370d3da0ac455", size = 1672604, upload-time = "2026-01-03T17:29:26.099Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/77/6b4ffcbcac4c6a5d041343a756f34a6dd26174ae07f977a64fe028dda5b0/aiohttp-3.13.3-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:75ca857eba4e20ce9f546cd59c7007b33906a4cd48f2ff6ccf1ccfc3b646f279", size = 1554370, upload-time = "2026-01-03T17:29:28.121Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/f0/e3ddfa93f17d689dbe014ba048f18e0c9f9b456033b70e94349a2e9048be/aiohttp-3.13.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:81e97251d9298386c2b7dbeb490d3d1badbdc69107fb8c9299dd04eb39bddc0e", size = 1642023, upload-time = "2026-01-03T17:29:30.002Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/45/c14019c9ec60a8e243d06d601b33dcc4fd92379424bde3021725859d7f99/aiohttp-3.13.3-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:c0e2d366af265797506f0283487223146af57815b388623f0357ef7eac9b209d", size = 1649680, upload-time = "2026-01-03T17:29:31.782Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/fd/09c9451dae5aa5c5ed756df95ff9ef549d45d4be663bafd1e4954fd836f0/aiohttp-3.13.3-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:4e239d501f73d6db1522599e14b9b321a7e3b1de66ce33d53a765d975e9f4808", size = 1692407, upload-time = "2026-01-03T17:29:33.392Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/81/938bc2ec33c10efd6637ccb3d22f9f3160d08e8f3aa2587a2c2d5ab578eb/aiohttp-3.13.3-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:0db318f7a6f065d84cb1e02662c526294450b314a02bd9e2a8e67f0d8564ce40", size = 1543047, upload-time = "2026-01-03T17:29:34.855Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/23/80488ee21c8d567c83045e412e1d9b7077d27171591a4eb7822586e8c06a/aiohttp-3.13.3-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:bfc1cc2fe31a6026a8a88e4ecfb98d7f6b1fec150cfd708adbfd1d2f42257c29", size = 1715264, upload-time = "2026-01-03T17:29:36.389Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/83/259a8da6683182768200b368120ab3deff5370bed93880fb9a3a86299f34/aiohttp-3.13.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:af71fff7bac6bb7508956696dce8f6eec2bbb045eceb40343944b1ae62b5ef11", size = 1657275, upload-time = "2026-01-03T17:29:38.162Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/4f/2c41f800a0b560785c10fb316216ac058c105f9be50bdc6a285de88db625/aiohttp-3.13.3-cp310-cp310-win32.whl", hash = "sha256:37da61e244d1749798c151421602884db5270faf479cf0ef03af0ff68954c9dd", size = 434053, upload-time = "2026-01-03T17:29:40.074Z" },
-    { url = "https://files.pythonhosted.org/packages/80/df/29cd63c7ecfdb65ccc12f7d808cac4fa2a19544660c06c61a4a48462de0c/aiohttp-3.13.3-cp310-cp310-win_amd64.whl", hash = "sha256:7e63f210bc1b57ef699035f2b4b6d9ce096b5914414a49b0997c839b2bd2223c", size = 456687, upload-time = "2026-01-03T17:29:41.819Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/4c/a164164834f03924d9a29dc3acd9e7ee58f95857e0b467f6d04298594ebb/aiohttp-3.13.3-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:5b6073099fb654e0a068ae678b10feff95c5cae95bbfcbfa7af669d361a8aa6b", size = 746051, upload-time = "2026-01-03T17:29:43.287Z" },
-    { url = "https://files.pythonhosted.org/packages/82/71/d5c31390d18d4f58115037c432b7e0348c60f6f53b727cad33172144a112/aiohttp-3.13.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:1cb93e166e6c28716c8c6aeb5f99dfb6d5ccf482d29fe9bf9a794110e6d0ab64", size = 499234, upload-time = "2026-01-03T17:29:44.822Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/c9/741f8ac91e14b1d2e7100690425a5b2b919a87a5075406582991fb7de920/aiohttp-3.13.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:28e027cf2f6b641693a09f631759b4d9ce9165099d2b5d92af9bd4e197690eea", size = 494979, upload-time = "2026-01-03T17:29:46.405Z" },
-    { url = "https://files.pythonhosted.org/packages/75/b5/31d4d2e802dfd59f74ed47eba48869c1c21552c586d5e81a9d0d5c2ad640/aiohttp-3.13.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3b61b7169ababd7802f9568ed96142616a9118dd2be0d1866e920e77ec8fa92a", size = 1748297, upload-time = "2026-01-03T17:29:48.083Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/3e/eefad0ad42959f226bb79664826883f2687d602a9ae2941a18e0484a74d3/aiohttp-3.13.3-cp311-cp311-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:80dd4c21b0f6237676449c6baaa1039abae86b91636b6c91a7f8e61c87f89540", size = 1707172, upload-time = "2026-01-03T17:29:49.648Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/3a/54a64299fac2891c346cdcf2aa6803f994a2e4beeaf2e5a09dcc54acc842/aiohttp-3.13.3-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:65d2ccb7eabee90ce0503c17716fc77226be026dcc3e65cce859a30db715025b", size = 1805405, upload-time = "2026-01-03T17:29:51.244Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/70/ddc1b7169cf64075e864f64595a14b147a895a868394a48f6a8031979038/aiohttp-3.13.3-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5b179331a481cb5529fca8b432d8d3c7001cb217513c94cd72d668d1248688a3", size = 1899449, upload-time = "2026-01-03T17:29:53.938Z" },
-    { url = "https://files.pythonhosted.org/packages/a1/7e/6815aab7d3a56610891c76ef79095677b8b5be6646aaf00f69b221765021/aiohttp-3.13.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9d4c940f02f49483b18b079d1c27ab948721852b281f8b015c058100e9421dd1", size = 1748444, upload-time = "2026-01-03T17:29:55.484Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/f2/073b145c4100da5511f457dc0f7558e99b2987cf72600d42b559db856fbc/aiohttp-3.13.3-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f9444f105664c4ce47a2a7171a2418bce5b7bae45fb610f4e2c36045d85911d3", size = 1606038, upload-time = "2026-01-03T17:29:57.179Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/c1/778d011920cae03ae01424ec202c513dc69243cf2db303965615b81deeea/aiohttp-3.13.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:694976222c711d1d00ba131904beb60534f93966562f64440d0c9d41b8cdb440", size = 1724156, upload-time = "2026-01-03T17:29:58.914Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/cb/3419eabf4ec1e9ec6f242c32b689248365a1cf621891f6f0386632525494/aiohttp-3.13.3-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:f33ed1a2bf1997a36661874b017f5c4b760f41266341af36febaf271d179f6d7", size = 1722340, upload-time = "2026-01-03T17:30:01.962Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/e5/76cf77bdbc435bf233c1f114edad39ed4177ccbfab7c329482b179cff4f4/aiohttp-3.13.3-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:e636b3c5f61da31a92bf0d91da83e58fdfa96f178ba682f11d24f31944cdd28c", size = 1783041, upload-time = "2026-01-03T17:30:03.609Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/d4/dd1ca234c794fd29c057ce8c0566b8ef7fd6a51069de5f06fa84b9a1971c/aiohttp-3.13.3-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:5d2d94f1f5fcbe40838ac51a6ab5704a6f9ea42e72ceda48de5e6b898521da51", size = 1596024, upload-time = "2026-01-03T17:30:05.132Z" },
-    { url = "https://files.pythonhosted.org/packages/55/58/4345b5f26661a6180afa686c473620c30a66afdf120ed3dd545bbc809e85/aiohttp-3.13.3-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:2be0e9ccf23e8a94f6f0650ce06042cefc6ac703d0d7ab6c7a917289f2539ad4", size = 1804590, upload-time = "2026-01-03T17:30:07.135Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/06/05950619af6c2df7e0a431d889ba2813c9f0129cec76f663e547a5ad56f2/aiohttp-3.13.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:9af5e68ee47d6534d36791bbe9b646d2a7c7deb6fc24d7943628edfbb3581f29", size = 1740355, upload-time = "2026-01-03T17:30:09.083Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/80/958f16de79ba0422d7c1e284b2abd0c84bc03394fbe631d0a39ffa10e1eb/aiohttp-3.13.3-cp311-cp311-win32.whl", hash = "sha256:a2212ad43c0833a873d0fb3c63fa1bacedd4cf6af2fee62bf4b739ceec3ab239", size = 433701, upload-time = "2026-01-03T17:30:10.869Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/f2/27cdf04c9851712d6c1b99df6821a6623c3c9e55956d4b1e318c337b5a48/aiohttp-3.13.3-cp311-cp311-win_amd64.whl", hash = "sha256:642f752c3eb117b105acbd87e2c143de710987e09860d674e068c4c2c441034f", size = 457678, upload-time = "2026-01-03T17:30:12.719Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/be/4fc11f202955a69e0db803a12a062b8379c970c7c84f4882b6da17337cc1/aiohttp-3.13.3-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:b903a4dfee7d347e2d87697d0713be59e0b87925be030c9178c5faa58ea58d5c", size = 739732, upload-time = "2026-01-03T17:30:14.23Z" },
-    { url = "https://files.pythonhosted.org/packages/97/2c/621d5b851f94fa0bb7430d6089b3aa970a9d9b75196bc93bb624b0db237a/aiohttp-3.13.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:a45530014d7a1e09f4a55f4f43097ba0fd155089372e105e4bff4ca76cb1b168", size = 494293, upload-time = "2026-01-03T17:30:15.96Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/43/4be01406b78e1be8320bb8316dc9c42dbab553d281c40364e0f862d5661c/aiohttp-3.13.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:27234ef6d85c914f9efeb77ff616dbf4ad2380be0cda40b4db086ffc7ddd1b7d", size = 493533, upload-time = "2026-01-03T17:30:17.431Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/a8/5a35dc56a06a2c90d4742cbf35294396907027f80eea696637945a106f25/aiohttp-3.13.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d32764c6c9aafb7fb55366a224756387cd50bfa720f32b88e0e6fa45b27dcf29", size = 1737839, upload-time = "2026-01-03T17:30:19.422Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/62/4b9eeb331da56530bf2e198a297e5303e1c1ebdceeb00fe9b568a65c5a0c/aiohttp-3.13.3-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:b1a6102b4d3ebc07dad44fbf07b45bb600300f15b552ddf1851b5390202ea2e3", size = 1703932, upload-time = "2026-01-03T17:30:21.756Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/f6/af16887b5d419e6a367095994c0b1332d154f647e7dc2bd50e61876e8e3d/aiohttp-3.13.3-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c014c7ea7fb775dd015b2d3137378b7be0249a448a1612268b5a90c2d81de04d", size = 1771906, upload-time = "2026-01-03T17:30:23.932Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/83/397c634b1bcc24292fa1e0c7822800f9f6569e32934bdeef09dae7992dfb/aiohttp-3.13.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:2b8d8ddba8f95ba17582226f80e2de99c7a7948e66490ef8d947e272a93e9463", size = 1871020, upload-time = "2026-01-03T17:30:26Z" },
-    { url = "https://files.pythonhosted.org/packages/86/f6/a62cbbf13f0ac80a70f71b1672feba90fdb21fd7abd8dbf25c0105fb6fa3/aiohttp-3.13.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9ae8dd55c8e6c4257eae3a20fd2c8f41edaea5992ed67156642493b8daf3cecc", size = 1755181, upload-time = "2026-01-03T17:30:27.554Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/87/20a35ad487efdd3fba93d5843efdfaa62d2f1479eaafa7453398a44faf13/aiohttp-3.13.3-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:01ad2529d4b5035578f5081606a465f3b814c542882804e2e8cda61adf5c71bf", size = 1561794, upload-time = "2026-01-03T17:30:29.254Z" },
-    { url = "https://files.pythonhosted.org/packages/de/95/8fd69a66682012f6716e1bc09ef8a1a2a91922c5725cb904689f112309c4/aiohttp-3.13.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:bb4f7475e359992b580559e008c598091c45b5088f28614e855e42d39c2f1033", size = 1697900, upload-time = "2026-01-03T17:30:31.033Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/66/7b94b3b5ba70e955ff597672dad1691333080e37f50280178967aff68657/aiohttp-3.13.3-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:c19b90316ad3b24c69cd78d5c9b4f3aa4497643685901185b65166293d36a00f", size = 1728239, upload-time = "2026-01-03T17:30:32.703Z" },
-    { url = "https://files.pythonhosted.org/packages/47/71/6f72f77f9f7d74719692ab65a2a0252584bf8d5f301e2ecb4c0da734530a/aiohttp-3.13.3-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:96d604498a7c782cb15a51c406acaea70d8c027ee6b90c569baa6e7b93073679", size = 1740527, upload-time = "2026-01-03T17:30:34.695Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/b4/75ec16cbbd5c01bdaf4a05b19e103e78d7ce1ef7c80867eb0ace42ff4488/aiohttp-3.13.3-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:084911a532763e9d3dd95adf78a78f4096cd5f58cdc18e6fdbc1b58417a45423", size = 1554489, upload-time = "2026-01-03T17:30:36.864Z" },
-    { url = "https://files.pythonhosted.org/packages/52/8f/bc518c0eea29f8406dcf7ed1f96c9b48e3bc3995a96159b3fc11f9e08321/aiohttp-3.13.3-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:7a4a94eb787e606d0a09404b9c38c113d3b099d508021faa615d70a0131907ce", size = 1767852, upload-time = "2026-01-03T17:30:39.433Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/f2/a07a75173124f31f11ea6f863dc44e6f09afe2bca45dd4e64979490deab1/aiohttp-3.13.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:87797e645d9d8e222e04160ee32aa06bc5c163e8499f24db719e7852ec23093a", size = 1722379, upload-time = "2026-01-03T17:30:41.081Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/4a/1a3fee7c21350cac78e5c5cef711bac1b94feca07399f3d406972e2d8fcd/aiohttp-3.13.3-cp312-cp312-win32.whl", hash = "sha256:b04be762396457bef43f3597c991e192ee7da460a4953d7e647ee4b1c28e7046", size = 428253, upload-time = "2026-01-03T17:30:42.644Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/b7/76175c7cb4eb73d91ad63c34e29fc4f77c9386bba4a65b53ba8e05ee3c39/aiohttp-3.13.3-cp312-cp312-win_amd64.whl", hash = "sha256:e3531d63d3bdfa7e3ac5e9b27b2dd7ec9df3206a98e0b3445fa906f233264c57", size = 455407, upload-time = "2026-01-03T17:30:44.195Z" },
-    { url = "https://files.pythonhosted.org/packages/97/8a/12ca489246ca1faaf5432844adbfce7ff2cc4997733e0af120869345643a/aiohttp-3.13.3-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:5dff64413671b0d3e7d5918ea490bdccb97a4ad29b3f311ed423200b2203e01c", size = 734190, upload-time = "2026-01-03T17:30:45.832Z" },
-    { url = "https://files.pythonhosted.org/packages/32/08/de43984c74ed1fca5c014808963cc83cb00d7bb06af228f132d33862ca76/aiohttp-3.13.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:87b9aab6d6ed88235aa2970294f496ff1a1f9adcd724d800e9b952395a80ffd9", size = 491783, upload-time = "2026-01-03T17:30:47.466Z" },
-    { url = "https://files.pythonhosted.org/packages/17/f8/8dd2cf6112a5a76f81f81a5130c57ca829d101ad583ce57f889179accdda/aiohttp-3.13.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:425c126c0dc43861e22cb1c14ba4c8e45d09516d0a3ae0a3f7494b79f5f233a3", size = 490704, upload-time = "2026-01-03T17:30:49.373Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/40/a46b03ca03936f832bc7eaa47cfbb1ad012ba1be4790122ee4f4f8cba074/aiohttp-3.13.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7f9120f7093c2a32d9647abcaf21e6ad275b4fbec5b55969f978b1a97c7c86bf", size = 1720652, upload-time = "2026-01-03T17:30:50.974Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/7e/917fe18e3607af92657e4285498f500dca797ff8c918bd7d90b05abf6c2a/aiohttp-3.13.3-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:697753042d57f4bf7122cab985bf15d0cef23c770864580f5af4f52023a56bd6", size = 1692014, upload-time = "2026-01-03T17:30:52.729Z" },
-    { url = "https://files.pythonhosted.org/packages/71/b6/cefa4cbc00d315d68973b671cf105b21a609c12b82d52e5d0c9ae61d2a09/aiohttp-3.13.3-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:6de499a1a44e7de70735d0b39f67c8f25eb3d91eb3103be99ca0fa882cdd987d", size = 1759777, upload-time = "2026-01-03T17:30:54.537Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/e3/e06ee07b45e59e6d81498b591fc589629be1553abb2a82ce33efe2a7b068/aiohttp-3.13.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:37239e9f9a7ea9ac5bf6b92b0260b01f8a22281996da609206a84df860bc1261", size = 1861276, upload-time = "2026-01-03T17:30:56.512Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/24/75d274228acf35ceeb2850b8ce04de9dd7355ff7a0b49d607ee60c29c518/aiohttp-3.13.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f76c1e3fe7d7c8afad7ed193f89a292e1999608170dcc9751a7462a87dfd5bc0", size = 1743131, upload-time = "2026-01-03T17:30:58.256Z" },
-    { url = "https://files.pythonhosted.org/packages/04/98/3d21dde21889b17ca2eea54fdcff21b27b93f45b7bb94ca029c31ab59dc3/aiohttp-3.13.3-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:fc290605db2a917f6e81b0e1e0796469871f5af381ce15c604a3c5c7e51cb730", size = 1556863, upload-time = "2026-01-03T17:31:00.445Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/84/da0c3ab1192eaf64782b03971ab4055b475d0db07b17eff925e8c93b3aa5/aiohttp-3.13.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:4021b51936308aeea0367b8f006dc999ca02bc118a0cc78c303f50a2ff6afb91", size = 1682793, upload-time = "2026-01-03T17:31:03.024Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/0f/5802ada182f575afa02cbd0ec5180d7e13a402afb7c2c03a9aa5e5d49060/aiohttp-3.13.3-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:49a03727c1bba9a97d3e93c9f93ca03a57300f484b6e935463099841261195d3", size = 1716676, upload-time = "2026-01-03T17:31:04.842Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/8c/714d53bd8b5a4560667f7bbbb06b20c2382f9c7847d198370ec6526af39c/aiohttp-3.13.3-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:3d9908a48eb7416dc1f4524e69f1d32e5d90e3981e4e37eb0aa1cd18f9cfa2a4", size = 1733217, upload-time = "2026-01-03T17:31:06.868Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/79/e2176f46d2e963facea939f5be2d26368ce543622be6f00a12844d3c991f/aiohttp-3.13.3-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:2712039939ec963c237286113c68dbad80a82a4281543f3abf766d9d73228998", size = 1552303, upload-time = "2026-01-03T17:31:08.958Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/6a/28ed4dea1759916090587d1fe57087b03e6c784a642b85ef48217b0277ae/aiohttp-3.13.3-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:7bfdc049127717581866fa4708791220970ce291c23e28ccf3922c700740fdc0", size = 1763673, upload-time = "2026-01-03T17:31:10.676Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/35/4a3daeb8b9fab49240d21c04d50732313295e4bd813a465d840236dd0ce1/aiohttp-3.13.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8057c98e0c8472d8846b9c79f56766bcc57e3e8ac7bfd510482332366c56c591", size = 1721120, upload-time = "2026-01-03T17:31:12.575Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/9f/d643bb3c5fb99547323e635e251c609fbbc660d983144cfebec529e09264/aiohttp-3.13.3-cp313-cp313-win32.whl", hash = "sha256:1449ceddcdbcf2e0446957863af03ebaaa03f94c090f945411b61269e2cb5daf", size = 427383, upload-time = "2026-01-03T17:31:14.382Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/f1/ab0395f8a79933577cdd996dd2f9aa6014af9535f65dddcf88204682fe62/aiohttp-3.13.3-cp313-cp313-win_amd64.whl", hash = "sha256:693781c45a4033d31d4187d2436f5ac701e7bbfe5df40d917736108c1cc7436e", size = 453899, upload-time = "2026-01-03T17:31:15.958Z" },
-    { url = "https://files.pythonhosted.org/packages/99/36/5b6514a9f5d66f4e2597e40dea2e3db271e023eb7a5d22defe96ba560996/aiohttp-3.13.3-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:ea37047c6b367fd4bd632bff8077449b8fa034b69e812a18e0132a00fae6e808", size = 737238, upload-time = "2026-01-03T17:31:17.909Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/49/459327f0d5bcd8c6c9ca69e60fdeebc3622861e696490d8674a6d0cb90a6/aiohttp-3.13.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:6fc0e2337d1a4c3e6acafda6a78a39d4c14caea625124817420abceed36e2415", size = 492292, upload-time = "2026-01-03T17:31:19.919Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/0b/b97660c5fd05d3495b4eb27f2d0ef18dc1dc4eff7511a9bf371397ff0264/aiohttp-3.13.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c685f2d80bb67ca8c3837823ad76196b3694b0159d232206d1e461d3d434666f", size = 493021, upload-time = "2026-01-03T17:31:21.636Z" },
-    { url = "https://files.pythonhosted.org/packages/54/d4/438efabdf74e30aeceb890c3290bbaa449780583b1270b00661126b8aae4/aiohttp-3.13.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:48e377758516d262bde50c2584fc6c578af272559c409eecbdd2bae1601184d6", size = 1717263, upload-time = "2026-01-03T17:31:23.296Z" },
-    { url = "https://files.pythonhosted.org/packages/71/f2/7bddc7fd612367d1459c5bcf598a9e8f7092d6580d98de0e057eb42697ad/aiohttp-3.13.3-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:34749271508078b261c4abb1767d42b8d0c0cc9449c73a4df494777dc55f0687", size = 1669107, upload-time = "2026-01-03T17:31:25.334Z" },
-    { url = "https://files.pythonhosted.org/packages/00/5a/1aeaecca40e22560f97610a329e0e5efef5e0b5afdf9f857f0d93839ab2e/aiohttp-3.13.3-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:82611aeec80eb144416956ec85b6ca45a64d76429c1ed46ae1b5f86c6e0c9a26", size = 1760196, upload-time = "2026-01-03T17:31:27.394Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/f8/0ff6992bea7bd560fc510ea1c815f87eedd745fe035589c71ce05612a19a/aiohttp-3.13.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:2fff83cfc93f18f215896e3a190e8e5cb413ce01553901aca925176e7568963a", size = 1843591, upload-time = "2026-01-03T17:31:29.238Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/d1/e30e537a15f53485b61f5be525f2157da719819e8377298502aebac45536/aiohttp-3.13.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bbe7d4cecacb439e2e2a8a1a7b935c25b812af7a5fd26503a66dadf428e79ec1", size = 1720277, upload-time = "2026-01-03T17:31:31.053Z" },
-    { url = "https://files.pythonhosted.org/packages/84/45/23f4c451d8192f553d38d838831ebbc156907ea6e05557f39563101b7717/aiohttp-3.13.3-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b928f30fe49574253644b1ca44b1b8adbd903aa0da4b9054a6c20fc7f4092a25", size = 1548575, upload-time = "2026-01-03T17:31:32.87Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/ed/0a42b127a43712eda7807e7892c083eadfaf8429ca8fb619662a530a3aab/aiohttp-3.13.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7b5e8fe4de30df199155baaf64f2fcd604f4c678ed20910db8e2c66dc4b11603", size = 1679455, upload-time = "2026-01-03T17:31:34.76Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/b5/c05f0c2b4b4fe2c9d55e73b6d3ed4fd6c9dc2684b1d81cbdf77e7fad9adb/aiohttp-3.13.3-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:8542f41a62bcc58fc7f11cf7c90e0ec324ce44950003feb70640fc2a9092c32a", size = 1687417, upload-time = "2026-01-03T17:31:36.699Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/6b/915bc5dad66aef602b9e459b5a973529304d4e89ca86999d9d75d80cbd0b/aiohttp-3.13.3-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:5e1d8c8b8f1d91cd08d8f4a3c2b067bfca6ec043d3ff36de0f3a715feeedf926", size = 1729968, upload-time = "2026-01-03T17:31:38.622Z" },
-    { url = "https://files.pythonhosted.org/packages/11/3b/e84581290a9520024a08640b63d07673057aec5ca548177a82026187ba73/aiohttp-3.13.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:90455115e5da1c3c51ab619ac57f877da8fd6d73c05aacd125c5ae9819582aba", size = 1545690, upload-time = "2026-01-03T17:31:40.57Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/04/0c3655a566c43fd647c81b895dfe361b9f9ad6d58c19309d45cff52d6c3b/aiohttp-3.13.3-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:042e9e0bcb5fba81886c8b4fbb9a09d6b8a00245fd8d88e4d989c1f96c74164c", size = 1746390, upload-time = "2026-01-03T17:31:42.857Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/53/71165b26978f719c3419381514c9690bd5980e764a09440a10bb816ea4ab/aiohttp-3.13.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2eb752b102b12a76ca02dff751a801f028b4ffbbc478840b473597fc91a9ed43", size = 1702188, upload-time = "2026-01-03T17:31:44.984Z" },
-    { url = "https://files.pythonhosted.org/packages/29/a7/cbe6c9e8e136314fa1980da388a59d2f35f35395948a08b6747baebb6aa6/aiohttp-3.13.3-cp314-cp314-win32.whl", hash = "sha256:b556c85915d8efaed322bf1bdae9486aa0f3f764195a0fb6ee962e5c71ef5ce1", size = 433126, upload-time = "2026-01-03T17:31:47.463Z" },
-    { url = "https://files.pythonhosted.org/packages/de/56/982704adea7d3b16614fc5936014e9af85c0e34b58f9046655817f04306e/aiohttp-3.13.3-cp314-cp314-win_amd64.whl", hash = "sha256:9bf9f7a65e7aa20dd764151fb3d616c81088f91f8df39c3893a536e279b4b984", size = 459128, upload-time = "2026-01-03T17:31:49.2Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/2a/3c79b638a9c3d4658d345339d22070241ea341ed4e07b5ac60fb0f418003/aiohttp-3.13.3-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:05861afbbec40650d8a07ea324367cb93e9e8cc7762e04dd4405df99fa65159c", size = 769512, upload-time = "2026-01-03T17:31:51.134Z" },
-    { url = "https://files.pythonhosted.org/packages/29/b9/3e5014d46c0ab0db8707e0ac2711ed28c4da0218c358a4e7c17bae0d8722/aiohttp-3.13.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:2fc82186fadc4a8316768d61f3722c230e2c1dcab4200d52d2ebdf2482e47592", size = 506444, upload-time = "2026-01-03T17:31:52.85Z" },
-    { url = "https://files.pythonhosted.org/packages/90/03/c1d4ef9a054e151cd7839cdc497f2638f00b93cbe8043983986630d7a80c/aiohttp-3.13.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:0add0900ff220d1d5c5ebbf99ed88b0c1bbf87aa7e4262300ed1376a6b13414f", size = 510798, upload-time = "2026-01-03T17:31:54.91Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/76/8c1e5abbfe8e127c893fe7ead569148a4d5a799f7cf958d8c09f3eedf097/aiohttp-3.13.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:568f416a4072fbfae453dcf9a99194bbb8bdeab718e08ee13dfa2ba0e4bebf29", size = 1868835, upload-time = "2026-01-03T17:31:56.733Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/ac/984c5a6f74c363b01ff97adc96a3976d9c98940b8969a1881575b279ac5d/aiohttp-3.13.3-cp314-cp314t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:add1da70de90a2569c5e15249ff76a631ccacfe198375eead4aadf3b8dc849dc", size = 1720486, upload-time = "2026-01-03T17:31:58.65Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/9a/b7039c5f099c4eb632138728828b33428585031a1e658d693d41d07d89d1/aiohttp-3.13.3-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:10b47b7ba335d2e9b1239fa571131a87e2d8ec96b333e68b2a305e7a98b0bae2", size = 1847951, upload-time = "2026-01-03T17:32:00.989Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/02/3bec2b9a1ba3c19ff89a43a19324202b8eb187ca1e928d8bdac9bbdddebd/aiohttp-3.13.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3dd4dce1c718e38081c8f35f323209d4c1df7d4db4bab1b5c88a6b4d12b74587", size = 1941001, upload-time = "2026-01-03T17:32:03.122Z" },
-    { url = "https://files.pythonhosted.org/packages/37/df/d879401cedeef27ac4717f6426c8c36c3091c6e9f08a9178cc87549c537f/aiohttp-3.13.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:34bac00a67a812570d4a460447e1e9e06fae622946955f939051e7cc895cfab8", size = 1797246, upload-time = "2026-01-03T17:32:05.255Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/15/be122de1f67e6953add23335c8ece6d314ab67c8bebb3f181063010795a7/aiohttp-3.13.3-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a19884d2ee70b06d9204b2727a7b9f983d0c684c650254679e716b0b77920632", size = 1627131, upload-time = "2026-01-03T17:32:07.607Z" },
-    { url = "https://files.pythonhosted.org/packages/12/12/70eedcac9134cfa3219ab7af31ea56bc877395b1ac30d65b1bc4b27d0438/aiohttp-3.13.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:5f8ca7f2bb6ba8348a3614c7918cc4bb73268c5ac2a207576b7afea19d3d9f64", size = 1795196, upload-time = "2026-01-03T17:32:09.59Z" },
-    { url = "https://files.pythonhosted.org/packages/32/11/b30e1b1cd1f3054af86ebe60df96989c6a414dd87e27ad16950eee420bea/aiohttp-3.13.3-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:b0d95340658b9d2f11d9697f59b3814a9d3bb4b7a7c20b131df4bcef464037c0", size = 1782841, upload-time = "2026-01-03T17:32:11.445Z" },
-    { url = "https://files.pythonhosted.org/packages/88/0d/d98a9367b38912384a17e287850f5695c528cff0f14f791ce8ee2e4f7796/aiohttp-3.13.3-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:a1e53262fd202e4b40b70c3aff944a8155059beedc8a89bba9dc1f9ef06a1b56", size = 1795193, upload-time = "2026-01-03T17:32:13.705Z" },
-    { url = "https://files.pythonhosted.org/packages/43/a5/a2dfd1f5ff5581632c7f6a30e1744deda03808974f94f6534241ef60c751/aiohttp-3.13.3-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:d60ac9663f44168038586cab2157e122e46bdef09e9368b37f2d82d354c23f72", size = 1621979, upload-time = "2026-01-03T17:32:15.965Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/f0/12973c382ae7c1cccbc4417e129c5bf54c374dfb85af70893646e1f0e749/aiohttp-3.13.3-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:90751b8eed69435bac9ff4e3d2f6b3af1f57e37ecb0fbeee59c0174c9e2d41df", size = 1822193, upload-time = "2026-01-03T17:32:18.219Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/5f/24155e30ba7f8c96918af1350eb0663e2430aad9e001c0489d89cd708ab1/aiohttp-3.13.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:fc353029f176fd2b3ec6cfc71be166aba1936fe5d73dd1992ce289ca6647a9aa", size = 1769801, upload-time = "2026-01-03T17:32:20.25Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/f8/7314031ff5c10e6ece114da79b338ec17eeff3a079e53151f7e9f43c4723/aiohttp-3.13.3-cp314-cp314t-win32.whl", hash = "sha256:2e41b18a58da1e474a057b3d35248d8320029f61d70a37629535b16a0c8f3767", size = 466523, upload-time = "2026-01-03T17:32:22.215Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/63/278a98c715ae467624eafe375542d8ba9b4383a016df8fdefe0ae28382a7/aiohttp-3.13.3-cp314-cp314t-win_amd64.whl", hash = "sha256:44531a36aa2264a1860089ffd4dce7baf875ee5a6079d5fb42e261c704ef7344", size = 499694, upload-time = "2026-01-03T17:32:24.546Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/4d/4a99fb425c5e0cad715eea7bd190aff46f38b959a0a2dadb993705d34b26/aiohttp-3.14.3-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:eb0495d778817619273c108784292be161a924b9f5ae5cbbc70a2caa6838250b", size = 765848, upload-time = "2026-07-23T01:52:08.217Z" },
+    { url = "https://files.pythonhosted.org/packages/74/e8/43b85dc55b8e950dc644babe762add781319ea881b57b33d2cce12017d12/aiohttp-3.14.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:c3c200cf9757edd785051dc699c7ecbec22110dbfcb3fefc7a9f9695eda8ea7a", size = 517476, upload-time = "2026-07-23T01:52:10.846Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/9e/73b582c4dbbc3c12ef4473822475effaabf1f934b56f14f5b03fe5d3a2af/aiohttp-3.14.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:fd51ebf9d3a00c074df4ede271023f4d2dba289bcc740b88191872716014e3c5", size = 515334, upload-time = "2026-07-23T01:52:12.636Z" },
+    { url = "https://files.pythonhosted.org/packages/79/03/e98c3c9e05a5bdf97defe5ff9169baba4f0ec9a901f2d60e0f060c2f051e/aiohttp-3.14.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:134ac5ddcf61c6fad984b9a5727d83492ada43d63471db20fb73042c13fca62f", size = 1708830, upload-time = "2026-07-23T01:52:14.538Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/2c/26e60b694844dfd2176c57f913a22d0cd6a16f9ff202cbda7580d0328b98/aiohttp-3.14.3-cp310-cp310-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:70c987b27534f9ae1a723f47ae921571d616da21d3208282bf4c52af5164ac43", size = 1674012, upload-time = "2026-07-23T01:52:16.486Z" },
+    { url = "https://files.pythonhosted.org/packages/38/65/672df92e3172cd876aacfa97a952ac560877eb169384b2991ac5b273de4c/aiohttp-3.14.3-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1b59533861b70a2185c8f4f350f791f39d64358ef6944ce71c5240c9ec0982c9", size = 1767015, upload-time = "2026-07-23T01:52:18.28Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/c5/228dec7bfec1c373cc2217cdeb47d6456dcd7a13a4c55144930a75ae3851/aiohttp-3.14.3-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:1c5281acc88b92396f88c7e1e2748f8466689df22b80170e4f51efa712fb47a8", size = 1858700, upload-time = "2026-07-23T01:52:20.08Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/ff/cb36724e8c8d17f90ada567a9ff3efe1d6e9b549fba697a242aece180f21/aiohttp-3.14.3-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:48d67b87db6279c044760787eb01f6413032c2e6f3ba1cafaa492b1c8e578479", size = 1714075, upload-time = "2026-07-23T01:52:22.071Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/3a/296a4135c6366376263aeef54b15caca1f07676c2ae0c525d7832f2f808a/aiohttp-3.14.3-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f53bcd52f585e1ac3e590d61434eb61f9a88c38df041b4ea126d97144344a77b", size = 1588234, upload-time = "2026-07-23T01:52:23.757Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/81/9d5d853ef892dc066d1eb6db0e87a47348b920c1c879aa554612fdbd9d79/aiohttp-3.14.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:0fdea2281997af69da84c77ffa6f5938a0285f21fb3887c249d67419ca865b3d", size = 1677300, upload-time = "2026-07-23T01:52:25.861Z" },
+    { url = "https://files.pythonhosted.org/packages/68/96/021d386ae32d9b26d4b88df2e794546232ff56bb6be952bf6be227c0bbc7/aiohttp-3.14.3-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:cda5fd5c95ad7a125a2e8464acc78b98b94c475a3780d6aa0aa157c93f470f4d", size = 1691501, upload-time = "2026-07-23T01:52:28Z" },
+    { url = "https://files.pythonhosted.org/packages/29/9f/af66adce26a14af135c003cbd0f44ccaa68cebd30ff8ac99ca47fb4958f7/aiohttp-3.14.3-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:6debfa7312ff9d4c124dc71d72e9a0a4b9e0879e48ba6fcb42bef5c3300289e2", size = 1735113, upload-time = "2026-07-23T01:52:29.995Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/90/28c390d4c9851effe52ac25b5a2e1d92246acd00728b4fc7975dafb67484/aiohttp-3.14.3-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:f4e05329faa0ea1a404b37de4f034fd2c2defcca06a68dc6745e4e56c88e8a48", size = 1577486, upload-time = "2026-07-23T01:52:31.937Z" },
+    { url = "https://files.pythonhosted.org/packages/db/c2/00e23a1bf2abb70dd353f6987db7e7f2491d0261f7363997738c71c98f95/aiohttp-3.14.3-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:a3a8296e7ab5c295f53f1041487cb088e1480775aafbf7fe545d93b770a0f96f", size = 1751353, upload-time = "2026-07-23T01:52:33.688Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/7d/d51a706a8cbfa57f0611127daf61ab3ae02ab8420b0407412079227d1c65/aiohttp-3.14.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:5373dc80ad1aa2fb9ad95c83f24eef418bbda3a61375f128e5b0192e4f3f9b32", size = 1698681, upload-time = "2026-07-23T01:52:38.167Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/b0/90bd5cd9fdd9787cb4211d284d1fb8401339a933cb0227a15b71e789232f/aiohttp-3.14.3-cp310-cp310-win32.whl", hash = "sha256:a3e22975f905b89a55a488c2a08f2fdb2186175349e917d48985cc468a3d4c6e", size = 456733, upload-time = "2026-07-23T01:52:41.823Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/15/fe5b8f6a71ae112bc677163d0b0701bda5dc15005249582258ede0eb88c7/aiohttp-3.14.3-cp310-cp310-win_amd64.whl", hash = "sha256:bdd0e2834dce1a26c1bbe26464861e16bbe217042cbff619247c11594472518c", size = 480460, upload-time = "2026-07-23T01:52:43.905Z" },
+    { url = "https://files.pythonhosted.org/packages/54/00/45e98b6645cd7f00a4b78b749ebd309094b0eaeb2d2e96157eadbc0d0050/aiohttp-3.14.3-cp310-cp310-win_arm64.whl", hash = "sha256:eac645b09bcfdf73df7536331f0678c1086ea250981118ddb5199e17ccef72bb", size = 453479, upload-time = "2026-07-23T01:52:46.075Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/5c/b3e4ff8ad43a8afef9602c5e90285936da1beaea8b029016b793891f03c3/aiohttp-3.14.3-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:e568e14940c09955aa51f4e645b6daa18a581c5dcfcd73744dcc86a856e3ced3", size = 764250, upload-time = "2026-07-23T01:52:48.525Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/da/f1b384465e51449d844056b75070461da03a9a23e6c1747003695bf4172a/aiohttp-3.14.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:54cfcdee2770dac994417cbb0ee1f3eb0e7cb6b30c79bf44f2c02ff79ec5124a", size = 516281, upload-time = "2026-07-23T01:52:51.047Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/3f/01264f820ee2e3712a827892b1cd6ff80f3300c1fcbffbb45714a915d47a/aiohttp-3.14.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:21c016079415ed3fd676963e9793700a566d85dbbd6bfc564b9b2d209147dcc8", size = 514742, upload-time = "2026-07-23T01:52:53.779Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/8d/a71c6f2db52ac1ed142b133f7feddaa6b70539c3f4de24d7e226c95b794c/aiohttp-3.14.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d6088ec9894113802bddb3c09e974929aed2c7b3a8c456219b8aab4481f1a239", size = 1780613, upload-time = "2026-07-23T01:52:56.948Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/11/3dd9b3fb3a170f6ec9011b5291d876a6fab4086714c9e158600edf01b4fd/aiohttp-3.14.3-cp311-cp311-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:16ea7e24c309fb7c0bbd505d149abe4fe4dccfb8db911db7dbec0921bc889a6f", size = 1737688, upload-time = "2026-07-23T01:52:59.294Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/3e/834c26918be7d88068822b40e0db30fca50b5f4fe79104aa16a93f1d74e6/aiohttp-3.14.3-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:56f355e79f71aef2a85c80305cc915f894b170dba76de5fe84f6351939b83c06", size = 1845742, upload-time = "2026-07-23T01:53:01.641Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/c9/49ab8572df7d66bc13d11e31f781292badb04180dd87ba98733066c6aed7/aiohttp-3.14.3-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:18c441d0a8fca6de8d1f546849b9f0ab20d435993e2c5b59562b2fae6be2f929", size = 1928412, upload-time = "2026-07-23T01:53:04.018Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/b9/2b8f0c0ce09c87a1daf80fd483431b56b1435d3f62789bc86f572e1245de/aiohttp-3.14.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:53e7b4ce82b54a8bcc71b3b67a5cbd177ca1d7f592cbc92cd38b7349f73482db", size = 1786220, upload-time = "2026-07-23T01:53:06.481Z" },
+    { url = "https://files.pythonhosted.org/packages/85/00/9c45f81de11710460edfa1dc81317b6e882703b160926c879a9d20da9fcc/aiohttp-3.14.3-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f55119f7bf25f49ed210f6096090715da24f2943c62102448915fde3c62877ce", size = 1637231, upload-time = "2026-07-23T01:53:10.258Z" },
+    { url = "https://files.pythonhosted.org/packages/19/ce/967d628e910756f3539c6107cb7844a1b69440dcb3029a5ee7871b09ab63/aiohttp-3.14.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:9aa6e61fdf20105c4144e755bd586008ff450791d67b1c8146fdc15959c4d51c", size = 1753161, upload-time = "2026-07-23T01:53:13.817Z" },
+    { url = "https://files.pythonhosted.org/packages/11/b2/0c3d4114f0aee4f580f5b3b4eb71b24d7a23b834ea506a4dfebe76513f35/aiohttp-3.14.3-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:ccd4893707b3e2a13e39c90d43cf80edf2e4d0457935bcc103bf2346214c3f15", size = 1756356, upload-time = "2026-07-23T01:53:16.211Z" },
+    { url = "https://files.pythonhosted.org/packages/63/5d/99e7d91c82f1399d1ae2a854e080bd1493fbc31e5e959dbc4ec33dac3bec/aiohttp-3.14.3-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:b2466434105a4e03113c36ec775cc2ebe6676b62eae326fa670bb607ef788c1c", size = 1819846, upload-time = "2026-07-23T01:53:18.289Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/05/d5e1cb6480eeffd3f901d40a2c5e2d1e7effdc797837da3b490272699f13/aiohttp-3.14.3-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:ba59d59aba08ac02fc03b0c8983ccd5ee39a199d0552ce9e6d2b4845b34d59ae", size = 1628531, upload-time = "2026-07-23T01:53:23.86Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/90/b934682bcaefae18a9e04f3dff5b68522ba810906358ae5029b68110ea3b/aiohttp-3.14.3-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:ed099d105449c4f9e84f24af203cd131349d4761d8813fa7e02c32e7128cd910", size = 1832712, upload-time = "2026-07-23T01:53:27.551Z" },
+    { url = "https://files.pythonhosted.org/packages/21/df/6061679faaf81fac746e7307c7adb71e858071a5d34c27583afefc64f543/aiohttp-3.14.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:152516815ef926786a0b6ae2b8f1fd2e0c71582dee0b435636865316fd4891b7", size = 1775014, upload-time = "2026-07-23T01:53:30.223Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/1d/f854878bbc69b88faefe924b619a34a6f59ec05fd387c77690667eaa75eb/aiohttp-3.14.3-cp311-cp311-win32.whl", hash = "sha256:a4af35c443e0b1a1bd6a8af3f3485d7fda15c142751a00f3ff8090f0b93346fa", size = 456006, upload-time = "2026-07-23T01:53:34.97Z" },
+    { url = "https://files.pythonhosted.org/packages/73/0c/2af9d1674baccd1dbd47282a93d660a22e57ef6167c856deb24b4214fbab/aiohttp-3.14.3-cp311-cp311-win_amd64.whl", hash = "sha256:e1e74298bab6ee0d6e749ed4fd1901c7e604bdda32c03d787a2cc71c46d0433d", size = 481069, upload-time = "2026-07-23T01:53:39.673Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/76/88401ff3fc95e85c5fc38d588f36f55e61ecb64343b2bc8d69326f453cc0/aiohttp-3.14.3-cp311-cp311-win_arm64.whl", hash = "sha256:03cd2bde3d7f085b64e549c985f4bb928cad7e8ecf5323bfca320db548d81b39", size = 453021, upload-time = "2026-07-23T01:53:43.749Z" },
+    { url = "https://files.pythonhosted.org/packages/18/d4/eb96299230e20acf2efae207cb8d69051f1f68e357e5ea5e479bf6fb097a/aiohttp-3.14.3-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:39aded8c7f3b935b54aab1d8d73c70ec0ee2d3ec3b943e0e86611bc150ba47f5", size = 754690, upload-time = "2026-07-23T01:53:47.332Z" },
+    { url = "https://files.pythonhosted.org/packages/88/11/e7a70a209eb9a067c0d3212b518a0134e3484f5178c7533878b6b514d469/aiohttp-3.14.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:5bcb6ff3fdab1258a192679ff1a05d44f59626430aa05cd1a9d2447423599228", size = 509484, upload-time = "2026-07-23T01:53:51.159Z" },
+    { url = "https://files.pythonhosted.org/packages/30/07/4bbc222cc8dbe31d4c3e8a5baad2286e4d42026ac0c570027b89afce6344/aiohttp-3.14.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:617105e2c3018ee38d0c8ce5ee3c84f621a6d8b9f723202aacaff28449ca91ee", size = 511949, upload-time = "2026-07-23T01:53:55.083Z" },
+    { url = "https://files.pythonhosted.org/packages/54/b9/42e74c46b7b7c794b995bbc1f573fb48950c38b19d8600c62a6804ee2d67/aiohttp-3.14.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f631fe87a6f30df5fbe6d79640b25e4cffb38c31c7fb6f10871517b84b0f8c1a", size = 1765282, upload-time = "2026-07-23T01:53:59.662Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/ed/62bc4d74363ad346d518e0720363a949f63e2e23439a79eb5813d4d29bb3/aiohttp-3.14.3-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:a94dbaae5ae27bd849c93570669bff91e0510f33a80805738e3de72a7be0447b", size = 1741511, upload-time = "2026-07-23T01:54:04.063Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/9f/181e8a8bc79e47d13c7fc4540bd7a3b729d9505609c61f392a8dd2fbfe55/aiohttp-3.14.3-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:8f2f1c4c032c7cedd7d8da6f54c97b70266c6570c3108d3fdffee7188bb70529", size = 1810680, upload-time = "2026-07-23T01:54:09.882Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/9a/dec94d6ad694552fe3424e3f1928d7a606a5d9d9433a04e7ecdd9d38ae7f/aiohttp-3.14.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ea05e1f97ceea523942d9b2a7d7c0359d781d683d6b043f5943a602b14da4787", size = 1905646, upload-time = "2026-07-23T01:54:13.475Z" },
+    { url = "https://files.pythonhosted.org/packages/52/b7/7cd31f29d6055bd711ae6e669367fba6f5ae9de463910a793e30556a8db7/aiohttp-3.14.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:543906c127fb1d929b95076db19b83fa2d46751006ff1e23b093aa5ac4d8db42", size = 1792122, upload-time = "2026-07-23T01:54:15.752Z" },
+    { url = "https://files.pythonhosted.org/packages/66/73/10b1ef93afa61f4963c746257b70ced619cf31a4798671de5fdb2608501d/aiohttp-3.14.3-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:0a5ff2dfbb9ce645fa5b8ef3e02c6c0b9cc3f6030ff863d0c51fffc50cb5541b", size = 1591127, upload-time = "2026-07-23T01:54:19.489Z" },
+    { url = "https://files.pythonhosted.org/packages/49/ed/3b203fa6de1b338c14acdc06bf6ca9b043b7944f005966958c2ced932cde/aiohttp-3.14.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:041badb8f84396357c4d3ad26de6afd7a32b112f43d3c63045c0c8278cfd2043", size = 1725210, upload-time = "2026-07-23T01:54:24.129Z" },
+    { url = "https://files.pythonhosted.org/packages/28/b7/1c2aab8c706436dcc28598452488ac9cd7c409da815237c28c27d58993e6/aiohttp-3.14.3-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:530125ee1163c4219af35dc3aa1206e541e7b31b6efc1a3f93b70a136f65d427", size = 1764848, upload-time = "2026-07-23T01:54:27.973Z" },
+    { url = "https://files.pythonhosted.org/packages/54/50/94c28f08b131c4bf10984ea2c7a536c9920608bb2d6e7f95642c30cc87b7/aiohttp-3.14.3-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:c8653fd547c93a61aadc612007790f5555cdd18946fa48cf45e26d8ea4ea473d", size = 1777102, upload-time = "2026-07-23T01:54:31.775Z" },
+    { url = "https://files.pythonhosted.org/packages/13/d4/e7d09ba7d345fb2d74440fd2fa033c5e079fac05552927705986f41a364f/aiohttp-3.14.3-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:89176250f686cb9853c0fb7ead90e639e915b84a6f43eedc2a4e7ec21f1037f0", size = 1580205, upload-time = "2026-07-23T01:54:34.518Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/84/072a91d68e1e1eb587985b54baab94221277f877e8ef274fc213a0ceae28/aiohttp-3.14.3-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:3a26434dafe408229ff3403458ca58de24fb51936504decac49ce6755f77e59d", size = 1797219, upload-time = "2026-07-23T01:54:36.995Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/eb/aad34e897e668424d6e995da5dff8a4a09af93363d3392488772957a63aa/aiohttp-3.14.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:d1558173930a5a8d3069cee5c92fc91c87c4dbcb099debbb3622053717145a19", size = 1768629, upload-time = "2026-07-23T01:54:40.103Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/2b/6bb88ddba0fecd9122aa3ebcad25996cf6c083a4a7040dbb3a4f97972af6/aiohttp-3.14.3-cp312-cp312-win32.whl", hash = "sha256:16100ad3ab8d649fdfbee87602d9d2dcdca9df0b9eda8a1b5fdc0d41f96da559", size = 451481, upload-time = "2026-07-23T01:54:42.547Z" },
+    { url = "https://files.pythonhosted.org/packages/76/9b/f2f8f108da17ecef2cc3efc424e8b7ad3782b1a8360f7b8eae8ced84f6ea/aiohttp-3.14.3-cp312-cp312-win_amd64.whl", hash = "sha256:33a2d7c28d33797a2e99923dffa63f83d908a19b6bf26cfe80fa790aa5e1a75a", size = 476845, upload-time = "2026-07-23T01:54:44.853Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/44/28dac80a8941b604f4da10ce21097614ca1bf905ce93dca28d8d7de9c1e7/aiohttp-3.14.3-cp312-cp312-win_arm64.whl", hash = "sha256:362a3fd481769cac1a824514bcd86fda51c65e8fe6e051099e008fddde6db17c", size = 448050, upload-time = "2026-07-23T01:54:47.087Z" },
+    { url = "https://files.pythonhosted.org/packages/57/be/5afd201cc0ab139029aadb75392efe85a293403d9dd3a3226161c21ce00c/aiohttp-3.14.3-cp313-cp313-android_21_arm64_v8a.whl", hash = "sha256:2e9878ae68e4a5f1c0abe4dd497dbc3d51946f5837b56759e2a02e78fa90ef86", size = 506269, upload-time = "2026-07-23T01:54:49.075Z" },
+    { url = "https://files.pythonhosted.org/packages/22/09/dec8189d62b45ade009f6792a2264b942a90cb88aeaf181239933cd72c3c/aiohttp-3.14.3-cp313-cp313-android_21_x86_64.whl", hash = "sha256:f3d2669fe7dec7fc359ecdb5984b29b50d85d5d00f8c1cb61de4f4a24ee42627", size = 515166, upload-time = "2026-07-23T01:54:51.894Z" },
+    { url = "https://files.pythonhosted.org/packages/28/24/2854869d29ed8a8b19d74f9ec6629515f7e04d02dd329d9d179201e58e47/aiohttp-3.14.3-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:cc7cb243a68167172f48c1fd43cee91ec4b1d40cefd190edd43369d1a6bc9c82", size = 486263, upload-time = "2026-07-23T01:54:54.223Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/dd/57187c8be2a35aea65eaee3bd2c3dcbbcf0204f5106c89637e3610380cd1/aiohttp-3.14.3-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:78253b573e6ffab5028924fc98bc281aae05445969982a10864bc360dea2016c", size = 492299, upload-time = "2026-07-23T01:54:56.236Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/11/06ae6ed8f0d414edf4068861e233d8fe23ee699bfd4b3ceb8663db948a62/aiohttp-3.14.3-cp313-cp313-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:7041d52c3a7fa20c9e8c182b534704abb19502c8bdcbde7ab23bfda6f642394f", size = 502235, upload-time = "2026-07-23T01:54:58.377Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/a3/559639c34a345d2cf7c52dff6838119f2eaf29eb508227b5b83f573af813/aiohttp-3.14.3-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:ac74facc01463f138b0da5580329cfcc82818dea5656e83ddcd11268fc12ff80", size = 750883, upload-time = "2026-07-23T01:55:00.65Z" },
+    { url = "https://files.pythonhosted.org/packages/91/cd/41e131f13afd1e7b0172a9d9eda085ef90eb8439f41f0d279db81ed3ae60/aiohttp-3.14.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:d6218d92e450824e9b4881f44e8c09f1853b490f9a64130801024a4793b1b3b0", size = 508473, upload-time = "2026-07-23T01:55:02.945Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/6b/e7f13410d391c6e55b4c007a8de024355389d7d459e3d64c42b2d33617e5/aiohttp-3.14.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:11fb37ef075669eee52ab1928fbf6e1741fada40409fa309ebde9607a962aebf", size = 509190, upload-time = "2026-07-23T01:55:05.173Z" },
+    { url = "https://files.pythonhosted.org/packages/97/21/6464573e53d69672cc1eada3e5c5cb2d2efa82701e8305a0f2047a576967/aiohttp-3.14.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:55bdcc472aafe2de4a253045cc128007a64f1e0264fb675791e132ea5edaa3bd", size = 1761478, upload-time = "2026-07-23T01:55:07.383Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/81/d217043a4c17fbce360905e3b2bdd20139ebc9a2de836d035d179c4da006/aiohttp-3.14.3-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:c39846c3aad97a8530c89d7a3869a8f8e9e3762c6ac0504481e5c80948f7e807", size = 1735092, upload-time = "2026-07-23T01:55:09.803Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/66/e13a02d0eeb1a9a502402a977abb4e4abff9fe4051c26f80558c57a7c975/aiohttp-3.14.3-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:5895ef58c4620afe02fa16044f023dc4dafec08158f9d08874a46a7dbc0341b8", size = 1800546, upload-time = "2026-07-23T01:55:12.012Z" },
+    { url = "https://files.pythonhosted.org/packages/26/5e/57d42fca1d18cb5acc1cad945d017fabc5d6ae71d8a08ad66be8dc3ee544/aiohttp-3.14.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:fa9467a8113aa69d3d7c55a70ef0b7c636010a40993f3df9d9d0d73b3eb7ef24", size = 1895250, upload-time = "2026-07-23T01:55:14.357Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/1c/7da8d08e74d56f00070822f9638ff3f1c563f8ad87d1efa996c87bfc8644/aiohttp-3.14.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d7d2deec16eeedf55f2c7cf75b521ea3856a5177e123844f8fd0f114ce252cb5", size = 1789289, upload-time = "2026-07-23T01:55:16.668Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/0f/cf16bcf56896981c1a0319f5d5db9337994b5165730c48a8fa07e9b34be6/aiohttp-3.14.3-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:dd54d0e8717de95939766febac482ac0474d8ac3b048115f9f2b1d23a16e7db4", size = 1586706, upload-time = "2026-07-23T01:55:18.913Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/6f/76eac12a7f2480e1e304f842efdb07db33256b0d9165b866b6ef0806c202/aiohttp-3.14.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:df82f3787c940c94986b34222d59c9e38843fba85139f36e85255a82ad5355a9", size = 1724652, upload-time = "2026-07-23T01:55:21.296Z" },
+    { url = "https://files.pythonhosted.org/packages/39/b6/19c8c592baeeb94b75f966547d40c02ac7590902306ec5863d5c027cf506/aiohttp-3.14.3-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:42a67efc36300d052fb4508a53e8b6901b9284b599ae63945c377569c5fcc1e1", size = 1756239, upload-time = "2026-07-23T01:55:23.705Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/c9/4e9383150296f97f873b680c4de8fb2cd88608fb9f48c79edcb111611abc/aiohttp-3.14.3-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:7a75aa63cbf9b21cfaf60dc2657e19df2c2867d91707d653fee171ffeedd1371", size = 1769161, upload-time = "2026-07-23T01:55:26.082Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/1e/147bdc6cc5de5f3ab011be8bf5d6e786633249f22c20bae06f85e45f5387/aiohttp-3.14.3-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:e92eb8acc45eb6a9f4935071a77edf5b85cc6f8dfad5cd99e97653c26593cdde", size = 1578759, upload-time = "2026-07-23T01:55:28.846Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/31/78388a9d6040ece2e11df62ea229a822cf5e52d238374b220ae9975b2623/aiohttp-3.14.3-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:b014a6ed7cf912e787149fdc529166d3ceabac23f26efeea3158c9aba2354e7e", size = 1792025, upload-time = "2026-07-23T01:55:31.457Z" },
+    { url = "https://files.pythonhosted.org/packages/03/51/a3d29fdf2c25d796746af8ad6fe56a45d6256c38b0a8a2ed752e1160b3a2/aiohttp-3.14.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:3d4f72af88ac2474bb5bca640030320e3d38a0163a1d7533500e87be458eef71", size = 1768477, upload-time = "2026-07-23T01:55:33.87Z" },
+    { url = "https://files.pythonhosted.org/packages/29/a6/442e18b5afeade534d877a2dc3c3e392aff8d49787890b0cf84790410267/aiohttp-3.14.3-cp313-cp313-win32.whl", hash = "sha256:5f08ec777f35ee70720233b8b9811d3bb5d728137f30ac91b7457709c3261ac0", size = 451069, upload-time = "2026-07-23T01:55:36.121Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/69/3d876ac02659f271cf7f6769f14a8e3de5b6e888ed8b5a7e998086a4cec8/aiohttp-3.14.3-cp313-cp313-win_amd64.whl", hash = "sha256:dff9461ec275f22135650d5ba4b4931a11f3958df7dfbb8db630000d4dee0883", size = 476518, upload-time = "2026-07-23T01:55:38.303Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/0e/50d6e6471cd31edce8b282bdec59375a3a69124d8a989a0b1313355cae52/aiohttp-3.14.3-cp313-cp313-win_arm64.whl", hash = "sha256:ddcac3c6b382e81f1dd0499199d4136b877beb4cb5ef770bbbfba56c4b8f55d2", size = 447676, upload-time = "2026-07-23T01:55:40.451Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/20/887fdcf832326571b370ffc347b3e70abe101096f3720126aac161b1d872/aiohttp-3.14.3-cp314-cp314-android_24_arm64_v8a.whl", hash = "sha256:49f7325beb0f85ef4aef5f48f490269575f83e6e2acad00a1d80b807eb027062", size = 509067, upload-time = "2026-07-23T01:55:42.618Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/a3/92cec936f78cc4bf0fa5554ebe593b73459d94e3c62303e1902a4cccb6f7/aiohttp-3.14.3-cp314-cp314-android_24_x86_64.whl", hash = "sha256:e3be98a7c30b8c25d573dafba7171d66dfb05ee6a9070fc46535464ff97700a6", size = 514774, upload-time = "2026-07-23T01:55:44.937Z" },
+    { url = "https://files.pythonhosted.org/packages/29/ba/2a0c38df3fc557620b6a5acd98364af050053b6285b4dc7ee74100c63c18/aiohttp-3.14.3-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:614c61d478b83953e261d02bb2df750f17227cd33ef8002945bf5aebbde21919", size = 488134, upload-time = "2026-07-23T01:55:47.135Z" },
+    { url = "https://files.pythonhosted.org/packages/48/d6/d51b7d4bf309af3693940d8ffd2b9ed0b682434ef85959b7c9c137f60cf8/aiohttp-3.14.3-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:1caa7b0d05f3e3a36f87788c59e970a7ee1cefcfcbb924a9f138c4a6551c9cb7", size = 494201, upload-time = "2026-07-23T01:55:49.451Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/5a/8f624384e5f1efabb5229b94157eb966b021e97bdb188c62860c2ae243c2/aiohttp-3.14.3-cp314-cp314-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:dfa68deb2a443bdaa3ea5297b0699c1464f08aef3812b486d1348eee61b07dc0", size = 502766, upload-time = "2026-07-23T01:55:51.656Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/26/4ff0164370deec18fb19254ee4ab10b7a73304ac0c860b13f5f84663759b/aiohttp-3.14.3-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:e72ee89e28d907a18f46959b4eb0bb06701cc7f8cf4366e00029e2ccfaaf5924", size = 756557, upload-time = "2026-07-23T01:55:53.964Z" },
+    { url = "https://files.pythonhosted.org/packages/97/a3/7056b86dc0d9ec709ea9777eae3b0161428f943372f8b98c01c11593b682/aiohttp-3.14.3-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:ad4c8b7488d745d2ca4838ebd8ae5ba9b56341d30b1da43640e4ce87f9f49646", size = 510168, upload-time = "2026-07-23T01:55:56.22Z" },
+    { url = "https://files.pythonhosted.org/packages/85/ed/0357a015892fd68058bf2d39d3fd1958e459b997a7db30aaa6aaa434ae96/aiohttp-3.14.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:db332af25642007330fca8be5c4d194caf2bea7a7fc84415aff3497af5dfee6b", size = 512957, upload-time = "2026-07-23T01:55:58.437Z" },
+    { url = "https://files.pythonhosted.org/packages/47/d1/8aba53f15ccb2238405f5e9d30e2a8ca44f93878c26e7165ade00d374b1c/aiohttp-3.14.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:25bd2708db6bdf6a6630dd37bdcdfcb47c4434d22ac69c64665b802910140b30", size = 1750149, upload-time = "2026-07-23T01:56:00.856Z" },
+    { url = "https://files.pythonhosted.org/packages/49/bd/40c3fee327529284375c6701cbb0fa4600cc2e8432af1378f897e2ef7d3a/aiohttp-3.14.3-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:cef89a58e628c4efcac3275c2d68083f82426dcdc89c1492a6f654f9f7ea6ab9", size = 1707685, upload-time = "2026-07-23T01:56:03.371Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/a3/ca0cc6724cca8114b05694abd916060758c79894c3aa5b012cdadc1bc28e/aiohttp-3.14.3-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c23ec8ee9d5ab2f5421f9c7fffce208435607af27fd46d4a44e031954352838f", size = 1803911, upload-time = "2026-07-23T01:56:05.817Z" },
+    { url = "https://files.pythonhosted.org/packages/95/b5/85b099c299c3ffd38ad9b3e43694c8a346934e4a30c88c4fd5a841234f77/aiohttp-3.14.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:e2667f0bbe7eb6c74eae5e9691441ad186e5845ca3cff63230fc09c4e7514f5d", size = 1876929, upload-time = "2026-07-23T01:56:08.413Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/b7/1da684a04175473fa4cddbf9a2f572e79514c3fd27a74597f43057d4f3da/aiohttp-3.14.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:18cb43369747b2ae007bd2655fb8e63a099c2ff1d207962943636dac989b3147", size = 1761112, upload-time = "2026-07-23T01:56:10.918Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/16/bc4b55e3e5cb175fd69c53c90d60d2f47797cb343da5106e23863dc4dba4/aiohttp-3.14.3-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d77640cc618c1d99fc4f8589c0f24a730adfa54eb1e57ef7bf0c8dfb78da898c", size = 1583500, upload-time = "2026-07-23T01:56:13.613Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/e8/13a9d957a1ee40837f46aa30f0f4c657e673ad86a2e6362a9f9be20d26d9/aiohttp-3.14.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:53e5179d8abb5710f8e83ba207c41c8d1261fcffd4616500e15ca2b7a33be10a", size = 1713940, upload-time = "2026-07-23T01:56:15.969Z" },
+    { url = "https://files.pythonhosted.org/packages/38/05/d33c680c1bcf1c7e130f9cbfc1fc02fe8bb0c4af2a94a53dd5fb56131e5c/aiohttp-3.14.3-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:cd817772b2fcf2b8c0905795318485f9ec16eae60b29feb7f4c77085311637f0", size = 1724413, upload-time = "2026-07-23T01:56:18.591Z" },
+    { url = "https://files.pythonhosted.org/packages/85/1d/af798d306f7a74b6a632dbcabcf62a4c91391b7582d2a8c6d7712e2cc54e/aiohttp-3.14.3-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:4e3ac92d90e92773b2362d506068e9a948192bd553e743c5b2429e28527c8661", size = 1770748, upload-time = "2026-07-23T01:56:21.074Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/92/ad720d472556a995049206867765e9410969684f86ee09423ff9969044c1/aiohttp-3.14.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:3f42e9b78301f11c8f861746175d8b9c1ccef713fcad9eab396e2f6db8ed4a22", size = 1577564, upload-time = "2026-07-23T01:56:23.475Z" },
+    { url = "https://files.pythonhosted.org/packages/60/ad/0ed7586cbef7a884e23a752fa2bb987a122e6a5dd50dab109258d0a95193/aiohttp-3.14.3-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:9d9edccfe496b476db5f398d97b865e9a6752bcf8aec4eef8390ce20fb64bb41", size = 1782080, upload-time = "2026-07-23T01:56:25.994Z" },
+    { url = "https://files.pythonhosted.org/packages/97/ea/dbaed0d73e8a69aad653b045dab451c67c2454bb731a37b45a86593e9422/aiohttp-3.14.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:1c5ec8fb1bcc31a8466f74aaf26c345d5c386fa4bd08a3f0eb9c7a4a3fe8b5bf", size = 1745813, upload-time = "2026-07-23T01:56:28.604Z" },
+    { url = "https://files.pythonhosted.org/packages/81/1b/6893d4bc57e434fc93a6c9217c637d967a0b651d989f6e3265179375754a/aiohttp-3.14.3-cp314-cp314-win32.whl", hash = "sha256:38901a84da3ce22249f6e860bf8f90d141bcab7da090cc398f8bb58c0e44b7da", size = 455872, upload-time = "2026-07-23T01:56:31.031Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/8b/c7baa1ba1eda4db6989baefe5de6d99834921b84ebd7918624febcb9f290/aiohttp-3.14.3-cp314-cp314-win_amd64.whl", hash = "sha256:8b3b60de05f3dcb6f6a00f818bb2ec781cee4de0645f59ccaf99b1d1823b6100", size = 481030, upload-time = "2026-07-23T01:56:33.365Z" },
+    { url = "https://files.pythonhosted.org/packages/22/8c/c29d067df825a2df88ca432db848aa2fe8199598359cc06c12b09320cac9/aiohttp-3.14.3-cp314-cp314-win_arm64.whl", hash = "sha256:1576145bdceeb92382d899751e12743a3a5b8e460a841e3e50543859e54864dc", size = 453669, upload-time = "2026-07-23T01:56:35.731Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/a4/9c033beb355d39b6147980597ec9645e4729243f686ee4dc73945de72030/aiohttp-3.14.3-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:8800c996b01c2772a783e3e46f3e1abd5823029adca0df54231960de9bfefa5b", size = 791403, upload-time = "2026-07-23T01:56:37.972Z" },
+    { url = "https://files.pythonhosted.org/packages/80/ca/87c32a0a7704583cfc49660bd817889bae5b830bf53b5dcb4e92145ac2da/aiohttp-3.14.3-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:ebe8e504f058fe91223351cecd2d9d6946c9d241bb0250d898ffbdf584cc72b0", size = 526413, upload-time = "2026-07-23T01:56:40.523Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/d8/8ec0e471248c500acdce2be3f46db8fb62b5eb60efef072529cc85ee1d26/aiohttp-3.14.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:30402d03a7c0ff52bce290b57e564e9079fd9d0cb545c8aba73f86a103162d2e", size = 532135, upload-time = "2026-07-23T01:56:42.876Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/45/f8919fd936e8b79fcd9bda7b6d8e62613462a713f4f17987fd7c34399142/aiohttp-3.14.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9fc7b5bfec6573f3ae844f457fdde5adeb713f8b8e4a81ad64fc207b49383716", size = 1922742, upload-time = "2026-07-23T01:56:45.528Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/ec/9ca76b28a27525b0cc53e20842e0228b022f301ce1f436b7d814b4aaf2df/aiohttp-3.14.3-cp314-cp314t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:8a5fd34f7f7410d1730d5c2ba873cacb2eed3fede366feb268a70ba22581ed8f", size = 1787371, upload-time = "2026-07-23T01:56:48.045Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/04/6acdbf17315f7b55f1937e3387acb89a3cddeb4995689553d064af8e92ab/aiohttp-3.14.3-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:270d3dace9ca2f10f0da5d8ebe519b7a310fc6112ed916e32df5866df0888553", size = 1912623, upload-time = "2026-07-23T01:56:50.605Z" },
+    { url = "https://files.pythonhosted.org/packages/86/e6/438b0c79ca6f45eb9fd9817dd4c01a91919a38c0de5ee9e05e2b4dc0ece7/aiohttp-3.14.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3ae5b3a59436d089b5395d910121a390feed4d00578eb95a0fd1a329fe963100", size = 2005515, upload-time = "2026-07-23T01:56:53.153Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/6b/62cbd6577758699525f5c712d1ddef57d9875fbab0ae8d5f5a202fd598f8/aiohttp-3.14.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2498f0fe69ead802f9675beca44a7c21c62fdaa4ec5145ea1c3ad6edbee29f85", size = 1879906, upload-time = "2026-07-23T01:56:55.818Z" },
+    { url = "https://files.pythonhosted.org/packages/00/95/18bcbf830a21dc3aae24d8f6b6feaf3db1d2090242d00a7868db2ffb0b67/aiohttp-3.14.3-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a0dc483c00da8b673abbb367eb6f8d8f4bcec30eb58529ea13cb42e7fd2dfa33", size = 1675849, upload-time = "2026-07-23T01:56:58.861Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/19/47f4968659c5e23606c3790c80fc624e691c153d036148449ee84d31b287/aiohttp-3.14.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c7d3a97c678d34fc5b59da671ee9cd630096ddc643e7b5a30d54a2a6f3574d3f", size = 1843496, upload-time = "2026-07-23T01:57:01.591Z" },
+    { url = "https://files.pythonhosted.org/packages/64/af/38c33c4dd82fddcb4e56c4653b6f1072a8edbc6b7fa15809f14932c41e2d/aiohttp-3.14.3-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:f8fb78a83c9e5f741ca3a68cfb455c1f5bb83b4e7249a3848b3cd78d0a8563b0", size = 1827746, upload-time = "2026-07-23T01:57:05.131Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/9d/0537cda4885ac8f5b7053d164dd06312f4c483a4edcb8ee5b8aaf2a989bf/aiohttp-3.14.3-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:74ab5b6a9fb13e873e5a90946588baecaf488745e1db1a4a5c433f971f035098", size = 1853810, upload-time = "2026-07-23T01:57:08.043Z" },
+    { url = "https://files.pythonhosted.org/packages/19/fe/26f9c5e6458385aa86497836b0dea6fb2f027827d63f37c7856cce9286ee/aiohttp-3.14.3-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:bd52f811e65f6fb634b1047159657c98f52b407f8efec907bcfc09da9a4c0a25", size = 1668895, upload-time = "2026-07-23T01:57:10.837Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/4c/618b1db9b9ba079b8875d2cdf78e7c4a3bf72903bd5850fee7dd9544600a/aiohttp-3.14.3-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:f0f177d1b195b9e06376cfd7d308d8a1b920909a609d03ac82a8c73bbb16d3b9", size = 1883833, upload-time = "2026-07-23T01:57:13.672Z" },
+    { url = "https://files.pythonhosted.org/packages/94/c6/bd959bd1e4771f9fd944e9e436224c48c77b018b73b519b5aad346335bcc/aiohttp-3.14.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:498c6c623134f8e09a3c4e60bcd607a0b4590dd7dbf08dd40851b27cbb520ccb", size = 1844251, upload-time = "2026-07-23T01:57:16.593Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/19/08d41839658bdd44a0ed2480f3891705ecb487ce28c0dde62c9040c997e0/aiohttp-3.14.3-cp314-cp314t-win32.whl", hash = "sha256:b304db572b4368edd8dda8a2274f73156fe15558fca4a917cb8a09fc47af5963", size = 474180, upload-time = "2026-07-23T01:57:19.306Z" },
+    { url = "https://files.pythonhosted.org/packages/99/5d/3cd6ef0a2b2851f7ab913b5b079334781bd50ff56a323e4454063377a080/aiohttp-3.14.3-cp314-cp314t-win_amd64.whl", hash = "sha256:b20032766aedf6261c7a566585a40867d092ac03a0d81592d5370ef9b054f99b", size = 500528, upload-time = "2026-07-23T01:57:21.762Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/37/cfd1ed540a4d318da025590d96b728e63713c09e9377950fc655dadeb856/aiohttp-3.14.3-cp314-cp314t-win_arm64.whl", hash = "sha256:2e1161602f45a54de2ce0905243a95f58cb42dcd378402f3697f5e0b21e9d2e7", size = 469280, upload-time = "2026-07-23T01:57:24.241Z" },
 ]
 
 [[package]]
@@ -512,21 +246,20 @@ wheels = [
 
 [[package]]
 name = "anthropic"
-version = "0.76.0"
+version = "1.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
-    { name = "distro" },
     { name = "docstring-parser" },
-    { name = "httpx" },
+    { name = "httpx2" },
     { name = "jiter" },
     { name = "pydantic" },
     { name = "sniffio" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6e/be/d11abafaa15d6304826438170f7574d750218f49a106c54424a40cef4494/anthropic-0.76.0.tar.gz", hash = "sha256:e0cae6a368986d5cf6df743dfbb1b9519e6a9eee9c6c942ad8121c0b34416ffe", size = 495483, upload-time = "2026-01-13T18:41:14.908Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6e/43/6f3f6006f5216d43a059a1a856d275ef6536cdfa94883b64cc04d7873cb7/anthropic-1.5.0.tar.gz", hash = "sha256:b25f87f5758861f25993383a5c9bf274eb6e0f1b010c84019ad91854cb4e1bc6", size = 1156657, upload-time = "2026-09-10T17:45:35.93Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e5/70/7b0fd9c1a738f59d3babe2b4212031c34ab7d0fda4ffef15b58a55c5bcea/anthropic-0.76.0-py3-none-any.whl", hash = "sha256:81efa3113901192af2f0fe977d3ec73fdadb1e691586306c4256cd6d5ccc331c", size = 390309, upload-time = "2026-01-13T18:41:13.483Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/1c/c32fce35ca0be0205f2377d2238e3ed73dea5abc2be09d15fbd032091d60/anthropic-1.5.0-py3-none-any.whl", hash = "sha256:d9ce04b29ad1f7025dda3e3bc478cde8d2924d2de5417d2d4a4bb0378ecbc2a6", size = 1235236, upload-time = "2026-09-10T17:45:34.216Z" },
 ]
 
 [[package]]
@@ -553,30 +286,12 @@ wheels = [
 ]
 
 [[package]]
-name = "argcomplete"
-version = "3.6.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/38/61/0b9ae6399dd4a58d8c1b1dc5a27d6f2808023d0b5dd3104bb99f45a33ff6/argcomplete-3.6.3.tar.gz", hash = "sha256:62e8ed4fd6a45864acc8235409461b72c9a28ee785a2011cc5eb78318786c89c", size = 73754, upload-time = "2025-10-20T03:33:34.741Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/74/f5/9373290775639cb67a2fce7f629a1c240dce9f12fe927bc32b2736e16dfc/argcomplete-3.6.3-py3-none-any.whl", hash = "sha256:f5007b3a600ccac5d25bbce33089211dfd49eab4a7718da3f10e3082525a92ce", size = 43846, upload-time = "2025-10-20T03:33:33.021Z" },
-]
-
-[[package]]
 name = "async-timeout"
 version = "5.0.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a5/ae/136395dfbfe00dfc94da3f3e136d0b13f394cba8f4841120e34226265780/async_timeout-5.0.1.tar.gz", hash = "sha256:d9321a7a3d5a6a5e187e824d2fa0793ce379a202935782d555d6e9d2735677d3", size = 9274, upload-time = "2024-11-06T16:41:39.6Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fe/ba/e2081de779ca30d473f21f5b30e0e737c438205440784c7dfc81efc2b029/async_timeout-5.0.1-py3-none-any.whl", hash = "sha256:39e3809566ff85354557ec2398b55e096c8364bacac9405a7a1fa429e77fe76c", size = 6233, upload-time = "2024-11-06T16:41:37.9Z" },
-]
-
-[[package]]
-name = "asyncio"
-version = "4.0.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/71/ea/26c489a11f7ca862d5705db67683a7361ce11c23a7b98fc6c2deaeccede2/asyncio-4.0.0.tar.gz", hash = "sha256:570cd9e50db83bc1629152d4d0b7558d6451bb1bfd5dfc2e935d96fc2f40329b", size = 5371, upload-time = "2025-08-05T02:51:46.605Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/57/64/eff2564783bd650ca25e15938d1c5b459cda997574a510f7de69688cb0b4/asyncio-4.0.0-py3-none-any.whl", hash = "sha256:c1eddb0659231837046809e68103969b2bef8b0400d59cfa6363f6b5ed8cc88b", size = 5555, upload-time = "2025-08-05T02:51:45.767Z" },
 ]
 
 [[package]]
@@ -590,142 +305,15 @@ wheels = [
 
 [[package]]
 name = "authlib"
-version = "1.6.6"
+version = "1.8.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
+    { name = "joserfc" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bb/9b/b1661026ff24bc641b76b78c5222d614776b0c085bcfdac9bd15a1cb4b35/authlib-1.6.6.tar.gz", hash = "sha256:45770e8e056d0f283451d9996fbb59b70d45722b45d854d58f32878d0a40c38e", size = 164894, upload-time = "2025-12-12T08:01:41.464Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f1/51/bc1729d3cfdc214b4935f4e886e4dd443c3065fd8e1e66423fe84b490f81/authlib-1.8.0.tar.gz", hash = "sha256:f3ecd5f1da737262fb53bf1a4d95c4ea1ad9dd509316587a255c99ab1838a4f0", size = 177759, upload-time = "2026-08-30T12:12:34.833Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/54/51/321e821856452f7386c4e9df866f196720b1ad0c5ea1623ea7399969ae3b/authlib-1.6.6-py2.py3-none-any.whl", hash = "sha256:7d9e9bc535c13974313a87f53e8430eb6ea3d1cf6ae4f6efcd793f2e949143fd", size = 244005, upload-time = "2025-12-12T08:01:40.209Z" },
-]
-
-[[package]]
-name = "azure-ai-agents"
-version = "1.2.0b5"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "azure-core" },
-    { name = "isodate" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/ed/57/8adeed578fa8984856c67b4229e93a58e3f6024417d448d0037aafa4ee9b/azure_ai_agents-1.2.0b5.tar.gz", hash = "sha256:1a16ef3f305898aac552269f01536c34a00473dedee0bca731a21fdb739ff9d5", size = 394876, upload-time = "2025-09-30T01:55:02.328Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/6d/6d/15070d23d7a94833a210da09d5d7ed3c24838bb84f0463895e5d159f1695/azure_ai_agents-1.2.0b5-py3-none-any.whl", hash = "sha256:257d0d24a6bf13eed4819cfa5c12fb222e5908deafb3cbfd5711d3a511cc4e88", size = 217948, upload-time = "2025-09-30T01:55:04.155Z" },
-]
-
-[[package]]
-name = "azure-ai-projects"
-version = "2.0.0b3"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "azure-core" },
-    { name = "azure-identity" },
-    { name = "azure-storage-blob" },
-    { name = "isodate" },
-    { name = "openai" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/24/e0/3512d3f07e9dd2eb4af684387c31598c435bd87833b6a81850972963cb9c/azure_ai_projects-2.0.0b3.tar.gz", hash = "sha256:6d09ad110086e450a47b991ee8a3644f1be97fa3085d5981d543f900d78f4505", size = 431749, upload-time = "2026-01-06T05:31:25.849Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/4e/b6/8fbd4786bb5c0dd19eaff86ddce0fbfb53a6f90d712038272161067a076a/azure_ai_projects-2.0.0b3-py3-none-any.whl", hash = "sha256:3b3048a3ba3904d556ba392b7bd20b6e84c93bb39df6d43a6470cdb0ad08af8c", size = 240717, upload-time = "2026-01-06T05:31:27.716Z" },
-]
-
-[[package]]
-name = "azure-common"
-version = "1.1.28"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/3e/71/f6f71a276e2e69264a97ad39ef850dca0a04fce67b12570730cb38d0ccac/azure-common-1.1.28.zip", hash = "sha256:4ac0cd3214e36b6a1b6a442686722a5d8cc449603aa833f3f0f40bda836704a3", size = 20914, upload-time = "2022-02-03T19:39:44.373Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/62/55/7f118b9c1b23ec15ca05d15a578d8207aa1706bc6f7c87218efffbbf875d/azure_common-1.1.28-py2.py3-none-any.whl", hash = "sha256:5c12d3dcf4ec20599ca6b0d3e09e86e146353d443e7fcc050c9a19c1f9df20ad", size = 14462, upload-time = "2022-02-03T19:39:42.417Z" },
-]
-
-[[package]]
-name = "azure-core"
-version = "1.38.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "requests" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/dc/1b/e503e08e755ea94e7d3419c9242315f888fc664211c90d032e40479022bf/azure_core-1.38.0.tar.gz", hash = "sha256:8194d2682245a3e4e3151a667c686464c3786fed7918b394d035bdcd61bb5993", size = 363033, upload-time = "2026-01-12T17:03:05.535Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/fc/d8/b8fcba9464f02b121f39de2db2bf57f0b216fe11d014513d666e8634380d/azure_core-1.38.0-py3-none-any.whl", hash = "sha256:ab0c9b2cd71fecb1842d52c965c95285d3cfb38902f6766e4a471f1cd8905335", size = 217825, upload-time = "2026-01-12T17:03:07.291Z" },
-]
-
-[[package]]
-name = "azure-functions"
-version = "1.25.0b3"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "werkzeug" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/ad/69/d28046766a4af4152fbe694dcfeefae7fc6fbf8cad03b98ba1502d50b29d/azure_functions-1.25.0b3.tar.gz", hash = "sha256:1b49217d387dd356f732648f3292056bd30f953f534df99d0060fbb801bbeaf0", size = 141886, upload-time = "2026-02-09T15:40:53.614Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e7/1b/7d65288576a2ff612c948b9ebf7208ddfa6f2136ca0978ed4f7528527ae9/azure_functions-1.25.0b3-py3-none-any.whl", hash = "sha256:b4217a021bd679c0bd21b59bc92cc5abfe568bf023d24c4ac37354f4acf4259c", size = 112548, upload-time = "2026-02-09T15:40:52.113Z" },
-]
-
-[[package]]
-name = "azure-functions-durable"
-version = "1.5.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "aiohttp" },
-    { name = "azure-functions" },
-    { name = "furl" },
-    { name = "opentelemetry-api" },
-    { name = "opentelemetry-sdk" },
-    { name = "python-dateutil" },
-    { name = "requests" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/d0/7c/3654377e7000c4bd6b6edbb959efc4ad867005353843a4d810dfa8fbb72b/azure_functions_durable-1.5.0.tar.gz", hash = "sha256:131fbdf08fa1140d94dc3948fcf9000d8da58aaa5a0ffc4db0ea3be97d5551e2", size = 183733, upload-time = "2026-02-04T20:33:45.788Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b8/25/fb054d81c1fda64b229b04b4051657fedd4a72f53c51c59fcaca3a454d2f/azure_functions_durable-1.5.0-py3-none-any.whl", hash = "sha256:aea683193328924ae56eebb8f80647e186baf93e26c061f09ce532702c279ddc", size = 146619, upload-time = "2026-02-04T20:33:16.838Z" },
-]
-
-[[package]]
-name = "azure-identity"
-version = "1.25.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "azure-core" },
-    { name = "cryptography" },
-    { name = "msal" },
-    { name = "msal-extensions" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/06/8d/1a6c41c28a37eab26dc85ab6c86992c700cd3f4a597d9ed174b0e9c69489/azure_identity-1.25.1.tar.gz", hash = "sha256:87ca8328883de6036443e1c37b40e8dc8fb74898240f61071e09d2e369361456", size = 279826, upload-time = "2025-10-06T20:30:02.194Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/83/7b/5652771e24fff12da9dde4c20ecf4682e606b104f26419d139758cc935a6/azure_identity-1.25.1-py3-none-any.whl", hash = "sha256:e9edd720af03dff020223cd269fa3a61e8f345ea75443858273bcb44844ab651", size = 191317, upload-time = "2025-10-06T20:30:04.251Z" },
-]
-
-[[package]]
-name = "azure-search-documents"
-version = "11.7.0b2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "azure-common" },
-    { name = "azure-core" },
-    { name = "isodate" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/f9/ba/bde0f03e0a742ba3bbcc929f91ed2f3b1420c2bb84c9a7f878f3b87ebfce/azure_search_documents-11.7.0b2.tar.gz", hash = "sha256:b6e039f8038ff2210d2057e704e867c6e29bb46bfcd400da4383e45e4b8bb189", size = 423956, upload-time = "2025-11-14T20:09:32.876Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e5/26/ed4498374f9088818278ac225f2bea688b4ec979d81bf83a5355c8c366af/azure_search_documents-11.7.0b2-py3-none-any.whl", hash = "sha256:f82117b321344a84474269ed26df194c24cca619adc024d981b1b86aee3c6f05", size = 432037, upload-time = "2025-11-14T20:09:34.347Z" },
-]
-
-[[package]]
-name = "azure-storage-blob"
-version = "12.29.0b1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "azure-core" },
-    { name = "cryptography" },
-    { name = "isodate" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/d4/e1/f4b957d7f080c9f58b5d4e5a6b026fb745e7d6273d7f9147d26724f842df/azure_storage_blob-12.29.0b1.tar.gz", hash = "sha256:6fe4c61984178f970af36fdac47a67abcc9c80bbb5ac3c1c4947682d66626764", size = 612000, upload-time = "2026-01-27T16:30:30.356Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e7/1a/f356cbfbcd8c2a1cbe8e8edce4d4b0f9a776fcc91759e34e5b980897bb23/azure_storage_blob-12.29.0b1-py3-none-any.whl", hash = "sha256:64702c0c67b7ac709feb80aacb61183bb5960ad615d36c43e95fe197c9bf610c", size = 434480, upload-time = "2026-01-27T16:30:35.091Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/c6/6f124bcfbbfb20fba22c939b4e43a06dccfc0e1ca20e5634ca573cb1e271/authlib-1.8.0-py2.py3-none-any.whl", hash = "sha256:88aebbd9af6757e14e912d5dc007ae1dc1f3e27e3b2152ce7c552ee2c3b3c121", size = 260804, upload-time = "2026-08-30T12:12:33.162Z" },
 ]
 
 [[package]]
@@ -1010,11 +598,89 @@ wheels = [
 
 [[package]]
 name = "cachetools"
-version = "6.2.4"
+version = "7.1.8"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/bc/1d/ede8680603f6016887c062a2cf4fc8fdba905866a3ab8831aa8aa651320c/cachetools-6.2.4.tar.gz", hash = "sha256:82c5c05585e70b6ba2d3ae09ea60b79548872185d2f24ae1f2709d37299fd607", size = 31731, upload-time = "2025-12-15T18:24:53.744Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4b/39/9a4689914dd907915cee74733b95888fc1d8a21aad47a24a0a2deec73ac4/cachetools-7.1.8.tar.gz", hash = "sha256:1221d547a0b24b7f26fa891d40d488b5258beab9aebd8ed68c729be3af849c43", size = 40909, upload-time = "2026-08-31T19:02:53.985Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2c/fc/1d7b80d0eb7b714984ce40efc78859c022cd930e402f599d8ca9e39c78a4/cachetools-6.2.4-py3-none-any.whl", hash = "sha256:69a7a52634fed8b8bf6e24a050fb60bff1c9bd8f6d24572b99c32d4e71e62a51", size = 11551, upload-time = "2025-12-15T18:24:52.332Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/3d/9487690d0e937854db587205c66bab3c3cf88d9f00ed380b74cb88cc94ee/cachetools-7.1.8-py3-none-any.whl", hash = "sha256:a81e3844acaa7355b6567f97bd67a94a14ec3a9bc2cbbdae45b9592cc036775b", size = 16842, upload-time = "2026-08-31T19:02:52.554Z" },
+]
+
+[[package]]
+name = "caio"
+version = "0.9.25"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.11'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/92/88/b8527e1b00c1811db339a1df8bd1ae49d146fcea9d6a5c40e3a80aaeb38d/caio-0.9.25.tar.gz", hash = "sha256:16498e7f81d1d0f5a4c0ad3f2540e65fe25691376e0a5bd367f558067113ed10", size = 26781, upload-time = "2025-12-26T15:21:36.501Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6a/80/ea4ead0c5d52a9828692e7df20f0eafe8d26e671ce4883a0a146bb91049e/caio-0.9.25-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:ca6c8ecda611478b6016cb94d23fd3eb7124852b985bdec7ecaad9f3116b9619", size = 36836, upload-time = "2025-12-26T15:22:04.662Z" },
+    { url = "https://files.pythonhosted.org/packages/17/b9/36715c97c873649d1029001578f901b50250916295e3dddf20c865438865/caio-0.9.25-cp310-cp310-manylinux2010_x86_64.manylinux2014_x86_64.manylinux_2_12_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:db9b5681e4af8176159f0d6598e73b2279bb661e718c7ac23342c550bd78c241", size = 79695, upload-time = "2025-12-26T15:22:18.818Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/ab/07080ecb1adb55a02cbd8ec0126aa8e43af343ffabb6a71125b42670e9a1/caio-0.9.25-cp310-cp310-manylinux_2_34_aarch64.whl", hash = "sha256:bf61d7d0c4fd10ffdd98ca47f7e8db4d7408e74649ffaf4bef40b029ada3c21b", size = 79457, upload-time = "2026-03-04T22:08:16.024Z" },
+    { url = "https://files.pythonhosted.org/packages/88/95/dd55757bb671eb4c376e006c04e83beb413486821f517792ea603ef216e9/caio-0.9.25-cp310-cp310-manylinux_2_34_x86_64.whl", hash = "sha256:ab52e5b643f8bbd64a0605d9412796cd3464cb8ca88593b13e95a0f0b10508ae", size = 77705, upload-time = "2026-03-04T22:08:17.202Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/90/543f556fcfcfa270713eef906b6352ab048e1e557afec12925c991dc93c2/caio-0.9.25-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:d6956d9e4a27021c8bd6c9677f3a59eb1d820cc32d0343cea7961a03b1371965", size = 36839, upload-time = "2025-12-26T15:21:40.267Z" },
+    { url = "https://files.pythonhosted.org/packages/51/3b/36f3e8ec38dafe8de4831decd2e44c69303d2a3892d16ceda42afed44e1b/caio-0.9.25-cp311-cp311-manylinux2010_x86_64.manylinux2014_x86_64.manylinux_2_12_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:bf84bfa039f25ad91f4f52944452a5f6f405e8afab4d445450978cd6241d1478", size = 80255, upload-time = "2025-12-26T15:22:20.271Z" },
+    { url = "https://files.pythonhosted.org/packages/df/ce/65e64867d928e6aff1b4f0e12dba0ef6d5bf412c240dc1df9d421ac10573/caio-0.9.25-cp311-cp311-manylinux_2_34_aarch64.whl", hash = "sha256:ae3d62587332bce600f861a8de6256b1014d6485cfd25d68c15caf1611dd1f7c", size = 80052, upload-time = "2026-03-04T22:08:20.402Z" },
+    { url = "https://files.pythonhosted.org/packages/46/90/e278863c47e14ec58309aa2e38a45882fbe67b4cc29ec9bc8f65852d3e45/caio-0.9.25-cp311-cp311-manylinux_2_34_x86_64.whl", hash = "sha256:fc220b8533dcf0f238a6b1a4a937f92024c71e7b10b5a2dfc1c73604a25709bc", size = 78273, upload-time = "2026-03-04T22:08:21.368Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/25/79c98ebe12df31548ba4eaf44db11b7cad6b3e7b4203718335620939083c/caio-0.9.25-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:fb7ff95af4c31ad3f03179149aab61097a71fd85e05f89b4786de0359dffd044", size = 36983, upload-time = "2025-12-26T15:21:36.075Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/2b/21288691f16d479945968a0a4f2856818c1c5be56881d51d4dac9b255d26/caio-0.9.25-cp312-cp312-manylinux2010_x86_64.manylinux2014_x86_64.manylinux_2_12_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:97084e4e30dfa598449d874c4d8e0c8d5ea17d2f752ef5e48e150ff9d240cd64", size = 82012, upload-time = "2025-12-26T15:22:20.983Z" },
+    { url = "https://files.pythonhosted.org/packages/03/c4/8a1b580875303500a9c12b9e0af58cb82e47f5bcf888c2457742a138273c/caio-0.9.25-cp312-cp312-manylinux_2_34_aarch64.whl", hash = "sha256:4fa69eba47e0f041b9d4f336e2ad40740681c43e686b18b191b6c5f4c5544bfb", size = 81502, upload-time = "2026-03-04T22:08:22.381Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/1c/0fe770b8ffc8362c48134d1592d653a81a3d8748d764bec33864db36319d/caio-0.9.25-cp312-cp312-manylinux_2_34_x86_64.whl", hash = "sha256:6bebf6f079f1341d19f7386db9b8b1f07e8cc15ae13bfdaff573371ba0575d69", size = 80200, upload-time = "2026-03-04T22:08:23.382Z" },
+    { url = "https://files.pythonhosted.org/packages/31/57/5e6ff127e6f62c9f15d989560435c642144aa4210882f9494204bc892305/caio-0.9.25-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:d6c2a3411af97762a2b03840c3cec2f7f728921ff8adda53d7ea2315a8563451", size = 36979, upload-time = "2025-12-26T15:21:35.484Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/9f/f21af50e72117eb528c422d4276cbac11fb941b1b812b182e0a9c70d19c5/caio-0.9.25-cp313-cp313-manylinux2010_x86_64.manylinux2014_x86_64.manylinux_2_12_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0998210a4d5cd5cb565b32ccfe4e53d67303f868a76f212e002a8554692870e6", size = 81900, upload-time = "2025-12-26T15:22:21.919Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/12/c39ae2a4037cb10ad5eb3578eb4d5f8c1a2575c62bba675f3406b7ef0824/caio-0.9.25-cp313-cp313-manylinux_2_34_aarch64.whl", hash = "sha256:1a177d4777141b96f175fe2c37a3d96dec7911ed9ad5f02bac38aaa1c936611f", size = 81523, upload-time = "2026-03-04T22:08:25.187Z" },
+    { url = "https://files.pythonhosted.org/packages/22/59/f8f2e950eb4f1a5a3883e198dca514b9d475415cb6cd7b78b9213a0dd45a/caio-0.9.25-cp313-cp313-manylinux_2_34_x86_64.whl", hash = "sha256:9ed3cfb28c0e99fec5e208c934e5c157d0866aa9c32aa4dc5e9b6034af6286b7", size = 80243, upload-time = "2026-03-04T22:08:26.449Z" },
+    { url = "https://files.pythonhosted.org/packages/69/ca/a08fdc7efdcc24e6a6131a93c85be1f204d41c58f474c42b0670af8c016b/caio-0.9.25-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:fab6078b9348e883c80a5e14b382e6ad6aabbc4429ca034e76e730cf464269db", size = 36978, upload-time = "2025-12-26T15:21:41.055Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/6c/d4d24f65e690213c097174d26eda6831f45f4734d9d036d81790a27e7b78/caio-0.9.25-cp314-cp314-manylinux2010_x86_64.manylinux2014_x86_64.manylinux_2_12_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:44a6b58e52d488c75cfaa5ecaa404b2b41cc965e6c417e03251e868ecd5b6d77", size = 81832, upload-time = "2025-12-26T15:22:22.757Z" },
+    { url = "https://files.pythonhosted.org/packages/87/a4/e534cf7d2d0e8d880e25dd61e8d921ffcfe15bd696734589826f5a2df727/caio-0.9.25-cp314-cp314-manylinux_2_34_aarch64.whl", hash = "sha256:628a630eb7fb22381dd8e3c8ab7f59e854b9c806639811fc3f4310c6bd711d79", size = 81565, upload-time = "2026-03-04T22:08:27.483Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/ed/bf81aeac1d290017e5e5ac3e880fd56ee15e50a6d0353986799d1bc5cfd5/caio-0.9.25-cp314-cp314-manylinux_2_34_x86_64.whl", hash = "sha256:0ba16aa605ccb174665357fc729cf500679c2d94d5f1458a6f0d5ca48f2060a7", size = 80071, upload-time = "2026-03-04T22:08:28.751Z" },
+    { url = "https://files.pythonhosted.org/packages/86/93/1f76c8d1bafe3b0614e06b2195784a3765bbf7b0a067661af9e2dd47fc33/caio-0.9.25-py3-none-any.whl", hash = "sha256:06c0bb02d6b929119b1cfbe1ca403c768b2013a369e2db46bfa2a5761cf82e40", size = 19087, upload-time = "2025-12-26T15:22:00.221Z" },
+]
+
+[[package]]
+name = "caio"
+version = "0.12.4"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14'",
+    "python_full_version == '3.13.*'",
+    "python_full_version == '3.12.*'",
+    "python_full_version == '3.11.*'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d2/c9/ac301b7f86ccf6ad02ee78eb953ce8f75175754cc5e76d398e447af42e3e/caio-0.12.4.tar.gz", hash = "sha256:32d8e9f3e2099c8db29446679252766c9bcd806eb88b4fb60ad274f73df2a5e9", size = 81006, upload-time = "2026-09-07T06:52:39.18Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/29/7a/c056466f49dde257502c7ff36c5dbb751a3479ac71968c80abcec52e2e2f/caio-0.12.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:8e9eda6a88f309a0a53bcba844471638da01a92758015e2df099fa361891dc72", size = 41095, upload-time = "2026-09-07T06:52:01.972Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/56/e82ae6505d959357e4156da0380d207898f3348f67cf6c265e0eb2fe94c4/caio-0.12.4-cp310-cp310-manylinux_2_34_aarch64.whl", hash = "sha256:51b8600eadc8756751dfc152514852040c6c28deb6bdcd6bfbdddb2a38e424e1", size = 156820, upload-time = "2026-09-07T06:52:03.292Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/75/d759aa402a062f4ef36cc7c4fb6515cca7ee04294802e72461ef3fbd7de4/caio-0.12.4-cp310-cp310-manylinux_2_34_x86_64.whl", hash = "sha256:97bff8f7da696321552b42629d1869983a8ced2f010bac9731b2719c1195a20c", size = 153618, upload-time = "2026-09-07T06:52:04.345Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/b5/a5985255f2083d9a69e78a6ef69da1a2242e4e6378ac2273e826c6196745/caio-0.12.4-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:759b952df48a5bbdb16e90631c748c877fb0ec7ca9d64eef1066569925ccdd30", size = 154468, upload-time = "2026-09-07T06:52:05.601Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/61/efc29a9697b574eb7528cc718e58fd872cf4c46f267d4df0fe15e4798dbb/caio-0.12.4-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:20f1d3fe05be285d82413b00bd8061eeb62d3027d3f565adaf7db10bebc594dc", size = 153360, upload-time = "2026-09-07T06:52:06.737Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/c6/168bc0eef2c77681e186957d5a1145208802bb0ecdcfd4d7f67b38b629c7/caio-0.12.4-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:b0444d20067642bb272e423de3cc8ef05bf134d335d57fa5bddcfcc98e04313e", size = 47768, upload-time = "2026-09-07T06:52:07.809Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/81/ae41a0473525229e56d7ffbb420b7fc7f72e04e468160a3519596ce094ba/caio-0.12.4-cp311-cp311-manylinux_2_34_aarch64.whl", hash = "sha256:780465251a0680039b29c990bca73b40b843e39d06505c62e353ed56490e4576", size = 159620, upload-time = "2026-09-07T06:52:08.881Z" },
+    { url = "https://files.pythonhosted.org/packages/86/c5/53838d8ece904637dadc3177e5b5b5b6e4f7af9ce17a1f42c6f6214edc1d/caio-0.12.4-cp311-cp311-manylinux_2_34_x86_64.whl", hash = "sha256:67f1bddc997bef281db36600e3e58d6b16d6486b3540eb62c9e54c6584f137fd", size = 156089, upload-time = "2026-09-07T06:52:09.99Z" },
+    { url = "https://files.pythonhosted.org/packages/83/39/34e416ee20493c96d5beda9e4196bec236117b012f6f4d0efdb96b91932c/caio-0.12.4-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:20acd9a8df90d25b63bc0b7dc264e2a09b99082a420b5d640c76056027ee6b52", size = 157195, upload-time = "2026-09-07T06:52:11.196Z" },
+    { url = "https://files.pythonhosted.org/packages/26/c9/f7b78203beaee0e984b219c48c810e547b27353f899ef82d49133f3c4817/caio-0.12.4-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:0d8d2826bf622644fc374a9f53ac00918b489d03599783953fcbe79af19123f5", size = 155700, upload-time = "2026-09-07T06:52:12.379Z" },
+    { url = "https://files.pythonhosted.org/packages/68/35/7ddc8de48cd0142797db186c07e901005b966dc6e8a7852f0273d33e4840/caio-0.12.4-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:67b725641fea682a2e9b1d3b2a150d21f1a25383e3ec8351bd7677ff857fa982", size = 47927, upload-time = "2026-09-07T06:52:13.58Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/b4/37556bde83253cf1ed071a754c8405d02b955febd021c400f0ffa6258d5f/caio-0.12.4-cp312-cp312-manylinux_2_34_aarch64.whl", hash = "sha256:4854a029e359e5ddfb5589ab66157a34af6a0dda0acdaa43f5e640d60182c1ea", size = 161402, upload-time = "2026-09-07T06:52:14.581Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/11/519e40a1da4d18515ab5ddb54e75cdd896532339010f2dcee7e798e4edab/caio-0.12.4-cp312-cp312-manylinux_2_34_x86_64.whl", hash = "sha256:f063624a98a64bab387430c5eaea61ef3825a98399104a297b8da4741c15139f", size = 159311, upload-time = "2026-09-07T06:52:15.853Z" },
+    { url = "https://files.pythonhosted.org/packages/45/2a/0db30de6c2561e41721d94ac627aa65db61a403545e67914814d8c2b5305/caio-0.12.4-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8a926d562f8c06767774a91239770ebaa93c10a24074e21ea741db208df9cc1d", size = 158910, upload-time = "2026-09-07T06:52:17.27Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/e0/5eb43a89aecdf9d6f929b0080e49d92ccdf3f88bbc637353f52843b483af/caio-0.12.4-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:53605636e3b1eaeca368b475f1471ad9774736c6502a4b58b8b6b8d74b531770", size = 158973, upload-time = "2026-09-07T06:52:18.527Z" },
+    { url = "https://files.pythonhosted.org/packages/11/ab/12e4896a1e74ff9a65c84894acdfc3b70b8b49e63874a37e0dffcc31f396/caio-0.12.4-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:134d9d145d75f454de5ece9e87595bad433639b51061b693bafc369f689f8742", size = 47934, upload-time = "2026-09-07T06:52:19.644Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/d4/3a96f5537e3fa4e3256f93244fe883a5a4879f2b9e2d59d50151bb417f37/caio-0.12.4-cp313-cp313-manylinux_2_34_aarch64.whl", hash = "sha256:27ec5671ac05650abc7ac1fb12e95ad09417ae495ce9be565927786688edd6c5", size = 161559, upload-time = "2026-09-07T06:52:20.637Z" },
+    { url = "https://files.pythonhosted.org/packages/05/64/f33b9aaf7bc9bad988211d8e42b4b85c25a1d5dcc0906798aebe49bd421b/caio-0.12.4-cp313-cp313-manylinux_2_34_x86_64.whl", hash = "sha256:1e1d5570fd0ec75b1b2c2877c5545ed9f0738b5d23b000e2b6a8fc830dc8b310", size = 159453, upload-time = "2026-09-07T06:52:22.011Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/9e/3fc5e143728d99f8af11453789d755937fbe795a6c5c9c9ea529c91df519/caio-0.12.4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:e22ce2e69d94e4c80e0c11c871e547b3c2d147f977632894cb2527ddb6e87a8d", size = 159028, upload-time = "2026-09-07T06:52:23.225Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/8d/e7a165aa44bb2876bec96f7fb1995346d14e43d46237421382f8af4f37da/caio-0.12.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9dc0fd6f09ef72d18d3f43ca3d1140295222d925c583114ab9b1e8843a109a6e", size = 159088, upload-time = "2026-09-07T06:52:24.362Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/31/d31ed073a7f8e02d352b390ff556757ba82afbd747c68238b1bda638ce6f/caio-0.12.4-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:413565d77dfdf2dd841ac100571ef1cc710f9c56137312f3ec51356350b4f3a5", size = 41919, upload-time = "2026-09-07T06:52:25.5Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/07/ab0bc8a481126e6b4f6f56f3bb94e41568fc4604df15420616251b2e28da/caio-0.12.4-cp314-cp314-macosx_26_0_arm64.whl", hash = "sha256:cd1d00ed1867a3b7a4cffb64b1bd8644de4b6f88cb25240cf82a9cc160ace975", size = 41131, upload-time = "2026-09-07T06:52:26.512Z" },
+    { url = "https://files.pythonhosted.org/packages/24/3b/49382d9f7b3f65c76bb63a18a657833c4bfa695555b9663139950dec3c11/caio-0.12.4-cp314-cp314-manylinux_2_34_aarch64.whl", hash = "sha256:4189104e5579553031340a677762398c130b81ddb7d7c9b69eebffddaecc4f58", size = 162063, upload-time = "2026-09-07T06:52:27.717Z" },
+    { url = "https://files.pythonhosted.org/packages/14/7c/eaf41fb7e0c864c3a5ce4c259eba0f505633efe4f789fffb6d3f1eb7e9e1/caio-0.12.4-cp314-cp314-manylinux_2_34_x86_64.whl", hash = "sha256:4f2e0b6d393dc0ea78cfd13a9a4321fc35fd6a2db802e5f64651317e859fc929", size = 159514, upload-time = "2026-09-07T06:52:28.914Z" },
+    { url = "https://files.pythonhosted.org/packages/41/7e/4041947d8caa760b74a27c8082844c72974da7cbfb96737990b8c6749e53/caio-0.12.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:710ffe4a6f3d69dbfe98e9f856c24a544e4d639c7bd210f9f5503a26e62502f4", size = 159753, upload-time = "2026-09-07T06:52:30.081Z" },
+    { url = "https://files.pythonhosted.org/packages/32/76/b6c524a51eca13b861e8f98c927b933fdf5766f0c7c9017a21d889a84e3d/caio-0.12.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ddf8d946b795ebd7c75b331b6dcbab4808fdd2c9f16ca76012b4757512861133", size = 159167, upload-time = "2026-09-07T06:52:31.288Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/f4/c39ed874d420bb2719d52932d763953c28371c536d6bf264de1febeb27d5/caio-0.12.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:17a41de51203fc4d787d8d577bd56f169167aa9822f14fada015504688791aa4", size = 41920, upload-time = "2026-09-07T06:52:32.432Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/54/58f4ba2ac9ba69bd30e5c89493d34aa483743f823f79a854f20771fb80ca/caio-0.12.4-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:ee9de68d6ede7ed69e55a1c09073ce146d9f9470088796d55238c485a93fe203", size = 183327, upload-time = "2026-09-07T06:52:33.492Z" },
+    { url = "https://files.pythonhosted.org/packages/25/81/6b86722be50975b80a636afebed5af1a6e6588afeff0ae1a0a7f8c262707/caio-0.12.4-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:1c1a387f8784a86a56a8912ca42e1ad67599f16406f497b5b655b461a1b89426", size = 179368, upload-time = "2026-09-07T06:52:34.66Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/a3/19ab810f11d1688bb2009e669b2645410a89b7a35b608239ac4076dc1611/caio-0.12.4-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:ceee64265a55b9aba9c38c1d01a159b99f1e36eb56938022018199d2e7fe1742", size = 181460, upload-time = "2026-09-07T06:52:35.841Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/b2/e54e6e445d600e22b107e4005714cad0657bc7dc19d200817ab7a62ac722/caio-0.12.4-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:456a93868ff007cea65d916d96d192cda8b9992c6eee046cb0159040f9446ab5", size = 179230, upload-time = "2026-09-07T06:52:36.978Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/e6/07100a694613344d22958fb6d803fdf914ee9395278fe58ad1b1b9c59e52/caio-0.12.4-py3-none-any.whl", hash = "sha256:7a5e231bbf81eaed269f99afa9ef46457f51f9407952a1795c0795b3a62c23c0", size = 25628, upload-time = "2026-09-07T06:52:38.147Z" },
 ]
 
 [[package]]
@@ -1280,46 +946,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f4/18/2ac35d6b3015a0c74e923d94fc69baf8307f7c3233de015d69f99e17afa8/cloudpathlib-0.23.0.tar.gz", hash = "sha256:eb38a34c6b8a048ecfd2b2f60917f7cbad4a105b7c979196450c2f541f4d6b4b", size = 53126, upload-time = "2025-10-07T22:47:56.278Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ae/8a/c4bb04426d608be4a3171efa2e233d2c59a5c8937850c10d098e126df18e/cloudpathlib-0.23.0-py3-none-any.whl", hash = "sha256:8520b3b01468fee77de37ab5d50b1b524ea6b4a8731c35d1b7407ac0cd716002", size = 62755, upload-time = "2025-10-07T22:47:54.905Z" },
-]
-
-[[package]]
-name = "cloudpickle"
-version = "3.1.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/27/fb/576f067976d320f5f0114a8d9fa1215425441bb35627b1993e5afd8111e5/cloudpickle-3.1.2.tar.gz", hash = "sha256:7fda9eb655c9c230dab534f1983763de5835249750e85fbcef43aaa30a9a2414", size = 22330, upload-time = "2025-11-03T09:25:26.604Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl", hash = "sha256:9acb47f6afd73f60dc1df93bb801b472f05ff42fa6c84167d25cb206be1fbf4a", size = 22228, upload-time = "2025-11-03T09:25:25.534Z" },
-]
-
-[[package]]
-name = "clr-loader"
-version = "0.2.10"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "cffi", marker = "python_full_version < '3.14'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/18/24/c12faf3f61614b3131b5c98d3bf0d376b49c7feaa73edca559aeb2aee080/clr_loader-0.2.10.tar.gz", hash = "sha256:81f114afbc5005bafc5efe5af1341d400e22137e275b042a8979f3feb9fc9446", size = 83605, upload-time = "2026-01-03T23:13:06.984Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c8/61/cf819f8e8bb4d4c74661acf2498ba8d4a296714be3478d21eaabf64f5b9b/clr_loader-0.2.10-py3-none-any.whl", hash = "sha256:ebbbf9d511a7fe95fa28a95a4e04cd195b097881dfe66158dc2c281d3536f282", size = 56483, upload-time = "2026-01-03T23:13:05.439Z" },
-]
-
-[[package]]
-name = "cohere"
-version = "5.20.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "fastavro" },
-    { name = "httpx" },
-    { name = "pydantic" },
-    { name = "pydantic-core" },
-    { name = "requests" },
-    { name = "tokenizers" },
-    { name = "types-requests" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/dd/52/08564d1820970010d30421cd6e36f2e4ca552646504d3fe532eef282c88d/cohere-5.20.2.tar.gz", hash = "sha256:0aa9f3735626b70eedf15c231c61f3a58e7f8bbe5f0509fe7b2e6606c5d420f1", size = 180820, upload-time = "2026-01-23T13:42:51.308Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e0/10/d76f045eefe42fb3f4e271d17ab41b5e73a3b6de69c98e15ab1cb0c8e6f6/cohere-5.20.2-py3-none-any.whl", hash = "sha256:26156d83bf3e3e4475e4caa1d8c4148475c5b0a253aee6066d83c643e9045be6", size = 318986, upload-time = "2026-01-23T13:42:50.151Z" },
 ]
 
 [[package]]
@@ -1680,6 +1306,15 @@ wheels = [
 ]
 
 [[package]]
+name = "defusedxml"
+version = "0.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/d5/c66da9b79e5bdb124974bfe172b4daf3c984ebd9c2a06e2b8a4dc7331c72/defusedxml-0.7.1.tar.gz", hash = "sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69", size = 75520, upload-time = "2021-03-08T10:59:26.269Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/6c/aa3f2f849e01cb6a001cd8554a88d4c77c5c1a31c95bdf1cf9301e6d9ef4/defusedxml-0.7.1-py2.py3-none-any.whl", hash = "sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61", size = 25604, upload-time = "2021-03-08T10:59:24.45Z" },
+]
+
+[[package]]
 name = "deprecated"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1698,15 +1333,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/db/04/d24f6e645ad82ba0ef092fa17d9ef7a21953781663648a01c9371d9e8e98/dirtyjson-1.0.8.tar.gz", hash = "sha256:90ca4a18f3ff30ce849d100dcf4a003953c79d3a2348ef056f1d9c22231a25fd", size = 30782, upload-time = "2022-11-28T23:32:33.319Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/68/69/1bcf70f81de1b4a9f21b3a62ec0c83bdff991c88d6cc2267d02408457e88/dirtyjson-1.0.8-py3-none-any.whl", hash = "sha256:125e27248435a58acace26d5c2c4c11a1c0de0a9c5124c5a94ba78e517d74f53", size = 25197, upload-time = "2022-11-28T23:32:31.219Z" },
-]
-
-[[package]]
-name = "diskcache"
-version = "5.6.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/3f/21/1c1ffc1a039ddcc459db43cc108658f32c57d271d7289a2794e401d0fdb6/diskcache-5.6.3.tar.gz", hash = "sha256:2c3a3fa2743d8535d832ec61c2054a1641f41775aa7c556758a109941e33e4fc", size = 67916, upload-time = "2023-08-31T06:12:00.316Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3f/27/4570e78fc0bf5ea0ca45eb1de3818a23787af9b390c0b0a0033a1b8236f9/diskcache-5.6.3-py3-none-any.whl", hash = "sha256:5e31b2d5fbad117cc363ebaf6b689474db18a1f6438bc82358b024abd4c2ca19", size = 45550, upload-time = "2023-08-31T06:11:58.822Z" },
 ]
 
 [[package]]
@@ -1769,34 +1395,6 @@ wheels = [
 ]
 
 [[package]]
-name = "durabletask"
-version = "1.3.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "asyncio" },
-    { name = "grpcio" },
-    { name = "packaging" },
-    { name = "protobuf" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/c9/27/3d021e6b36fc1aab6099fafc56dfc8059b4e8968615a26c1a0418601e50a/durabletask-1.3.0.tar.gz", hash = "sha256:11e38dda6df4737fadca0c71fc0a0f769955877c8a8bdb25ccbf90cf45afbf63", size = 57830, upload-time = "2026-01-12T21:54:30.465Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/44/87/31ea460dbfaf50d9877f143e2ce9829cac2fb106747d9900cc353356ea77/durabletask-1.3.0-py3-none-any.whl", hash = "sha256:411f23e13391b8845edca010873dd7a87ee7cfc1fe05753ab28a7cd7c3c1bd77", size = 64112, upload-time = "2026-01-12T21:54:29.471Z" },
-]
-
-[[package]]
-name = "durabletask-azuremanaged"
-version = "1.3.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "azure-identity" },
-    { name = "durabletask" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/29/29/6bb0b5fe51aa92e117adcdc93efe97cf5476d86c1496e5c5ab35d99a8d07/durabletask_azuremanaged-1.3.0.tar.gz", hash = "sha256:55172588e075afa80d46dcc2e5ddbd84be0a20cc78c74f687040c3720677d34c", size = 4343, upload-time = "2026-01-12T21:58:23.95Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/08/11/4d34fec302c4813e626080f1532d189767eb31d6d80e8f3698c230512f14/durabletask_azuremanaged-1.3.0-py3-none-any.whl", hash = "sha256:9da914f569da1597c858d494a95eda37e4372726c0ee65f30080dcafab262d60", size = 6366, upload-time = "2026-01-12T21:58:23.28Z" },
-]
-
-[[package]]
 name = "durationpy"
 version = "0.10"
 source = { registry = "https://pypi.org/simple" }
@@ -1828,15 +1426,6 @@ wheels = [
 ]
 
 [[package]]
-name = "eval-type-backport"
-version = "0.3.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/fb/a3/cafafb4558fd638aadfe4121dc6cefb8d743368c085acb2f521df0f3d9d7/eval_type_backport-0.3.1.tar.gz", hash = "sha256:57e993f7b5b69d271e37482e62f74e76a0276c82490cf8e4f0dffeb6b332d5ed", size = 9445, upload-time = "2025-12-02T11:51:42.987Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/cf/22/fdc2e30d43ff853720042fa15baa3e6122722be1a7950a98233ebb55cd71/eval_type_backport-0.3.1-py3-none-any.whl", hash = "sha256:279ab641905e9f11129f56a8a78f493518515b83402b860f6f06dd7c011fdfa8", size = 6063, upload-time = "2025-12-02T11:51:41.665Z" },
-]
-
-[[package]]
 name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1849,122 +1438,83 @@ wheels = [
 ]
 
 [[package]]
-name = "executing"
-version = "2.2.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/cc/28/c14e053b6762b1044f34a13aab6859bbf40456d37d23aa286ac24cfd9a5d/executing-2.2.1.tar.gz", hash = "sha256:3632cc370565f6648cc328b32435bd120a1e4ebb20c77e3fdde9a13cd1e533c4", size = 1129488, upload-time = "2025-09-01T09:48:10.866Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c1/ea/53f2148663b321f21b5a606bd5f191517cf40b7072c0497d3c92c4a13b1e/executing-2.2.1-py2.py3-none-any.whl", hash = "sha256:760643d3452b4d777d295bb167ccc74c64a81df23fb5e08eff250c425a4b2017", size = 28317, upload-time = "2025-09-01T09:48:08.5Z" },
-]
-
-[[package]]
-name = "fakeredis"
-version = "2.33.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "redis" },
-    { name = "sortedcontainers" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/5f/f9/57464119936414d60697fcbd32f38909bb5688b616ae13de6e98384433e0/fakeredis-2.33.0.tar.gz", hash = "sha256:d7bc9a69d21df108a6451bbffee23b3eba432c21a654afc7ff2d295428ec5770", size = 175187, upload-time = "2025-12-16T19:45:52.269Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/6e/78/a850fed8aeef96d4a99043c90b818b2ed5419cd5b24a4049fd7cfb9f1471/fakeredis-2.33.0-py3-none-any.whl", hash = "sha256:de535f3f9ccde1c56672ab2fdd6a8efbc4f2619fc2f1acc87b8737177d71c965", size = 119605, upload-time = "2025-12-16T19:45:51.08Z" },
-]
-
-[package.optional-dependencies]
-lua = [
-    { name = "lupa" },
-]
-
-[[package]]
 name = "fastapi"
-version = "0.128.0"
+version = "0.141.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-doc" },
     { name = "pydantic" },
     { name = "starlette" },
     { name = "typing-extensions" },
+    { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/52/08/8c8508db6c7b9aae8f7175046af41baad690771c9bcde676419965e338c7/fastapi-0.128.0.tar.gz", hash = "sha256:1cc179e1cef10a6be60ffe429f79b829dce99d8de32d7acb7e6c8dfdf7f2645a", size = 365682, upload-time = "2025-12-27T15:21:13.714Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8a/02/91e3416a8fdd715abb903a952a6bec7cdd8d14eed55d415fc8595524c319/fastapi-0.141.1.tar.gz", hash = "sha256:e8822fc40db1e1858054d7a949a888695bc9bdce70139178e33bd2871a453ca1", size = 425799, upload-time = "2026-07-29T17:18:05.568Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5c/05/5cbb59154b093548acd0f4c7c474a118eda06da25aa75c616b72d8fcd92a/fastapi-0.128.0-py3-none-any.whl", hash = "sha256:aebd93f9716ee3b4f4fcfe13ffb7cf308d99c9f3ab5622d8877441072561582d", size = 103094, upload-time = "2025-12-27T15:21:12.154Z" },
-]
-
-[[package]]
-name = "fastavro"
-version = "1.12.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/65/8b/fa2d3287fd2267be6261d0177c6809a7fa12c5600ddb33490c8dc29e77b2/fastavro-1.12.1.tar.gz", hash = "sha256:2f285be49e45bc047ab2f6bed040bb349da85db3f3c87880e4b92595ea093b2b", size = 1025661, upload-time = "2025-10-10T15:40:55.41Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/40/a0/077fd7cbfc143152cb96780cb592ed6cb6696667d8bc1b977745eb2255a8/fastavro-1.12.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:00650ca533907361edda22e6ffe8cf87ab2091c5d8aee5c8000b0f2dcdda7ed3", size = 1000335, upload-time = "2025-10-10T15:40:59.834Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/ae/a115e027f3a75df237609701b03ecba0b7f0aa3d77fe0161df533fde1eb7/fastavro-1.12.1-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ac76d6d95f909c72ee70d314b460b7e711d928845771531d823eb96a10952d26", size = 3221067, upload-time = "2025-10-10T15:41:04.399Z" },
-    { url = "https://files.pythonhosted.org/packages/94/4e/c4991c3eec0175af9a8a0c161b88089cb7bf7fe353b3e3be1bc4cf9036b2/fastavro-1.12.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1f55eef18c41d4476bd32a82ed5dd86aabc3f614e1b66bdb09ffa291612e1670", size = 3228979, upload-time = "2025-10-10T15:41:06.738Z" },
-    { url = "https://files.pythonhosted.org/packages/21/0c/f2afb8eaea38799ccb1ed07d68bf2659f2e313f1902bbd36774cf6a1bef9/fastavro-1.12.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:81563e1f93570e6565487cdb01ba241a36a00e58cff9c5a0614af819d1155d8f", size = 3160740, upload-time = "2025-10-10T15:41:08.731Z" },
-    { url = "https://files.pythonhosted.org/packages/0d/1a/f4d367924b40b86857862c1fa65f2afba94ddadf298b611e610a676a29e5/fastavro-1.12.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:bec207360f76f0b3de540758a297193c5390e8e081c43c3317f610b1414d8c8f", size = 3235787, upload-time = "2025-10-10T15:41:10.869Z" },
-    { url = "https://files.pythonhosted.org/packages/90/ec/8db9331896e3dfe4f71b2b3c23f2e97fbbfd90129777467ca9f8bafccb74/fastavro-1.12.1-cp310-cp310-win_amd64.whl", hash = "sha256:c0390bfe4a9f8056a75ac6785fbbff8f5e317f5356481d2e29ec980877d2314b", size = 449350, upload-time = "2025-10-10T15:41:12.104Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/e9/31c64b47cefc0951099e7c0c8c8ea1c931edd1350f34d55c27cbfbb08df1/fastavro-1.12.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:6b632b713bc5d03928a87d811fa4a11d5f25cd43e79c161e291c7d3f7aa740fd", size = 1016585, upload-time = "2025-10-10T15:41:13.717Z" },
-    { url = "https://files.pythonhosted.org/packages/10/76/111560775b548f5d8d828c1b5285ff90e2d2745643fb80ecbf115344eea4/fastavro-1.12.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:eaa7ab3769beadcebb60f0539054c7755f63bd9cf7666e2c15e615ab605f89a8", size = 3404629, upload-time = "2025-10-10T15:41:15.642Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/07/6bb93cb963932146c2b6c5c765903a0a547ad9f0f8b769a4a9aad8c06369/fastavro-1.12.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:123fb221df3164abd93f2d042c82f538a1d5a43ce41375f12c91ce1355a9141e", size = 3428594, upload-time = "2025-10-10T15:41:17.779Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/67/8115ec36b584197ea737ec79e3499e1f1b640b288d6c6ee295edd13b80f6/fastavro-1.12.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:632a4e3ff223f834ddb746baae0cc7cee1068eb12c32e4d982c2fee8a5b483d0", size = 3344145, upload-time = "2025-10-10T15:41:19.89Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/9e/a7cebb3af967e62539539897c10138fa0821668ec92525d1be88a9cd3ee6/fastavro-1.12.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:83e6caf4e7a8717d932a3b1ff31595ad169289bbe1128a216be070d3a8391671", size = 3431942, upload-time = "2025-10-10T15:41:22.076Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/d1/7774ddfb8781c5224294c01a593ebce2ad3289b948061c9701bd1903264d/fastavro-1.12.1-cp311-cp311-win_amd64.whl", hash = "sha256:b91a0fe5a173679a6c02d53ca22dcaad0a2c726b74507e0c1c2e71a7c3f79ef9", size = 450542, upload-time = "2025-10-10T15:41:23.333Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/f0/10bd1a3d08667fa0739e2b451fe90e06df575ec8b8ba5d3135c70555c9bd/fastavro-1.12.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:509818cb24b98a804fc80be9c5fed90f660310ae3d59382fc811bfa187122167", size = 1009057, upload-time = "2025-10-10T15:41:24.556Z" },
-    { url = "https://files.pythonhosted.org/packages/78/ad/0d985bc99e1fa9e74c636658000ba38a5cd7f5ab2708e9c62eaf736ecf1a/fastavro-1.12.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:089e155c0c76e0d418d7e79144ce000524dd345eab3bc1e9c5ae69d500f71b14", size = 3391866, upload-time = "2025-10-10T15:41:26.882Z" },
-    { url = "https://files.pythonhosted.org/packages/0d/9e/b4951dc84ebc34aac69afcbfbb22ea4a91080422ec2bfd2c06076ff1d419/fastavro-1.12.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:44cbff7518901c91a82aab476fcab13d102e4999499df219d481b9e15f61af34", size = 3458005, upload-time = "2025-10-10T15:41:29.017Z" },
-    { url = "https://files.pythonhosted.org/packages/af/f8/5a8df450a9f55ca8441f22ea0351d8c77809fc121498b6970daaaf667a21/fastavro-1.12.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a275e48df0b1701bb764b18a8a21900b24cf882263cb03d35ecdba636bbc830b", size = 3295258, upload-time = "2025-10-10T15:41:31.564Z" },
-    { url = "https://files.pythonhosted.org/packages/99/b2/40f25299111d737e58b85696e91138a66c25b7334f5357e7ac2b0e8966f8/fastavro-1.12.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2de72d786eb38be6b16d556b27232b1bf1b2797ea09599507938cdb7a9fe3e7c", size = 3430328, upload-time = "2025-10-10T15:41:33.689Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/07/85157a7c57c5f8b95507d7829b5946561e5ee656ff80e9dd9a757f53ddaf/fastavro-1.12.1-cp312-cp312-win_amd64.whl", hash = "sha256:9090f0dee63fe022ee9cc5147483366cc4171c821644c22da020d6b48f576b4f", size = 444140, upload-time = "2025-10-10T15:41:34.902Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/57/26d5efef9182392d5ac9f253953c856ccb66e4c549fd3176a1e94efb05c9/fastavro-1.12.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:78df838351e4dff9edd10a1c41d1324131ffecbadefb9c297d612ef5363c049a", size = 1000599, upload-time = "2025-10-10T15:41:36.554Z" },
-    { url = "https://files.pythonhosted.org/packages/33/cb/8ab55b21d018178eb126007a56bde14fd01c0afc11d20b5f2624fe01e698/fastavro-1.12.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:780476c23175d2ae457c52f45b9ffa9d504593499a36cd3c1929662bf5b7b14b", size = 3335933, upload-time = "2025-10-10T15:41:39.07Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/03/9c94ec9bf873eb1ffb0aa694f4e71940154e6e9728ddfdc46046d7e8ced4/fastavro-1.12.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0714b285160fcd515eb0455540f40dd6dac93bdeacdb03f24e8eac3d8aa51f8d", size = 3402066, upload-time = "2025-10-10T15:41:41.608Z" },
-    { url = "https://files.pythonhosted.org/packages/75/c8/cb472347c5a584ccb8777a649ebb28278fccea39d005fc7df19996f41df8/fastavro-1.12.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a8bc2dcec5843d499f2489bfe0747999108f78c5b29295d877379f1972a3d41a", size = 3240038, upload-time = "2025-10-10T15:41:43.743Z" },
-    { url = "https://files.pythonhosted.org/packages/e1/77/569ce9474c40304b3a09e109494e020462b83e405545b78069ddba5f614e/fastavro-1.12.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:3b1921ac35f3d89090a5816b626cf46e67dbecf3f054131f84d56b4e70496f45", size = 3369398, upload-time = "2025-10-10T15:41:45.719Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/1f/9589e35e9ea68035385db7bdbf500d36b8891db474063fb1ccc8215ee37c/fastavro-1.12.1-cp313-cp313-win_amd64.whl", hash = "sha256:5aa777b8ee595b50aa084104cd70670bf25a7bbb9fd8bb5d07524b0785ee1699", size = 444220, upload-time = "2025-10-10T15:41:47.39Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/d2/78435fe737df94bd8db2234b2100f5453737cffd29adee2504a2b013de84/fastavro-1.12.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:c3d67c47f177e486640404a56f2f50b165fe892cc343ac3a34673b80cc7f1dd6", size = 1086611, upload-time = "2025-10-10T15:41:48.818Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/be/428f99b10157230ddac77ec8cc167005b29e2bd5cbe228345192bb645f30/fastavro-1.12.1-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5217f773492bac43dae15ff2931432bce2d7a80be7039685a78d3fab7df910bd", size = 3541001, upload-time = "2025-10-10T15:41:50.871Z" },
-    { url = "https://files.pythonhosted.org/packages/16/08/a2eea4f20b85897740efe44887e1ac08f30dfa4bfc3de8962bdcbb21a5a1/fastavro-1.12.1-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:469fecb25cba07f2e1bfa4c8d008477cd6b5b34a59d48715e1b1a73f6160097d", size = 3432217, upload-time = "2025-10-10T15:41:53.149Z" },
-    { url = "https://files.pythonhosted.org/packages/87/bb/b4c620b9eb6e9838c7f7e4b7be0762834443adf9daeb252a214e9ad3178c/fastavro-1.12.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:d71c8aa841ef65cfab709a22bb887955f42934bced3ddb571e98fdbdade4c609", size = 3366742, upload-time = "2025-10-10T15:41:55.237Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/d1/e69534ccdd5368350646fea7d93be39e5f77c614cca825c990bd9ca58f67/fastavro-1.12.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:b81fc04e85dfccf7c028e0580c606e33aa8472370b767ef058aae2c674a90746", size = 3383743, upload-time = "2025-10-10T15:41:57.68Z" },
-    { url = "https://files.pythonhosted.org/packages/58/54/b7b4a0c3fb5fcba38128542da1b26c4e6d69933c923f493548bdfd63ab6a/fastavro-1.12.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:9445da127751ba65975d8e4bdabf36bfcfdad70fc35b2d988e3950cce0ec0e7c", size = 1001377, upload-time = "2025-10-10T15:41:59.241Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/4f/0e589089c7df0d8f57d7e5293fdc34efec9a3b758a0d4d0c99a7937e2492/fastavro-1.12.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ed924233272719b5d5a6a0b4d80ef3345fc7e84fc7a382b6232192a9112d38a6", size = 3320401, upload-time = "2025-10-10T15:42:01.682Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/19/260110d56194ae29d7e423a336fccea8bcd103196d00f0b364b732bdb84e/fastavro-1.12.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3616e2f0e1c9265e92954fa099db79c6e7817356d3ff34f4bcc92699ae99697c", size = 3350894, upload-time = "2025-10-10T15:42:04.073Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/96/58b0411e8be9694d5972bee3167d6c1fd1fdfdf7ce253c1a19a327208f4f/fastavro-1.12.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:cb0337b42fd3c047fcf0e9b7597bd6ad25868de719f29da81eabb6343f08d399", size = 3229644, upload-time = "2025-10-10T15:42:06.221Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/db/38660660eac82c30471d9101f45b3acfdcbadfe42d8f7cdb129459a45050/fastavro-1.12.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:64961ab15b74b7c168717bbece5660e0f3d457837c3cc9d9145181d011199fa7", size = 3329704, upload-time = "2025-10-10T15:42:08.384Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/a9/1672910f458ecb30b596c9e59e41b7c00309b602a0494341451e92e62747/fastavro-1.12.1-cp314-cp314-win_amd64.whl", hash = "sha256:792356d320f6e757e89f7ac9c22f481e546c886454a6709247f43c0dd7058004", size = 452911, upload-time = "2025-10-10T15:42:09.795Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/8d/2e15d0938ded1891b33eff252e8500605508b799c2e57188a933f0bd744c/fastavro-1.12.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:120aaf82ac19d60a1016afe410935fe94728752d9c2d684e267e5b7f0e70f6d9", size = 3541999, upload-time = "2025-10-10T15:42:11.794Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/1c/6dfd082a205be4510543221b734b1191299e6a1810c452b6bc76dfa6968e/fastavro-1.12.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b6a3462934b20a74f9ece1daa49c2e4e749bd9a35fa2657b53bf62898fba80f5", size = 3433972, upload-time = "2025-10-10T15:42:14.485Z" },
-    { url = "https://files.pythonhosted.org/packages/24/90/9de694625a1a4b727b1ad0958d220cab25a9b6cf7f16a5c7faa9ea7b2261/fastavro-1.12.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:1f81011d54dd47b12437b51dd93a70a9aa17b61307abf26542fc3c13efbc6c51", size = 3368752, upload-time = "2025-10-10T15:42:16.618Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/93/b44f67589e4d439913dab6720f7e3507b0fa8b8e56d06f6fc875ced26afb/fastavro-1.12.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:43ded16b3f4a9f1a42f5970c2aa618acb23ea59c4fcaa06680bdf470b255e5a8", size = 3386636, upload-time = "2025-10-10T15:42:18.974Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/03/10388a42375ee7e4ac9b94eb2c5c569c8b5795e377e701c9ac3ad63de890/fastapi-0.141.1-py3-none-any.whl", hash = "sha256:bfb91aa2d334c61cb35ba9a116fc123b3d3df31640b801cf57a7a78ec3f603b3", size = 131954, upload-time = "2026-07-29T17:18:04.364Z" },
 ]
 
 [[package]]
 name = "fastmcp"
-version = "2.14.4"
+version = "4.0.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "fastmcp-slim", extra = ["client", "server"] },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5d/1a/bee10aff530338f3b8982a3dd1c377c3ba5d0bc724615bf358422c4e9ecf/fastmcp-4.0.3.tar.gz", hash = "sha256:0dd50baf070105ee4436c245f087ac3c047e655c32d9e783de16d0bf15783a98", size = 42311418, upload-time = "2026-09-05T00:31:36.932Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e4/cb/66600db497b3be21cf141f01296308169859d48ed9b1bc8ba7c9d83279b7/fastmcp-4.0.3-py3-none-any.whl", hash = "sha256:f743f43193e1daf606e6497a9dddba5bbaad7df7957a98fd093716ecf4458b99", size = 8076, upload-time = "2026-09-05T00:31:33.957Z" },
+]
+
+[[package]]
+name = "fastmcp-slim"
+version = "4.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mcp-types" },
+    { name = "platformdirs" },
+    { name = "pydantic", extra = ["email"] },
+    { name = "pydantic-settings" },
+    { name = "python-dotenv" },
+    { name = "rich" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b0/a9/b7b796b0d4a5e095dadef233833c82ac1136f5c110dd9947b2e9a4988518/fastmcp_slim-4.0.3.tar.gz", hash = "sha256:3ce04a82b82cc41ccb12bb3bb366cfd65b52bc797b8fee332a75da9d480f9b74", size = 685704, upload-time = "2026-09-05T00:31:12.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/4b/6b31820d87f56d5773538860878c8634b618cd1e9044b3bfbd8a78380a0f/fastmcp_slim-4.0.3-py3-none-any.whl", hash = "sha256:3756ed4bd9f82f40adaf51974b7cdd1463ab6b9f479cf69b69b2692969312b87", size = 859717, upload-time = "2026-09-05T00:31:10.93Z" },
+]
+
+[package.optional-dependencies]
+client = [
+    { name = "authlib" },
+    { name = "exceptiongroup" },
+    { name = "httpx2" },
+    { name = "mcp" },
+    { name = "opentelemetry-api" },
+    { name = "py-key-value-aio", extra = ["filetree", "keyring", "memory"] },
+    { name = "starlette" },
+]
+server = [
     { name = "authlib" },
     { name = "cyclopts" },
     { name = "exceptiongroup" },
-    { name = "httpx" },
+    { name = "griffelib" },
+    { name = "httpx2" },
+    { name = "joserfc" },
     { name = "jsonref" },
     { name = "jsonschema-path" },
     { name = "mcp" },
     { name = "openapi-pydantic" },
+    { name = "opentelemetry-api" },
     { name = "packaging" },
-    { name = "platformdirs" },
-    { name = "py-key-value-aio", extra = ["disk", "keyring", "memory"] },
-    { name = "pydantic", extra = ["email"] },
-    { name = "pydocket" },
+    { name = "py-key-value-aio", extra = ["filetree", "keyring", "memory"] },
     { name = "pyperclip" },
-    { name = "python-dotenv" },
-    { name = "rich" },
+    { name = "python-multipart" },
+    { name = "pyyaml" },
+    { name = "starlette" },
+    { name = "uncalled-for" },
     { name = "uvicorn" },
+    { name = "watchfiles" },
     { name = "websockets" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/fd/a9/a57d5e5629ebd4ef82b495a7f8e346ce29ef80cc86b15c8c40570701b94d/fastmcp-2.14.4.tar.gz", hash = "sha256:c01f19845c2adda0a70d59525c9193be64a6383014c8d40ce63345ac664053ff", size = 8302239, upload-time = "2026-01-22T17:29:37.024Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3e/41/c4d407e2218fd60d84acb6cc5131d28ff876afecf325e3fd9d27b8318581/fastmcp-2.14.4-py3-none-any.whl", hash = "sha256:5858cff5e4c8ea8107f9bca2609d71d6256e0fce74495912f6e51625e466c49a", size = 417788, upload-time = "2026-01-22T17:29:35.159Z" },
 ]
 
 [[package]]
@@ -2187,29 +1737,16 @@ wheels = [
 ]
 
 [[package]]
-name = "furl"
-version = "2.1.4"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "orderedmultidict" },
-    { name = "six" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/53/e4/203a76fa2ef46cdb0a618295cc115220cbb874229d4d8721068335eb87f0/furl-2.1.4.tar.gz", hash = "sha256:877657501266c929269739fb5f5980534a41abd6bbabcb367c136d1d3b2a6015", size = 57526, upload-time = "2025-03-09T05:36:21.175Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/61/8c/dce3b1b7593858eba995b2dfdb833f872c7f863e3da92aab7128a6b11af4/furl-2.1.4-py2.py3-none-any.whl", hash = "sha256:da34d0b34e53ffe2d2e6851a7085a05d96922b5b578620a37377ff1dbeeb11c8", size = 27550, upload-time = "2025-03-09T05:36:19.928Z" },
-]
-
-[[package]]
 name = "genai-prices"
-version = "0.0.51"
+version = "0.1.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "httpx" },
+    { name = "httpx2" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3d/22/427934ef8e7ed29c35afc274666b87fe01a3a27ec7ff102f5839ce4723c0/genai_prices-0.0.51.tar.gz", hash = "sha256:003da98172641c94d7516b0fd8cec5ecf2dbab64a884996c26cc194c5e0b592e", size = 58071, upload-time = "2026-01-13T12:49:11.872Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1a/16/e5a507d42c0eb629b48ebe6c278f2d8c3f929bb6b28f18108bdd66d8ae12/genai_prices-0.1.6.tar.gz", hash = "sha256:802c1e4cc3ed5e70a09083b83af441a58d91f62e12768f7f1b6b26c98a33fcac", size = 111810, upload-time = "2026-09-02T14:53:54.895Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4a/af/b11b80d02aaefc2fc6bfaabb3ae873439c90dc464b3a29eda51b969842b0/genai_prices-0.0.51-py3-none-any.whl", hash = "sha256:4e0f5892a7ec757d59f343c5dbf9675b0f9e8ed65f4fe26ac7df600e34788ca0", size = 60656, upload-time = "2026-01-13T12:49:12.867Z" },
+    { url = "https://files.pythonhosted.org/packages/48/a1/43fa2a4c5557cd977e83eecec265b0b77b726b0c7b9f2f180b46c6fdb458/genai_prices-0.1.6-py3-none-any.whl", hash = "sha256:35ac8043dbcf2958488129413bfecba7304fe12a68ad4a78c5b0d15281e82814", size = 118834, upload-time = "2026-09-02T14:53:53.758Z" },
 ]
 
 [[package]]
@@ -2222,50 +1759,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/d9/29/d40217cbe2f6b1359e00c6c307bb3fc876ba74068cbab3dde77f03ca0dc4/ghp-import-2.1.0.tar.gz", hash = "sha256:9c535c4c61193c2df8871222567d7fd7e5014d835f97dc7b7439069e2413d343", size = 10943, upload-time = "2022-05-02T15:47:16.11Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f7/ec/67fbef5d497f86283db54c22eec6f6140243aae73265799baaaa19cd17fb/ghp_import-2.1.0-py3-none-any.whl", hash = "sha256:8337dd7b50877f163d4c0289bc1f1c7f127550241988d568c1db512c4324a619", size = 11034, upload-time = "2022-05-02T15:47:14.552Z" },
-]
-
-[[package]]
-name = "github-copilot-sdk"
-version = "0.1.25"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.11'",
-]
-dependencies = [
-    { name = "pydantic", marker = "python_full_version < '3.11'" },
-    { name = "python-dateutil", marker = "python_full_version < '3.11'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
-]
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/87/06/1dec504b54c724d69283969d4ed004225ec8bbb1c0a5e9e0c3b6b048099a/github_copilot_sdk-0.1.25-py3-none-macosx_10_9_x86_64.whl", hash = "sha256:d32c3fc2c393f70923a645a133607da2e562d078b87437f499100d5bb8c1902f", size = 58097936, upload-time = "2026-02-18T00:07:20.672Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/a3/a6ad1ca47af561069d6d8d0a4b074b000b0be1dfa9e66215b264ee31650c/github_copilot_sdk-0.1.25-py3-none-macosx_11_0_arm64.whl", hash = "sha256:7af33d3afbe09a78dfc9d65a843526e47aba15631e90926c42a21a200fab12da", size = 54867128, upload-time = "2026-02-18T00:07:25.228Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/08/74fd9be0ed292d524a15fa4db950f43f4afefb77514f856e36fd1203bf13/github_copilot_sdk-0.1.25-py3-none-manylinux_2_17_aarch64.whl", hash = "sha256:bc74a3d08ee45313ac02a3f7159c583ec41fc16090ec5f27f88c4b737f03139e", size = 60999905, upload-time = "2026-02-18T00:07:29.462Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/01/daae53c8586c0cadae9a2a146d1da9bd6dbd7e89b7dcd72643b453267345/github_copilot_sdk-0.1.25-py3-none-manylinux_2_17_x86_64.whl", hash = "sha256:13ef99fa8c709c5f80d820672bf36ee9176bc33f0efce6a2b5cbf6d1bb2369e8", size = 59183062, upload-time = "2026-02-18T00:07:34.059Z" },
-    { url = "https://files.pythonhosted.org/packages/81/a8/2ec7d47a18b042cca2c140cabb5fe6621697c1b43b8721637061122c51ed/github_copilot_sdk-0.1.25-py3-none-win_amd64.whl", hash = "sha256:1a90ee583309ff308fea42f9edec61203645a33ca1d3dc42953628fb8c3eda07", size = 53624148, upload-time = "2026-02-18T00:07:38.558Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/2e/4cffd33552ede91de7517641835a3365571abd3f436c9d76a4f50793033c/github_copilot_sdk-0.1.25-py3-none-win_arm64.whl", hash = "sha256:5249a63d1ac1e4d325c70c9902e81327b0baca53afa46010f52ac3fd3b5a111b", size = 51623455, upload-time = "2026-02-18T00:07:42.156Z" },
-]
-
-[[package]]
-name = "github-copilot-sdk"
-version = "1.0.0"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.14'",
-    "python_full_version == '3.13.*'",
-    "python_full_version == '3.12.*'",
-    "python_full_version == '3.11.*'",
-]
-dependencies = [
-    { name = "pydantic", marker = "python_full_version >= '3.11'" },
-    { name = "python-dateutil", marker = "python_full_version >= '3.11'" },
-]
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7a/d2/e74fdf476d0dde5c3802b3ba360f1b1e250e55d6d39c03f578c28ac9864e/github_copilot_sdk-1.0.0-py3-none-macosx_10_9_x86_64.whl", hash = "sha256:3cae245fb825e26a74395b74f10d9fd90bc464aa77005848ae0809c9a46c96df", size = 94986104, upload-time = "2026-06-02T14:59:55.022Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/81/e4d9dd01b0a563e488427aa879166287c88de3fccf7b8a95e22a6c652fc3/github_copilot_sdk-1.0.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:b344a00a877c86ef717244e42bd01acb3694b7377644661c82fc278ccc990e37", size = 91435649, upload-time = "2026-06-02T15:00:02.567Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/ec/e94b8f5a299850e600ffe1fe14bd21b48e01172b9e8b490a0ebd0d0c8d27/github_copilot_sdk-1.0.0-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:dd3a6b7637a3b12476854aeb599c6bed030f6a166fbd942d872c9a11a695517c", size = 97301959, upload-time = "2026-06-02T15:00:11.019Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/bf/dfba743a11d9745b0664ec5e1ae6e05055a5cbef0ccc6d593222319184eb/github_copilot_sdk-1.0.0-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:bbd2c64fe37016c74620a02d778eaacbd526b4c3b668a3cdff019f831c752eee", size = 96071193, upload-time = "2026-06-02T15:00:22.634Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/9b/d953dcbb898f4d44efc0cb592e9a703ad43a4b673aafb5bbd763962ab2fd/github_copilot_sdk-1.0.0-py3-none-win_amd64.whl", hash = "sha256:2d46fff634eece978532b1329c0d9e1d784b08ad521e71e6af06c5c28ae2e7c5", size = 90374124, upload-time = "2026-06-02T15:00:31.376Z" },
-    { url = "https://files.pythonhosted.org/packages/f4/f7/0f9943b1439e3dcc52854140676b65d8f63405c471a77c58291a8f4bfb52/github_copilot_sdk-1.0.0-py3-none-win_arm64.whl", hash = "sha256:ebfb80395caa834df8ab16ab4aab3e5d8db883ed3b024f723c394b1514e47221", size = 87874846, upload-time = "2026-06-02T15:00:38.737Z" },
 ]
 
 [[package]]
@@ -2287,76 +1780,51 @@ wheels = [
 
 [[package]]
 name = "google-adk"
-version = "1.1.1"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "aiohttp" },
+    { name = "aiosqlite" },
     { name = "authlib" },
     { name = "click" },
     { name = "fastapi" },
-    { name = "google-api-python-client" },
-    { name = "google-cloud-aiplatform" },
-    { name = "google-cloud-secret-manager" },
-    { name = "google-cloud-speech" },
-    { name = "google-cloud-storage" },
+    { name = "google-auth", extra = ["pyopenssl"] },
     { name = "google-genai" },
     { name = "graphviz" },
-    { name = "mcp" },
+    { name = "httpx" },
+    { name = "jsonschema" },
     { name = "opentelemetry-api" },
-    { name = "opentelemetry-exporter-gcp-trace" },
     { name = "opentelemetry-sdk" },
+    { name = "packaging" },
     { name = "pydantic" },
     { name = "python-dotenv" },
+    { name = "python-multipart" },
     { name = "pyyaml" },
-    { name = "sqlalchemy" },
+    { name = "requests" },
+    { name = "starlette" },
+    { name = "tenacity" },
+    { name = "typing-extensions" },
     { name = "tzlocal" },
     { name = "uvicorn" },
+    { name = "watchdog" },
+    { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0f/38/a67f59a3ecf9630d93007848ec3f41beec4415014e3fd1fa8f159c7e85fc/google_adk-1.1.1.tar.gz", hash = "sha256:9418675574d2e9fd8a3c8e423186b86fe4ad3f211dd5da400cf24f1ef39fe2d7", size = 1094600, upload-time = "2025-05-29T00:13:31.572Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fb/50/cc4b5563222fab77ee7f95367e2e6bc0663ef74b62e0b519e2028157cb0d/google_adk-2.7.0.tar.gz", hash = "sha256:283e16dc5ffab7684e17098f7282470339e88a3d16ecfa62b4025680672c906b", size = 3806369, upload-time = "2026-08-13T22:22:06.379Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/53/1d/cefb793fed19159e8a1975cb1767288b848b9c14020f70c1f0c8048a706c/google_adk-1.1.1-py3-none-any.whl", hash = "sha256:c6cdca1b9cab7126efa4984abaff2d7b26da7945da9e6b0e2e6ea1727fb3f966", size = 1235870, upload-time = "2025-05-29T00:13:29.563Z" },
-]
-
-[[package]]
-name = "google-api-core"
-version = "2.25.2"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.14'",
-]
-dependencies = [
-    { name = "google-auth", marker = "python_full_version >= '3.14'" },
-    { name = "googleapis-common-protos", marker = "python_full_version >= '3.14'" },
-    { name = "proto-plus", marker = "python_full_version >= '3.14'" },
-    { name = "protobuf", marker = "python_full_version >= '3.14'" },
-    { name = "requests", marker = "python_full_version >= '3.14'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/09/cd/63f1557235c2440fe0577acdbc32577c5c002684c58c7f4d770a92366a24/google_api_core-2.25.2.tar.gz", hash = "sha256:1c63aa6af0d0d5e37966f157a77f9396d820fba59f9e43e9415bc3dc5baff300", size = 166266, upload-time = "2025-10-03T00:07:34.778Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c8/d8/894716a5423933f5c8d2d5f04b16f052a515f78e815dab0c2c6f1fd105dc/google_api_core-2.25.2-py3-none-any.whl", hash = "sha256:e9a8f62d363dc8424a8497f4c2a47d6bcda6c16514c935629c257ab5d10210e7", size = 162489, upload-time = "2025-10-03T00:07:32.924Z" },
-]
-
-[package.optional-dependencies]
-grpc = [
-    { name = "grpcio", marker = "python_full_version >= '3.14'" },
-    { name = "grpcio-status", marker = "python_full_version >= '3.14'" },
+    { url = "https://files.pythonhosted.org/packages/d3/6e/c97d9fe60a47f605aa5013a28ef76beef573f3d96a356532e840fa05ee20/google_adk-2.7.0-py3-none-any.whl", hash = "sha256:6517c0383d9449484b6398a5b60c6408dbd4de369e957eebc3b9d8d0c90736e9", size = 4395958, upload-time = "2026-08-13T22:22:04.119Z" },
 ]
 
 [[package]]
 name = "google-api-core"
 version = "2.29.0"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version == '3.13.*'",
-    "python_full_version == '3.12.*'",
-    "python_full_version == '3.11.*'",
-    "python_full_version < '3.11'",
-]
 dependencies = [
-    { name = "google-auth", marker = "python_full_version < '3.14'" },
-    { name = "googleapis-common-protos", marker = "python_full_version < '3.14'" },
-    { name = "proto-plus", marker = "python_full_version < '3.14'" },
-    { name = "protobuf", marker = "python_full_version < '3.14'" },
-    { name = "requests", marker = "python_full_version < '3.14'" },
+    { name = "google-auth" },
+    { name = "googleapis-common-protos" },
+    { name = "proto-plus" },
+    { name = "protobuf", version = "5.29.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
+    { name = "protobuf", version = "6.33.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "requests" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0d/10/05572d33273292bac49c2d1785925f7bc3ff2fe50e3044cf1062c1dde32e/google_api_core-2.29.0.tar.gz", hash = "sha256:84181be0f8e6b04006df75ddfe728f24489f0af57c96a529ff7cf45bc28797f7", size = 177828, upload-time = "2026-01-08T22:21:39.269Z" }
 wheels = [
@@ -2365,80 +1833,56 @@ wheels = [
 
 [package.optional-dependencies]
 grpc = [
-    { name = "grpcio", marker = "python_full_version < '3.14'" },
-    { name = "grpcio-status", marker = "python_full_version < '3.14'" },
-]
-
-[[package]]
-name = "google-api-python-client"
-version = "2.188.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "google-api-core", version = "2.25.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
-    { name = "google-api-core", version = "2.29.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "google-auth" },
-    { name = "google-auth-httplib2" },
-    { name = "httplib2" },
-    { name = "uritemplate" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/a8/d7/14613c7efbab5b428b400961f5dbac46ad9e019c44e1f3fd14d67c33111c/google_api_python_client-2.188.0.tar.gz", hash = "sha256:5c469db6614f071009e3e5bb8b6aeeccae3beb3647fa9c6cd97f0d551edde0b6", size = 14302906, upload-time = "2026-01-13T22:15:13.747Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/33/67/a99a7d79d7a37a67cb8008f1d7dcedc46d29c6df5063aeb446112afd4aa4/google_api_python_client-2.188.0-py3-none-any.whl", hash = "sha256:3cad1b68f9d48b82b93d77927e8370a6f43f33d97848242601f14a93a1c70ef5", size = 14870005, upload-time = "2026-01-13T22:15:11.345Z" },
+    { name = "grpcio" },
+    { name = "grpcio-status", version = "1.71.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
+    { name = "grpcio-status", version = "1.76.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
 ]
 
 [[package]]
 name = "google-auth"
-version = "2.47.0"
+version = "2.58.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "cryptography" },
     { name = "pyasn1-modules" },
-    { name = "rsa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/60/3c/ec64b9a275ca22fa1cd3b6e77fefcf837b0732c890aa32d2bd21313d9b33/google_auth-2.47.0.tar.gz", hash = "sha256:833229070a9dfee1a353ae9877dcd2dec069a8281a4e72e72f77d4a70ff945da", size = 323719, upload-time = "2026-01-06T21:55:31.045Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ac/ca/f398a483ce5aad18ca2f735646e45ccee2439bd94a41a4ad0cfa646bd495/google_auth-2.58.0.tar.gz", hash = "sha256:55e30cf15e737de92c5323d78cda8a83fcd57e7ffbaf900c4600039fd60a80fd", size = 380018, upload-time = "2026-09-09T20:49:38.043Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/db/18/79e9008530b79527e0d5f79e7eef08d3b179b7f851cfd3a2f27822fbdfa9/google_auth-2.47.0-py3-none-any.whl", hash = "sha256:c516d68336bfde7cf0da26aab674a36fedcf04b37ac4edd59c597178760c3498", size = 234867, upload-time = "2026-01-06T21:55:28.6Z" },
+    { url = "https://files.pythonhosted.org/packages/59/13/477d90d09591b3938b45c4e11f4d8a51291682112cb5efcac961e815d562/google_auth-2.58.0-py3-none-any.whl", hash = "sha256:8a9c4645bb4c8e91668fb1934b95ae6a8687084232753639220ba9bf04a1610d", size = 262404, upload-time = "2026-09-09T20:49:33.951Z" },
 ]
 
 [package.optional-dependencies]
+pyopenssl = [
+    { name = "cryptography" },
+]
 requests = [
     { name = "requests" },
 ]
 
 [[package]]
-name = "google-auth-httplib2"
-version = "0.3.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "google-auth" },
-    { name = "httplib2" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/d5/ad/c1f2b1175096a8d04cf202ad5ea6065f108d26be6fc7215876bde4a7981d/google_auth_httplib2-0.3.0.tar.gz", hash = "sha256:177898a0175252480d5ed916aeea183c2df87c1f9c26705d74ae6b951c268b0b", size = 11134, upload-time = "2025-12-15T22:13:51.825Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/99/d5/3c97526c8796d3caf5f4b3bed2b05e8a7102326f00a334e7a438237f3b22/google_auth_httplib2-0.3.0-py3-none-any.whl", hash = "sha256:426167e5df066e3f5a0fc7ea18768c08e7296046594ce4c8c409c2457dd1f776", size = 9529, upload-time = "2025-12-15T22:13:51.048Z" },
-]
-
-[[package]]
 name = "google-cloud-aiplatform"
-version = "1.134.0"
+version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "certifi" },
     { name = "docstring-parser" },
-    { name = "google-api-core", version = "2.25.2", source = { registry = "https://pypi.org/simple" }, extra = ["grpc"], marker = "python_full_version >= '3.14'" },
-    { name = "google-api-core", version = "2.29.0", source = { registry = "https://pypi.org/simple" }, extra = ["grpc"], marker = "python_full_version < '3.14'" },
+    { name = "google-api-core", extra = ["grpc"] },
     { name = "google-auth" },
     { name = "google-cloud-bigquery" },
     { name = "google-cloud-resource-manager" },
-    { name = "google-cloud-storage" },
+    { name = "google-cloud-storage", version = "2.19.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
+    { name = "google-cloud-storage", version = "3.14.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
     { name = "google-genai" },
     { name = "packaging" },
     { name = "proto-plus" },
-    { name = "protobuf" },
+    { name = "protobuf", version = "5.29.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
+    { name = "protobuf", version = "6.33.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
     { name = "pydantic" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d3/24/de4f21d0728d640b57bf7bbcd7460827a4daf9eaca61cb5b91be608c40bc/google_cloud_aiplatform-1.134.0.tar.gz", hash = "sha256:964cea117ca1ffc71742970e1091985adac72dfe76e1a1614a02a8cda50d6992", size = 9931075, upload-time = "2026-01-20T19:19:58.867Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6f/cc/0c562f5d268f07234e712ee8822dd81ec4c836559f449d9e5e91e9aa2025/google_cloud_aiplatform-2.1.0.tar.gz", hash = "sha256:964eca160d4af48a2e04b5ee476fb4d38c84388f23b4420e2c71b30151d625bd", size = 11331982, upload-time = "2026-09-01T19:11:15.526Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/85/f4/6863f3951eb07afd790fe6f8f1a5984224f7df836546a34ed29ab0cfe9af/google_cloud_aiplatform-1.134.0-py2.py3-none-any.whl", hash = "sha256:f249ae67d622deca486310e0021093764892ac357fb744b9e79548f490017ddc", size = 8189190, upload-time = "2026-01-20T19:19:55.997Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/26/10f3d4ab6333672ff43ad56255b74e672c2a59b21b7a054632d05b7dd677/google_cloud_aiplatform-2.1.0-py2.py3-none-any.whl", hash = "sha256:de5c6dace6cb81943fc6ee1fad02f7a02e9b18e50c24b267bd9627f6b9cd3d14", size = 9452898, upload-time = "2026-09-01T19:11:08.19Z" },
 ]
 
 [[package]]
@@ -2446,8 +1890,7 @@ name = "google-cloud-bigquery"
 version = "3.40.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "google-api-core", version = "2.25.2", source = { registry = "https://pypi.org/simple" }, extra = ["grpc"], marker = "python_full_version >= '3.14'" },
-    { name = "google-api-core", version = "2.29.0", source = { registry = "https://pypi.org/simple" }, extra = ["grpc"], marker = "python_full_version < '3.14'" },
+    { name = "google-api-core", extra = ["grpc"] },
     { name = "google-auth" },
     { name = "google-cloud-core" },
     { name = "google-resumable-media" },
@@ -2465,8 +1908,7 @@ name = "google-cloud-core"
 version = "2.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "google-api-core", version = "2.25.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
-    { name = "google-api-core", version = "2.29.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
+    { name = "google-api-core" },
     { name = "google-auth" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a6/03/ef0bc99d0e0faf4fdbe67ac445e18cdaa74824fd93cd069e7bb6548cb52d/google_cloud_core-2.5.0.tar.gz", hash = "sha256:7c1b7ef5c92311717bd05301aa1a91ffbc565673d3b0b4163a52d8413a186963", size = 36027, upload-time = "2025-10-29T23:17:39.513Z" }
@@ -2479,13 +1921,13 @@ name = "google-cloud-resource-manager"
 version = "1.16.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "google-api-core", version = "2.25.2", source = { registry = "https://pypi.org/simple" }, extra = ["grpc"], marker = "python_full_version >= '3.14'" },
-    { name = "google-api-core", version = "2.29.0", source = { registry = "https://pypi.org/simple" }, extra = ["grpc"], marker = "python_full_version < '3.14'" },
+    { name = "google-api-core", extra = ["grpc"] },
     { name = "google-auth" },
     { name = "grpc-google-iam-v1" },
     { name = "grpcio" },
     { name = "proto-plus" },
-    { name = "protobuf" },
+    { name = "protobuf", version = "5.29.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
+    { name = "protobuf", version = "6.33.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/4e/7f/db00b2820475793a52958dc55fe9ec2eb8e863546e05fcece9b921f86ebe/google_cloud_resource_manager-1.16.0.tar.gz", hash = "sha256:cc938f87cc36c2672f062b1e541650629e0d954c405a4dac35ceedee70c267c3", size = 459840, upload-time = "2026-01-15T13:04:07.726Z" }
 wheels = [
@@ -2493,47 +1935,16 @@ wheels = [
 ]
 
 [[package]]
-name = "google-cloud-secret-manager"
-version = "2.26.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "google-api-core", version = "2.25.2", source = { registry = "https://pypi.org/simple" }, extra = ["grpc"], marker = "python_full_version >= '3.14'" },
-    { name = "google-api-core", version = "2.29.0", source = { registry = "https://pypi.org/simple" }, extra = ["grpc"], marker = "python_full_version < '3.14'" },
-    { name = "google-auth" },
-    { name = "grpc-google-iam-v1" },
-    { name = "grpcio" },
-    { name = "proto-plus" },
-    { name = "protobuf" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/c3/9c/a6c7144bc96df77376ae3fcc916fb639c40814c2e4bba2051d31dc136cd0/google_cloud_secret_manager-2.26.0.tar.gz", hash = "sha256:0d1d6f76327685a0ed78a4cf50f289e1bfbbe56026ed0affa98663b86d6d50d6", size = 277603, upload-time = "2025-12-18T00:29:31.065Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c8/30/a58739dd12cec0f7f761ed1efb518aed2250a407d4ed14c5a0eeee7eaaf9/google_cloud_secret_manager-2.26.0-py3-none-any.whl", hash = "sha256:940a5447a6ec9951446fd1a0f22c81a4303fde164cd747aae152c5f5c8e6723e", size = 223623, upload-time = "2025-12-18T00:29:29.311Z" },
-]
-
-[[package]]
-name = "google-cloud-speech"
-version = "2.36.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "google-api-core", version = "2.25.2", source = { registry = "https://pypi.org/simple" }, extra = ["grpc"], marker = "python_full_version >= '3.14'" },
-    { name = "google-api-core", version = "2.29.0", source = { registry = "https://pypi.org/simple" }, extra = ["grpc"], marker = "python_full_version < '3.14'" },
-    { name = "google-auth" },
-    { name = "grpcio" },
-    { name = "proto-plus" },
-    { name = "protobuf" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/73/01/0bfe56e1f935285ac21908ddfb5574b09bf5829ad3441649e1403f9f1b34/google_cloud_speech-2.36.0.tar.gz", hash = "sha256:3a445a033cc7772f7d073c03142a7e80048415db42981372c6b81edc76a1e27a", size = 401922, upload-time = "2026-01-15T13:04:52.77Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/cb/0e/29e5d7bfe636e7b7b2647d6f4d50ca07b84149ba9adba86c6be219ac8480/google_cloud_speech-2.36.0-py3-none-any.whl", hash = "sha256:bdd0047fe2961d42307bdb7393fe5c7c1491290b2e6d66bfc6e2b7bcdfb8794e", size = 342111, upload-time = "2026-01-15T13:02:59.482Z" },
-]
-
-[[package]]
 name = "google-cloud-storage"
 version = "2.19.0"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version == '3.12.*'",
+    "python_full_version == '3.11.*'",
+    "python_full_version < '3.11'",
+]
 dependencies = [
-    { name = "google-api-core", version = "2.25.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
-    { name = "google-api-core", version = "2.29.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
+    { name = "google-api-core" },
     { name = "google-auth" },
     { name = "google-cloud-core" },
     { name = "google-crc32c" },
@@ -2546,20 +1957,24 @@ wheels = [
 ]
 
 [[package]]
-name = "google-cloud-trace"
-version = "1.18.0"
+name = "google-cloud-storage"
+version = "3.14.1"
 source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "google-api-core", version = "2.25.2", source = { registry = "https://pypi.org/simple" }, extra = ["grpc"], marker = "python_full_version >= '3.14'" },
-    { name = "google-api-core", version = "2.29.0", source = { registry = "https://pypi.org/simple" }, extra = ["grpc"], marker = "python_full_version < '3.14'" },
-    { name = "google-auth" },
-    { name = "grpcio" },
-    { name = "proto-plus" },
-    { name = "protobuf" },
+resolution-markers = [
+    "python_full_version >= '3.14'",
+    "python_full_version == '3.13.*'",
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/02/34/b1883f4682f1681941100df0e411cb0185013f7c349489ab1330348d7c5c/google_cloud_trace-1.18.0.tar.gz", hash = "sha256:46d42b90273da3bc4850bb0d6b9a205eb826a54561ff1b30ca33cc92174c3f37", size = 103347, upload-time = "2026-01-15T13:04:56.441Z" }
+dependencies = [
+    { name = "google-api-core" },
+    { name = "google-auth" },
+    { name = "google-cloud-core" },
+    { name = "google-crc32c" },
+    { name = "google-resumable-media" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/06/33e124df40437c292c7d666616d890c12cfea5b83842acf5be7dc3fde016/google_cloud_storage-3.14.1.tar.gz", hash = "sha256:b24e74b493c60b19b83462933a83bb831e45b6ca4924b0d75eac8e176b58b3a7", size = 17348933, upload-time = "2026-09-08T17:10:11.871Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/87/15/366fd8b028a50a9018c933270d220a4e53dca8022ce9086618b72978ab90/google_cloud_trace-1.18.0-py3-none-any.whl", hash = "sha256:52c002d8d3da802e031fee62cd49a1baf899932d4f548a150f685af6815b5554", size = 107488, upload-time = "2026-01-15T12:17:21.519Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/65/7201c1816ae46e0b4e70a3ce61e5121963315dc9df2e00fcb8897a3d0926/google_cloud_storage-3.14.1-py3-none-any.whl", hash = "sha256:8f0fe2b74bd80ddcbd67247a3b47b81035a0a4f448569ed358fa40a46c940118", size = 343228, upload-time = "2026-09-08T17:10:09.833Z" },
 ]
 
 [[package]]
@@ -2599,7 +2014,7 @@ wheels = [
 
 [[package]]
 name = "google-genai"
-version = "1.60.0"
+version = "2.22.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -2613,9 +2028,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0a/3f/a753be0dcee352b7d63bc6d1ba14a72591d63b6391dac0cdff7ac168c530/google_genai-1.60.0.tar.gz", hash = "sha256:9768061775fddfaecfefb0d6d7a6cabefb3952ebd246cd5f65247151c07d33d1", size = 487721, upload-time = "2026-01-21T22:17:30.398Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/37/f1/f2f31b2a6bd826bc2cb73068df880954a026474c03a4315637d20cc13965/google_genai-2.22.0.tar.gz", hash = "sha256:9fa3b5d9ddb635005d8ab2d6206fb2b3d7204b66965bbce7de13ecd1a866ebcd", size = 684719, upload-time = "2026-09-02T18:06:02.906Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/31/e5/384b1f383917b5f0ae92e28f47bc27b16e3d26cd9bacb25e9f8ecab3c8fe/google_genai-1.60.0-py3-none-any.whl", hash = "sha256:967338378ffecebec19a8ed90cf8797b26818bacbefd7846a9280beb1099f7f3", size = 719431, upload-time = "2026-01-21T22:17:28.086Z" },
+    { url = "https://files.pythonhosted.org/packages/de/96/0120d214958cb54f2b9c48da9f564a0e6eae269e9dd702415fb1d0551cc7/google_genai-2.22.0-py3-none-any.whl", hash = "sha256:c514001c45470cc0a942440ae1b8215445d12bfb6c373aac94637127e1f74ec6", size = 1088792, upload-time = "2026-09-02T18:06:00.629Z" },
 ]
 
 [[package]]
@@ -2635,7 +2050,8 @@ name = "googleapis-common-protos"
 version = "1.72.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "protobuf" },
+    { name = "protobuf", version = "5.29.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
+    { name = "protobuf", version = "6.33.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e5/7b/adfd75544c415c487b33061fe7ae526165241c1ea133f9a9125a56b39fd8/googleapis_common_protos-1.72.0.tar.gz", hash = "sha256:e55a601c1b32b52d7a3e65f43563e2aa61bcd737998ee672ac9b951cd49319f5", size = 147433, upload-time = "2025-11-06T18:29:24.087Z" }
 wheels = [
@@ -2729,20 +2145,12 @@ wheels = [
 ]
 
 [[package]]
-name = "groq"
-version = "1.0.0"
+name = "griffelib"
+version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "anyio" },
-    { name = "distro" },
-    { name = "httpx" },
-    { name = "pydantic" },
-    { name = "sniffio" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/3f/12/f4099a141677fcd2ed79dcc1fcec431e60c52e0e90c9c5d935f0ffaf8c0e/groq-1.0.0.tar.gz", hash = "sha256:66cb7bb729e6eb644daac7ce8efe945e99e4eb33657f733ee6f13059ef0c25a9", size = 146068, upload-time = "2025-12-17T23:34:23.115Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/27/af/018c10bc9edd42b6ef6db2e96b09542050d5253f9b195e74bc910b2d13ab/griffelib-2.3.0.tar.gz", hash = "sha256:7b0952caf5bca6afa4bb5ee8c6a2d183fe3f21b62efc5f6c7243cb2b26d2d115", size = 234534, upload-time = "2026-09-04T15:08:17.472Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4a/88/3175759d2ef30406ea721f4d837bfa1ba4339fde3b81ba8c5640a96ed231/groq-1.0.0-py3-none-any.whl", hash = "sha256:6e22bf92ffad988f01d2d4df7729add66b8fd5dbfb2154b5bbf3af245b72c731", size = 138292, upload-time = "2025-12-17T23:34:21.957Z" },
+    { url = "https://files.pythonhosted.org/packages/41/63/e876e789525063c840ccfa8857febdabd6523bcef9ce7eb979b9305ea895/griffelib-2.3.0-py3-none-any.whl", hash = "sha256:1b8f9cd525681c26b1d6d574faa1371651e8459ca51d209684f50b8096ae06e0", size = 169423, upload-time = "2026-09-04T15:08:12.956Z" },
 ]
 
 [[package]]
@@ -2752,7 +2160,8 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos", extra = ["grpc"] },
     { name = "grpcio" },
-    { name = "protobuf" },
+    { name = "protobuf", version = "5.29.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
+    { name = "protobuf", version = "6.33.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/76/1e/1011451679a983f2f5c6771a1682542ecb027776762ad031fd0d7129164b/grpc_google_iam_v1-0.14.3.tar.gz", hash = "sha256:879ac4ef33136c5491a6300e27575a9ec760f6cdf9a2518798c1b8977a5dc389", size = 23745, upload-time = "2025-10-15T21:14:53.318Z" }
 wheels = [
@@ -2824,14 +2233,37 @@ wheels = [
 name = "grpcio-status"
 version = "1.71.2"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version == '3.13.*'",
+    "python_full_version == '3.12.*'",
+    "python_full_version == '3.11.*'",
+    "python_full_version < '3.11'",
+]
 dependencies = [
     { name = "googleapis-common-protos" },
     { name = "grpcio" },
-    { name = "protobuf" },
+    { name = "protobuf", version = "5.29.6", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/fd/d1/b6e9877fedae3add1afdeae1f89d1927d296da9cf977eca0eb08fb8a460e/grpcio_status-1.71.2.tar.gz", hash = "sha256:c7a97e176df71cdc2c179cd1847d7fc86cca5832ad12e9798d7fed6b7a1aab50", size = 13677, upload-time = "2025-06-28T04:24:05.426Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/67/58/317b0134129b556a93a3b0afe00ee675b5657f0155509e22fcb853bafe2d/grpcio_status-1.71.2-py3-none-any.whl", hash = "sha256:803c98cb6a8b7dc6dbb785b1111aed739f241ab5e9da0bba96888aa74704cfd3", size = 14424, upload-time = "2025-06-28T04:23:42.136Z" },
+]
+
+[[package]]
+name = "grpcio-status"
+version = "1.76.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14'",
+]
+dependencies = [
+    { name = "googleapis-common-protos" },
+    { name = "grpcio" },
+    { name = "protobuf", version = "6.33.6", source = { registry = "https://pypi.org/simple" } },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3f/46/e9f19d5be65e8423f886813a2a9d0056ba94757b0c5007aa59aed1a961fa/grpcio_status-1.76.0.tar.gz", hash = "sha256:25fcbfec74c15d1a1cb5da3fab8ee9672852dc16a5a9eeb5baf7d7a9952943cd", size = 13679, upload-time = "2025-10-21T16:28:52.545Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8c/cc/27ba60ad5a5f2067963e6a858743500df408eb5855e98be778eaef8c9b02/grpcio_status-1.76.0-py3-none-any.whl", hash = "sha256:380568794055a8efbbd8871162df92012e0228a5f6dffaf57f2a00c534103b18", size = 14425, upload-time = "2025-10-21T16:28:40.853Z" },
 ]
 
 [[package]]
@@ -2844,54 +2276,27 @@ wheels = [
 ]
 
 [[package]]
-name = "h2"
-version = "4.3.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "hpack" },
-    { name = "hyperframe" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/1d/17/afa56379f94ad0fe8defd37d6eb3f89a25404ffc71d4d848893d270325fc/h2-4.3.0.tar.gz", hash = "sha256:6c59efe4323fa18b47a632221a1888bd7fde6249819beda254aeca909f221bf1", size = 2152026, upload-time = "2025-08-23T18:12:19.778Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/69/b2/119f6e6dcbd96f9069ce9a2665e0146588dc9f88f29549711853645e736a/h2-4.3.0-py3-none-any.whl", hash = "sha256:c438f029a25f7945c69e0ccf0fb951dc3f73a5f6412981daee861431b70e2bdd", size = 61779, upload-time = "2025-08-23T18:12:17.779Z" },
-]
-
-[[package]]
 name = "hf-xet"
-version = "1.2.0"
+version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/5e/6e/0f11bacf08a67f7fb5ee09740f2ca54163863b07b70d579356e9222ce5d8/hf_xet-1.2.0.tar.gz", hash = "sha256:a8c27070ca547293b6890c4bf389f713f80e8c478631432962bb7f4bc0bd7d7f", size = 506020, upload-time = "2025-10-24T19:04:32.129Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/ab/522a2ab67f27971a9d48ca666d4fca85ef7d5282d142e31fd087e27b1bbe/hf_xet-1.6.0.tar.gz", hash = "sha256:2e58454a340b3556dfa4972d5451aff4fba8dd42a236600ba1a1d2b1514f0fef", size = 920527, upload-time = "2026-08-03T22:33:13.243Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9e/a5/85ef910a0aa034a2abcfadc360ab5ac6f6bc4e9112349bd40ca97551cff0/hf_xet-1.2.0-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:ceeefcd1b7aed4956ae8499e2199607765fbd1c60510752003b6cc0b8413b649", size = 2861870, upload-time = "2025-10-24T19:04:11.422Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/40/e2e0a7eb9a51fe8828ba2d47fe22a7e74914ea8a0db68a18c3aa7449c767/hf_xet-1.2.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:b70218dd548e9840224df5638fdc94bd033552963cfa97f9170829381179c813", size = 2717584, upload-time = "2025-10-24T19:04:09.586Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/7d/daf7f8bc4594fdd59a8a596f9e3886133fdc68e675292218a5e4c1b7e834/hf_xet-1.2.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7d40b18769bb9a8bc82a9ede575ce1a44c75eb80e7375a01d76259089529b5dc", size = 3315004, upload-time = "2025-10-24T19:04:00.314Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/ba/45ea2f605fbf6d81c8b21e4d970b168b18a53515923010c312c06cd83164/hf_xet-1.2.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:cd3a6027d59cfb60177c12d6424e31f4b5ff13d8e3a1247b3a584bf8977e6df5", size = 3222636, upload-time = "2025-10-24T19:03:58.111Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/1d/04513e3cab8f29ab8c109d309ddd21a2705afab9d52f2ba1151e0c14f086/hf_xet-1.2.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:6de1fc44f58f6dd937956c8d304d8c2dea264c80680bcfa61ca4a15e7b76780f", size = 3408448, upload-time = "2025-10-24T19:04:20.951Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/7c/60a2756d7feec7387db3a1176c632357632fbe7849fce576c5559d4520c7/hf_xet-1.2.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:f182f264ed2acd566c514e45da9f2119110e48a87a327ca271027904c70c5832", size = 3503401, upload-time = "2025-10-24T19:04:22.549Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/64/48fffbd67fb418ab07451e4ce641a70de1c40c10a13e25325e24858ebe5a/hf_xet-1.2.0-cp313-cp313t-win_amd64.whl", hash = "sha256:293a7a3787e5c95d7be1857358a9130694a9c6021de3f27fa233f37267174382", size = 2900866, upload-time = "2025-10-24T19:04:33.461Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/51/f7e2caae42f80af886db414d4e9885fac959330509089f97cccb339c6b87/hf_xet-1.2.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:10bfab528b968c70e062607f663e21e34e2bba349e8038db546646875495179e", size = 2861861, upload-time = "2025-10-24T19:04:19.01Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/1d/a641a88b69994f9371bd347f1dd35e5d1e2e2460a2e350c8d5165fc62005/hf_xet-1.2.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:2a212e842647b02eb6a911187dc878e79c4aa0aa397e88dd3b26761676e8c1f8", size = 2717699, upload-time = "2025-10-24T19:04:17.306Z" },
-    { url = "https://files.pythonhosted.org/packages/df/e0/e5e9bba7d15f0318955f7ec3f4af13f92e773fbb368c0b8008a5acbcb12f/hf_xet-1.2.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:30e06daccb3a7d4c065f34fc26c14c74f4653069bb2b194e7f18f17cbe9939c0", size = 3314885, upload-time = "2025-10-24T19:04:07.642Z" },
-    { url = "https://files.pythonhosted.org/packages/21/90/b7fe5ff6f2b7b8cbdf1bd56145f863c90a5807d9758a549bf3d916aa4dec/hf_xet-1.2.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:29c8fc913a529ec0a91867ce3d119ac1aac966e098cf49501800c870328cc090", size = 3221550, upload-time = "2025-10-24T19:04:05.55Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/cb/73f276f0a7ce46cc6a6ec7d6c7d61cbfe5f2e107123d9bbd0193c355f106/hf_xet-1.2.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e159cbfcfbb29f920db2c09ed8b660eb894640d284f102ada929b6e3dc410a", size = 3408010, upload-time = "2025-10-24T19:04:28.598Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/1e/d642a12caa78171f4be64f7cd9c40e3ca5279d055d0873188a58c0f5fbb9/hf_xet-1.2.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9c91d5ae931510107f148874e9e2de8a16052b6f1b3ca3c1b12f15ccb491390f", size = 3503264, upload-time = "2025-10-24T19:04:30.397Z" },
-    { url = "https://files.pythonhosted.org/packages/17/b5/33764714923fa1ff922770f7ed18c2daae034d21ae6e10dbf4347c854154/hf_xet-1.2.0-cp314-cp314t-win_amd64.whl", hash = "sha256:210d577732b519ac6ede149d2f2f34049d44e8622bf14eb3d63bbcd2d4b332dc", size = 2901071, upload-time = "2025-10-24T19:04:37.463Z" },
-    { url = "https://files.pythonhosted.org/packages/96/2d/22338486473df5923a9ab7107d375dbef9173c338ebef5098ef593d2b560/hf_xet-1.2.0-cp37-abi3-macosx_10_12_x86_64.whl", hash = "sha256:46740d4ac024a7ca9b22bebf77460ff43332868b661186a8e46c227fdae01848", size = 2866099, upload-time = "2025-10-24T19:04:15.366Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/8c/c5becfa53234299bc2210ba314eaaae36c2875e0045809b82e40a9544f0c/hf_xet-1.2.0-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:27df617a076420d8845bea087f59303da8be17ed7ec0cd7ee3b9b9f579dff0e4", size = 2722178, upload-time = "2025-10-24T19:04:13.695Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/92/cf3ab0b652b082e66876d08da57fcc6fa2f0e6c70dfbbafbd470bb73eb47/hf_xet-1.2.0-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3651fd5bfe0281951b988c0facbe726aa5e347b103a675f49a3fa8144c7968fd", size = 3320214, upload-time = "2025-10-24T19:04:03.596Z" },
-    { url = "https://files.pythonhosted.org/packages/46/92/3f7ec4a1b6a65bf45b059b6d4a5d38988f63e193056de2f420137e3c3244/hf_xet-1.2.0-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:d06fa97c8562fb3ee7a378dd9b51e343bc5bc8190254202c9771029152f5e08c", size = 3229054, upload-time = "2025-10-24T19:04:01.949Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/dd/7ac658d54b9fb7999a0ccb07ad863b413cbaf5cf172f48ebcd9497ec7263/hf_xet-1.2.0-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:4c1428c9ae73ec0939410ec73023c4f842927f39db09b063b9482dac5a3bb737", size = 3413812, upload-time = "2025-10-24T19:04:24.585Z" },
-    { url = "https://files.pythonhosted.org/packages/92/68/89ac4e5b12a9ff6286a12174c8538a5930e2ed662091dd2572bbe0a18c8a/hf_xet-1.2.0-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a55558084c16b09b5ed32ab9ed38421e2d87cf3f1f89815764d1177081b99865", size = 3508920, upload-time = "2025-10-24T19:04:26.927Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/44/870d44b30e1dcfb6a65932e3e1506c103a8a5aea9103c337e7a53180322c/hf_xet-1.2.0-cp37-abi3-win_amd64.whl", hash = "sha256:e6584a52253f72c9f52f9e549d5895ca7a471608495c4ecaa6cc73dba2b24d69", size = 2905735, upload-time = "2025-10-24T19:04:35.928Z" },
-]
-
-[[package]]
-name = "hpack"
-version = "4.1.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/2c/48/71de9ed269fdae9c8057e5a4c0aa7402e8bb16f2c6e90b3aa53327b113f8/hpack-4.1.0.tar.gz", hash = "sha256:ec5eca154f7056aa06f196a557655c5b009b382873ac8d1e66e79e87535f1dca", size = 51276, upload-time = "2025-01-22T21:44:58.347Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/07/c6/80c95b1b2b94682a72cbdbfb85b81ae2daffa4291fbfa1b1464502ede10d/hpack-4.1.0-py3-none-any.whl", hash = "sha256:157ac792668d995c657d93111f46b4535ed114f0c9c8d672271bbec7eae1b496", size = 34357, upload-time = "2025-01-22T21:44:56.92Z" },
+    { url = "https://files.pythonhosted.org/packages/41/62/3c062f593bd92ef4e77a0ef39541e3d82a0a1d3947c8a777a02a13a27828/hf_xet-1.6.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:70cbb9c896901600128cb9b6f06e132954fbede1db30f31f7c6c63f84cb7c31d", size = 4074584, upload-time = "2026-08-03T22:32:47.364Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/1e/c0ad437dd267a8e435bef594acf781bbc3874ff0b6435b4962d03ecf7cc4/hf_xet-1.6.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:23379c2f9ec8696d952b16414a2bae72cad86a52df869b050698ba60f538c675", size = 3867381, upload-time = "2026-08-03T22:32:49.049Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/ee/7c0d7b6ab336167531b1c30af2af003f054af4c749becbd7209ae33a77c3/hf_xet-1.6.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f2f7278c05c22fd60cb436cda1269649b3e81db65ecdc8496e5e164aa4143e7b", size = 4453982, upload-time = "2026-08-03T22:32:50.568Z" },
+    { url = "https://files.pythonhosted.org/packages/63/06/ad8eab1c9525246650cbaa821caa3cdbaca734ab1a5b8c91bea09cbd8d69/hf_xet-1.6.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:948f15d3a9545cfe5932f6bd8b440f6ae630aee108f14b7bd6c561f7c2dcc522", size = 4249445, upload-time = "2026-08-03T22:32:52.391Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/26/1eee8aedb0dafc1ab9717dc9ac602cde33361b232dc06803f1f6ed18b58c/hf_xet-1.6.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:5153e6bb103ad49d6ea9f1b2e230db5a2ea32551ad09a706d2f61d7c7c80d80e", size = 4451099, upload-time = "2026-08-03T22:32:54.114Z" },
+    { url = "https://files.pythonhosted.org/packages/67/57/0b88af1f194ab6c9c650547d9cc06bfeaab836ae4dcdb331676bfb8be95a/hf_xet-1.6.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:35cec30d75c6f9eb9c16a77cef68e85a103b72e24d4b473714ec9ff06428bab9", size = 4664712, upload-time = "2026-08-03T22:32:55.547Z" },
+    { url = "https://files.pythonhosted.org/packages/53/a0/26b717a9d1840e8abf48dcec64b5ed8fbe472671d38ad28d30e147132b33/hf_xet-1.6.0-cp314-cp314t-win_amd64.whl", hash = "sha256:5789835d7c6bc9436962853192082374297fb72d7eff7e7762ec25ceb7e25338", size = 4025906, upload-time = "2026-08-03T22:32:57.391Z" },
+    { url = "https://files.pythonhosted.org/packages/49/f6/4a9966633c6fef83af997e2cff68ec1963676d412bdfd096df2a93b8e185/hf_xet-1.6.0-cp314-cp314t-win_arm64.whl", hash = "sha256:75765820ce4700db3750c94acc8fe27c5fae4c9ec000a0dbac3ca082acf97765", size = 3849221, upload-time = "2026-08-03T22:32:59.123Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/50/7afa2c9c787405864fc47a0d1bbc02c62e9101947ed43c1f43899fc7d91d/hf_xet-1.6.0-cp38-abi3-macosx_10_12_x86_64.whl", hash = "sha256:633dc0cd71d32da58ab8c03ad38e2fac452c15c2b0a2866ebf6ededfe0a5061d", size = 4071729, upload-time = "2026-08-03T22:33:00.721Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/69/55b8dcf636142ae660fec1869fcac14c4da2e8412e14d6eee1523be77e9f/hf_xet-1.6.0-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:f0906082d9932ae0c0057fa194041c22b4e2cdb46b2592ef3b91f020d62a081a", size = 3876287, upload-time = "2026-08-03T22:33:02.251Z" },
+    { url = "https://files.pythonhosted.org/packages/67/4e/a28359bf1c1ecf11eba22123168c138698f7cb576ac678f5a2e16cd5da08/hf_xet-1.6.0-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d62671bb130879cef0ee4c9ebe47a14af6c66ec53e6d84dc15936e5ffdfac82f", size = 4464663, upload-time = "2026-08-03T22:33:03.802Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/69/1f0cbc2fb22ae6082d094f743d1b8945a3f36f6089cb95f42b7ee348cda7/hf_xet-1.6.0-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:0e6e21fa3cdfcdcd76748564bf593870a5e013f47d97cf10aed63aa222cff5b7", size = 4262538, upload-time = "2026-08-03T22:33:05.287Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/3a/4f4f2301ade26e404462d3336fa11f7958d914cabbabdd6e03c3c5d5658c/hf_xet-1.6.0-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:4fc74352a17015bd0ee90038bc9efe38db894cde45f268b6712b04fce8cd0acb", size = 4460520, upload-time = "2026-08-03T22:33:06.81Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/5f/311725e2a905534dfee2dcb5b08414f249147f1f12252bfc2bd24caa075c/hf_xet-1.6.0-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:8fb4f71cba6129110c3374a33f919001ff130488fc23553698e34cc1c2a1198c", size = 4675937, upload-time = "2026-08-03T22:33:08.616Z" },
+    { url = "https://files.pythonhosted.org/packages/98/b7/8c59a66d15205024662f1d66968136f13893f96df1ddc5087e2e281fc95f/hf_xet-1.6.0-cp38-abi3-win_amd64.whl", hash = "sha256:fb4fadde1b2b70bf4c0c14a6dccbe7194b1c28947fefd5bbe3fed9d940676c3b", size = 4033128, upload-time = "2026-08-03T22:33:10.171Z" },
+    { url = "https://files.pythonhosted.org/packages/73/63/ca511b6f802f28cf3489b280fe77475bcca8de85e81a6299d7916b5b5555/hf_xet-1.6.0-cp38-abi3-win_arm64.whl", hash = "sha256:3dc3e35441ba395006af5aaacc40ef2e603c51ef46c3530b9156185f00935ea3", size = 3859359, upload-time = "2026-08-03T22:33:11.725Z" },
 ]
 
 [[package]]
@@ -2908,15 +2313,16 @@ wheels = [
 ]
 
 [[package]]
-name = "httplib2"
-version = "0.31.2"
+name = "httpcore2"
+version = "2.12.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyparsing" },
+    { name = "h11" },
+    { name = "truststore" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c1/1f/e86365613582c027dda5ddb64e1010e57a3d53e99ab8a72093fa13d565ec/httplib2-0.31.2.tar.gz", hash = "sha256:385e0869d7397484f4eab426197a4c020b606edd43372492337c0b4010ae5d24", size = 250800, upload-time = "2026-01-23T11:04:44.165Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/be/ad/f4f0e57345f1870f3e8cb624e058d7eca6e5a27d33bcc3311d9b618734cd/httpcore2-2.12.0.tar.gz", hash = "sha256:9293522bba0aa7c4c8e9e3f040c16575bd8868e155a77fa30c7a9085a5eae648", size = 67548, upload-time = "2026-08-18T13:22:08.211Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2f/90/fd509079dfcab01102c0fdd87f3a9506894bc70afcf9e9785ef6b2b3aff6/httplib2-0.31.2-py3-none-any.whl", hash = "sha256:dbf0c2fa3862acf3c55c078ea9c0bc4481d7dc5117cae71be9514912cf9f8349", size = 91099, upload-time = "2026-01-23T11:04:42.78Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/74/d370e55600d9bcfa0d9794b0166126d49291a3d2b20c268fc98c453a4948/httpcore2-2.12.0-py3-none-any.whl", hash = "sha256:7e04258ce01013d7d615e5b910a3b27fac937d7a95038227e79652b4ba3b4ceb", size = 83074, upload-time = "2026-08-18T13:22:05.854Z" },
 ]
 
 [[package]]
@@ -2977,42 +2383,50 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
 ]
 
-[package.optional-dependencies]
-http2 = [
-    { name = "h2" },
+[[package]]
+name = "httpx2"
+version = "2.12.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio", marker = "sys_platform != 'emscripten'" },
+    { name = "httpcore2", marker = "sys_platform != 'emscripten'" },
+    { name = "httpx2-jsfetch", marker = "python_full_version >= '3.12' and sys_platform == 'emscripten'" },
+    { name = "idna" },
+    { name = "truststore", marker = "sys_platform != 'emscripten'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7f/f8/579a8b51e42e38ee32647df9f08aa25643ae788e275cc625b199829c4671/httpx2-2.12.0.tar.gz", hash = "sha256:7631fe9887a8a2275f4a2540e053aa670fcc50742864a9ae7c66e609fdcf12cf", size = 100040, upload-time = "2026-08-18T13:22:09.086Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/95/411ba65569158e862368917aaf56597f3e5fa3b91b0502919638465a08f3/httpx2-2.12.0-py3-none-any.whl", hash = "sha256:cc8b6eecb8661c146b8f89a60e97456ee086e91a784ed31ac450c3a9e613dd36", size = 95427, upload-time = "2026-08-18T13:22:06.834Z" },
 ]
 
 [[package]]
-name = "httpx-sse"
-version = "0.4.3"
+name = "httpx2-jsfetch"
+version = "1.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/c4/0e5636363151a2a1795e0a77617168b9ca438e1748ec05fc9b5687f93d64/httpx2_jsfetch-1.0.tar.gz", hash = "sha256:70a0e3eabfef7cce5ad9c629f7d01ca05e418f586646f4ddf14782e4c1454c60", size = 6872, upload-time = "2026-08-07T00:13:07.492Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/43/832f631d32e4f1211caa2ba368317739fe71f0b8530e4c9d15dc454bac2a/httpx2_jsfetch-1.0-py3-none-any.whl", hash = "sha256:cb916b707601e69a07721aabc8f3f6659be3a6893bc1ff5c6f9e02241df2da32", size = 6382, upload-time = "2026-08-07T00:13:06.567Z" },
 ]
 
 [[package]]
 name = "huggingface-hub"
-version = "0.36.0"
+version = "1.16.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "filelock" },
     { name = "fsspec" },
-    { name = "hf-xet", marker = "platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'" },
+    { name = "hf-xet", marker = "platform_machine == 'AMD64' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'" },
+    { name = "httpx" },
     { name = "packaging" },
     { name = "pyyaml" },
-    { name = "requests" },
     { name = "tqdm" },
+    { name = "typer" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/98/63/4910c5fa9128fdadf6a9c5ac138e8b1b6cee4ca44bf7915bbfbce4e355ee/huggingface_hub-0.36.0.tar.gz", hash = "sha256:47b3f0e2539c39bf5cde015d63b72ec49baff67b6931c3d97f3f84532e2b8d25", size = 463358, upload-time = "2025-10-23T12:12:01.413Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/48/0f/ed994dbade67a54407c28cab96ef845e0e6d25500be56aca6394f8bfc9dd/huggingface_hub-1.16.1.tar.gz", hash = "sha256:7f1dc4c5ec21aed69be630ad0c3378616be16f3de1a47b141c0e812965d9c832", size = 792534, upload-time = "2026-05-21T18:40:00.908Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cb/bd/1a875e0d592d447cbc02805fd3fe0f497714d6a2583f59d14fa9ebad96eb/huggingface_hub-0.36.0-py3-none-any.whl", hash = "sha256:7bcc9ad17d5b3f07b57c78e79d527102d08313caa278a641993acddcb894548d", size = 566094, upload-time = "2025-10-23T12:11:59.557Z" },
-]
-
-[package.optional-dependencies]
-inference = [
-    { name = "aiohttp" },
+    { url = "https://files.pythonhosted.org/packages/49/79/621a7dbb80c70974f73a597275351ebe03ce5bc65cb5f8f4acb5859252bc/huggingface_hub-1.16.1-py3-none-any.whl", hash = "sha256:64340de934b9ce37857ef85a82de72f5629e8a270f9119eabb12bf495eb53c22", size = 668176, upload-time = "2026-05-21T18:39:58.596Z" },
 ]
 
 [[package]]
@@ -3028,15 +2442,6 @@ wheels = [
 ]
 
 [[package]]
-name = "hyperframe"
-version = "6.1.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/02/e7/94f8232d4a74cc99514c13a9f995811485a6903d48e5d952771ef6322e30/hyperframe-6.1.0.tar.gz", hash = "sha256:f630908a00854a7adeabd6382b43923a4c4cd4b821fcb527e6ab9e15382a3b08", size = 26566, upload-time = "2025-01-22T21:41:49.302Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/48/30/47d0bf6072f7252e6521f3447ccfa40b421b6824517f82854703d0f5a98b/hyperframe-6.1.0-py3-none-any.whl", hash = "sha256:b03380493a519fce58ea5af42e4a42317bf9bd425596f7a0835ffce80f1a42e5", size = 13007, upload-time = "2025-01-22T21:41:47.295Z" },
-]
-
-[[package]]
 name = "identify"
 version = "2.6.16"
 source = { registry = "https://pypi.org/simple" }
@@ -3047,11 +2452,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.11"
+version = "3.19"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5f/f7/abb373e5757eaec4b922b92f97ec8d6d7e057cf06778247604fbc4e7c3f3/idna-3.19.tar.gz", hash = "sha256:5e0811a4383b21dc5838069f801c4fb62113b7447663d2530d2bd6e77b49bf15", size = 215237, upload-time = "2026-08-18T05:14:24.27Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+    { url = "https://files.pythonhosted.org/packages/57/b0/0e52c878c53f245edd3a11020f20979b3f490f245af532c7cae3027754b5/idna-3.19-py3-none-any.whl", hash = "sha256:815e7be7a7806d54abb586dc943addc79e8b2ee16915059658cbeff4b1b43bf4", size = 68550, upload-time = "2026-08-18T05:14:22.343Z" },
 ]
 
 [[package]]
@@ -3086,45 +2491,25 @@ wheels = [
 
 [[package]]
 name = "instructor"
-version = "1.14.4"
+version = "1.16.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
-    { name = "diskcache" },
     { name = "docstring-parser" },
     { name = "jinja2" },
     { name = "jiter" },
     { name = "openai" },
-    { name = "pre-commit" },
     { name = "pydantic" },
     { name = "pydantic-core" },
+    { name = "regex" },
     { name = "requests" },
     { name = "rich" },
     { name = "tenacity" },
-    { name = "ty" },
     { name = "typer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fe/9b/276310494f4614d0936c5e667385cfa0e9ad8edbf88198e99e1ce8ea4bc7/instructor-1.14.4.tar.gz", hash = "sha256:a6825d1fb5db679f4655619d231acee7c6fc099affbbdf114fa62514a2ca3b53", size = 69949315, upload-time = "2026-01-16T22:43:36.464Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e2/e3/b3487414c03c59ef2f2b9adb4630ada8948cf4b263413a6cd37d91407988/instructor-1.16.0.tar.gz", hash = "sha256:5176def4060e17650e70851e1461fe649e0470de80ce782f245ae444d53b6429", size = 70198815, upload-time = "2026-08-27T15:34:05.34Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/66/b4/06766740b0455dea79de9785ca85a78324977f07872927ef62d069ce1bbf/instructor-1.14.4-py3-none-any.whl", hash = "sha256:141f3509150b3952c6579496b42c48bda2b603d8a2e8ccc88a455e1e22c46dd5", size = 176883, upload-time = "2026-01-16T22:43:32.928Z" },
-]
-
-[[package]]
-name = "invoke"
-version = "2.2.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/de/bd/b461d3424a24c80490313fd77feeb666ca4f6a28c7e72713e3d9095719b4/invoke-2.2.1.tar.gz", hash = "sha256:515bf49b4a48932b79b024590348da22f39c4942dff991ad1fb8b8baea1be707", size = 304762, upload-time = "2025-10-11T00:36:35.172Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/32/4b/b99e37f88336009971405cbb7630610322ed6fbfa31e1d7ab3fbf3049a2d/invoke-2.2.1-py3-none-any.whl", hash = "sha256:2413bc441b376e5cd3f55bb5d364f973ad8bdd7bf87e53c79de3c11bf3feecc8", size = 160287, upload-time = "2025-10-11T00:36:33.703Z" },
-]
-
-[[package]]
-name = "isodate"
-version = "0.7.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/54/4d/e940025e2ce31a8ce1202635910747e5a87cc3a6a6bb2d00973375014749/isodate-0.7.2.tar.gz", hash = "sha256:4cd1aa0f43ca76f4a6c6c0292a85f40b35ec2e43e315b59f06e6d32171a953e6", size = 29705, upload-time = "2024-10-08T23:04:11.5Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/15/aa/0aca39a37d3c7eb941ba736ede56d689e7be91cab5d9ca846bde3999eba6/isodate-0.7.2-py3-none-any.whl", hash = "sha256:28009937d8031054830160fce6d409ed342816b543597cece116d966c6d99e15", size = 22320, upload-time = "2024-10-08T23:04:09.501Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/83/5d836d8239d1b9ea5d5d5bfa1558a765e4304f5504de19ae076db1c2b99f/instructor-1.16.0-py3-none-any.whl", hash = "sha256:313ac2ef4f13a4828889a24d65ad3ed63d794506759bd3412c4b71eda197db33", size = 260086, upload-time = "2026-08-27T15:33:58.515Z" },
 ]
 
 [[package]]
@@ -3141,26 +2526,26 @@ wheels = [
 
 [[package]]
 name = "jaraco-context"
-version = "6.1.0"
+version = "6.1.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "backports-tarfile", marker = "python_full_version < '3.12'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/cb/9c/a788f5bb29c61e456b8ee52ce76dbdd32fd72cd73dd67bc95f42c7a8d13c/jaraco_context-6.1.0.tar.gz", hash = "sha256:129a341b0a85a7db7879e22acd66902fda67882db771754574338898b2d5d86f", size = 15850, upload-time = "2026-01-13T02:53:53.847Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/af/50/4763cd07e722bb6285316d390a164bc7e479db9d90daa769f22578f698b4/jaraco_context-6.1.2.tar.gz", hash = "sha256:f1a6c9d391e661cc5b8d39861ff077a7dc24dc23833ccee564b234b81c82dfe3", size = 16801, upload-time = "2026-03-20T22:13:33.922Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8d/48/aa685dbf1024c7bd82bede569e3a85f82c32fd3d79ba5fea578f0159571a/jaraco_context-6.1.0-py3-none-any.whl", hash = "sha256:a43b5ed85815223d0d3cfdb6d7ca0d2bc8946f28f30b6f3216bda070f68badda", size = 7065, upload-time = "2026-01-13T02:53:53.031Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/58/bc8954bda5fcda97bd7c19be11b85f91973d67a706ed4a3aec33e7de22db/jaraco_context-6.1.2-py3-none-any.whl", hash = "sha256:bf8150b79a2d5d91ae48629d8b427a8f7ba0e1097dd6202a9059f29a36379535", size = 7871, upload-time = "2026-03-20T22:13:32.808Z" },
 ]
 
 [[package]]
 name = "jaraco-functools"
-version = "4.4.0"
+version = "4.6.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "more-itertools" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0f/27/056e0638a86749374d6f57d0b0db39f29509cce9313cf91bdc0ac4d91084/jaraco_functools-4.4.0.tar.gz", hash = "sha256:da21933b0417b89515562656547a77b4931f98176eb173644c0d35032a33d6bb", size = 19943, upload-time = "2025-12-21T09:29:43.6Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6c/1f/c23395957d41ccf27c4e535c3d334c4051e5395b3752057ba4cbaec35c56/jaraco_functools-4.6.0.tar.gz", hash = "sha256:880c577ec9720b3a052d5bc611fb9f2269b3d87902ef42440df443b88e443280", size = 20837, upload-time = "2026-07-14T01:28:02.544Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fd/c4/813bb09f0985cb21e959f21f2464169eca882656849adf727ac7bb7e1767/jaraco_functools-4.4.0-py3-none-any.whl", hash = "sha256:9eec1e36f45c818d9bf307c8948eb03b2b56cd44087b3cdc989abca1f20b9176", size = 10481, upload-time = "2025-12-21T09:29:42.27Z" },
+    { url = "https://files.pythonhosted.org/packages/02/36/ecc85bc96c273dc8a11273ed4782272975e6338d4a3e9228621175edf0e3/jaraco_functools-4.6.0-py3-none-any.whl", hash = "sha256:99e3dc0060c5cbe8fcd1cdb36258e2a65ca40f1566b2033b12abb1bb44dd3c30", size = 11677, upload-time = "2026-07-14T01:28:01.59Z" },
 ]
 
 [[package]]
@@ -3300,6 +2685,18 @@ wheels = [
 ]
 
 [[package]]
+name = "joserfc"
+version = "1.7.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/94/80fea1514b7c6d7d37804d3fe9ca81455f633347fc98731bd71ffe1faa17/joserfc-1.7.5.tar.gz", hash = "sha256:d5ff536e658e17664f8c1b1ab60dc4aa62aa973fcef1edd33cc44bda45d6f5ea", size = 234990, upload-time = "2026-08-29T13:05:42.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/67/c5/82addfd375e5ee6520644e0553e4aadde92d668c4fc99cc716d337fe7bb3/joserfc-1.7.5-py3-none-any.whl", hash = "sha256:add2c2c84e8373b084d526a8b53daba5d7a513a118cd2dcd9fc9f979d0922159", size = 71269, upload-time = "2026-08-29T13:05:40.718Z" },
+]
+
+[[package]]
 name = "json-repair"
 version = "0.25.2"
 source = { registry = "https://pypi.org/simple" }
@@ -3327,18 +2724,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/42/78/18813351fe5d63acad16aec57f94ec2b70a09e53ca98145589e185423873/jsonpatch-1.33.tar.gz", hash = "sha256:9fcd4009c41e6d12348b4a0ff2563ba56a2923a7dfee731d004e212e1ee5030c", size = 21699, upload-time = "2023-06-26T12:07:29.144Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/73/07/02e16ed01e04a374e644b575638ec7987ae846d25ad97bcc9945a3ee4b0e/jsonpatch-1.33-py2.py3-none-any.whl", hash = "sha256:0ae28c0cd062bbd8b8ecc26d7d164fbbea9652a1a3693f3b956c1eae5145dade", size = 12898, upload-time = "2023-06-16T21:01:28.466Z" },
-]
-
-[[package]]
-name = "jsonpath-ng"
-version = "1.7.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "ply" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/6d/86/08646239a313f895186ff0a4573452038eed8c86f54380b3ebac34d32fb2/jsonpath-ng-1.7.0.tar.gz", hash = "sha256:f6f5f7fd4e5ff79c785f1573b394043b39849fb2bb47bcead935d12b00beab3c", size = 37838, upload-time = "2024-10-11T15:41:42.404Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/35/5a/73ecb3d82f8615f32ccdadeb9356726d6cae3a4bbc840b437ceb95708063/jsonpath_ng-1.7.0-py3-none-any.whl", hash = "sha256:f3d7f9e848cba1b6da28c55b1c26ff915dc9e0b1ba7e752a53d6da8d5cbd00b6", size = 30105, upload-time = "2024-11-20T17:58:30.418Z" },
 ]
 
 [[package]]
@@ -3440,11 +2825,27 @@ wheels = [
 ]
 
 [[package]]
-name = "langchain-core"
-version = "1.2.7"
+name = "langchain"
+version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "langchain-core" },
+    { name = "langgraph" },
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c4/5d/0ef368fdcf5df08a394787196fb7a80f473a9c7b3fc4cd2e3b53a7a5853d/langchain-1.4.0.tar.gz", hash = "sha256:08da122a439f738f4c09a5158cfa3d2c1d8bea2d0bde7fbbf4aeb4d7f7fd9d80", size = 729354, upload-time = "2026-09-03T16:59:32.442Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/92/fa/7da07d9977a5e292ef602c1bb911514ff8206e85dc09a66961874345d57a/langchain-1.4.0-py3-none-any.whl", hash = "sha256:af1dc0161d30944a52ec7844d9bf890d0497b12ec0703069f3503b4003cbbac3", size = 161534, upload-time = "2026-09-03T16:59:31.154Z" },
+]
+
+[[package]]
+name = "langchain-core"
+version = "1.6.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
     { name = "jsonpatch" },
+    { name = "langchain-protocol" },
     { name = "langsmith" },
     { name = "packaging" },
     { name = "pydantic" },
@@ -3453,9 +2854,80 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "uuid-utils" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a2/0e/664d8d81b3493e09cbab72448d2f9d693d1fa5aa2bcc488602203a9b6da0/langchain_core-1.2.7.tar.gz", hash = "sha256:e1460639f96c352b4a41c375f25aeb8d16ffc1769499fb1c20503aad59305ced", size = 837039, upload-time = "2026-01-09T17:44:25.505Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/89/7b/406b4a8dd43dd01f69e04aafdee206809a2097134b2f944e12802eae7948/langchain_core-1.6.2.tar.gz", hash = "sha256:1ec6d3a98f7c8cdbb5bb0deff86e7ca37e16bf4f8f49f022d10723656c62352d", size = 1004390, upload-time = "2026-09-04T21:29:22.769Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6e/6f/34a9fba14d191a67f7e2ee3dbce3e9b86d2fa7310e2c7f2c713583481bd2/langchain_core-1.2.7-py3-none-any.whl", hash = "sha256:452f4fef7a3d883357b22600788d37e3d8854ef29da345b7ac7099f33c31828b", size = 490232, upload-time = "2026-01-09T17:44:24.236Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/62/d3fb7c215cb2f237c3fe84880bf347a38deafef6033b6d5f1339ba8ca401/langchain_core-1.6.2-py3-none-any.whl", hash = "sha256:21e6c7cf097c68b777fd69ea00864f09bd9ca76ac73e3e3fa14e1ee366eb4711", size = 571690, upload-time = "2026-09-04T21:29:21.175Z" },
+]
+
+[[package]]
+name = "langchain-protocol"
+version = "0.0.19"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/14/56/913599f2f9cec8524868929f12d72b2ede377a6056ca8a40a32bdadfa535/langchain_protocol-0.0.19.tar.gz", hash = "sha256:79d90a1425122ac87e8052e2ec054fbd09c3edbf341bdfb6397112a495c7bf8c", size = 6265, upload-time = "2026-08-26T21:12:00.703Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/80/c9/f6cbf357d48ccbd18bb394433b1fd7ad9be004eed9377ad08bb85777e5e6/langchain_protocol-0.0.19-py3-none-any.whl", hash = "sha256:4cdf879a492a35980fd859ae792d3c65458ccaae504e183c9a10d7eac1f0720f", size = 7327, upload-time = "2026-08-26T21:11:59.781Z" },
+]
+
+[[package]]
+name = "langgraph"
+version = "1.2.11"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "langchain-core" },
+    { name = "langgraph-checkpoint" },
+    { name = "langgraph-prebuilt" },
+    { name = "langgraph-sdk" },
+    { name = "pydantic" },
+    { name = "xxhash" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/56/0d/c8e7ee98896659e1b6555db0ab115a9ca899844744645d5d894032bab1d7/langgraph-1.2.11.tar.gz", hash = "sha256:9ecfe11e50d338b34b15cf4d8a442642de103e8ae6971320efba84e4542eb363", size = 725753, upload-time = "2026-08-11T14:00:36.945Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0a/7f/c5c30e4be99ff821029c7ac872a480676bb179c9f3df85ea3f38d13f86d4/langgraph-1.2.11-py3-none-any.whl", hash = "sha256:8bab70de7b2d00b5300fb289bcf38d8b241400f3184c1e95e8ce706fb0e8686b", size = 248854, upload-time = "2026-08-11T14:00:35.494Z" },
+]
+
+[[package]]
+name = "langgraph-checkpoint"
+version = "4.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "langchain-core" },
+    { name = "ormsgpack" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/dc/e1/089c4c9e0a2fec7f883f82ae8e6a727138d50074cfeb6644bc2d13b1019b/langgraph_checkpoint-4.2.0.tar.gz", hash = "sha256:51a593b6bee684b0818e5d6e58e28ab340c6db7794575056ce7bd1b746a84ed7", size = 180239, upload-time = "2026-08-07T20:05:03.756Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/05/71/3b475f09bd57d3a5649792c66353312b4432afd843f301739dfcebd157f0/langgraph_checkpoint-4.2.0-py3-none-any.whl", hash = "sha256:0547fd228935a0b758865de3a3d6d7a2537c308895d0f9ab092ce9151b5da942", size = 56833, upload-time = "2026-08-07T20:05:02.655Z" },
+]
+
+[[package]]
+name = "langgraph-prebuilt"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "langchain-core" },
+    { name = "langgraph-checkpoint" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/29/66/ed9b93f56bc17ef22d551892f0ac2b225a97fe0fcf23a511b857f70d590b/langgraph_prebuilt-1.1.0.tar.gz", hash = "sha256:3c579cf6eed2d17f9c157c2d0fcaddcd8688524e7022d3b22b37a3bf4589d528", size = 178833, upload-time = "2026-05-12T03:37:49.332Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/43/3fe1a700b8490ed02679cdbbc8c915eb23a092faf496c9c1118abcd10be3/langgraph_prebuilt-1.1.0-py3-none-any.whl", hash = "sha256:51e311747d755b751d5c6b39b0c1446124d3a7643d2515017e6714b323508fc9", size = 41043, upload-time = "2026-05-12T03:37:48.007Z" },
+]
+
+[[package]]
+name = "langgraph-sdk"
+version = "0.4.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+    { name = "langchain-core" },
+    { name = "langchain-protocol" },
+    { name = "orjson" },
+    { name = "websockets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3f/ae/91446c1fffa04a2dc1f81afbfb5bfff3590452891a72bd9098a656ab2657/langgraph_sdk-0.4.4.tar.gz", hash = "sha256:4e651ffa09de695681579396375377bdde23bedbc8e35b070e615cbd5af7da8b", size = 345789, upload-time = "2026-08-27T21:25:22.593Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/d5/2ad7f3a835c6fcebf58b6669552536ecd52d2dfe4cf49c6c36648fd83572/langgraph_sdk-0.4.4-py3-none-any.whl", hash = "sha256:39afe416c91742925e6f8a93715f566d499b36e1b636b804a4ffe3190e4f4e64", size = 162270, upload-time = "2026-08-27T21:25:21.072Z" },
 ]
 
 [[package]]
@@ -3552,7 +3024,7 @@ wheels = [
 
 [[package]]
 name = "litellm"
-version = "1.81.3"
+version = "1.95.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -3568,14 +3040,48 @@ dependencies = [
     { name = "tiktoken" },
     { name = "tokenizers" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ce/dd/d70835d5b231617761717cd5ba60342b677693093a71d5ce13ae9d254aee/litellm-1.81.3.tar.gz", hash = "sha256:a7688b429a88abfdd02f2a8c3158ebb5385689cfb7f9d4ac1473d018b2047e1b", size = 13612652, upload-time = "2026-01-25T02:45:58.888Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ae/64/3604383a6cae547d86f0f6efc7b3cd24a12f71d1ee5f0a416c9b830fcbe6/litellm-1.95.1.tar.gz", hash = "sha256:fc53333a5378e639b13558d0efbc0119510f32c422b9304788e88bc09f5daaf0", size = 17515255, upload-time = "2026-08-09T02:32:35.827Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/83/62/d3f53c665261fdd5bb2401246e005a4ea8194ad1c4d8c663318ae3d638bf/litellm-1.81.3-py3-none-any.whl", hash = "sha256:3f60fd8b727587952ad3dd18b68f5fed538d6f43d15bb0356f4c3a11bccb2b92", size = 11946995, upload-time = "2026-01-25T02:45:55.887Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/4d/948cbb403f62460c1b711d6d5c51d5212f5a7b61d70112692850ab806d0a/litellm-1.95.1-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:ab22d1697a4b6c75168ea322fd81c5fd11c8c9f0c00644de4033589eeeb4f4ed", size = 25787334, upload-time = "2026-08-09T02:31:00.231Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/a6/1e4e9f56d2a1ef0bd993283740b1bf822582eb15ea83bf7bb21c816979be/litellm-1.95.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:e5abbd22d1e7877d3daf403e22a1e8d6fef2813fe1d5c70b6b56fdc62745545d", size = 25497279, upload-time = "2026-08-09T02:31:03.054Z" },
+    { url = "https://files.pythonhosted.org/packages/25/19/004942c7d8efa3dfa3ee3167f0d75da8c778cde421401732f0c11a902dd9/litellm-1.95.1-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:2f80dad31394f1d5b14793a2f754c626a034795b6ce86a2640e7ad425dbf2c0b", size = 26426688, upload-time = "2026-08-09T02:31:05.551Z" },
+    { url = "https://files.pythonhosted.org/packages/22/6a/cbfdaae910a766a74799b2c8223367fd6f626da2e81084413ac9fa5f8b59/litellm-1.95.1-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:46cf40bb40baa19396b920a5e02bd0dfd487b959a9f1e4b3917b4e6af8fb9347", size = 26304065, upload-time = "2026-08-09T02:31:08.098Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/b8/d31d66f91cfd33a31785e5646ec278c7136c7f3167eed77304459c0665da/litellm-1.95.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:9d160ba72992c8e52c9522616538901c8c07674f1ac240342222417a6a421904", size = 26501279, upload-time = "2026-08-09T02:31:11.058Z" },
+    { url = "https://files.pythonhosted.org/packages/02/f7/2563c056073fb86c850c53a06f9005d08aedca78758b7b30a7f9eca6f96e/litellm-1.95.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:16094cdea1755df3e607841feba83f7446bf8131c5fe6859ac5bb53b039ecd44", size = 26713209, upload-time = "2026-08-09T02:31:13.894Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/c9/dd845ad7e5be9191a45c04419f9301d315affc7e30e2fd9553dd3d16dc33/litellm-1.95.1-cp310-cp310-win_amd64.whl", hash = "sha256:ca9bf381603b26c4ff119b720fe85d8994134b9064c04f5df25cd83cf43354fb", size = 24920672, upload-time = "2026-08-09T02:31:16.44Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/b9/7701959e5113c94acfd9d05833d27a011381c274827875c76f654844ee71/litellm-1.95.1-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:458495b66725632cd1f60387775dc1cd39104fd7b14b210f56408989b9fd0a37", size = 25787414, upload-time = "2026-08-09T02:31:18.93Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/33/bd4c37937ecaf514095848f472ceff27d8ef122768104835485fc8bd6947/litellm-1.95.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:7f254821aa94247a24c40cfbdab5ec0cae288833c4e7c9d77c9a29f4c370d3e7", size = 25497380, upload-time = "2026-08-09T02:31:21.625Z" },
+    { url = "https://files.pythonhosted.org/packages/63/b5/8c628865422c4424108e39f979376926d9461de59a5446efb5a505298259/litellm-1.95.1-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:51a5ee42b63dd7b9872dba1a8e4fd0a091cda58264f80a0107dffa286a8ef8de", size = 26425660, upload-time = "2026-08-09T02:31:24.022Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/78/410fb31cca5aaf6a0223206c7c832365ed6f9ee759ee073081bb391538f0/litellm-1.95.1-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:e9670e862843f4dfa8b97edaaabf188c36f6605696c742725f79f7c879b5dbef", size = 26303487, upload-time = "2026-08-09T02:31:26.675Z" },
+    { url = "https://files.pythonhosted.org/packages/15/bc/42e39fe47e80c156a0da4031fb7a99b3aa00d1eb6fe4bc0e70426d008a28/litellm-1.95.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:86809a804bd2480d48c9cd0fa528a4af064a78e8be10cb824199376386e049fa", size = 26500359, upload-time = "2026-08-09T02:31:29.452Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/f4/db01774abae168bbb6fa4cf3142c75eb4a7228473996207039bbb7212604/litellm-1.95.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:d057113c0daa6a4547aa0dc9eabd5bc5387626b2936b2b34b336eb78d9d31794", size = 26712129, upload-time = "2026-08-09T02:31:31.986Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/6e/8a3b2e7656f9ce5e5557a273b8fb021207aebc2bc0d69f1f82b48d4923d5/litellm-1.95.1-cp311-cp311-win_amd64.whl", hash = "sha256:ff6aed26f8659b94e9a9cdfb697de093bba140b9f3d2ebec3a67683a60958d04", size = 24920772, upload-time = "2026-08-09T02:31:34.453Z" },
+    { url = "https://files.pythonhosted.org/packages/57/5a/d54e5ec67016c8ef9a7535673d39252a5eae964f71fc21da3671df0659be/litellm-1.95.1-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:5588b6742e749f601efdd7c1485f7db375d1a3cf8ac8d103998eaac0690866b5", size = 25787340, upload-time = "2026-08-09T02:31:37.112Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/38/edf065a49a26105746a3d8273e0acddb6a06d4346b0c42ee6db191bf88e4/litellm-1.95.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:884476f661c389b4fe2a70ee8c962d7e899c7495b246c8f903171ceb37ca531e", size = 25488078, upload-time = "2026-08-09T02:31:39.736Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/f8/7c08aeb423d49b29662b0a21b5f8d6a69876b2cbdb4d4b82e320e7fea3e6/litellm-1.95.1-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:122c406b0dbe3c4c0a10933fe6d2f39a847982479f2ec59da23769c607858d39", size = 26421410, upload-time = "2026-08-09T02:31:42.406Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/1c/4178c4428bf777df37e9a7df306cc1292cab426489a76323191004f6b307/litellm-1.95.1-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:9d387672c00573d516795134f664e8cbd89849e9acd7a65c90e49f4e8dfa96ad", size = 26300094, upload-time = "2026-08-09T02:31:45.053Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/05/4d7860b7a64261fda522c5c1d5fd5c1cfaa5ea192616e5e3a0b98b6daa32/litellm-1.95.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:def055e7cb3c5aaee6755c8f6dba90a5a4151847fe8deb026132ff05ac1dee6a", size = 26495826, upload-time = "2026-08-09T02:31:47.628Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/13/ebdecfe1cbc20c03df5e905e78aa7bc4e6f7d18534848a79876428a3c7c7/litellm-1.95.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:ce63278ad967a7dcbd68a8fb43f2462b0e7766dc720ddf21f03ad5dcb91397a2", size = 26708217, upload-time = "2026-08-09T02:31:50.549Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/be/57d17bede20cd7faeaad5a495e7af8e48f5617f13049e0a2df122f440c83/litellm-1.95.1-cp312-cp312-win_amd64.whl", hash = "sha256:deb200719605df439207ae92ec43e36195fbf8c9262a25179332fc46f2e0af1c", size = 24917977, upload-time = "2026-08-09T02:31:53.74Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/40/cfc7a8c7c2809c13c9fcb86687313d3678cf470533939697b04a74fc8583/litellm-1.95.1-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:ace4a7fdb28e69f092510c40c86f5ef1cef1333a6688a9167028d7e0f5aab01e", size = 25788164, upload-time = "2026-08-09T02:31:56.561Z" },
+    { url = "https://files.pythonhosted.org/packages/77/0e/337689f90ac54d495904f4e9b041d0aac2db38375730cd0c6da152c91319/litellm-1.95.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:7697a426405064a18832b645c4d3dc37677ad984fd6d57ebd4558cfa513db7f7", size = 25488617, upload-time = "2026-08-09T02:31:59.148Z" },
+    { url = "https://files.pythonhosted.org/packages/09/88/9b81636f87ce1f1b73b473ca2033c52efd6a7e3b797d687625ee0858ba8b/litellm-1.95.1-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:57d567000b72bf6ed0d6b3f3510a2e36e9ce89de5a6676189a156c59597aa4e8", size = 26422361, upload-time = "2026-08-09T02:32:01.666Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/5e/7ca75d611ec581ebb537c613d3dbd21a6999fe04c508fb9558f1b92955c8/litellm-1.95.1-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:ee4946db0a13da8095b7ee2142f63017a34aabaa25c90d879e3b107216d8c709", size = 26300628, upload-time = "2026-08-09T02:32:04.128Z" },
+    { url = "https://files.pythonhosted.org/packages/71/e6/97ab93136a4262dbf1231827ca3907b0a67cf1bee2a9a814b0c1a5fdbae6/litellm-1.95.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:bbacb7bbb36770b67694f09c185e1d56d3002213beb21e7669f1e81b0e4b4a39", size = 26496011, upload-time = "2026-08-09T02:32:06.798Z" },
+    { url = "https://files.pythonhosted.org/packages/55/6c/b575e84bb699896eecd4c4c6ca51fe913c5d8ed02dcfb4291a601f83fb0e/litellm-1.95.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:14c3d019fabf2293c43aa95a590c35b55aae3ebb018c63fb598b45bd1ec623fc", size = 26708083, upload-time = "2026-08-09T02:32:09.836Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/72/75966b5693b5c33b5f6b26b8c62e40477f5455dde2fdf6af9e3b79664c63/litellm-1.95.1-cp313-cp313-win_amd64.whl", hash = "sha256:57e04f3e1033bd885212b98c48304555454c85f3b195b921983396fe0275f569", size = 24917728, upload-time = "2026-08-09T02:32:12.654Z" },
+    { url = "https://files.pythonhosted.org/packages/37/6f/4865c14fb60880590fc4ebfc4733f8ea9d485b9c58ccedc8f50eb6582a75/litellm-1.95.1-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:d822008554232bbceeb4b0252c7d2747a7f53f3e07c41ea2f57bb9875f7e984e", size = 25789646, upload-time = "2026-08-09T02:32:15.452Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/fa/87761dc114c1e9fe7335bd9f3346e19838745ca1391e5ce3b7acb859ad95/litellm-1.95.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:01aa7139f437df6c20676fbc0f5156a3c86b445d57ca6b81627e0feb60cafdde", size = 25497334, upload-time = "2026-08-09T02:32:18.347Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/b7/97884154e937c96b1ccd6f831a67d950521a6b1b54f99d986b57aca929bc/litellm-1.95.1-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:2d0290d912a17d57066c896d0ab9155fca219108b3dcc284ca9bd70bff9f3d17", size = 26423369, upload-time = "2026-08-09T02:32:20.934Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/76/f4019a026d4772e3594eee62525930e5a880e6d0ea0d7a702eb79fe9c1fa/litellm-1.95.1-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:5825a7edf65e1bd37874b9731d382ad77946ad0e290d5bdf9829d50c88dfa41f", size = 26299658, upload-time = "2026-08-09T02:32:24.193Z" },
+    { url = "https://files.pythonhosted.org/packages/99/ed/1b330df46b7a914639841e48449e6e1972f5fd14f5d50a18e4d5c801c189/litellm-1.95.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:9f9ca909d36409de064956c9411c044fcb771b75ec8a8f99f44f627bcc3ec87c", size = 26496554, upload-time = "2026-08-09T02:32:27.163Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/14/93ae7cd8a974741c80f819cef21b641fc13bc2bef83df7ccb907afee1a85/litellm-1.95.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:6e4e75df75200c5f8d733d0531981d0b9d604fdf077abff87edabc7a5a919990", size = 26709858, upload-time = "2026-08-09T02:32:29.919Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/b8/c9822b2205bda610d217b9125c36b13de3d7a20dc83831867195fb1a355c/litellm-1.95.1-cp314-cp314-win_amd64.whl", hash = "sha256:f3e238120fda6ac33d2362cda7dea265cecb5208fbd3d0796dc3952a747195f6", size = 24920618, upload-time = "2026-08-09T02:32:33.253Z" },
 ]
 
 [[package]]
 name = "llama-index-core"
-version = "0.14.13"
+version = "0.14.24"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -3603,65 +3109,42 @@ dependencies = [
     { name = "sqlalchemy", extra = ["asyncio"] },
     { name = "tenacity" },
     { name = "tiktoken" },
+    { name = "tinytag" },
     { name = "tqdm" },
     { name = "typing-extensions" },
     { name = "typing-inspect" },
     { name = "wrapt" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/74/54/d6043a088e5e9c1d62300db7ad0ef417c6b9a92f7b4a5cade066aeafdaca/llama_index_core-0.14.13.tar.gz", hash = "sha256:c3b30d20ae0407e5d0a1d35bb3376a98e242661ebfc22da754b5a3da1f8108c0", size = 11589074, upload-time = "2026-01-21T20:44:16.287Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d9/7a/e54d5ea405b51c1b7e1ed078036f698bcbeefc82128d5c48b7cb6d997ce6/llama_index_core-0.14.24.tar.gz", hash = "sha256:4b2eb3af98eecf3579707ef018be0346bd851be2c7660102d88fab0457b95b61", size = 11590565, upload-time = "2026-08-19T18:47:21.401Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/76/59/9769f03f1cccadcc014b3b65c166de18999b51459a0f0a579d80f6c91d80/llama_index_core-0.14.13-py3-none-any.whl", hash = "sha256:392f0a5a09433e9dea786964ef5fe5ca2a2b10aee9f979a9507c19a14da2a20a", size = 11934761, upload-time = "2026-01-21T20:44:18.892Z" },
+    { url = "https://files.pythonhosted.org/packages/be/f8/8a2aec65cba9459b24cce9bc188392014f70c2af0dc43c4cc668c685912e/llama_index_core-0.14.24-py3-none-any.whl", hash = "sha256:a12f39b8a777cc526bf400d929016cd244372af61c5e98f6f4186f51a0b9288c", size = 11927515, upload-time = "2026-08-19T18:47:18.772Z" },
 ]
 
 [[package]]
 name = "llama-index-instrumentation"
-version = "0.4.2"
+version = "0.6.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "deprecated" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/af/b9/a7a74de6d8aacf4be329329495983d78d96b1a6e69b6d9fcf4a233febd4b/llama_index_instrumentation-0.4.2.tar.gz", hash = "sha256:dc4957b64da0922060690e85a6be9698ac08e34e0f69e90b01364ddec4f3de7f", size = 46146, upload-time = "2025-10-13T20:44:48.85Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/70/ac/ffc116bac024cb0a54b4d28ca9b421e9a08f408c1fcc0039a36de2c0c97b/llama_index_instrumentation-0.6.0.tar.gz", hash = "sha256:b185c4e28a7f32899c27649cc2e2d7d54267fa2ff0cd43cbe2b5212bae98fe3a", size = 56517, upload-time = "2026-08-29T15:33:16.861Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/40/54/df8063b0441242e250e03d1e31ebde5dffbe24e1af32b025cb1a4544150c/llama_index_instrumentation-0.4.2-py3-none-any.whl", hash = "sha256:b4989500e6454059ab3f3c4a193575d47ab1fadb730c2e8f2b962649ae88b70b", size = 15411, upload-time = "2025-10-13T20:44:47.685Z" },
+    { url = "https://files.pythonhosted.org/packages/02/b5/332eb32835360125fa1c90a4b81c58831c48dded5b8426d44e9acd4bf328/llama_index_instrumentation-0.6.0-py3-none-any.whl", hash = "sha256:9588618b271e6c74e58dc81542ea022547c427f036e7cacb655865c4982610bb", size = 16445, upload-time = "2026-08-29T15:33:15.766Z" },
 ]
 
 [[package]]
 name = "llama-index-workflows"
-version = "2.13.0"
+version = "2.23.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "llama-index-instrumentation" },
     { name = "pydantic" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c1/42/f7992c268cabab3690dd8999467bcbf8394cd7b753aaa49ef7d309bbf20b/llama_index_workflows-2.13.0.tar.gz", hash = "sha256:84854d913f465045fa6503a9d7c7b5b785fb3bcba5fe9a961c36b1403e1f0f52", size = 83011, upload-time = "2026-01-23T21:56:00.564Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/74/f8/cb9968d2453b16dc8951b8542ea827a59b937ecb0aa1a06d3ca418a311f4/llama_index_workflows-2.23.3.tar.gz", hash = "sha256:fba140ea4d4aa7e7ca58f3ddc2526b92bfb31bfaf45ab2b4345401ae527061b4", size = 138873, upload-time = "2026-08-22T14:26:19.13Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/12/96/3ecff262aaf17fba8b6ea8c1406616304d75e279cc76985aad1390a3b547/llama_index_workflows-2.13.0-py3-none-any.whl", hash = "sha256:eb055cfa7d6a66c63b1dcd33545bdcc8abc6dd2be4ada52374a6b1c6386a4017", size = 106034, upload-time = "2026-01-23T21:56:01.695Z" },
-]
-
-[[package]]
-name = "logfire"
-version = "4.19.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "executing" },
-    { name = "opentelemetry-exporter-otlp-proto-http" },
-    { name = "opentelemetry-instrumentation" },
-    { name = "opentelemetry-sdk" },
-    { name = "protobuf" },
-    { name = "rich" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/1e/a4/518b4deb1b6bffc150c5229b209121b76185ecd369a460fc3b740e8e4af0/logfire-4.19.0.tar.gz", hash = "sha256:4ec49f1e6be2512f2c60ade053fd8a7610539dbe570e4ba53df91435ef7db888", size = 634738, upload-time = "2026-01-16T10:11:57.191Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ca/63/d1dfb4df34ada7a5064bbd46009ed5a14f5fdfda8381381bdba21eeeda3c/logfire-4.19.0-py3-none-any.whl", hash = "sha256:cbd52f6edb33944c2d38e801bbf1e7c76c14d5c9eb351aeeecb4d6d286b41443", size = 236432, upload-time = "2026-01-16T10:11:54.672Z" },
-]
-
-[package.optional-dependencies]
-httpx = [
-    { name = "opentelemetry-instrumentation-httpx" },
+    { url = "https://files.pythonhosted.org/packages/bf/35/27a651cee0c4e4540a5b65aaec1293f52e153b870accab7f8472d035809b/llama_index_workflows-2.23.3-py3-none-any.whl", hash = "sha256:d7ad51363ba4817b4140526c5e785d2f143861f618823456e2f379adfe0b321b", size = 166772, upload-time = "2026-08-22T14:26:17.911Z" },
 ]
 
 [[package]]
@@ -3671,80 +3154,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/4e/30/d8c098989ac64d74f279187626b602862a139521b970f44ca3bc1330598a/logfire_api-4.19.0.tar.gz", hash = "sha256:a38b3b42160df8c02d3cb722cf2d6a43d3a633e7b8ee832d01ac9a9a41fc0c76", size = 58668, upload-time = "2026-01-16T10:11:58.302Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7b/f5/b702b77968c08f5dc9407fd00b455e6c336a9f8c1e1aeee7180b5ac7186d/logfire_api-4.19.0-py3-none-any.whl", hash = "sha256:98c47e4995ab735791070529263f7cc19d07807204552be1f449bf1045f23ebc", size = 97027, upload-time = "2026-01-16T10:11:56.173Z" },
-]
-
-[[package]]
-name = "lupa"
-version = "2.6"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b8/1c/191c3e6ec6502e3dbe25a53e27f69a5daeac3e56de1f73c0138224171ead/lupa-2.6.tar.gz", hash = "sha256:9a770a6e89576be3447668d7ced312cd6fd41d3c13c2462c9dc2c2ab570e45d9", size = 7240282, upload-time = "2025-10-24T07:20:29.738Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a1/15/713cab5d0dfa4858f83b99b3e0329072df33dc14fc3ebbaa017e0f9755c4/lupa-2.6-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:6b3dabda836317e63c5ad052826e156610f356a04b3003dfa0dbe66b5d54d671", size = 954828, upload-time = "2025-10-24T07:17:15.726Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/71/704740cbc6e587dd6cc8dabf2f04820ac6a671784e57cc3c29db795476db/lupa-2.6-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:8726d1c123bbe9fbb974ce29825e94121824e66003038ff4532c14cc2ed0c51c", size = 1919259, upload-time = "2025-10-24T07:17:18.586Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/18/f248341c423c5d48837e35584c6c3eb4acab7e722b6057d7b3e28e42dae8/lupa-2.6-cp310-cp310-macosx_11_0_x86_64.whl", hash = "sha256:f4e159e7d814171199b246f9235ca8961f6461ea8c1165ab428afa13c9289a94", size = 984998, upload-time = "2025-10-24T07:17:20.428Z" },
-    { url = "https://files.pythonhosted.org/packages/44/1e/8a4bd471e018aad76bcb9455d298c2c96d82eced20f2ae8fcec8cd800948/lupa-2.6-cp310-cp310-manylinux2010_i686.manylinux_2_12_i686.manylinux_2_28_i686.whl", hash = "sha256:202160e80dbfddfb79316692a563d843b767e0f6787bbd1c455f9d54052efa6c", size = 1174871, upload-time = "2025-10-24T07:17:22.755Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/5c/3a3f23fd6a91b0986eea1ceaf82ad3f9b958fe3515a9981fb9c4eb046c8b/lupa-2.6-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5deede7c5b36ab64f869dae4831720428b67955b0bb186c8349cf6ea121c852b", size = 1057471, upload-time = "2025-10-24T07:17:24.908Z" },
-    { url = "https://files.pythonhosted.org/packages/45/ac/01be1fed778fb0c8f46ee8cbe344e4d782f6806fac12717f08af87aa4355/lupa-2.6-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:86f04901f920bbf7c0cac56807dc9597e42347123e6f1f3ca920f15f54188ce5", size = 2100592, upload-time = "2025-10-24T07:17:27.089Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/6c/1a05bb873e30830f8574e10cd0b4cdbc72e9dbad2a09e25810b5e3b1f75d/lupa-2.6-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:6deef8f851d6afb965c84849aa5b8c38856942df54597a811ce0369ced678610", size = 1081396, upload-time = "2025-10-24T07:17:29.064Z" },
-    { url = "https://files.pythonhosted.org/packages/a2/c2/a19dd80d6dc98b39bbf8135b8198e38aa7ca3360b720eac68d1d7e9286b5/lupa-2.6-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:21f2b5549681c2a13b1170a26159d30875d367d28f0247b81ca347222c755038", size = 1192007, upload-time = "2025-10-24T07:17:31.362Z" },
-    { url = "https://files.pythonhosted.org/packages/4f/43/e1b297225c827f55752e46fdbfb021c8982081b0f24490e42776ea69ae3b/lupa-2.6-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:66eea57630eab5e6f49fdc5d7811c0a2a41f2011be4ea56a087ea76112011eb7", size = 2196661, upload-time = "2025-10-24T07:17:33.484Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/8f/2272d429a7fa9dc8dbd6e9c5c9073a03af6007eb22a4c78829fec6a34b80/lupa-2.6-cp310-cp310-win32.whl", hash = "sha256:60a403de8cab262a4fe813085dd77010effa6e2eb1886db2181df803140533b1", size = 1412738, upload-time = "2025-10-24T07:17:35.11Z" },
-    { url = "https://files.pythonhosted.org/packages/35/2a/1708911271dd49ad87b4b373b5a4b0e0a0516d3d2af7b76355946c7ee171/lupa-2.6-cp310-cp310-win_amd64.whl", hash = "sha256:e4656a39d93dfa947cf3db56dc16c7916cb0cc8024acd3a952071263f675df64", size = 1656898, upload-time = "2025-10-24T07:17:36.949Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/29/1f66907c1ebf1881735afa695e646762c674f00738ebf66d795d59fc0665/lupa-2.6-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:6d988c0f9331b9f2a5a55186701a25444ab10a1432a1021ee58011499ecbbdd5", size = 962875, upload-time = "2025-10-24T07:17:39.107Z" },
-    { url = "https://files.pythonhosted.org/packages/e6/67/4a748604be360eb9c1c215f6a0da921cd1a2b44b2c5951aae6fb83019d3a/lupa-2.6-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:ebe1bbf48259382c72a6fe363dea61a0fd6fe19eab95e2ae881e20f3654587bf", size = 1935390, upload-time = "2025-10-24T07:17:41.427Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/0c/8ef9ee933a350428b7bdb8335a37ef170ab0bb008bbf9ca8f4f4310116b6/lupa-2.6-cp311-cp311-macosx_11_0_x86_64.whl", hash = "sha256:a8fcee258487cf77cdd41560046843bb38c2e18989cd19671dd1e2596f798306", size = 992193, upload-time = "2025-10-24T07:17:43.231Z" },
-    { url = "https://files.pythonhosted.org/packages/65/46/e6c7facebdb438db8a65ed247e56908818389c1a5abbf6a36aab14f1057d/lupa-2.6-cp311-cp311-manylinux2010_i686.manylinux_2_12_i686.manylinux_2_28_i686.whl", hash = "sha256:561a8e3be800827884e767a694727ed8482d066e0d6edfcbf423b05e63b05535", size = 1165844, upload-time = "2025-10-24T07:17:45.437Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/26/9f1154c6c95f175ccbf96aa96c8f569c87f64f463b32473e839137601a8b/lupa-2.6-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:af880a62d47991cae78b8e9905c008cbfdc4a3a9723a66310c2634fc7644578c", size = 1048069, upload-time = "2025-10-24T07:17:47.181Z" },
-    { url = "https://files.pythonhosted.org/packages/68/67/2cc52ab73d6af81612b2ea24c870d3fa398443af8e2875e5befe142398b1/lupa-2.6-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:80b22923aa4023c86c0097b235615f89d469a0c4eee0489699c494d3367c4c85", size = 2079079, upload-time = "2025-10-24T07:17:49.755Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/dc/f843f09bbf325f6e5ee61730cf6c3409fc78c010d968c7c78acba3019ca7/lupa-2.6-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:153d2cc6b643f7efb9cfc0c6bb55ec784d5bac1a3660cfc5b958a7b8f38f4a75", size = 1071428, upload-time = "2025-10-24T07:17:51.991Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/60/37533a8d85bf004697449acb97ecdacea851acad28f2ad3803662487dd2a/lupa-2.6-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:3fa8777e16f3ded50b72967dc17e23f5a08e4f1e2c9456aff2ebdb57f5b2869f", size = 1181756, upload-time = "2025-10-24T07:17:53.752Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/f2/cf29b20dbb4927b6a3d27c339ac5d73e74306ecc28c8e2c900b2794142ba/lupa-2.6-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:8dbdcbe818c02a2f56f5ab5ce2de374dab03e84b25266cfbaef237829bc09b3f", size = 2175687, upload-time = "2025-10-24T07:17:56.228Z" },
-    { url = "https://files.pythonhosted.org/packages/94/7c/050e02f80c7131b63db1474bff511e63c545b5a8636a24cbef3fc4da20b6/lupa-2.6-cp311-cp311-win32.whl", hash = "sha256:defaf188fde8f7a1e5ce3a5e6d945e533b8b8d547c11e43b96c9b7fe527f56dc", size = 1412592, upload-time = "2025-10-24T07:17:59.062Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/9a/6f2af98aa5d771cea661f66c8eb8f53772ec1ab1dfbce24126cfcd189436/lupa-2.6-cp311-cp311-win_amd64.whl", hash = "sha256:9505ae600b5c14f3e17e70f87f88d333717f60411faca1ddc6f3e61dce85fa9e", size = 1669194, upload-time = "2025-10-24T07:18:01.647Z" },
-    { url = "https://files.pythonhosted.org/packages/94/86/ce243390535c39d53ea17ccf0240815e6e457e413e40428a658ea4ee4b8d/lupa-2.6-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:47ce718817ef1cc0c40d87c3d5ae56a800d61af00fbc0fad1ca9be12df2f3b56", size = 951707, upload-time = "2025-10-24T07:18:03.884Z" },
-    { url = "https://files.pythonhosted.org/packages/86/85/cedea5e6cbeb54396fdcc55f6b741696f3f036d23cfaf986d50d680446da/lupa-2.6-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:7aba985b15b101495aa4b07112cdc08baa0c545390d560ad5cfde2e9e34f4d58", size = 1916703, upload-time = "2025-10-24T07:18:05.6Z" },
-    { url = "https://files.pythonhosted.org/packages/24/be/3d6b5f9a8588c01a4d88129284c726017b2089f3a3fd3ba8bd977292fea0/lupa-2.6-cp312-cp312-macosx_11_0_x86_64.whl", hash = "sha256:b766f62f95b2739f2248977d29b0722e589dcf4f0ccfa827ccbd29f0148bd2e5", size = 985152, upload-time = "2025-10-24T07:18:08.561Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/23/9f9a05beee5d5dce9deca4cb07c91c40a90541fc0a8e09db4ee670da550f/lupa-2.6-cp312-cp312-manylinux2010_i686.manylinux_2_12_i686.manylinux_2_28_i686.whl", hash = "sha256:00a934c23331f94cb51760097ebfab14b005d55a6b30a2b480e3c53dd2fa290d", size = 1159599, upload-time = "2025-10-24T07:18:10.346Z" },
-    { url = "https://files.pythonhosted.org/packages/40/4e/e7c0583083db9d7f1fd023800a9767d8e4391e8330d56c2373d890ac971b/lupa-2.6-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:21de9f38bd475303e34a042b7081aabdf50bd9bafd36ce4faea2f90fd9f15c31", size = 1038686, upload-time = "2025-10-24T07:18:12.112Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/9f/5a4f7d959d4feba5e203ff0c31889e74d1ca3153122be4a46dca7d92bf7c/lupa-2.6-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:cf3bda96d3fc41237e964a69c23647d50d4e28421111360274d4799832c560e9", size = 2071956, upload-time = "2025-10-24T07:18:14.572Z" },
-    { url = "https://files.pythonhosted.org/packages/92/34/2f4f13ca65d01169b1720176aedc4af17bc19ee834598c7292db232cb6dc/lupa-2.6-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:5a76ead245da54801a81053794aa3975f213221f6542d14ec4b859ee2e7e0323", size = 1057199, upload-time = "2025-10-24T07:18:16.379Z" },
-    { url = "https://files.pythonhosted.org/packages/35/2a/5f7d2eebec6993b0dcd428e0184ad71afb06a45ba13e717f6501bfed1da3/lupa-2.6-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:8dd0861741caa20886ddbda0a121d8e52fb9b5bb153d82fa9bba796962bf30e8", size = 1173693, upload-time = "2025-10-24T07:18:18.153Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/29/089b4d2f8e34417349af3904bb40bec40b65c8731f45e3fd8d497ca573e5/lupa-2.6-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:239e63948b0b23023f81d9a19a395e768ed3da6a299f84e7963b8f813f6e3f9c", size = 2164394, upload-time = "2025-10-24T07:18:20.403Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/1b/79c17b23c921f81468a111cad843b076a17ef4b684c4a8dff32a7969c3f0/lupa-2.6-cp312-cp312-win32.whl", hash = "sha256:325894e1099499e7a6f9c351147661a2011887603c71086d36fe0f964d52d1ce", size = 1420647, upload-time = "2025-10-24T07:18:23.368Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/15/5121e68aad3584e26e1425a5c9a79cd898f8a152292059e128c206ee817c/lupa-2.6-cp312-cp312-win_amd64.whl", hash = "sha256:c735a1ce8ee60edb0fe71d665f1e6b7c55c6021f1d340eb8c865952c602cd36f", size = 1688529, upload-time = "2025-10-24T07:18:25.523Z" },
-    { url = "https://files.pythonhosted.org/packages/28/1d/21176b682ca5469001199d8b95fa1737e29957a3d185186e7a8b55345f2e/lupa-2.6-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:663a6e58a0f60e7d212017d6678639ac8df0119bc13c2145029dcba084391310", size = 947232, upload-time = "2025-10-24T07:18:27.878Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/4c/d327befb684660ca13cf79cd1f1d604331808f9f1b6fb6bf57832f8edf80/lupa-2.6-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:d1f5afda5c20b1f3217a80e9bc1b77037f8a6eb11612fd3ada19065303c8f380", size = 1908625, upload-time = "2025-10-24T07:18:29.944Z" },
-    { url = "https://files.pythonhosted.org/packages/66/8e/ad22b0a19454dfd08662237a84c792d6d420d36b061f239e084f29d1a4f3/lupa-2.6-cp313-cp313-macosx_11_0_x86_64.whl", hash = "sha256:26f2b3c085fe76e9119e48c1013c1cccdc1f51585d456858290475aa38e7089e", size = 981057, upload-time = "2025-10-24T07:18:31.553Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/48/74859073ab276bd0566c719f9ca0108b0cfc1956ca0d68678d117d47d155/lupa-2.6-cp313-cp313-manylinux2010_i686.manylinux_2_12_i686.manylinux_2_28_i686.whl", hash = "sha256:60d2f902c7b96fb8ab98493dcff315e7bb4d0b44dc9dd76eb37de575025d5685", size = 1156227, upload-time = "2025-10-24T07:18:33.981Z" },
-    { url = "https://files.pythonhosted.org/packages/09/6c/0e9ded061916877253c2266074060eb71ed99fb21d73c8c114a76725bce2/lupa-2.6-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a02d25dee3a3250967c36590128d9220ae02f2eda166a24279da0b481519cbff", size = 1035752, upload-time = "2025-10-24T07:18:36.32Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/ef/f8c32e454ef9f3fe909f6c7d57a39f950996c37a3deb7b391fec7903dab7/lupa-2.6-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6eae1ee16b886b8914ff292dbefbf2f48abfbdee94b33a88d1d5475e02423203", size = 2069009, upload-time = "2025-10-24T07:18:38.072Z" },
-    { url = "https://files.pythonhosted.org/packages/53/dc/15b80c226a5225815a890ee1c11f07968e0aba7a852df41e8ae6fe285063/lupa-2.6-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:b0edd5073a4ee74ab36f74fe61450148e6044f3952b8d21248581f3c5d1a58be", size = 1056301, upload-time = "2025-10-24T07:18:40.165Z" },
-    { url = "https://files.pythonhosted.org/packages/31/14/2086c1425c985acfb30997a67e90c39457122df41324d3c179d6ee2292c6/lupa-2.6-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:0c53ee9f22a8a17e7d4266ad48e86f43771951797042dd51d1494aaa4f5f3f0a", size = 1170673, upload-time = "2025-10-24T07:18:42.426Z" },
-    { url = "https://files.pythonhosted.org/packages/10/e5/b216c054cf86576c0191bf9a9f05de6f7e8e07164897d95eea0078dca9b2/lupa-2.6-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:de7c0f157a9064a400d828789191a96da7f4ce889969a588b87ec80de9b14772", size = 2162227, upload-time = "2025-10-24T07:18:46.112Z" },
-    { url = "https://files.pythonhosted.org/packages/59/2f/33ecb5bedf4f3bc297ceacb7f016ff951331d352f58e7e791589609ea306/lupa-2.6-cp313-cp313-win32.whl", hash = "sha256:ee9523941ae0a87b5b703417720c5d78f72d2f5bc23883a2ea80a949a3ed9e75", size = 1419558, upload-time = "2025-10-24T07:18:48.371Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/b4/55e885834c847ea610e111d87b9ed4768f0afdaeebc00cd46810f25029f6/lupa-2.6-cp313-cp313-win_amd64.whl", hash = "sha256:b1335a5835b0a25ebdbc75cf0bda195e54d133e4d994877ef025e218c2e59db9", size = 1683424, upload-time = "2025-10-24T07:18:50.976Z" },
-    { url = "https://files.pythonhosted.org/packages/66/9d/d9427394e54d22a35d1139ef12e845fd700d4872a67a34db32516170b746/lupa-2.6-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:dcb6d0a3264873e1653bc188499f48c1fb4b41a779e315eba45256cfe7bc33c1", size = 953818, upload-time = "2025-10-24T07:18:53.378Z" },
-    { url = "https://files.pythonhosted.org/packages/10/41/27bbe81953fb2f9ecfced5d9c99f85b37964cfaf6aa8453bb11283983721/lupa-2.6-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:a37e01f2128f8c36106726cb9d360bac087d58c54b4522b033cc5691c584db18", size = 1915850, upload-time = "2025-10-24T07:18:55.259Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/98/f9ff60db84a75ba8725506bbf448fb085bc77868a021998ed2a66d920568/lupa-2.6-cp314-cp314-macosx_11_0_x86_64.whl", hash = "sha256:458bd7e9ff3c150b245b0fcfbb9bd2593d1152ea7f0a7b91c1d185846da033fe", size = 982344, upload-time = "2025-10-24T07:18:57.05Z" },
-    { url = "https://files.pythonhosted.org/packages/41/f7/f39e0f1c055c3b887d86b404aaf0ca197b5edfd235a8b81b45b25bac7fc3/lupa-2.6-cp314-cp314-manylinux2010_i686.manylinux_2_12_i686.manylinux_2_28_i686.whl", hash = "sha256:052ee82cac5206a02df77119c325339acbc09f5ce66967f66a2e12a0f3211cad", size = 1156543, upload-time = "2025-10-24T07:18:59.251Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/9c/59e6cffa0d672d662ae17bd7ac8ecd2c89c9449dee499e3eb13ca9cd10d9/lupa-2.6-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:96594eca3c87dd07938009e95e591e43d554c1dbd0385be03c100367141db5a8", size = 1047974, upload-time = "2025-10-24T07:19:01.449Z" },
-    { url = "https://files.pythonhosted.org/packages/23/c6/a04e9cef7c052717fcb28fb63b3824802488f688391895b618e39be0f684/lupa-2.6-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e8faddd9d198688c8884091173a088a8e920ecc96cda2ffed576a23574c4b3f6", size = 2073458, upload-time = "2025-10-24T07:19:03.369Z" },
-    { url = "https://files.pythonhosted.org/packages/e6/10/824173d10f38b51fc77785228f01411b6ca28826ce27404c7c912e0e442c/lupa-2.6-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:daebb3a6b58095c917e76ba727ab37b27477fb926957c825205fbda431552134", size = 1067683, upload-time = "2025-10-24T07:19:06.2Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/dc/9692fbcf3c924d9c4ece2d8d2f724451ac2e09af0bd2a782db1cef34e799/lupa-2.6-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:f3154e68972befe0f81564e37d8142b5d5d79931a18309226a04ec92487d4ea3", size = 1171892, upload-time = "2025-10-24T07:19:08.544Z" },
-    { url = "https://files.pythonhosted.org/packages/84/ff/e318b628d4643c278c96ab3ddea07fc36b075a57383c837f5b11e537ba9d/lupa-2.6-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:e4dadf77b9fedc0bfa53417cc28dc2278a26d4cbd95c29f8927ad4d8fe0a7ef9", size = 2166641, upload-time = "2025-10-24T07:19:10.485Z" },
-    { url = "https://files.pythonhosted.org/packages/12/f7/a6f9ec2806cf2d50826980cdb4b3cffc7691dc6f95e13cc728846d5cb793/lupa-2.6-cp314-cp314-win32.whl", hash = "sha256:cb34169c6fa3bab3e8ac58ca21b8a7102f6a94b6a5d08d3636312f3f02fafd8f", size = 1456857, upload-time = "2025-10-24T07:19:37.989Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/de/df71896f25bdc18360fdfa3b802cd7d57d7fede41a0e9724a4625b412c85/lupa-2.6-cp314-cp314-win_amd64.whl", hash = "sha256:b74f944fe46c421e25d0f8692aef1e842192f6f7f68034201382ac440ef9ea67", size = 1731191, upload-time = "2025-10-24T07:19:40.281Z" },
-    { url = "https://files.pythonhosted.org/packages/47/3c/a1f23b01c54669465f5f4c4083107d496fbe6fb45998771420e9aadcf145/lupa-2.6-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:0e21b716408a21ab65723f8841cf7f2f37a844b7a965eeabb785e27fca4099cf", size = 999343, upload-time = "2025-10-24T07:19:12.519Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/6d/501994291cb640bfa2ccf7f554be4e6914afa21c4026bd01bff9ca8aac57/lupa-2.6-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:589db872a141bfff828340079bbdf3e9a31f2689f4ca0d88f97d9e8c2eae6142", size = 2000730, upload-time = "2025-10-24T07:19:14.869Z" },
-    { url = "https://files.pythonhosted.org/packages/53/a5/457ffb4f3f20469956c2d4c4842a7675e884efc895b2f23d126d23e126cc/lupa-2.6-cp314-cp314t-macosx_11_0_x86_64.whl", hash = "sha256:cd852a91a4a9d4dcbb9a58100f820a75a425703ec3e3f049055f60b8533b7953", size = 1021553, upload-time = "2025-10-24T07:19:17.123Z" },
-    { url = "https://files.pythonhosted.org/packages/51/6b/36bb5a5d0960f2a5c7c700e0819abb76fd9bf9c1d8a66e5106416d6e9b14/lupa-2.6-cp314-cp314t-manylinux2010_i686.manylinux_2_12_i686.manylinux_2_28_i686.whl", hash = "sha256:0334753be028358922415ca97a64a3048e4ed155413fc4eaf87dd0a7e2752983", size = 1133275, upload-time = "2025-10-24T07:19:20.51Z" },
-    { url = "https://files.pythonhosted.org/packages/19/86/202ff4429f663013f37d2229f6176ca9f83678a50257d70f61a0a97281bf/lupa-2.6-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:661d895cd38c87658a34780fac54a690ec036ead743e41b74c3fb81a9e65a6aa", size = 1038441, upload-time = "2025-10-24T07:19:22.509Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/42/d8125f8e420714e5b52e9c08d88b5329dfb02dcca731b4f21faaee6cc5b5/lupa-2.6-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6aa58454ccc13878cc177c62529a2056be734da16369e451987ff92784994ca7", size = 2058324, upload-time = "2025-10-24T07:19:24.979Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/2c/47bf8b84059876e877a339717ddb595a4a7b0e8740bacae78ba527562e1c/lupa-2.6-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:1425017264e470c98022bba8cff5bd46d054a827f5df6b80274f9cc71dafd24f", size = 1060250, upload-time = "2025-10-24T07:19:27.262Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/06/d88add2b6406ca1bdec99d11a429222837ca6d03bea42ca75afa169a78cb/lupa-2.6-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:224af0532d216e3105f0a127410f12320f7c5f1aa0300bdf9646b8d9afb0048c", size = 1151126, upload-time = "2025-10-24T07:19:29.522Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/a0/89e6a024c3b4485b89ef86881c9d55e097e7cb0bdb74efb746f2fa6a9a76/lupa-2.6-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9abb98d5a8fd27c8285302e82199f0e56e463066f88f619d6594a450bf269d80", size = 2153693, upload-time = "2025-10-24T07:19:31.379Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/36/a0f007dc58fc1bbf51fb85dcc82fcb1f21b8c4261361de7dab0e3d8521ef/lupa-2.6-cp314-cp314t-win32.whl", hash = "sha256:1849efeba7a8f6fb8aa2c13790bee988fd242ae404bd459509640eeea3d1e291", size = 1590104, upload-time = "2025-10-24T07:19:33.514Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/5e/db903ce9cf82c48d6b91bf6d63ae4c8d0d17958939a4e04ba6b9f38b8643/lupa-2.6-cp314-cp314t-win_amd64.whl", hash = "sha256:fc1498d1a4fc028bc521c26d0fad4ca00ed63b952e32fb95949bda76a04bad52", size = 1913818, upload-time = "2025-10-24T07:19:36.039Z" },
 ]
 
 [[package]]
@@ -3867,15 +3276,15 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.26.0"
+version = "2.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
-    { name = "httpx" },
-    { name = "httpx-sse" },
+    { name = "httpx2" },
     { name = "jsonschema" },
+    { name = "mcp-types" },
+    { name = "opentelemetry-api" },
     { name = "pydantic" },
-    { name = "pydantic-settings" },
     { name = "pyjwt", extra = ["crypto"] },
     { name = "python-multipart" },
     { name = "pywin32", marker = "sys_platform == 'win32'" },
@@ -3885,14 +3294,22 @@ dependencies = [
     { name = "typing-inspection" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fc/6d/62e76bbb8144d6ed86e202b5edd8a4cb631e7c8130f3f4893c3f90262b10/mcp-1.26.0.tar.gz", hash = "sha256:db6e2ef491eecc1a0d93711a76f28dec2e05999f93afd48795da1c1137142c66", size = 608005, upload-time = "2026-01-24T19:40:32.468Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d4/6e/21fb8e5d579dbe21d96ea4d5034200d46d8bdf2261053b5bd041f3c2f612/mcp-2.1.1.tar.gz", hash = "sha256:50b7ba1ebbe117008ea7bdd288234043e69c20b403d6851d19661e6d431a75ef", size = 3984589, upload-time = "2026-08-25T16:14:02.376Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fd/d9/eaa1f80170d2b7c5ba23f3b59f766f3a0bb41155fbc32a69adfa1adaaef9/mcp-1.26.0-py3-none-any.whl", hash = "sha256:904a21c33c25aa98ddbeb47273033c435e595bbacfdb177f4bd87f6dceebe1ca", size = 233615, upload-time = "2026-01-24T19:40:30.652Z" },
+    { url = "https://files.pythonhosted.org/packages/50/af/8644cc5fa26a59afd2df2e98eeb19e72926887fa4b7441aba4ff661140db/mcp-2.1.1-py3-none-any.whl", hash = "sha256:1c6c31c5d6471c58db76af3af8af67f46d11d01f0a59077d0a308cbdb3d3e915", size = 357912, upload-time = "2026-08-25T16:13:59.024Z" },
 ]
 
-[package.optional-dependencies]
-ws = [
-    { name = "websockets" },
+[[package]]
+name = "mcp-types"
+version = "2.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6a/dd/1c4417dc0b722c23a1669032d5f044e41170fe5d4773b488a50fcce98c32/mcp_types-2.1.1.tar.gz", hash = "sha256:77dcbe48fba73cca71a673f2646a5f037a017b7a0a07ac89cec1113028890eda", size = 66674, upload-time = "2026-08-25T16:14:03.861Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/d0/242e63c510f4a17381f55b1549a3f94f5687a0595984febd2b6f87a687a0/mcp_types-2.1.1-py3-none-any.whl", hash = "sha256:26f9f7f03f2a5730717a5b98e2ab7eb640ac352d05a00cdc725c311864778295", size = 69656, upload-time = "2026-08-25T16:14:00.667Z" },
 ]
 
 [[package]]
@@ -3905,88 +3322,12 @@ wheels = [
 ]
 
 [[package]]
-name = "mem0ai"
-version = "1.0.3"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "openai" },
-    { name = "posthog" },
-    { name = "protobuf" },
-    { name = "pydantic" },
-    { name = "pytz" },
-    { name = "qdrant-client" },
-    { name = "sqlalchemy" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/ce/b6/9d3a747a5c1af2b4f73572a3d296bf5e99c99630a3f201b0ddbb14e811e6/mem0ai-1.0.3.tar.gz", hash = "sha256:8f7abe485a61653e3f2d3f8c222f531f8b52660b19d88820c56522103d9f31b5", size = 182698, upload-time = "2026-02-03T05:38:04.608Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/84/3e/b300ab9fa6efd36c78f1402684eab1483f282c4ca6e983920fceb9c0f4fb/mem0ai-1.0.3-py3-none-any.whl", hash = "sha256:f500c3decc12c2663b2ad829ac4edcd0c674f2bd9bf4abf7f5c0522aef3d3cf8", size = 275722, upload-time = "2026-02-03T05:38:03.126Z" },
-]
-
-[[package]]
 name = "mergedeep"
 version = "1.3.4"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/3a/41/580bb4006e3ed0361b8151a01d324fb03f420815446c7def45d02f74c270/mergedeep-1.3.4.tar.gz", hash = "sha256:0096d52e9dad9939c3d975a774666af186eda617e6ca84df4c94dec30004f2a8", size = 4661, upload-time = "2021-02-05T18:55:30.623Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2c/19/04f9b178c2d8a15b076c8b5140708fa6ffc5601fb6f1e975537072df5b2a/mergedeep-1.3.4-py3-none-any.whl", hash = "sha256:70775750742b25c0d8f36c55aed03d24c3384d17c951b3175d898bd778ef0307", size = 6354, upload-time = "2021-02-05T18:55:29.583Z" },
-]
-
-[[package]]
-name = "microsoft-agents-activity"
-version = "0.8.0.dev3"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pydantic" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/04/b9/71b14f447073f52a051789005370cc9e83321d5b03cddef272aaef530662/microsoft_agents_activity-0.8.0.dev3.tar.gz", hash = "sha256:5012d413ccedf4b7cba3654418c1e9cb0553131574bb9ae96b3d6a47228082b4", size = 61256, upload-time = "2026-02-12T09:06:57.779Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b3/cb/a54a18033a75c55dabbec0af2f9973b7d64312c1f143c4a04ab09ab3a2e0/microsoft_agents_activity-0.8.0.dev3-py3-none-any.whl", hash = "sha256:119faf77a64424524383508276b515a6b9d11df6d5c116039e1491fcdd86096a", size = 132957, upload-time = "2026-02-12T09:07:10.305Z" },
-]
-
-[[package]]
-name = "microsoft-agents-copilotstudio-client"
-version = "0.8.0.dev3"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "microsoft-agents-hosting-core" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/1f/ea/baed4709ff7eab73414a506814d9a5c90deeea0277354236e8ca050a2f2f/microsoft_agents_copilotstudio_client-0.8.0.dev3.tar.gz", hash = "sha256:326deb8205061c0eeca74d85b80a217332758da71e604f9a8048bf0d2c6c3bf3", size = 12692, upload-time = "2026-02-12T09:07:00.612Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/be/52/77addb3bcaec6c4e511a5807d7e95b3e251f5dfcc71fd8c46aad832305c9/microsoft_agents_copilotstudio_client-0.8.0.dev3-py3-none-any.whl", hash = "sha256:0cf0a85da09c2f3cf4f3e116d9784df1dda12162ea9c8f4f55d082c28b8c5c1d", size = 13507, upload-time = "2026-02-12T09:07:12.437Z" },
-]
-
-[[package]]
-name = "microsoft-agents-hosting-core"
-version = "0.8.0.dev3"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "azure-core" },
-    { name = "isodate" },
-    { name = "microsoft-agents-activity" },
-    { name = "pyjwt" },
-    { name = "python-dotenv" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/73/43/8ef9dcf65505c14787f80d8f3dfde4f3977915b931dd2c86fe6a7673c541/microsoft_agents_hosting_core-0.8.0.dev3.tar.gz", hash = "sha256:8554f56563179414eb46f60afe1ce1a4a3afeadd254efe06813f60ff919b0cba", size = 94181, upload-time = "2026-02-12T09:07:05.007Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3e/32/c6a3609c7c03bf493834f07b65114c34efe68d3d1e6b943f0d0a5ecf56e9/microsoft_agents_hosting_core-0.8.0.dev3-py3-none-any.whl", hash = "sha256:2e96c4ca865387eb376ac81d75a7c6c6ce608f12c59d618a1a5c3344133763e1", size = 139600, upload-time = "2026-02-12T09:07:14.413Z" },
-]
-
-[[package]]
-name = "mistralai"
-version = "1.9.11"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "eval-type-backport" },
-    { name = "httpx" },
-    { name = "invoke" },
-    { name = "pydantic" },
-    { name = "python-dateutil" },
-    { name = "pyyaml" },
-    { name = "typing-inspection" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/5a/8d/d8b7af67a966b6f227024e1cb7287fc19901a434f87a5a391dcfe635d338/mistralai-1.9.11.tar.gz", hash = "sha256:3df9e403c31a756ec79e78df25ee73cea3eb15f86693773e16b16adaf59c9b8a", size = 208051, upload-time = "2025-10-02T15:53:40.473Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/fe/76/4ce12563aea5a76016f8643eff30ab731e6656c845e9e4d090ef10c7b925/mistralai-1.9.11-py3-none-any.whl", hash = "sha256:7a3dc2b8ef3fceaa3582220234261b5c4e3e03a972563b07afa150e44a25a6d3", size = 442796, upload-time = "2025-10-02T15:53:39.134Z" },
 ]
 
 [[package]]
@@ -4107,52 +3448,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/24/75/d30af27a2906f00eb90143470272376d728521997800f5dce5b340ba35bc/mkdocstrings_python-2.0.1.tar.gz", hash = "sha256:843a562221e6a471fefdd4b45cc6c22d2607ccbad632879234fa9692e9cf7732", size = 199345, upload-time = "2025-12-03T14:26:11.755Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/81/06/c5f8deba7d2cbdfa7967a716ae801aa9ca5f734b8f54fd473ef77a088dbe/mkdocstrings_python-2.0.1-py3-none-any.whl", hash = "sha256:66ecff45c5f8b71bf174e11d49afc845c2dfc7fc0ab17a86b6b337e0f24d8d90", size = 105055, upload-time = "2025-12-03T14:26:10.184Z" },
-]
-
-[[package]]
-name = "ml-dtypes"
-version = "0.5.4"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.4.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/0e/4a/c27b42ed9b1c7d13d9ba8b6905dece787d6259152f2309338aed29b2447b/ml_dtypes-0.5.4.tar.gz", hash = "sha256:8ab06a50fb9bf9666dd0fe5dfb4676fa2b0ac0f31ecff72a6c3af8e22c063453", size = 692314, upload-time = "2025-11-17T22:32:31.031Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/fe/3a/c5b855752a70267ff729c349e650263adb3c206c29d28cc8ea7ace30a1d5/ml_dtypes-0.5.4-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:b95e97e470fe60ed493fd9ae3911d8da4ebac16bd21f87ffa2b7c588bf22ea2c", size = 679735, upload-time = "2025-11-17T22:31:31.367Z" },
-    { url = "https://files.pythonhosted.org/packages/41/79/7433f30ee04bd4faa303844048f55e1eb939131c8e5195a00a96a0939b64/ml_dtypes-0.5.4-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b4b801ebe0b477be666696bda493a9be8356f1f0057a57f1e35cd26928823e5a", size = 5051883, upload-time = "2025-11-17T22:31:33.658Z" },
-    { url = "https://files.pythonhosted.org/packages/10/b1/8938e8830b0ee2e167fc75a094dea766a1152bde46752cd9bfc57ee78a82/ml_dtypes-0.5.4-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:388d399a2152dd79a3f0456a952284a99ee5c93d3e2f8dfe25977511e0515270", size = 5030369, upload-time = "2025-11-17T22:31:35.595Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/a3/51886727bd16e2f47587997b802dd56398692ce8c6c03c2e5bb32ecafe26/ml_dtypes-0.5.4-cp310-cp310-win_amd64.whl", hash = "sha256:4ff7f3e7ca2972e7de850e7b8fcbb355304271e2933dd90814c1cb847414d6e2", size = 210738, upload-time = "2025-11-17T22:31:37.43Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/5e/712092cfe7e5eb667b8ad9ca7c54442f21ed7ca8979745f1000e24cf8737/ml_dtypes-0.5.4-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:6c7ecb74c4bd71db68a6bea1edf8da8c34f3d9fe218f038814fd1d310ac76c90", size = 679734, upload-time = "2025-11-17T22:31:39.223Z" },
-    { url = "https://files.pythonhosted.org/packages/4f/cf/912146dfd4b5c0eea956836c01dcd2fce6c9c844b2691f5152aca196ce4f/ml_dtypes-0.5.4-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bc11d7e8c44a65115d05e2ab9989d1e045125d7be8e05a071a48bc76eb6d6040", size = 5056165, upload-time = "2025-11-17T22:31:41.071Z" },
-    { url = "https://files.pythonhosted.org/packages/a9/80/19189ea605017473660e43762dc853d2797984b3c7bf30ce656099add30c/ml_dtypes-0.5.4-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:19b9a53598f21e453ea2fbda8aa783c20faff8e1eeb0d7ab899309a0053f1483", size = 5034975, upload-time = "2025-11-17T22:31:42.758Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/24/70bd59276883fdd91600ca20040b41efd4902a923283c4d6edcb1de128d2/ml_dtypes-0.5.4-cp311-cp311-win_amd64.whl", hash = "sha256:7c23c54a00ae43edf48d44066a7ec31e05fdc2eee0be2b8b50dd1903a1db94bb", size = 210742, upload-time = "2025-11-17T22:31:44.068Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/c9/64230ef14e40aa3f1cb254ef623bf812735e6bec7772848d19131111ac0d/ml_dtypes-0.5.4-cp311-cp311-win_arm64.whl", hash = "sha256:557a31a390b7e9439056644cb80ed0735a6e3e3bb09d67fd5687e4b04238d1de", size = 160709, upload-time = "2025-11-17T22:31:46.557Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/b8/3c70881695e056f8a32f8b941126cf78775d9a4d7feba8abcb52cb7b04f2/ml_dtypes-0.5.4-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:a174837a64f5b16cab6f368171a1a03a27936b31699d167684073ff1c4237dac", size = 676927, upload-time = "2025-11-17T22:31:48.182Z" },
-    { url = "https://files.pythonhosted.org/packages/54/0f/428ef6881782e5ebb7eca459689448c0394fa0a80bea3aa9262cba5445ea/ml_dtypes-0.5.4-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a7f7c643e8b1320fd958bf098aa7ecf70623a42ec5154e3be3be673f4c34d900", size = 5028464, upload-time = "2025-11-17T22:31:50.135Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/cb/28ce52eb94390dda42599c98ea0204d74799e4d8047a0eb559b6fd648056/ml_dtypes-0.5.4-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9ad459e99793fa6e13bd5b7e6792c8f9190b4e5a1b45c63aba14a4d0a7f1d5ff", size = 5009002, upload-time = "2025-11-17T22:31:52.001Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/f0/0cfadd537c5470378b1b32bd859cf2824972174b51b873c9d95cfd7475a5/ml_dtypes-0.5.4-cp312-cp312-win_amd64.whl", hash = "sha256:c1a953995cccb9e25a4ae19e34316671e4e2edaebe4cf538229b1fc7109087b7", size = 212222, upload-time = "2025-11-17T22:31:53.742Z" },
-    { url = "https://files.pythonhosted.org/packages/16/2e/9acc86985bfad8f2c2d30291b27cd2bb4c74cea08695bd540906ed744249/ml_dtypes-0.5.4-cp312-cp312-win_arm64.whl", hash = "sha256:9bad06436568442575beb2d03389aa7456c690a5b05892c471215bfd8cf39460", size = 160793, upload-time = "2025-11-17T22:31:55.358Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/a1/4008f14bbc616cfb1ac5b39ea485f9c63031c4634ab3f4cf72e7541f816a/ml_dtypes-0.5.4-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:8c760d85a2f82e2bed75867079188c9d18dae2ee77c25a54d60e9cc79be1bc48", size = 676888, upload-time = "2025-11-17T22:31:56.907Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/b7/dff378afc2b0d5a7d6cd9d3209b60474d9819d1189d347521e1688a60a53/ml_dtypes-0.5.4-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ce756d3a10d0c4067172804c9cc276ba9cc0ff47af9078ad439b075d1abdc29b", size = 5036993, upload-time = "2025-11-17T22:31:58.497Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/33/40cd74219417e78b97c47802037cf2d87b91973e18bb968a7da48a96ea44/ml_dtypes-0.5.4-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:533ce891ba774eabf607172254f2e7260ba5f57bdd64030c9a4fcfbd99815d0d", size = 5010956, upload-time = "2025-11-17T22:31:59.931Z" },
-    { url = "https://files.pythonhosted.org/packages/e1/8b/200088c6859d8221454825959df35b5244fa9bdf263fd0249ac5fb75e281/ml_dtypes-0.5.4-cp313-cp313-win_amd64.whl", hash = "sha256:f21c9219ef48ca5ee78402d5cc831bd58ea27ce89beda894428bc67a52da5328", size = 212224, upload-time = "2025-11-17T22:32:01.349Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/75/dfc3775cb36367816e678f69a7843f6f03bd4e2bcd79941e01ea960a068e/ml_dtypes-0.5.4-cp313-cp313-win_arm64.whl", hash = "sha256:35f29491a3e478407f7047b8a4834e4640a77d2737e0b294d049746507af5175", size = 160798, upload-time = "2025-11-17T22:32:02.864Z" },
-    { url = "https://files.pythonhosted.org/packages/4f/74/e9ddb35fd1dd43b1106c20ced3f53c2e8e7fc7598c15638e9f80677f81d4/ml_dtypes-0.5.4-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:304ad47faa395415b9ccbcc06a0350800bc50eda70f0e45326796e27c62f18b6", size = 702083, upload-time = "2025-11-17T22:32:04.08Z" },
-    { url = "https://files.pythonhosted.org/packages/74/f5/667060b0aed1aa63166b22897fdf16dca9eb704e6b4bbf86848d5a181aa7/ml_dtypes-0.5.4-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6a0df4223b514d799b8a1629c65ddc351b3efa833ccf7f8ea0cf654a61d1e35d", size = 5354111, upload-time = "2025-11-17T22:32:05.546Z" },
-    { url = "https://files.pythonhosted.org/packages/40/49/0f8c498a28c0efa5f5c95a9e374c83ec1385ca41d0e85e7cf40e5d519a21/ml_dtypes-0.5.4-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:531eff30e4d368cb6255bc2328d070e35836aa4f282a0fb5f3a0cd7260257298", size = 5366453, upload-time = "2025-11-17T22:32:07.115Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/27/12607423d0a9c6bbbcc780ad19f1f6baa2b68b18ce4bddcdc122c4c68dc9/ml_dtypes-0.5.4-cp313-cp313t-win_amd64.whl", hash = "sha256:cb73dccfc991691c444acc8c0012bee8f2470da826a92e3a20bb333b1a7894e6", size = 225612, upload-time = "2025-11-17T22:32:08.615Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/80/5a5929e92c72936d5b19872c5fb8fc09327c1da67b3b68c6a13139e77e20/ml_dtypes-0.5.4-cp313-cp313t-win_arm64.whl", hash = "sha256:3bbbe120b915090d9dd1375e4684dd17a20a2491ef25d640a908281da85e73f1", size = 164145, upload-time = "2025-11-17T22:32:09.782Z" },
-    { url = "https://files.pythonhosted.org/packages/72/4e/1339dc6e2557a344f5ba5590872e80346f76f6cb2ac3dd16e4666e88818c/ml_dtypes-0.5.4-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:2b857d3af6ac0d39db1de7c706e69c7f9791627209c3d6dedbfca8c7e5faec22", size = 673781, upload-time = "2025-11-17T22:32:11.364Z" },
-    { url = "https://files.pythonhosted.org/packages/04/f9/067b84365c7e83bda15bba2b06c6ca250ce27b20630b1128c435fb7a09aa/ml_dtypes-0.5.4-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:805cef3a38f4eafae3a5bf9ebdcdb741d0bcfd9e1bd90eb54abd24f928cd2465", size = 5036145, upload-time = "2025-11-17T22:32:12.783Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/bb/82c7dcf38070b46172a517e2334e665c5bf374a262f99a283ea454bece7c/ml_dtypes-0.5.4-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:14a4fd3228af936461db66faccef6e4f41c1d82fcc30e9f8d58a08916b1d811f", size = 5010230, upload-time = "2025-11-17T22:32:14.38Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/93/2bfed22d2498c468f6bcd0d9f56b033eaa19f33320389314c19ef6766413/ml_dtypes-0.5.4-cp314-cp314-win_amd64.whl", hash = "sha256:8c6a2dcebd6f3903e05d51960a8058d6e131fe69f952a5397e5dbabc841b6d56", size = 221032, upload-time = "2025-11-17T22:32:15.763Z" },
-    { url = "https://files.pythonhosted.org/packages/76/a3/9c912fe6ea747bb10fe2f8f54d027eb265db05dfb0c6335e3e063e74e6e8/ml_dtypes-0.5.4-cp314-cp314-win_arm64.whl", hash = "sha256:5a0f68ca8fd8d16583dfa7793973feb86f2fbb56ce3966daf9c9f748f52a2049", size = 163353, upload-time = "2025-11-17T22:32:16.932Z" },
-    { url = "https://files.pythonhosted.org/packages/cd/02/48aa7d84cc30ab4ee37624a2fd98c56c02326785750cd212bc0826c2f15b/ml_dtypes-0.5.4-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:bfc534409c5d4b0bf945af29e5d0ab075eae9eecbb549ff8a29280db822f34f9", size = 702085, upload-time = "2025-11-17T22:32:18.175Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/e7/85cb99fe80a7a5513253ec7faa88a65306be071163485e9a626fce1b6e84/ml_dtypes-0.5.4-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2314892cdc3fcf05e373d76d72aaa15fda9fb98625effa73c1d646f331fcecb7", size = 5355358, upload-time = "2025-11-17T22:32:19.7Z" },
-    { url = "https://files.pythonhosted.org/packages/79/2b/a826ba18d2179a56e144aef69e57fb2ab7c464ef0b2111940ee8a3a223a2/ml_dtypes-0.5.4-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0d2ffd05a2575b1519dc928c0b93c06339eb67173ff53acb00724502cda231cf", size = 5366332, upload-time = "2025-11-17T22:32:21.193Z" },
-    { url = "https://files.pythonhosted.org/packages/84/44/f4d18446eacb20ea11e82f133ea8f86e2bf2891785b67d9da8d0ab0ef525/ml_dtypes-0.5.4-cp314-cp314t-win_amd64.whl", hash = "sha256:4381fe2f2452a2d7589689693d3162e876b3ddb0a832cde7a414f8e1adf7eab1", size = 236612, upload-time = "2025-11-17T22:32:22.579Z" },
-    { url = "https://files.pythonhosted.org/packages/ad/3f/3d42e9a78fe5edf792a83c074b13b9b770092a4fbf3462872f4303135f09/ml_dtypes-0.5.4-cp314-cp314t-win_arm64.whl", hash = "sha256:11942cbf2cf92157db91e5022633c0d9474d4dfd813a909383bd23ce828a4b7d", size = 168825, upload-time = "2025-11-17T22:32:23.766Z" },
 ]
 
 [[package]]
@@ -4286,29 +3581,59 @@ wheels = [
 ]
 
 [[package]]
-name = "msal"
-version = "1.34.0"
+name = "msgspec"
+version = "0.21.1"
 source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "cryptography" },
-    { name = "pyjwt", extra = ["crypto"] },
-    { name = "requests" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/cf/0e/c857c46d653e104019a84f22d4494f2119b4fe9f896c92b4b864b3b045cc/msal-1.34.0.tar.gz", hash = "sha256:76ba83b716ea5a6d75b0279c0ac353a0e05b820ca1f6682c0eb7f45190c43c2f", size = 153961, upload-time = "2025-09-22T23:05:48.989Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e3/60/f79b9b013a16fa3a58350c9295ddc6789f2e335f36ea61ed10a21b215364/msgspec-0.21.1.tar.gz", hash = "sha256:2313508e394b0d208f8f56892ca9b2799e2561329de9763b19619595a6c0f72c", size = 319193, upload-time = "2026-04-12T21:44:50.394Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c2/dc/18d48843499e278538890dc709e9ee3dea8375f8be8e82682851df1b48b5/msal-1.34.0-py3-none-any.whl", hash = "sha256:f669b1644e4950115da7a176441b0e13ec2975c29528d8b9e81316023676d6e1", size = 116987, upload-time = "2025-09-22T23:05:47.294Z" },
-]
-
-[[package]]
-name = "msal-extensions"
-version = "1.3.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "msal" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/01/99/5d239b6156eddf761a636bded1118414d161bd6b7b37a9335549ed159396/msal_extensions-1.3.1.tar.gz", hash = "sha256:c5b0fd10f65ef62b5f1d62f4251d51cbcaf003fcedae8c91b040a488614be1a4", size = 23315, upload-time = "2025-03-14T23:51:03.902Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/5e/75/bd9b7bb966668920f06b200e84454c8f3566b102183bc55c5473d96cb2b9/msal_extensions-1.3.1-py3-none-any.whl", hash = "sha256:96d3de4d034504e969ac5e85bae8106c8373b5c6568e4c8fa7af2eca9dbe6bca", size = 20583, upload-time = "2025-03-14T23:51:03.016Z" },
+    { url = "https://files.pythonhosted.org/packages/96/38/d591d9f66d43d897ecbd249f2833665823d19c8b043f16619bc8343e23df/msgspec-0.21.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:72d9cd03241b8b2edb2e12dcc66c500fa480d8cbd71a8bac105809d468882064", size = 195172, upload-time = "2026-04-12T21:43:45.062Z" },
+    { url = "https://files.pythonhosted.org/packages/69/1a/6899188b5982ec1324e0c629b7801eed2db987f6634fab58abd9fc82d317/msgspec-0.21.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:ed2ab278200e743a1d2610a4e0c8fc74f6cecb8548544cdec43f927bd9265238", size = 188316, upload-time = "2026-04-12T21:43:46.641Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/95/7e591b4fa11fdbbf9891164473c23420a8c781ef553295abe416bf335f42/msgspec-0.21.1-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dd677e3001fdfed9186de72eab434da2976303cd5eb9550921d3d0c3e3e168ce", size = 216565, upload-time = "2026-04-12T21:43:48.081Z" },
+    { url = "https://files.pythonhosted.org/packages/19/86/714feeaf3b84cf2027235681725593840153dedd2868578f9f2715e296bb/msgspec-0.21.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f667b90b37fad734a91671abd68e0d7f4d066862771b87e91c53996dcb7a9027", size = 222689, upload-time = "2026-04-12T21:43:49.385Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/b9/4384243e814f2579e5205e17d170b9c1a30121afd1393298d904817a7fa7/msgspec-0.21.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:49880fd20fdbcfe1b793f07dd83f12572bab679c9800352c8b2240289aa46a06", size = 222343, upload-time = "2026-04-12T21:43:50.612Z" },
+    { url = "https://files.pythonhosted.org/packages/04/01/4b227d9c4057346271043632bad41979cf8c3dca372e41bb1f7d546395b2/msgspec-0.21.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:ae0162e22849a5e91eaad907766525107523b0daea3df267a9fcb5ba4e0936ae", size = 225607, upload-time = "2026-04-12T21:43:52.129Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/ce/27021d1c3e5da837743092a7b7a5e8818397e1f4c05ee8b068bd7d1fd78a/msgspec-0.21.1-cp310-cp310-win_amd64.whl", hash = "sha256:f041a2279f31e3a53319005e4d60ba77c085cfcbe394cdc7ce803c2d01fe9449", size = 188392, upload-time = "2026-04-12T21:43:53.384Z" },
+    { url = "https://files.pythonhosted.org/packages/80/2b/daf7a8d6d7cf00e0dcd0439178b284ade701234abdcadf3385601da04fbd/msgspec-0.21.1-cp310-cp310-win_arm64.whl", hash = "sha256:1bf17cbd7b28a5dffc7e764c654eed8ccde5e0f1de7970628608304640d4ce4e", size = 174191, upload-time = "2026-04-12T21:43:54.6Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/7f/bbc4e74cd33d316b75541149e4d35b163b63bce066530ae185a2ec3b5bfc/msgspec-0.21.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:b504b6e7f7a22a24b27232b73034421692147865162daaec9f3bf62439007c87", size = 193131, upload-time = "2026-04-12T21:43:56.094Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/60/504886af1aaf854112663b842d5eea9a15d9588f9bf7d0d2df736424b84d/msgspec-0.21.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4692b7c1609155708c4418f88e92f63c13fdf08aa095c84bae82bad75b53389b", size = 186597, upload-time = "2026-04-12T21:43:57.242Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/54/d24ddeaa65b5278c9e67f48ce3c17a9831e8f3722f3c8322ee120aca22ef/msgspec-0.21.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d3124010b3815451494c85ff345e693cb9fe5889cfcbbef39ed8622e0e72319c", size = 215158, upload-time = "2026-04-12T21:43:58.442Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/75/bb79c8b89a93ae23cd33c0d802373f16feaf9633f05d8af77091350dda0a/msgspec-0.21.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6badc03b9725352219cca017bfe71c61f2fbd0fb5982b410ac17c97c213deb30", size = 219856, upload-time = "2026-04-12T21:44:00.015Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/9c/c5ca26b46f0ebbd3a6683695ef89396712cb9e4199fd1f0bc1dd968216b1/msgspec-0.21.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:5d2d4116ebe3035a78d9ec76e99a9d64e5fa6d44fe61a9c5de7fd1acf54bcc69", size = 220314, upload-time = "2026-04-12T21:44:01.548Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/31/645a351c4285dce40ed6755c3dcc0aa648e26dacb20a98018fe2cce5e87b/msgspec-0.21.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:0d1009f6715f5bff3b54d4ff5c7428ad96197e0534e1645b8e9b955890c84664", size = 223215, upload-time = "2026-04-12T21:44:02.884Z" },
+    { url = "https://files.pythonhosted.org/packages/09/af/8bf15736a6dd3cb4f90c5467f6dc39197d2daaf10754490cdc0aa17b7312/msgspec-0.21.1-cp311-cp311-win_amd64.whl", hash = "sha256:c6faffe5bb644ec884052679af4dfd776d4b5ca90e4a7ec7e7e319e4e6b93a6e", size = 188554, upload-time = "2026-04-12T21:44:04.151Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/29/cc7db3a165b62d16e64a83f82eccb79655055cb5bc1f60459a6f9d7c82f2/msgspec-0.21.1-cp311-cp311-win_arm64.whl", hash = "sha256:ee9e3f11fa94603f7d673bf795cfa31b549c4a2c723bc39b45beb1e7f5a3fb99", size = 174517, upload-time = "2026-04-12T21:44:05.66Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/cf/317224852c00248c620a9bcf4b26e2e4ab8afd752f18d2a6ef73ebd423b6/msgspec-0.21.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d4248cf0b6129b7d230eacd493c17cc2d4f3989f3bb7f633a928a85b7dcfa251", size = 196188, upload-time = "2026-04-12T21:44:07.181Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/81/074612945c0666078f7366f40000013de9f6ba687491d450df699bceebc9/msgspec-0.21.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:5102c7e9b3acff82178449b85006d96310e690291bb1ea0142f1b24bcb8aabcb", size = 188473, upload-time = "2026-04-12T21:44:08.736Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/37/655101799590bcc5fddb2bd3fe0e6194e816c2d1da7c361725f5eb89a910/msgspec-0.21.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:846758412e9518252b2ac9bffd6f0e54d9ff614f5f9488df7749f81ff5c80920", size = 218871, upload-time = "2026-04-12T21:44:09.917Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/d1/d4cd9fe89c7d400d7a18f86ccc94daa3f0927f53558846fcb60791dce5d6/msgspec-0.21.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:21995e74b5c598c2e004110ad66ec7f1b8c20bf2bcf3b2de8fd9a3094422d3ff", size = 225025, upload-time = "2026-04-12T21:44:11.191Z" },
+    { url = "https://files.pythonhosted.org/packages/24/bf/e20549e602b9edccadeeff98760345a416f9cce846a657e8b18e3396b212/msgspec-0.21.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:6129f0cca52992e898fd5344187f7c8127b63d810b2fd73e36fca73b4c6475ee", size = 222672, upload-time = "2026-04-12T21:44:12.481Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/68/04d7a8f0f786545cf9b8c280c57aa6befb5977af6e884b8b54191cbe44b3/msgspec-0.21.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:ef3ec2296248d1f8b9231acb051b6d471dfde8f21819e86c9adaaa9f42918521", size = 227303, upload-time = "2026-04-12T21:44:13.709Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/4d/619866af2840875be408047bf9e70ceafbae6ab50660de7134ed1b25eb86/msgspec-0.21.1-cp312-cp312-win_amd64.whl", hash = "sha256:d4ab834a054c6f0cbeef6df9e7e1b33d5f1bc7b86dea1d2fd7cad003873e783d", size = 190017, upload-time = "2026-04-12T21:44:14.977Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/2e/a8f9eca8fd00e097d7a9e99ba8a4685db994494448e3d4f0b7f6e9a3c0f7/msgspec-0.21.1-cp312-cp312-win_arm64.whl", hash = "sha256:628aaa35c74950a8c59da330d7e98917e1c7188f983745782027748ee4ca573e", size = 175345, upload-time = "2026-04-12T21:44:16.431Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/74/f11ede02839b19ff459f88e3145df5d711626ca84da4e23520cebf819367/msgspec-0.21.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:764173717a01743f007e9f74520ed281f24672c604514f7d76c1c3a10e8edb66", size = 196176, upload-time = "2026-04-12T21:44:17.613Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/40/4476c1bd341418a046c4955aff632ec769315d1e3cb94e6acf86d461f9ed/msgspec-0.21.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:344c7cd0eaed1fb81d7959f99100ef71ec9b536881a376f11b9a6c4803365697", size = 188524, upload-time = "2026-04-12T21:44:18.815Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/d9/9e9d7d7e5061b47540d03d640fab9b3965ba7ae49c1b2154861c8f007518/msgspec-0.21.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:48943e278b3854c2f89f955ddc6f9f430d3f0784b16e47d10604ee0463cd21f5", size = 218880, upload-time = "2026-04-12T21:44:20.028Z" },
+    { url = "https://files.pythonhosted.org/packages/74/66/2bb344f34abb4b57e60c7c9c761994e0417b9718ec1460bf00c296f2a7ea/msgspec-0.21.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a9aa659ebb0101b1cbc31461212b87e341d961f0ab0772aaf068a99e001ec4aa", size = 225050, upload-time = "2026-04-12T21:44:21.577Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/84/7c1e412f76092277bf760cef12b7979d03314d259ab5b5cafde5d0c1722d/msgspec-0.21.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7b27d1a8ead2b6f5b0c4f2d07b8be1ccfcc041c8a0e704781edebe3ae13c484", size = 222713, upload-time = "2026-04-12T21:44:22.83Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/27/0bba04b2b4ef05f3d068429410bc71d2cea925f1596a8f41152cccd5edb8/msgspec-0.21.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:38fe93e86b61328fe544cb7fd871fad5a27c8734bfda90f65e5dbe288ae50f61", size = 227259, upload-time = "2026-04-12T21:44:24.11Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/2d/09574b0eea02fed2c2c1383dbaae2c7f79dc16dcd6487a886000afb5d7c4/msgspec-0.21.1-cp313-cp313-win_amd64.whl", hash = "sha256:8bc666331c35fcce05a7cd2d6221adbe0f6058f8e750711413d22793c080ac6a", size = 189857, upload-time = "2026-04-12T21:44:25.359Z" },
+    { url = "https://files.pythonhosted.org/packages/46/34/105b1576ad182879914f0c821f17ee1d13abb165cb060448f96fe2aff078/msgspec-0.21.1-cp313-cp313-win_arm64.whl", hash = "sha256:42bb1241e0750c1a4346f2aa84db26c5ffd99a4eb3a954927d9f149ff2f42898", size = 175403, upload-time = "2026-04-12T21:44:26.608Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/ad/86954e987d1d6a5c579e2c2e7832b65e0fff194179fdac4f581536086024/msgspec-0.21.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:fab48eb45fdbfbdb2c0edfec00ffc53b6b6085beefc6b50b61e01659f9f8757f", size = 196261, upload-time = "2026-04-12T21:44:27.807Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/a1/c5e46c3e42b866199365e35d11dddfd1fbd8bba4fdb3c52f965b1607ce94/msgspec-0.21.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:3cb779ea0c35bc807ff941d415875c1f69ca0be91a2e907ab99a171811d86a9a", size = 188729, upload-time = "2026-04-12T21:44:28.99Z" },
+    { url = "https://files.pythonhosted.org/packages/85/7d/1e29a319d678d6cb962ae5bdf32a6858ebdf38f73bc654c0e9c742a0c2c8/msgspec-0.21.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:68604db36b3b4dd9bf160e436e12798a4738848144cea1aca1cb984011eb160f", size = 219866, upload-time = "2026-04-12T21:44:31.104Z" },
+    { url = "https://files.pythonhosted.org/packages/25/1f/cca084ca2572810fff12ea9dbdcbe39eac048f40daf4a9077b49fcbe8cee/msgspec-0.21.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3d6b9dc50948eaf65df54d2fd0ff66e6d8c32f116037209ee861810eb9b676cb", size = 224993, upload-time = "2026-04-12T21:44:32.649Z" },
+    { url = "https://files.pythonhosted.org/packages/71/94/d2120fc9d419a89a3a7c13e5b7078798c4b392a96a02a6e2b3ce43a8766c/msgspec-0.21.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:52c5e21930942302394429c5a582ce7e6b62c7f983b3760834c2ce107e0dd6df", size = 223535, upload-time = "2026-04-12T21:44:33.839Z" },
+    { url = "https://files.pythonhosted.org/packages/75/17/42418b66a3ad972a89bab73dd78b79cc6282bb488a25e73c853cee7443b9/msgspec-0.21.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:abbb39d65681fa24ed394e01af3d59d869068324f900c61d06062b7fb9980f2f", size = 227222, upload-time = "2026-04-12T21:44:35.093Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/33/265c894268cca88ff67b144ca2b4c522fc8b9a6f1966a3640c70516e78e1/msgspec-0.21.1-cp314-cp314-win_amd64.whl", hash = "sha256:5666b1b560b97b6ec2eb3fca8a502298ebac56e13bbca1f88523538ce83d01ea", size = 193810, upload-time = "2026-04-12T21:44:36.612Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/8f/a6d35f25bf1fc63c492fdd88fdce01ba0875ead48c2b91f90f33653b4131/msgspec-0.21.1-cp314-cp314-win_arm64.whl", hash = "sha256:d8b8578e4c83b14ceea4cef0d0b747e31d9330fe4b03b2b2ad4063866a178f93", size = 179125, upload-time = "2026-04-12T21:44:38.198Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/39/74839641e64b99d87da55af0fc472854d42b46e2183b9e2a67fe1bb2a512/msgspec-0.21.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:15f523d51c00ebad412213bfe9f06f0a50ec2b93e0c19e824a2d267cabb48ea2", size = 200171, upload-time = "2026-04-12T21:44:39.414Z" },
+    { url = "https://files.pythonhosted.org/packages/70/9b/ce0cca6d2d87fcd4b6ff97600790494e64f26a2c55d61507cd2755c16193/msgspec-0.21.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:4e47390360583ba3d5c6cb44cf0a9f61b0a06a899d3c2c00627cedebb2e2884b", size = 192879, upload-time = "2026-04-12T21:44:40.882Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/08/673a7bb05e5702dc787ddd3011195b509f9867927970da59052211929987/msgspec-0.21.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f60800e6299b798142dc40b0644da77ceac5ea0568be58228417eae14135c847", size = 226281, upload-time = "2026-04-12T21:44:42.181Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/45/86508cf57283e9070b3c447e3ab25b792a7a0855a3ea4e0c6d111ac34c97/msgspec-0.21.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5f8e9dfcd98419cf7568808470c4317a3fb30bef0e3715b568730a2b272a20d7", size = 229863, upload-time = "2026-04-12T21:44:43.442Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/62/e7c9367cd08d590559faacd711edbae36840342843e669440363f33c7d36/msgspec-0.21.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:92d89dfad13bd1ea640dc3e37e724ed380da1030b272bdf5ecafb983c3ad7c75", size = 230445, upload-time = "2026-04-12T21:44:44.806Z" },
+    { url = "https://files.pythonhosted.org/packages/42/b4/c0f54632103846b658a10930025f4de41c8724b5e4805a5f3b395586cb7e/msgspec-0.21.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:0d03867786e5d7ba25d666df4b11320c27170f4aeafcb8e3a8b0a50a4fb742ca", size = 231822, upload-time = "2026-04-12T21:44:46.343Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/1d/0d85cc79d0ccf5508e9c846cc66552a6a16bf92abd1dbd8362617f7b35cd/msgspec-0.21.1-cp314-cp314t-win_amd64.whl", hash = "sha256:740fbf1c9d59992ca3537d6fbe9ebbf9eaf726a65fbf31448e0ecbc710697a63", size = 206650, upload-time = "2026-04-12T21:44:47.601Z" },
+    { url = "https://files.pythonhosted.org/packages/90/91/56c5d560f20e6c20e9e4f55bd0e458f7f162aa689ee350346c04c48eac0b/msgspec-0.21.1-cp314-cp314t-win_arm64.whl", hash = "sha256:0d2cc73df6058d811a126ac3a8ad63a4dfa210c82f9cf5a004802eaf4712de90", size = 183149, upload-time = "2026-04-12T21:44:48.833Z" },
 ]
 
 [[package]]
@@ -4582,14 +3907,14 @@ wheels = [
 
 [[package]]
 name = "neo4j"
-version = "6.1.0"
+version = "6.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pytz" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1b/01/d6ce65e4647f6cb2b9cca3b813978f7329b54b4e36660aaec1ddf0ccce7a/neo4j-6.1.0.tar.gz", hash = "sha256:b5dde8c0d8481e7b6ae3733569d990dd3e5befdc5d452f531ad1884ed3500b84", size = 239629, upload-time = "2026-01-12T11:27:34.777Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9d/57/f939c3b9b28e5851095eafb823b5a996eea3f21a14be513bcf9b355f97da/neo4j-6.3.0.tar.gz", hash = "sha256:d0d3986c37ad174a549a39dfec6d22a00a061ebcb0267f1a5caf856589838e73", size = 242487, upload-time = "2026-08-28T10:25:04.743Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/70/5c/ee71e2dd955045425ef44283f40ba1da67673cf06404916ca2950ac0cd39/neo4j-6.1.0-py3-none-any.whl", hash = "sha256:3bd93941f3a3559af197031157220af9fd71f4f93a311db687bd69ffa417b67d", size = 325326, upload-time = "2026-01-12T11:27:33.196Z" },
+    { url = "https://files.pythonhosted.org/packages/47/47/d29d93455fe2959e5b8383e52f68b3633d729f39e87fef94743f9f2240ae/neo4j-6.3.0-py3-none-any.whl", hash = "sha256:d243f9c8adf882ae7205a76eb2419b0a632d5f3c89383d4a0044d737a2223991", size = 331471, upload-time = "2026-08-28T10:25:03.263Z" },
 ]
 
 [[package]]
@@ -4605,14 +3930,14 @@ dependencies = [
 
 [package.optional-dependencies]
 all = [
-    { name = "agent-framework" },
+    { name = "agent-framework-core" },
     { name = "anthropic" },
     { name = "crewai" },
     { name = "langchain-core" },
     { name = "litellm" },
     { name = "llama-index-core" },
     { name = "openai" },
-    { name = "pydantic-ai" },
+    { name = "pydantic-ai-slim", extra = ["openai"] },
     { name = "rapidfuzz" },
 ]
 anthropic = [
@@ -4636,7 +3961,7 @@ extraction = [
     { name = "spacy" },
 ]
 full = [
-    { name = "agent-framework" },
+    { name = "agent-framework-core" },
     { name = "anthropic" },
     { name = "crewai" },
     { name = "gliner" },
@@ -4645,7 +3970,7 @@ full = [
     { name = "litellm" },
     { name = "llama-index-core" },
     { name = "openai" },
-    { name = "pydantic-ai" },
+    { name = "pydantic-ai-slim", extra = ["openai"] },
     { name = "rapidfuzz" },
     { name = "sentence-transformers" },
     { name = "spacy" },
@@ -4658,14 +3983,20 @@ gliner = [
 ]
 google = [
     { name = "google-cloud-aiplatform" },
+    { name = "google-genai" },
 ]
 google-adk = [
     { name = "google-adk" },
+    { name = "google-genai" },
 ]
 instructor = [
     { name = "instructor" },
 ]
 langchain = [
+    { name = "langchain-core" },
+]
+langchain-agents = [
+    { name = "langchain" },
     { name = "langchain-core" },
 ]
 litellm = [
@@ -4678,7 +4009,7 @@ mcp = [
     { name = "fastmcp" },
 ]
 microsoft-agent = [
-    { name = "agent-framework" },
+    { name = "agent-framework-core" },
 ]
 nams = [
     { name = "httpx" },
@@ -4702,7 +4033,7 @@ opik = [
     { name = "opik" },
 ]
 pydantic-ai = [
-    { name = "pydantic-ai" },
+    { name = "pydantic-ai-slim", extra = ["openai"] },
 ]
 sentence-transformers = [
     { name = "sentence-transformers" },
@@ -4716,6 +4047,7 @@ strands = [
 ]
 vertex-ai = [
     { name = "google-cloud-aiplatform" },
+    { name = "google-genai" },
 ]
 
 [package.dev-dependencies]
@@ -4729,6 +4061,7 @@ dev = [
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "pytest-timeout" },
+    { name = "python-dotenv" },
     { name = "respx" },
     { name = "ruff" },
     { name = "testcontainers", extra = ["neo4j"] },
@@ -4743,29 +4076,34 @@ docs = [
 
 [package.metadata]
 requires-dist = [
-    { name = "agent-framework", marker = "extra == 'microsoft-agent'", specifier = ">=1.0.0b260212" },
-    { name = "anthropic", marker = "extra == 'anthropic'", specifier = ">=0.20.0" },
+    { name = "agent-framework-core", marker = "extra == 'microsoft-agent'", specifier = ">=1.13,<2" },
+    { name = "anthropic", marker = "extra == 'anthropic'", specifier = ">=1.0,<2" },
     { name = "boto3", marker = "extra == 'aws'", specifier = ">=1.26.0" },
     { name = "boto3", marker = "extra == 'bedrock'", specifier = ">=1.26.0" },
     { name = "boto3", marker = "extra == 'strands'", specifier = ">=1.26.0" },
     { name = "click", marker = "extra == 'cli'", specifier = ">=8.0.0" },
-    { name = "crewai", marker = "extra == 'crewai'", specifier = ">=0.50.0" },
-    { name = "fastmcp", marker = "extra == 'mcp'", specifier = ">=2.0.0,<3" },
+    { name = "crewai", marker = "extra == 'crewai'", specifier = ">=1.0,<2" },
+    { name = "fastmcp", marker = "extra == 'mcp'", specifier = ">=4.0,<5" },
     { name = "gliner", marker = "extra == 'extraction'", specifier = ">=0.2.0" },
     { name = "gliner", marker = "extra == 'gliner'", specifier = ">=0.2.0" },
-    { name = "google-adk", marker = "extra == 'google-adk'", specifier = ">=0.1.0" },
-    { name = "google-cloud-aiplatform", marker = "extra == 'google'", specifier = ">=1.38.0" },
-    { name = "google-cloud-aiplatform", marker = "extra == 'vertex-ai'", specifier = ">=1.38.0" },
+    { name = "google-adk", marker = "extra == 'google-adk'", specifier = ">=2.0,<3" },
+    { name = "google-cloud-aiplatform", marker = "extra == 'google'", specifier = ">=2.0,<3" },
+    { name = "google-cloud-aiplatform", marker = "extra == 'vertex-ai'", specifier = ">=2.0,<3" },
+    { name = "google-genai", marker = "extra == 'google'", specifier = ">=1.66" },
+    { name = "google-genai", marker = "extra == 'google-adk'", specifier = ">=1.0" },
+    { name = "google-genai", marker = "extra == 'vertex-ai'", specifier = ">=1.66" },
     { name = "httpx", marker = "extra == 'nams'", specifier = ">=0.27.0" },
-    { name = "instructor", marker = "extra == 'instructor'", specifier = ">=1.7.0" },
-    { name = "langchain-core", marker = "extra == 'langchain'", specifier = ">=0.2.0" },
-    { name = "litellm", marker = "extra == 'litellm'", specifier = ">=1.50.0,<2.0" },
-    { name = "llama-index-core", marker = "extra == 'llamaindex'", specifier = ">=0.10.0" },
-    { name = "neo4j", specifier = ">=5.20.0" },
+    { name = "instructor", marker = "extra == 'instructor'", specifier = ">=1.7,<2" },
+    { name = "langchain", marker = "extra == 'langchain-agents'", specifier = ">=1.0,<2" },
+    { name = "langchain-core", marker = "extra == 'langchain'", specifier = ">=1.0,<2" },
+    { name = "langchain-core", marker = "extra == 'langchain-agents'", specifier = ">=1.0,<2" },
+    { name = "litellm", marker = "extra == 'litellm'", specifier = ">=1.50,<2" },
+    { name = "llama-index-core", marker = "extra == 'llamaindex'", specifier = ">=0.14,<1" },
+    { name = "neo4j", specifier = ">=5.20,<7" },
     { name = "neo4j-agent-memory", extras = ["all", "sentence-transformers", "spacy", "gliner", "instructor"], marker = "extra == 'full'" },
     { name = "neo4j-agent-memory", extras = ["openai", "anthropic", "litellm", "fuzzy", "langchain", "llamaindex", "pydantic-ai", "crewai", "openai-agents", "microsoft-agent"], marker = "extra == 'all'" },
-    { name = "openai", marker = "extra == 'openai'", specifier = ">=1.0.0" },
-    { name = "openai", marker = "extra == 'openai-agents'", specifier = ">=1.0.0" },
+    { name = "openai", marker = "extra == 'openai'", specifier = ">=2.0,<4" },
+    { name = "openai", marker = "extra == 'openai-agents'", specifier = ">=2.0,<4" },
     { name = "opentelemetry-api", marker = "extra == 'observability'", specifier = ">=1.20.0" },
     { name = "opentelemetry-api", marker = "extra == 'opentelemetry'", specifier = ">=1.20.0" },
     { name = "opentelemetry-exporter-otlp", marker = "extra == 'opentelemetry'", specifier = ">=1.20.0" },
@@ -4773,22 +4111,22 @@ requires-dist = [
     { name = "opentelemetry-sdk", marker = "extra == 'opentelemetry'", specifier = ">=1.20.0" },
     { name = "opik", marker = "extra == 'opik'", specifier = ">=1.0.0" },
     { name = "pydantic", specifier = ">=2.0.0" },
-    { name = "pydantic-ai", marker = "extra == 'pydantic-ai'", specifier = ">=0.1.0" },
+    { name = "pydantic-ai-slim", extras = ["openai"], marker = "extra == 'pydantic-ai'", specifier = ">=2.0,<3" },
     { name = "pydantic-settings", specifier = ">=2.0.0" },
     { name = "rapidfuzz", marker = "extra == 'fuzzy'", specifier = ">=3.0.0" },
     { name = "rich", marker = "extra == 'cli'", specifier = ">=13.0.0" },
-    { name = "sentence-transformers", marker = "extra == 'sentence-transformers'", specifier = ">=2.2.0" },
+    { name = "sentence-transformers", marker = "extra == 'sentence-transformers'", specifier = ">=3.0,<7" },
     { name = "spacy", marker = "extra == 'extraction'", specifier = ">=3.7.0" },
     { name = "spacy", marker = "extra == 'spacy'", specifier = ">=3.7.0" },
-    { name = "strands-agents", marker = "extra == 'strands'", specifier = ">=1.44.0" },
+    { name = "strands-agents", marker = "extra == 'strands'", specifier = ">=1.52,<2" },
     { name = "typing-extensions", specifier = ">=4.4" },
 ]
-provides-extras = ["openai", "anthropic", "sentence-transformers", "vertex-ai", "bedrock", "litellm", "instructor", "google", "aws", "strands", "spacy", "gliner", "extraction", "fuzzy", "cli", "opentelemetry", "opik", "observability", "langchain", "llamaindex", "pydantic-ai", "crewai", "openai-agents", "microsoft-agent", "mcp", "google-adk", "nams", "all", "full"]
+provides-extras = ["openai", "anthropic", "sentence-transformers", "vertex-ai", "bedrock", "litellm", "instructor", "google", "aws", "strands", "spacy", "gliner", "extraction", "fuzzy", "cli", "opentelemetry", "opik", "observability", "langchain", "langchain-agents", "llamaindex", "pydantic-ai", "crewai", "openai-agents", "microsoft-agent", "mcp", "google-adk", "nams", "all", "full"]
 
 [package.metadata.requires-dev]
 dev = [
     { name = "beautifulsoup4", specifier = ">=4.12.0" },
-    { name = "fastmcp", specifier = ">=2.0.0,<3" },
+    { name = "fastmcp", specifier = ">=4.0,<5" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "mypy", specifier = ">=1.8.0" },
     { name = "pre-commit", specifier = ">=3.6.0" },
@@ -4796,6 +4134,7 @@ dev = [
     { name = "pytest-asyncio", specifier = ">=0.23.0" },
     { name = "pytest-cov", specifier = ">=4.1.0" },
     { name = "pytest-timeout", specifier = ">=2.3.0" },
+    { name = "python-dotenv", specifier = ">=1.0" },
     { name = "respx", specifier = ">=0.21.0" },
     { name = "ruff", specifier = ">=0.3.0" },
     { name = "testcontainers", extras = ["neo4j"], specifier = ">=4.0.0" },
@@ -4845,30 +4184,19 @@ wheels = [
 ]
 
 [[package]]
-name = "nexus-rpc"
-version = "1.2.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/06/50/95d7bc91f900da5e22662c82d9bf0f72a4b01f2a552708bf2f43807707a1/nexus_rpc-1.2.0.tar.gz", hash = "sha256:b4ddaffa4d3996aaeadf49b80dfcdfbca48fe4cb616defaf3b3c5c2c8fc61890", size = 74142, upload-time = "2025-11-17T19:17:06.798Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/13/04/eaac430d0e6bf21265ae989427d37e94be5e41dc216879f1fbb6c5339942/nexus_rpc-1.2.0-py3-none-any.whl", hash = "sha256:977876f3af811ad1a09b2961d3d1ac9233bda43ff0febbb0c9906483b9d9f8a3", size = 28166, upload-time = "2025-11-17T19:17:05.64Z" },
-]
-
-[[package]]
 name = "nltk"
-version = "3.9.2"
+version = "3.10.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
+    { name = "defusedxml" },
     { name = "joblib" },
     { name = "regex" },
     { name = "tqdm" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f9/76/3a5e4312c19a028770f86fd7c058cf9f4ec4321c6cf7526bab998a5b683c/nltk-3.9.2.tar.gz", hash = "sha256:0f409e9b069ca4177c1903c3e843eef90c7e92992fa4931ae607da6de49e1419", size = 2887629, upload-time = "2025-10-01T07:19:23.764Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/e6/fe51d2bb1a3b446f59c5c8165999a9fee208bc346af90a7cbf7657bc0d75/nltk-3.10.3.tar.gz", hash = "sha256:bb9327a461c3811c2fa4900e03840401f2126adfb30c0072827c433bd2444ea4", size = 5137152, upload-time = "2026-08-12T23:46:37.258Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/60/90/81ac364ef94209c100e12579629dc92bf7a709a84af32f8c551b02c07e94/nltk-3.9.2-py3-none-any.whl", hash = "sha256:1e209d2b3009110635ed9709a67a1a3e33a10f799490fa71cf4bec218c11c88a", size = 1513404, upload-time = "2025-10-01T07:19:21.648Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/6d/ebd2af4640b12168fdf0cb74b6118df2f32a2f62ec7e0c06fbfd80706639/nltk-3.10.3-py3-none-any.whl", hash = "sha256:ff9598a8e20518ee0d557745890cc4435b9578489e2dcbc69c4f81fa060caf7c", size = 1798643, upload-time = "2026-08-12T23:44:13.478Z" },
 ]
 
 [[package]]
@@ -5174,19 +4502,6 @@ wheels = [
 ]
 
 [[package]]
-name = "ollama"
-version = "0.6.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "httpx" },
-    { name = "pydantic" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/9d/5a/652dac4b7affc2b37b95386f8ae78f22808af09d720689e3d7a86b6ed98e/ollama-0.6.1.tar.gz", hash = "sha256:478c67546836430034b415ed64fa890fd3d1ff91781a9d548b3325274e69d7c6", size = 51620, upload-time = "2025-11-13T23:02:17.416Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/47/4f/4a617ee93d8208d2bcf26b2d8b9402ceaed03e3853c754940e2290fed063/ollama-0.6.1-py3-none-any.whl", hash = "sha256:fc4c984b345735c5486faeee67d8a265214a31cbb828167782dc642ce0a2bf8c", size = 14354, upload-time = "2025-11-13T23:02:16.292Z" },
-]
-
-[[package]]
 name = "onnxruntime"
 version = "1.23.2"
 source = { registry = "https://pypi.org/simple" }
@@ -5196,7 +4511,8 @@ dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.4.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "packaging" },
-    { name = "protobuf" },
+    { name = "protobuf", version = "5.29.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
+    { name = "protobuf", version = "6.33.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
     { name = "sympy" },
 ]
 wheels = [
@@ -5226,7 +4542,7 @@ wheels = [
 
 [[package]]
 name = "openai"
-version = "2.15.0"
+version = "2.54.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -5238,43 +4554,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/94/f4/4690ecb5d70023ce6bfcfeabfe717020f654bde59a775058ec6ac4692463/openai-2.15.0.tar.gz", hash = "sha256:42eb8cbb407d84770633f31bf727d4ffb4138711c670565a41663d9439174fba", size = 627383, upload-time = "2026-01-09T22:10:08.603Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/50/9a/8c75e8c8a5b407a0586faeb2afac91674ff955c191ecc1d6d3b6669f6788/openai-2.54.0.tar.gz", hash = "sha256:e3e6f8bc1ba30ddf381ace1a14340eed381cb984a1a59bd0f34b5be3b5d49cfa", size = 1100285, upload-time = "2026-08-11T18:46:59.035Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b5/df/c306f7375d42bafb379934c2df4c2fa3964656c8c782bac75ee10c102818/openai-2.15.0-py3-none-any.whl", hash = "sha256:6ae23b932cd7230f7244e52954daa6602716d6b9bf235401a107af731baea6c3", size = 1067879, upload-time = "2026-01-09T22:10:06.446Z" },
-]
-
-[[package]]
-name = "openai-agents"
-version = "0.8.3"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "griffe" },
-    { name = "mcp" },
-    { name = "openai" },
-    { name = "pydantic" },
-    { name = "requests" },
-    { name = "types-requests" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/00/6b/f86002a00f16b387b0570860e461475660d81eb00e2817391926d3947933/openai_agents-0.8.3.tar.gz", hash = "sha256:07a6e900b0fe4b7fd8f91a06ed9ab4fec9df335ed676f1c9e1125f60cb57919b", size = 2378346, upload-time = "2026-02-10T00:11:07.048Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7b/38/d77602daf5308395ee067954ffa7e96cb9ecf9292ad3b5f398f1c77e0b36/openai_agents-0.8.3-py3-none-any.whl", hash = "sha256:e562ec1a70177abaa34ca6f0428241a9dbeb6b3d73f88a7f4ba3ee3d72b3b98d", size = 378042, upload-time = "2026-02-10T00:11:04.967Z" },
-]
-
-[[package]]
-name = "openai-chatkit"
-version = "1.6.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "jinja2" },
-    { name = "openai" },
-    { name = "openai-agents" },
-    { name = "pydantic" },
-    { name = "uvicorn" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/d7/77/ddf5b0a49dc9b42af005e544ad521892b79519c491fae5cbbaa28f071b40/openai_chatkit-1.6.1.tar.gz", hash = "sha256:470b97db391f199984de04c93bd461d2311c38a3ed19b35c56f9bd40b47e1d08", size = 61046, upload-time = "2026-02-17T18:51:51.442Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/44/22/3f9ffe41ee15756509360828ffbf243fe02e6c2eb9c9f77c3b0382768490/openai_chatkit-1.6.1-py3-none-any.whl", hash = "sha256:1c7e1e33742b88ec5715133d79f0e751406577d51d22aad8fbbf979923aaa36b", size = 42291, upload-time = "2026-02-17T18:51:50.3Z" },
+    { url = "https://files.pythonhosted.org/packages/64/a8/bb76c7356de8ad57f59d5ff993d434df0607f07f08bcc9c9a5c275e399c0/openai-2.54.0-py3-none-any.whl", hash = "sha256:89089789197ccdb87f173a03145ed1598d00795220c93e96cf712b1cbf5e5f2b", size = 1660351, upload-time = "2026-08-11T18:46:56.684Z" },
 ]
 
 [[package]]
@@ -5303,60 +4585,44 @@ wheels = [
 
 [[package]]
 name = "opentelemetry-api"
-version = "1.39.1"
+version = "1.43.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "importlib-metadata" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/97/b9/3161be15bb8e3ad01be8be5a968a9237c3027c5be504362ff800fca3e442/opentelemetry_api-1.39.1.tar.gz", hash = "sha256:fbde8c80e1b937a2c61f20347e91c0c18a1940cecf012d62e65a7caf08967c9c", size = 65767, upload-time = "2025-12-11T13:32:39.182Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ae/cc/e4c9584181f86494df0f6bdec1a4f3280c50db44704dc2a407e994fc87bb/opentelemetry_api-1.43.0.tar.gz", hash = "sha256:107d0d03857ea8fc7c5fcbbbd83f800c281f0d560553d61c1d675fccfd1761c1", size = 73476, upload-time = "2026-06-24T15:19:55.323Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cf/df/d3f1ddf4bb4cb50ed9b1139cc7b1c54c34a1e7ce8fd1b9a37c0d1551a6bd/opentelemetry_api-1.39.1-py3-none-any.whl", hash = "sha256:2edd8463432a7f8443edce90972169b195e7d6a05500cd29e6d13898187c9950", size = 66356, upload-time = "2025-12-11T13:32:17.304Z" },
-]
-
-[[package]]
-name = "opentelemetry-exporter-gcp-trace"
-version = "1.11.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "google-cloud-trace" },
-    { name = "opentelemetry-api" },
-    { name = "opentelemetry-resourcedetector-gcp" },
-    { name = "opentelemetry-sdk" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/10/9c/4c3b26e5494f8b53c7873732a2317df905abe2b8ab33e9edfcbd5a8ff79b/opentelemetry_exporter_gcp_trace-1.11.0.tar.gz", hash = "sha256:c947ab4ab53e16517ade23d6fe71fe88cf7ca3f57a42c9f0e4162d2b929fecb6", size = 18770, upload-time = "2025-11-04T19:32:15.109Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/5f/4a/876703e8c5845198d95cd4006c8d1b2e3b129a9e288558e33133360f8d5d/opentelemetry_exporter_gcp_trace-1.11.0-py3-none-any.whl", hash = "sha256:b3dcb314e1a9985e9185cb7720b693eb393886fde98ae4c095ffc0893de6cefa", size = 14016, upload-time = "2025-11-04T19:32:09.009Z" },
+    { url = "https://files.pythonhosted.org/packages/17/83/6dba32b85f31868400440dc7ad2ca1eab94cbbf3a7b0459ed39f8311a9e2/opentelemetry_api-1.43.0-py3-none-any.whl", hash = "sha256:20acf45e9b21851926835292e4045d290acade1edd2ff3de86d2f069687ba1fd", size = 61912, upload-time = "2026-06-24T15:19:35.434Z" },
 ]
 
 [[package]]
 name = "opentelemetry-exporter-otlp"
-version = "1.39.1"
+version = "1.43.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-exporter-otlp-proto-grpc" },
     { name = "opentelemetry-exporter-otlp-proto-http" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/30/9c/3ab1db90f32da200dba332658f2bbe602369e3d19f6aba394031a42635be/opentelemetry_exporter_otlp-1.39.1.tar.gz", hash = "sha256:7cf7470e9fd0060c8a38a23e4f695ac686c06a48ad97f8d4867bc9b420180b9c", size = 6147, upload-time = "2025-12-11T13:32:40.309Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/47/b77366bcbe719373a8cac2b4e8ad01f8ff3c9f2c223374d77ece280aae6f/opentelemetry_exporter_otlp-1.43.0.tar.gz", hash = "sha256:65aded6c50ee7dd2b9948c9d0e59ddb4ed4eea6e8532fba95cbe6a4a64a566ba", size = 6086, upload-time = "2026-06-24T15:19:58.003Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/00/6c/bdc82a066e6fb1dcf9e8cc8d4e026358fe0f8690700cc6369a6bf9bd17a7/opentelemetry_exporter_otlp-1.39.1-py3-none-any.whl", hash = "sha256:68ae69775291f04f000eb4b698ff16ff685fdebe5cb52871bc4e87938a7b00fe", size = 7019, upload-time = "2025-12-11T13:32:19.387Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/26/d28cc854d2eb779f91351216c51ed0d54886f89f2dd56db9d493ba9fd429/opentelemetry_exporter_otlp-1.43.0-py3-none-any.whl", hash = "sha256:70f3fe740a64596d4157588a2ee7e4fd37d2acc0c0f522a2882b8c29316cd0f0", size = 6726, upload-time = "2026-06-24T15:19:38.437Z" },
 ]
 
 [[package]]
 name = "opentelemetry-exporter-otlp-proto-common"
-version = "1.39.1"
+version = "1.43.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-proto" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e9/9d/22d241b66f7bbde88a3bfa6847a351d2c46b84de23e71222c6aae25c7050/opentelemetry_exporter_otlp_proto_common-1.39.1.tar.gz", hash = "sha256:763370d4737a59741c89a67b50f9e39271639ee4afc999dadfe768541c027464", size = 20409, upload-time = "2025-12-11T13:32:40.885Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/55/c1/e8098490ab15abf116dcaf9fa89ededcb35547c7d08d4b5a62f573dc1e63/opentelemetry_exporter_otlp_proto_common-1.43.0.tar.gz", hash = "sha256:c4e32ba6d6b13bdb2b8f6764c4fd28d00192826561aa04f6d14eedfce7ac076f", size = 20197, upload-time = "2026-06-24T15:20:00.247Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8c/02/ffc3e143d89a27ac21fd557365b98bd0653b98de8a101151d5805b5d4c33/opentelemetry_exporter_otlp_proto_common-1.39.1-py3-none-any.whl", hash = "sha256:08f8a5862d64cc3435105686d0216c1365dc5701f86844a8cd56597d0c764fde", size = 18366, upload-time = "2025-12-11T13:32:20.2Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/b2/41ebc74ae1d5859901f1b69305de58724bf043381103d6ef413521cbc35a/opentelemetry_exporter_otlp_proto_common-1.43.0-py3-none-any.whl", hash = "sha256:123c3f9cc87218562490c63b36f497bf3a722faf174a515d1443f31ababa6264", size = 17048, upload-time = "2026-06-24T15:19:41.264Z" },
 ]
 
 [[package]]
 name = "opentelemetry-exporter-otlp-proto-grpc"
-version = "1.39.1"
+version = "1.43.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
@@ -5367,14 +4633,14 @@ dependencies = [
     { name = "opentelemetry-sdk" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/53/48/b329fed2c610c2c32c9366d9dc597202c9d1e58e631c137ba15248d8850f/opentelemetry_exporter_otlp_proto_grpc-1.39.1.tar.gz", hash = "sha256:772eb1c9287485d625e4dbe9c879898e5253fea111d9181140f51291b5fec3ad", size = 24650, upload-time = "2025-12-11T13:32:41.429Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e2/1d/6336453716ca0a240d4417d19e6d5b77a5e7163e5670ec4f7ec4d3ede7bf/opentelemetry_exporter_otlp_proto_grpc-1.43.0.tar.gz", hash = "sha256:1b3e0627daa9bc21884d4a13946807c255eb558bfe5bdd543dffb6f4c9faee0d", size = 27213, upload-time = "2026-06-24T15:20:00.907Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/81/a3/cc9b66575bd6597b98b886a2067eea2693408d2d5f39dad9ab7fc264f5f3/opentelemetry_exporter_otlp_proto_grpc-1.39.1-py3-none-any.whl", hash = "sha256:fa1c136a05c7e9b4c09f739469cbdb927ea20b34088ab1d959a849b5cc589c18", size = 19766, upload-time = "2025-12-11T13:32:21.027Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/74/2700b5d5c946bf2dba87073fce3dfc198c46bc92ea3d5693f54bc51c90b1/opentelemetry_exporter_otlp_proto_grpc-1.43.0-py3-none-any.whl", hash = "sha256:6a10d1feacffffda19acacbf277b736094b1e2f4dbb98c90ccb2c6e1962e2ec6", size = 19626, upload-time = "2026-06-24T15:19:42.233Z" },
 ]
 
 [[package]]
 name = "opentelemetry-exporter-otlp-proto-http"
-version = "1.39.1"
+version = "1.43.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
@@ -5385,28 +4651,14 @@ dependencies = [
     { name = "requests" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/80/04/2a08fa9c0214ae38880df01e8bfae12b067ec0793446578575e5080d6545/opentelemetry_exporter_otlp_proto_http-1.39.1.tar.gz", hash = "sha256:31bdab9745c709ce90a49a0624c2bd445d31a28ba34275951a6a362d16a0b9cb", size = 17288, upload-time = "2025-12-11T13:32:42.029Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fc/92/0b9f56412483a8891d4843890294796c9df8ab42417bd9bad8035d840cb3/opentelemetry_exporter_otlp_proto_http-1.43.0.tar.gz", hash = "sha256:fa8a42bb7d00ee5391f4c0b04d8e6a46c03caa437903296ab73a81dc11ba118f", size = 25406, upload-time = "2026-06-24T15:20:01.515Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/95/f1/b27d3e2e003cd9a3592c43d099d2ed8d0a947c15281bf8463a256db0b46c/opentelemetry_exporter_otlp_proto_http-1.39.1-py3-none-any.whl", hash = "sha256:d9f5207183dd752a412c4cd564ca8875ececba13be6e9c6c370ffb752fd59985", size = 19641, upload-time = "2025-12-11T13:32:22.248Z" },
-]
-
-[[package]]
-name = "opentelemetry-exporter-prometheus"
-version = "0.60b1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "opentelemetry-api" },
-    { name = "opentelemetry-sdk" },
-    { name = "prometheus-client" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/14/39/7dafa6fff210737267bed35a8855b6ac7399b9e582b8cf1f25f842517012/opentelemetry_exporter_prometheus-0.60b1.tar.gz", hash = "sha256:a4011b46906323f71724649d301b4dc188aaa068852e814f4df38cc76eac616b", size = 14976, upload-time = "2025-12-11T13:32:42.944Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/9b/0d/4be6bf5477a3eb3d917d2f17d3c0b6720cd6cb97898444a61d43cc983f5c/opentelemetry_exporter_prometheus-0.60b1-py3-none-any.whl", hash = "sha256:49f59178de4f4590e3cef0b8b95cf6e071aae70e1f060566df5546fad773b8fd", size = 13019, upload-time = "2025-12-11T13:32:23.974Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/20/b685ed7af2e17c29ffc8af56f1fa8bc2033258fc30fb0d2b722f49d13ba0/opentelemetry_exporter_otlp_proto_http-1.43.0-py3-none-any.whl", hash = "sha256:647f603aa8efdbdb4dbff842e0729d0406a6fff26b295a72d3d60e7d963b2610", size = 21795, upload-time = "2026-06-24T15:19:43.164Z" },
 ]
 
 [[package]]
 name = "opentelemetry-instrumentation"
-version = "0.60b1"
+version = "0.64b0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-api" },
@@ -5414,111 +4666,63 @@ dependencies = [
     { name = "packaging" },
     { name = "wrapt" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/41/0f/7e6b713ac117c1f5e4e3300748af699b9902a2e5e34c9cf443dde25a01fa/opentelemetry_instrumentation-0.60b1.tar.gz", hash = "sha256:57ddc7974c6eb35865af0426d1a17132b88b2ed8586897fee187fd5b8944bd6a", size = 31706, upload-time = "2025-12-11T13:36:42.515Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/97/02fe6e1c8b1ffac42d0b429c18080edb24e0e0d18c86612edf72b5752382/opentelemetry_instrumentation-0.64b0.tar.gz", hash = "sha256:b47d528dead6271d7743114417eb67fc915bd9258111c48dbf9a4951d2efa88d", size = 41935, upload-time = "2026-06-24T15:19:12.951Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/77/d2/6788e83c5c86a2690101681aeef27eeb2a6bf22df52d3f263a22cee20915/opentelemetry_instrumentation-0.60b1-py3-none-any.whl", hash = "sha256:04480db952b48fb1ed0073f822f0ee26012b7be7c3eac1a3793122737c78632d", size = 33096, upload-time = "2025-12-11T13:35:33.067Z" },
-]
-
-[[package]]
-name = "opentelemetry-instrumentation-httpx"
-version = "0.60b1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "opentelemetry-api" },
-    { name = "opentelemetry-instrumentation" },
-    { name = "opentelemetry-semantic-conventions" },
-    { name = "opentelemetry-util-http" },
-    { name = "wrapt" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/86/08/11208bcfcab4fc2023252c3f322aa397fd9ad948355fea60f5fc98648603/opentelemetry_instrumentation_httpx-0.60b1.tar.gz", hash = "sha256:a506ebaf28c60112cbe70ad4f0338f8603f148938cb7b6794ce1051cd2b270ae", size = 20611, upload-time = "2025-12-11T13:37:01.661Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/43/59/b98e84eebf745ffc75397eaad4763795bff8a30cbf2373a50ed4e70646c5/opentelemetry_instrumentation_httpx-0.60b1-py3-none-any.whl", hash = "sha256:f37636dd742ad2af83d896ba69601ed28da51fa4e25d1ab62fde89ce413e275b", size = 15701, upload-time = "2025-12-11T13:36:04.56Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/0c/cb9fe342de5299c7af24582eb7d788661cc53a1c4b904da92309caaa9417/opentelemetry_instrumentation-0.64b0-py3-none-any.whl", hash = "sha256:133ab7ffca796557aec059bf6be3190a34b6dea987f25be3d9409e230cbdad8b", size = 35880, upload-time = "2026-06-24T15:18:17.277Z" },
 ]
 
 [[package]]
 name = "opentelemetry-instrumentation-threading"
-version = "0.60b1"
+version = "0.64b0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-api" },
     { name = "opentelemetry-instrumentation" },
     { name = "wrapt" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9b/0a/e36123ec4c0910a3936b92982545a53e9bca5b26a28df06883751a783f84/opentelemetry_instrumentation_threading-0.60b1.tar.gz", hash = "sha256:20b18a68abe5801fa9474336b7c27487d4af3e00b66f6a8734e4fdd75c8b0b43", size = 8768, upload-time = "2025-12-11T13:37:16.29Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/26/ef/d4a16eb4a0f0971e351ec2ff95846b501b66a619d07d90822942d70a3adc/opentelemetry_instrumentation_threading-0.64b0.tar.gz", hash = "sha256:0a07d7329f69dfae5036a7cb184f502c8b91cb0538012f5304bd32ffe9ade451", size = 9080, upload-time = "2026-06-24T15:19:43.22Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/a3/448738b927bcc1843ace7d4ed55dd54441a71363075eeeee89c5944dd740/opentelemetry_instrumentation_threading-0.60b1-py3-none-any.whl", hash = "sha256:92a52a60fee5e32bc6aa8f5acd749b15691ad0bc4457a310f5736b76a6d9d1de", size = 9312, upload-time = "2025-12-11T13:36:28.434Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/b3/8838d5f3db35b3854516ccfbf8ec26138d40388d828407182c890c3aa9d0/opentelemetry_instrumentation_threading-0.64b0-py3-none-any.whl", hash = "sha256:a285ffa750a958f7d368e947f5679a0214d588242cbffba0f5934cb02e9a17f4", size = 8487, upload-time = "2026-06-24T15:19:00.813Z" },
 ]
 
 [[package]]
 name = "opentelemetry-proto"
-version = "1.39.1"
+version = "1.43.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "protobuf" },
+    { name = "protobuf", version = "5.29.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
+    { name = "protobuf", version = "6.33.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/49/1d/f25d76d8260c156c40c97c9ed4511ec0f9ce353f8108ca6e7561f82a06b2/opentelemetry_proto-1.39.1.tar.gz", hash = "sha256:6c8e05144fc0d3ed4d22c2289c6b126e03bcd0e6a7da0f16cedd2e1c2772e2c8", size = 46152, upload-time = "2025-12-11T13:32:48.681Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/b9/d357faefb40bda1d4799913e6af611171ff22a2dedcb93576bc92242d056/opentelemetry_proto-1.43.0.tar.gz", hash = "sha256:224778df17e1f3fafeaaa21d874236ca5f6ffc2f86e0899298ec7351aac27924", size = 46481, upload-time = "2026-06-24T15:20:07.625Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/51/95/b40c96a7b5203005a0b03d8ce8cd212ff23f1793d5ba289c87a097571b18/opentelemetry_proto-1.39.1-py3-none-any.whl", hash = "sha256:22cdc78efd3b3765d09e68bfbd010d4fc254c9818afd0b6b423387d9dee46007", size = 72535, upload-time = "2025-12-11T13:32:33.866Z" },
-]
-
-[[package]]
-name = "opentelemetry-resourcedetector-gcp"
-version = "1.11.0a0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "opentelemetry-api" },
-    { name = "opentelemetry-sdk" },
-    { name = "requests" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/c1/5d/2b3240d914b87b6dd9cd5ca2ef1ccaf1d0626b897d4c06877e22c8c10fcf/opentelemetry_resourcedetector_gcp-1.11.0a0.tar.gz", hash = "sha256:915a1d6fd15daca9eedd3fc52b0f705375054f2ef140e2e7a6b4cca95a47cdb1", size = 18796, upload-time = "2025-11-04T19:32:16.59Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c3/6c/1e13fe142a7ca3dc6489167203a1209d32430cca12775e1df9c9a41c54b2/opentelemetry_resourcedetector_gcp-1.11.0a0-py3-none-any.whl", hash = "sha256:5d65a2a039b1d40c6f41421dbb08d5f441368275ac6de6e76a8fccd1f6acb67e", size = 18798, upload-time = "2025-11-04T19:32:10.915Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/a7/3e5308cf548b8f72529c7db1afdb3a404211982376a12927fd7759f77bf3/opentelemetry_proto-1.43.0-py3-none-any.whl", hash = "sha256:c58f1f7ef84bc7dc2834016c0c37fe0081dde7ca9f6339be1970fbf9cdaaa90d", size = 72489, upload-time = "2026-06-24T15:19:51.164Z" },
 ]
 
 [[package]]
 name = "opentelemetry-sdk"
-version = "1.39.1"
+version = "1.43.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-api" },
     { name = "opentelemetry-semantic-conventions" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/eb/fb/c76080c9ba07e1e8235d24cdcc4d125ef7aa3edf23eb4e497c2e50889adc/opentelemetry_sdk-1.39.1.tar.gz", hash = "sha256:cf4d4563caf7bff906c9f7967e2be22d0d6b349b908be0d90fb21c8e9c995cc6", size = 171460, upload-time = "2025-12-11T13:32:49.369Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3e/eb/5041074274ac0956b03637cc039d434569112468e875eddfcc9a0674ce06/opentelemetry_sdk-1.43.0.tar.gz", hash = "sha256:d8187c81c162df9913e4003dd6485f7390d9a24fc17026ec7387b8b8218b08e9", size = 254744, upload-time = "2026-06-24T15:20:08.467Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7c/98/e91cf858f203d86f4eccdf763dcf01cf03f1dae80c3750f7e635bfa206b6/opentelemetry_sdk-1.39.1-py3-none-any.whl", hash = "sha256:4d5482c478513ecb0a5d938dcc61394e647066e0cc2676bee9f3af3f3f45f01c", size = 132565, upload-time = "2025-12-11T13:32:35.069Z" },
+    { url = "https://files.pythonhosted.org/packages/49/e3/b17be23af124201c9f52eececd4cc8ddfed1597d37b4ee771895d325805c/opentelemetry_sdk-1.43.0-py3-none-any.whl", hash = "sha256:d1323a547c1ce69d6a069a17a44b7da82bb8b332051ecb074041f87642c86823", size = 178852, upload-time = "2026-06-24T15:19:52.169Z" },
 ]
 
 [[package]]
 name = "opentelemetry-semantic-conventions"
-version = "0.60b1"
+version = "0.64b0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-api" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/91/df/553f93ed38bf22f4b999d9be9c185adb558982214f33eae539d3b5cd0858/opentelemetry_semantic_conventions-0.60b1.tar.gz", hash = "sha256:87c228b5a0669b748c76d76df6c364c369c28f1c465e50f661e39737e84bc953", size = 137935, upload-time = "2025-12-11T13:32:50.487Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/30/5f26df29509eccd86b99b481ac9ffa39da49ba9577cc69071c552ae30447/opentelemetry_semantic_conventions-0.64b0.tar.gz", hash = "sha256:72f76fb2d1582d9d033dd1fcd84532e961e6ff3d90d24ba6fabc72975a83864c", size = 148340, upload-time = "2026-06-24T15:20:09.267Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7a/5e/5958555e09635d09b75de3c4f8b9cae7335ca545d77392ffe7331534c402/opentelemetry_semantic_conventions-0.60b1-py3-none-any.whl", hash = "sha256:9fa8c8b0c110da289809292b0591220d3a7b53c1526a23021e977d68597893fb", size = 219982, upload-time = "2025-12-11T13:32:36.955Z" },
-]
-
-[[package]]
-name = "opentelemetry-semantic-conventions-ai"
-version = "0.4.13"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ba/e6/40b59eda51ac47009fb47afcdf37c6938594a0bd7f3b9fadcbc6058248e3/opentelemetry_semantic_conventions_ai-0.4.13.tar.gz", hash = "sha256:94efa9fb4ffac18c45f54a3a338ffeb7eedb7e1bb4d147786e77202e159f0036", size = 5368, upload-time = "2025-08-22T10:14:17.387Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/35/b5/cf25da2218910f0d6cdf7f876a06bed118c4969eacaf60a887cbaef44f44/opentelemetry_semantic_conventions_ai-0.4.13-py3-none-any.whl", hash = "sha256:883a30a6bb5deaec0d646912b5f9f6dcbb9f6f72557b73d0f2560bf25d13e2d5", size = 6080, upload-time = "2025-08-22T10:14:16.477Z" },
-]
-
-[[package]]
-name = "opentelemetry-util-http"
-version = "0.60b1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/50/fc/c47bb04a1d8a941a4061307e1eddfa331ed4d0ab13d8a9781e6db256940a/opentelemetry_util_http-0.60b1.tar.gz", hash = "sha256:0d97152ca8c8a41ced7172d29d3622a219317f74ae6bb3027cfbdcf22c3cc0d6", size = 11053, upload-time = "2025-12-11T13:37:25.115Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/16/5c/d3f1733665f7cd582ef0842fb1d2ed0bc1fba10875160593342d22bba375/opentelemetry_util_http-0.60b1-py3-none-any.whl", hash = "sha256:66381ba28550c91bee14dcba8979ace443444af1ed609226634596b4b0faf199", size = 8947, upload-time = "2025-12-11T13:36:37.151Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/ca/23ba87a221b574a7c5a99d48849d80bfe8b047624681357e2b002e566187/opentelemetry_semantic_conventions-0.64b0-py3-none-any.whl", hash = "sha256:ea77e85e354b8f604ddbe5f3d9135216f982fa4d77e5859ac30f6d8a50505aa6", size = 203713, upload-time = "2026-06-24T15:19:53.339Z" },
 ]
 
 [[package]]
@@ -5545,18 +4749,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e0/41/0a7cc883a678c2cfaa4785b5c4c0deb8b40e431f0495f53398d4d7136dea/opik-1.9.98.tar.gz", hash = "sha256:e34deb967aac645b3e545e87aa6da3f754e7557f608890c1dec5ae127d7bc77b", size = 676598, upload-time = "2026-01-23T13:13:54.524Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/27/cb/b80556e9f22a3806cae5862cc3483f0ac60635c71b3e4f119aee39cd7394/opik-1.9.98-py3-none-any.whl", hash = "sha256:3b404e50affc40a746bfc605f401a9d71b39b363980476d9a166229a8294d3c4", size = 1157390, upload-time = "2026-01-23T13:13:52.156Z" },
-]
-
-[[package]]
-name = "orderedmultidict"
-version = "1.0.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "six" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/5c/62/61ad51f6c19d495970230a7747147ce7ed3c3a63c2af4ebfdb1f6d738703/orderedmultidict-1.0.2.tar.gz", hash = "sha256:16a7ae8432e02cc987d2d6d5af2df5938258f87c870675c73ee77a0920e6f4a6", size = 13973, upload-time = "2025-11-18T08:00:42.649Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b2/6c/d8a02ffb24876b5f51fbd781f479fc6525a518553a4196bd0433dae9ff8e/orderedmultidict-1.0.2-py2.py3-none-any.whl", hash = "sha256:ab5044c1dca4226ae4c28524cfc5cc4c939f0b49e978efa46a6ad6468049f79b", size = 11897, upload-time = "2025-11-18T08:00:41.44Z" },
 ]
 
 [[package]]
@@ -5641,6 +4833,62 @@ wheels = [
 ]
 
 [[package]]
+name = "ormsgpack"
+version = "1.12.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/12/0c/f1761e21486942ab9bb6feaebc610fa074f7c5e496e6962dea5873348077/ormsgpack-1.12.2.tar.gz", hash = "sha256:944a2233640273bee67521795a73cf1e959538e0dfb7ac635505010455e53b33", size = 39031, upload-time = "2026-01-18T20:55:28.023Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/93/fa/a91f70829ebccf6387c4946e0a1a109f6ba0d6a28d65f628bedfad94b890/ormsgpack-1.12.2-cp310-cp310-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:c1429217f8f4d7fcb053523bbbac6bed5e981af0b85ba616e6df7cce53c19657", size = 378262, upload-time = "2026-01-18T20:55:22.284Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/62/3698a9a0c487252b5c6a91926e5654e79e665708ea61f67a8bdeceb022bf/ormsgpack-1.12.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5f13034dc6c84a6280c6c33db7ac420253852ea233fc3ee27c8875f8dd651163", size = 203034, upload-time = "2026-01-18T20:55:53.324Z" },
+    { url = "https://files.pythonhosted.org/packages/66/3a/f716f64edc4aec2744e817660b317e2f9bb8de372338a95a96198efa1ac1/ormsgpack-1.12.2-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:59f5da97000c12bc2d50e988bdc8576b21f6ab4e608489879d35b2c07a8ab51a", size = 210538, upload-time = "2026-01-18T20:55:20.097Z" },
+    { url = "https://files.pythonhosted.org/packages/72/30/a436be9ce27d693d4e19fa94900028067133779f09fc45776db3f689c822/ormsgpack-1.12.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9e4459c3f27066beadb2b81ea48a076a417aafffff7df1d3c11c519190ed44f2", size = 212401, upload-time = "2026-01-18T20:55:46.447Z" },
+    { url = "https://files.pythonhosted.org/packages/10/c5/cde98300fd33fee84ca71de4751b19aeeca675f0cf3c0ec4b043f40f3b76/ormsgpack-1.12.2-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:7a1c460655d7288407ffa09065e322a7231997c0d62ce914bf3a96ad2dc6dedd", size = 387080, upload-time = "2026-01-18T20:56:00.884Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/31/30bf445ef827546747c10889dd254b3d84f92b591300efe4979d792f4c41/ormsgpack-1.12.2-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:458e4568be13d311ef7d8877275e7ccbe06c0e01b39baaac874caaa0f46d826c", size = 482346, upload-time = "2026-01-18T20:55:39.831Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/f5/e1745ddf4fa246c921b5ca253636c4c700ff768d78032f79171289159f6e/ormsgpack-1.12.2-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:8cde5eaa6c6cbc8622db71e4a23de56828e3d876aeb6460ffbcb5b8aff91093b", size = 425178, upload-time = "2026-01-18T20:55:27.106Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/a2/e6532ed7716aed03dede8df2d0d0d4150710c2122647d94b474147ccd891/ormsgpack-1.12.2-cp310-cp310-win_amd64.whl", hash = "sha256:dc7a33be14c347893edbb1ceda89afbf14c467d593a5ee92c11de4f1666b4d4f", size = 117183, upload-time = "2026-01-18T20:55:55.52Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/08/8b68f24b18e69d92238aa8f258218e6dfeacf4381d9d07ab8df303f524a9/ormsgpack-1.12.2-cp311-cp311-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:bd5f4bf04c37888e864f08e740c5a573c4017f6fd6e99fa944c5c935fabf2dd9", size = 378266, upload-time = "2026-01-18T20:55:59.876Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/24/29fc13044ecb7c153523ae0a1972269fcd613650d1fa1a9cec1044c6b666/ormsgpack-1.12.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:34d5b28b3570e9fed9a5a76528fc7230c3c76333bc214798958e58e9b79cc18a", size = 203035, upload-time = "2026-01-18T20:55:30.59Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/c2/00169fb25dd8f9213f5e8a549dfb73e4d592009ebc85fbbcd3e1dcac575b/ormsgpack-1.12.2-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3708693412c28f3538fb5a65da93787b6bbab3484f6bc6e935bfb77a62400ae5", size = 210539, upload-time = "2026-01-18T20:55:48.569Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/33/543627f323ff3c73091f51d6a20db28a1a33531af30873ea90c5ac95a9b5/ormsgpack-1.12.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:43013a3f3e2e902e1d05e72c0f1aeb5bedbb8e09240b51e26792a3c89267e181", size = 212401, upload-time = "2026-01-18T20:56:10.101Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/5d/f70e2c3da414f46186659d24745483757bcc9adccb481a6eb93e2b729301/ormsgpack-1.12.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:7c8b1667a72cbba74f0ae7ecf3105a5e01304620ed14528b2cb4320679d2869b", size = 387082, upload-time = "2026-01-18T20:56:12.047Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/d6/06e8dc920c7903e051f30934d874d4afccc9bb1c09dcaf0bc03a7de4b343/ormsgpack-1.12.2-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:df6961442140193e517303d0b5d7bc2e20e69a879c2d774316125350c4a76b92", size = 482346, upload-time = "2026-01-18T20:56:05.152Z" },
+    { url = "https://files.pythonhosted.org/packages/66/c4/f337ac0905eed9c393ef990c54565cd33644918e0a8031fe48c098c71dbf/ormsgpack-1.12.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:c6a4c34ddef109647c769d69be65fa1de7a6022b02ad45546a69b3216573eb4a", size = 425181, upload-time = "2026-01-18T20:55:37.83Z" },
+    { url = "https://files.pythonhosted.org/packages/78/29/6d5758fabef3babdf4bbbc453738cc7de9cd3334e4c38dd5737e27b85653/ormsgpack-1.12.2-cp311-cp311-win_amd64.whl", hash = "sha256:73670ed0375ecc303858e3613f407628dd1fca18fe6ac57b7b7ce66cc7bb006c", size = 117182, upload-time = "2026-01-18T20:55:31.472Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/57/17a15549233c37e7fd054c48fe9207492e06b026dbd872b826a0b5f833b6/ormsgpack-1.12.2-cp311-cp311-win_arm64.whl", hash = "sha256:c2be829954434e33601ae5da328cccce3266b098927ca7a30246a0baec2ce7bd", size = 111464, upload-time = "2026-01-18T20:55:38.811Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/36/16c4b1921c308a92cef3bf6663226ae283395aa0ff6e154f925c32e91ff5/ormsgpack-1.12.2-cp312-cp312-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:7a29d09b64b9694b588ff2f80e9826bdceb3a2b91523c5beae1fab27d5c940e7", size = 378618, upload-time = "2026-01-18T20:55:50.835Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/68/468de634079615abf66ed13bb5c34ff71da237213f29294363beeeca5306/ormsgpack-1.12.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0b39e629fd2e1c5b2f46f99778450b59454d1f901bc507963168985e79f09c5d", size = 203186, upload-time = "2026-01-18T20:56:11.163Z" },
+    { url = "https://files.pythonhosted.org/packages/73/a9/d756e01961442688b7939bacd87ce13bfad7d26ce24f910f6028178b2cc8/ormsgpack-1.12.2-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:958dcb270d30a7cb633a45ee62b9444433fa571a752d2ca484efdac07480876e", size = 210738, upload-time = "2026-01-18T20:56:09.181Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/ba/795b1036888542c9113269a3f5690ab53dd2258c6fb17676ac4bd44fcf94/ormsgpack-1.12.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:58d379d72b6c5e964851c77cfedfb386e474adee4fd39791c2c5d9efb53505cc", size = 212569, upload-time = "2026-01-18T20:56:06.135Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/aa/bff73c57497b9e0cba8837c7e4bcab584b1a6dbc91a5dd5526784a5030c8/ormsgpack-1.12.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8463a3fc5f09832e67bdb0e2fda6d518dc4281b133166146a67f54c08496442e", size = 387166, upload-time = "2026-01-18T20:55:36.738Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/cf/f8283cba44bcb7b14f97b6274d449db276b3a86589bdb363169b51bc12de/ormsgpack-1.12.2-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:eddffb77eff0bad4e67547d67a130604e7e2dfbb7b0cde0796045be4090f35c6", size = 482498, upload-time = "2026-01-18T20:55:29.626Z" },
+    { url = "https://files.pythonhosted.org/packages/05/be/71e37b852d723dfcbe952ad04178c030df60d6b78eba26bfd14c9a40575e/ormsgpack-1.12.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fcd55e5f6ba0dbce624942adf9f152062135f991a0126064889f68eb850de0dd", size = 425518, upload-time = "2026-01-18T20:55:49.556Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/0c/9803aa883d18c7ef197213cd2cbf73ba76472a11fe100fb7dab2884edf48/ormsgpack-1.12.2-cp312-cp312-win_amd64.whl", hash = "sha256:d024b40828f1dde5654faebd0d824f9cc29ad46891f626272dd5bfd7af2333a4", size = 117462, upload-time = "2026-01-18T20:55:47.726Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/9e/029e898298b2cc662f10d7a15652a53e3b525b1e7f07e21fef8536a09bb8/ormsgpack-1.12.2-cp312-cp312-win_arm64.whl", hash = "sha256:da538c542bac7d1c8f3f2a937863dba36f013108ce63e55745941dda4b75dbb6", size = 111559, upload-time = "2026-01-18T20:55:54.273Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/29/bb0eba3288c0449efbb013e9c6f58aea79cf5cb9ee1921f8865f04c1a9d7/ormsgpack-1.12.2-cp313-cp313-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:5ea60cb5f210b1cfbad8c002948d73447508e629ec375acb82910e3efa8ff355", size = 378661, upload-time = "2026-01-18T20:55:57.765Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/31/5efa31346affdac489acade2926989e019e8ca98129658a183e3add7af5e/ormsgpack-1.12.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f3601f19afdbea273ed70b06495e5794606a8b690a568d6c996a90d7255e51c1", size = 203194, upload-time = "2026-01-18T20:56:08.252Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/56/d0087278beef833187e0167f8527235ebe6f6ffc2a143e9de12a98b1ce87/ormsgpack-1.12.2-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:29a9f17a3dac6054c0dce7925e0f4995c727f7c41859adf9b5572180f640d172", size = 210778, upload-time = "2026-01-18T20:55:17.694Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/a2/072343e1413d9443e5a252a8eb591c2d5b1bffbe5e7bfc78c069361b92eb/ormsgpack-1.12.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:39c1bd2092880e413902910388be8715f70b9f15f20779d44e673033a6146f2d", size = 212592, upload-time = "2026-01-18T20:55:32.747Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/8b/a0da3b98a91d41187a63b02dda14267eefc2a74fcb43cc2701066cf1510e/ormsgpack-1.12.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:50b7249244382209877deedeee838aef1542f3d0fc28b8fe71ca9d7e1896a0d7", size = 387164, upload-time = "2026-01-18T20:55:40.853Z" },
+    { url = "https://files.pythonhosted.org/packages/19/bb/6d226bc4cf9fc20d8eb1d976d027a3f7c3491e8f08289a2e76abe96a65f3/ormsgpack-1.12.2-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:5af04800d844451cf102a59c74a841324868d3f1625c296a06cc655c542a6685", size = 482516, upload-time = "2026-01-18T20:55:42.033Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/f1/bb2c7223398543dedb3dbf8bb93aaa737b387de61c5feaad6f908841b782/ormsgpack-1.12.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:cec70477d4371cd524534cd16472d8b9cc187e0e3043a8790545a9a9b296c258", size = 425539, upload-time = "2026-01-18T20:55:24.727Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/e8/0fb45f57a2ada1fed374f7494c8cd55e2f88ccd0ab0a669aa3468716bf5f/ormsgpack-1.12.2-cp313-cp313-win_amd64.whl", hash = "sha256:21f4276caca5c03a818041d637e4019bc84f9d6ca8baa5ea03e5cc8bf56140e9", size = 117459, upload-time = "2026-01-18T20:55:56.876Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/d4/0cfeea1e960d550a131001a7f38a5132c7ae3ebde4c82af1f364ccc5d904/ormsgpack-1.12.2-cp313-cp313-win_arm64.whl", hash = "sha256:baca4b6773d20a82e36d6fd25f341064244f9f86a13dead95dd7d7f996f51709", size = 111577, upload-time = "2026-01-18T20:55:43.605Z" },
+    { url = "https://files.pythonhosted.org/packages/94/16/24d18851334be09c25e87f74307c84950f18c324a4d3c0b41dabdbf19c29/ormsgpack-1.12.2-cp314-cp314-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:bc68dd5915f4acf66ff2010ee47c8906dc1cf07399b16f4089f8c71733f6e36c", size = 378717, upload-time = "2026-01-18T20:55:26.164Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/a2/88b9b56f83adae8032ac6a6fa7f080c65b3baf9b6b64fd3d37bd202991d4/ormsgpack-1.12.2-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:46d084427b4132553940070ad95107266656cb646ea9da4975f85cb1a6676553", size = 203183, upload-time = "2026-01-18T20:55:18.815Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/80/43e4555963bf602e5bdc79cbc8debd8b6d5456c00d2504df9775e74b450b/ormsgpack-1.12.2-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c010da16235806cf1d7bc4c96bf286bfa91c686853395a299b3ddb49499a3e13", size = 210814, upload-time = "2026-01-18T20:55:33.973Z" },
+    { url = "https://files.pythonhosted.org/packages/78/e1/7cfbf28de8bca6efe7e525b329c31277d1b64ce08dcba723971c241a9d60/ormsgpack-1.12.2-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:18867233df592c997154ff942a6503df274b5ac1765215bceba7a231bea2745d", size = 212634, upload-time = "2026-01-18T20:55:28.634Z" },
+    { url = "https://files.pythonhosted.org/packages/95/f8/30ae5716e88d792a4e879debee195653c26ddd3964c968594ddef0a3cc7e/ormsgpack-1.12.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:b009049086ddc6b8f80c76b3955df1aa22a5fbd7673c525cd63bf91f23122ede", size = 387139, upload-time = "2026-01-18T20:56:02.013Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/81/aee5b18a3e3a0e52f718b37ab4b8af6fae0d9d6a65103036a90c2a8ffb5d/ormsgpack-1.12.2-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:1dcc17d92b6390d4f18f937cf0b99054824a7815818012ddca925d6e01c2e49e", size = 482578, upload-time = "2026-01-18T20:55:35.117Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/17/71c9ba472d5d45f7546317f467a5fc941929cd68fb32796ca3d13dcbaec2/ormsgpack-1.12.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:f04b5e896d510b07c0ad733d7fce2d44b260c5e6c402d272128f8941984e4285", size = 425539, upload-time = "2026-01-18T20:56:04.009Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/a6/ac99cd7fe77e822fed5250ff4b86fa66dd4238937dd178d2299f10b69816/ormsgpack-1.12.2-cp314-cp314-win_amd64.whl", hash = "sha256:ae3aba7eed4ca7cb79fd3436eddd29140f17ea254b91604aa1eb19bfcedb990f", size = 117493, upload-time = "2026-01-18T20:56:07.343Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/67/339872846a1ae4592535385a1c1f93614138566d7af094200c9c3b45d1e5/ormsgpack-1.12.2-cp314-cp314-win_arm64.whl", hash = "sha256:118576ea6006893aea811b17429bfc561b4778fad393f5f538c84af70b01260c", size = 111579, upload-time = "2026-01-18T20:55:21.161Z" },
+    { url = "https://files.pythonhosted.org/packages/49/c2/6feb972dc87285ad381749d3882d8aecbde9f6ecf908dd717d33d66df095/ormsgpack-1.12.2-cp314-cp314t-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:7121b3d355d3858781dc40dafe25a32ff8a8242b9d80c692fd548a4b1f7fd3c8", size = 378721, upload-time = "2026-01-18T20:55:52.12Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/9a/900a6b9b413e0f8a471cf07830f9cf65939af039a362204b36bd5b581d8b/ormsgpack-1.12.2-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4ee766d2e78251b7a63daf1cddfac36a73562d3ddef68cacfb41b2af64698033", size = 203170, upload-time = "2026-01-18T20:55:44.469Z" },
+    { url = "https://files.pythonhosted.org/packages/87/4c/27a95466354606b256f24fad464d7c97ab62bce6cc529dd4673e1179b8fb/ormsgpack-1.12.2-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:292410a7d23de9b40444636b9b8f1e4e4b814af7f1ef476e44887e52a123f09d", size = 212816, upload-time = "2026-01-18T20:55:23.501Z" },
+    { url = "https://files.pythonhosted.org/packages/73/cd/29cee6007bddf7a834e6cd6f536754c0535fcb939d384f0f37a38b1cddb8/ormsgpack-1.12.2-cp314-cp314t-win_amd64.whl", hash = "sha256:837dd316584485b72ef451d08dd3e96c4a11d12e4963aedb40e08f89685d8ec2", size = 117232, upload-time = "2026-01-18T20:55:45.448Z" },
+]
+
+[[package]]
 name = "overrides"
 version = "7.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -5683,15 +4931,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/4c/b2/bb8e495d5262bfec41ab5cb18f522f1012933347fb5d9e62452d446baca2/pathspec-1.0.3.tar.gz", hash = "sha256:bac5cf97ae2c2876e2d25ebb15078eb04d76e4b98921ee31c6f85ade8b59444d", size = 130841, upload-time = "2026-01-09T15:46:46.009Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/32/2b/121e912bd60eebd623f873fd090de0e84f322972ab25a7f9044c056804ed/pathspec-1.0.3-py3-none-any.whl", hash = "sha256:e80767021c1cc524aa3fb14bedda9c34406591343cc42797b386ce7b9354fb6c", size = 55021, upload-time = "2026-01-09T15:46:44.652Z" },
-]
-
-[[package]]
-name = "pathvalidate"
-version = "3.3.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/fa/2a/52a8da6fe965dea6192eb716b357558e103aea0a1e9a8352ad575a8406ca/pathvalidate-3.3.1.tar.gz", hash = "sha256:b18c07212bfead624345bb8e1d6141cdcf15a39736994ea0b94035ad2b1ba177", size = 63262, upload-time = "2025-06-15T09:07:20.736Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/9a/70/875f4a23bfc4731703a5835487d0d2fb999031bd415e7d17c0ae615c18b7/pathvalidate-3.3.1-py3-none-any.whl", hash = "sha256:5263baab691f8e1af96092fa5137ee17df5bdfbd6cff1fcac4d6ef4bc2e1735f", size = 24305, upload-time = "2025-06-15T09:07:19.117Z" },
 ]
 
 [[package]]
@@ -5838,15 +5077,6 @@ wheels = [
 ]
 
 [[package]]
-name = "ply"
-version = "3.11"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e5/69/882ee5c9d017149285cab114ebeab373308ef0f874fcdac9beb90e0ac4da/ply-3.11.tar.gz", hash = "sha256:00c7c1aaa88358b9c765b6d3000c6eec0ba42abca5351b095321aef446081da3", size = 159130, upload-time = "2018-02-15T19:01:31.097Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a3/58/35da89ee790598a0700ea49b2a66594140f44dec458c07e8e3d4979137fc/ply-3.11-py2.py3-none-any.whl", hash = "sha256:096f9b8350b65ebd2fd1346b12452efe5b9607f7482813ffca50c22722a807ce", size = 49567, upload-time = "2018-02-15T19:01:27.172Z" },
-]
-
-[[package]]
 name = "portalocker"
 version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -5872,19 +5102,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/48/20/60ae67bb9d82f00427946218d49e2e7e80fb41c15dc5019482289ec9ce8d/posthog-5.4.0.tar.gz", hash = "sha256:701669261b8d07cdde0276e5bc096b87f9e200e3b9589c5ebff14df658c5893c", size = 88076, upload-time = "2025-06-20T23:19:23.485Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4f/98/e480cab9a08d1c09b1c59a93dade92c1bb7544826684ff2acbfd10fcfbd4/posthog-5.4.0-py3-none-any.whl", hash = "sha256:284dfa302f64353484420b52d4ad81ff5c2c2d1d607c4e2db602ac72761831bd", size = 105364, upload-time = "2025-06-20T23:19:22.001Z" },
-]
-
-[[package]]
-name = "powerfx"
-version = "0.0.34"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "cffi", marker = "python_full_version < '3.14'" },
-    { name = "pythonnet", marker = "python_full_version < '3.14'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/9f/fb/6c4bf87e0c74ca1c563921ce89ca1c5785b7576bca932f7255cdf81082a7/powerfx-0.0.34.tar.gz", hash = "sha256:956992e7afd272657ed16d80f4cad24ec95d9e4a79fb9dfa4a068a09e136af32", size = 3237555, upload-time = "2025-12-22T15:50:59.682Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/6f/96/0f8a1f86485b3ec0315e3e8403326884a0334b3dcd699df2482669cca4be/powerfx-0.0.34-py3-none-any.whl", hash = "sha256:f2dc1c42ba8bfa4c72a7fcff2a00755b95394547388ca0b3e36579c49ee7ed75", size = 3483089, upload-time = "2025-12-22T15:50:57.536Z" },
 ]
 
 [[package]]
@@ -5961,27 +5178,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/31/9a/5ea9d6d95d5c07ba70166330a43bff7f0a074d0134eb7984eca6551e8c70/preshed-3.0.12-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:eafc08a86f77be78e722d96aa8a3a0aef0e3c7ac2f2ada22186a138e63d4033c", size = 910826, upload-time = "2025-11-17T13:00:16.861Z" },
     { url = "https://files.pythonhosted.org/packages/92/71/39024f9873ff317eac724b2759e94d013703800d970d51de77ccc6afff7e/preshed-3.0.12-cp314-cp314t-win_amd64.whl", hash = "sha256:fadaad54973b8697d5ef008735e150bd729a127b6497fd2cb068842074a6f3a7", size = 141358, upload-time = "2025-11-17T13:00:18.167Z" },
     { url = "https://files.pythonhosted.org/packages/9d/0d/431bb85252119f5d2260417fa7d164619b31eed8f1725b364dc0ade43a8e/preshed-3.0.12-cp314-cp314t-win_arm64.whl", hash = "sha256:c0c0d3b66b4c1e40aa6042721492f7b07fc9679ab6c361bc121aa54a1c3ef63f", size = 114839, upload-time = "2025-11-17T13:00:19.513Z" },
-]
-
-[[package]]
-name = "prometheus-client"
-version = "0.24.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f0/58/a794d23feb6b00fc0c72787d7e87d872a6730dd9ed7c7b3e954637d8f280/prometheus_client-0.24.1.tar.gz", hash = "sha256:7e0ced7fbbd40f7b84962d5d2ab6f17ef88a72504dcf7c0b40737b43b2a461f9", size = 85616, upload-time = "2026-01-14T15:26:26.965Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/74/c3/24a2f845e3917201628ecaba4f18bab4d18a337834c1df2a159ee9d22a42/prometheus_client-0.24.1-py3-none-any.whl", hash = "sha256:150db128af71a5c2482b36e588fc8a6b95e498750da4b17065947c16070f4055", size = 64057, upload-time = "2026-01-14T15:26:24.42Z" },
-]
-
-[[package]]
-name = "prompt-toolkit"
-version = "3.0.52"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "wcwidth" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/a1/96/06e01a7b38dce6fe1db213e061a4602dd6032a8a97ef6c1a862537732421/prompt_toolkit-3.0.52.tar.gz", hash = "sha256:28cde192929c8e7321de85de1ddbe736f1375148b02f2e17edd840042b1be855", size = 434198, upload-time = "2025-08-27T15:24:02.057Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/84/03/0d3ce49e2505ae70cf43bc5bb3033955d2fc9f932163e84dc0779cc47f48/prompt_toolkit-3.0.52-py3-none-any.whl", hash = "sha256:9aac639a3bbd33284347de5ad8d68ecc044b91a762dc39b7c21095fcd6a19955", size = 391431, upload-time = "2025-08-27T15:23:59.498Z" },
 ]
 
 [[package]]
@@ -6103,7 +5299,8 @@ name = "proto-plus"
 version = "1.27.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "protobuf" },
+    { name = "protobuf", version = "5.29.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
+    { name = "protobuf", version = "6.33.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/01/89/9cbe2f4bba860e149108b683bc2efec21f14d5f7ed6e25562ad86acbc373/proto_plus-1.27.0.tar.gz", hash = "sha256:873af56dd0d7e91836aee871e5799e1c6f1bda86ac9a983e0bb9f0c266a568c4", size = 56158, upload-time = "2025-12-16T13:46:25.729Z" }
 wheels = [
@@ -6114,6 +5311,12 @@ wheels = [
 name = "protobuf"
 version = "5.29.6"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version == '3.13.*'",
+    "python_full_version == '3.12.*'",
+    "python_full_version == '3.11.*'",
+    "python_full_version < '3.11'",
+]
 sdist = { url = "https://files.pythonhosted.org/packages/7e/57/394a763c103e0edf87f0938dafcd918d53b4c011dfc5c8ae80f3b0452dbb/protobuf-5.29.6.tar.gz", hash = "sha256:da9ee6a5424b6b30fd5e45c5ea663aef540ca95f9ad99d1e887e819cdf9b8723", size = 425623, upload-time = "2026-02-04T22:54:40.584Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d4/88/9ee58ff7863c479d6f8346686d4636dd4c415b0cbeed7a6a7d0617639c2a/protobuf-5.29.6-cp310-abi3-win32.whl", hash = "sha256:62e8a3114992c7c647bce37dcc93647575fc52d50e48de30c6fcb28a6a291eb1", size = 423357, upload-time = "2026-02-04T22:54:25.805Z" },
@@ -6125,44 +5328,47 @@ wheels = [
 ]
 
 [[package]]
+name = "protobuf"
+version = "6.33.6"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/70/e908e9c5e52ef7c3a6c7902c9dfbb34c7e29c25d2f81ade3856445fd5c94/protobuf-6.33.6.tar.gz", hash = "sha256:a6768d25248312c297558af96a9f9c929e8c4cee0659cb07e780731095f38135", size = 444531, upload-time = "2026-03-18T19:05:00.988Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fc/9f/2f509339e89cfa6f6a4c4ff50438db9ca488dec341f7e454adad60150b00/protobuf-6.33.6-cp310-abi3-win32.whl", hash = "sha256:7d29d9b65f8afef196f8334e80d6bc1d5d4adedb449971fefd3723824e6e77d3", size = 425739, upload-time = "2026-03-18T19:04:48.373Z" },
+    { url = "https://files.pythonhosted.org/packages/76/5d/683efcd4798e0030c1bab27374fd13a89f7c2515fb1f3123efdfaa5eab57/protobuf-6.33.6-cp310-abi3-win_amd64.whl", hash = "sha256:0cd27b587afca21b7cfa59a74dcbd48a50f0a6400cfb59391340ad729d91d326", size = 437089, upload-time = "2026-03-18T19:04:50.381Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/01/a3c3ed5cd186f39e7880f8303cc51385a198a81469d53d0fdecf1f64d929/protobuf-6.33.6-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:9720e6961b251bde64edfdab7d500725a2af5280f3f4c87e57c0208376aa8c3a", size = 427737, upload-time = "2026-03-18T19:04:51.866Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/90/b3c01fdec7d2f627b3a6884243ba328c1217ed2d978def5c12dc50d328a3/protobuf-6.33.6-cp39-abi3-manylinux2014_aarch64.whl", hash = "sha256:e2afbae9b8e1825e3529f88d514754e094278bb95eadc0e199751cdd9a2e82a2", size = 324610, upload-time = "2026-03-18T19:04:53.096Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/ca/25afc144934014700c52e05103c2421997482d561f3101ff352e1292fb81/protobuf-6.33.6-cp39-abi3-manylinux2014_s390x.whl", hash = "sha256:c96c37eec15086b79762ed265d59ab204dabc53056e3443e702d2681f4b39ce3", size = 339381, upload-time = "2026-03-18T19:04:54.616Z" },
+    { url = "https://files.pythonhosted.org/packages/16/92/d1e32e3e0d894fe00b15ce28ad4944ab692713f2e7f0a99787405e43533a/protobuf-6.33.6-cp39-abi3-manylinux2014_x86_64.whl", hash = "sha256:e9db7e292e0ab79dd108d7f1a94fe31601ce1ee3f7b79e0692043423020b0593", size = 323436, upload-time = "2026-03-18T19:04:55.768Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/72/02445137af02769918a93807b2b7890047c32bfb9f90371cbc12688819eb/protobuf-6.33.6-py3-none-any.whl", hash = "sha256:77179e006c476e69bf8e8ce866640091ec42e1beb80b213c3900006ecfba6901", size = 170656, upload-time = "2026-03-18T19:04:59.826Z" },
+]
+
+[[package]]
 name = "py-key-value-aio"
-version = "0.3.0"
+version = "0.4.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "beartype" },
-    { name = "py-key-value-shared" },
+    { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/93/ce/3136b771dddf5ac905cc193b461eb67967cf3979688c6696e1f2cdcde7ea/py_key_value_aio-0.3.0.tar.gz", hash = "sha256:858e852fcf6d696d231266da66042d3355a7f9871650415feef9fca7a6cd4155", size = 50801, upload-time = "2025-11-17T16:50:04.711Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fb/e2/d689d922894a7ecde73b6daeaf9b13dab5aae06fe6aaaf7514722644d382/py_key_value_aio-0.4.5.tar.gz", hash = "sha256:c6563a2c6abe5da5e20f4f9e875c2a9b425a2244a54fadbf46cf140a9eea45d7", size = 107547, upload-time = "2026-05-27T16:37:08.107Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/99/10/72f6f213b8f0bce36eff21fda0a13271834e9eeff7f9609b01afdc253c79/py_key_value_aio-0.3.0-py3-none-any.whl", hash = "sha256:1c781915766078bfd608daa769fefb97e65d1d73746a3dfb640460e322071b64", size = 96342, upload-time = "2025-11-17T16:50:03.801Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/95/b8ba862968712caa12a19666175334fa979e1f198b896a430adb3bacfe87/py_key_value_aio-0.4.5-py3-none-any.whl", hash = "sha256:ab862adbcb8c72547d1c57821f22cbbb71ab86509039c96f36e914e0336c8dd7", size = 170005, upload-time = "2026-05-27T16:37:06.629Z" },
 ]
 
 [package.optional-dependencies]
-disk = [
-    { name = "diskcache" },
-    { name = "pathvalidate" },
+filetree = [
+    { name = "aiofile", version = "3.9.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "aiofile", version = "3.12.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "anyio" },
 ]
 keyring = [
     { name = "keyring" },
 ]
 memory = [
     { name = "cachetools" },
-]
-redis = [
-    { name = "redis" },
-]
-
-[[package]]
-name = "py-key-value-shared"
-version = "0.3.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "beartype" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/7b/e4/1971dfc4620a3a15b4579fe99e024f5edd6e0967a71154771a059daff4db/py_key_value_shared-0.3.0.tar.gz", hash = "sha256:8fdd786cf96c3e900102945f92aa1473138ebe960ef49da1c833790160c28a4b", size = 11666, upload-time = "2025-11-17T16:50:06.849Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/51/e4/b8b0a03ece72f47dce2307d36e1c34725b7223d209fc679315ffe6a4e2c3/py_key_value_shared-0.3.0-py3-none-any.whl", hash = "sha256:5b0efba7ebca08bb158b1e93afc2f07d30b8f40c2fc12ce24a4c0d84f42f9298", size = 19560, upload-time = "2025-11-17T16:50:05.954Z" },
 ]
 
 [[package]]
@@ -6389,99 +5595,29 @@ email = [
 ]
 
 [[package]]
-name = "pydantic-ai"
-version = "1.47.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pydantic-ai-slim", extra = ["ag-ui", "anthropic", "bedrock", "cli", "cohere", "evals", "fastmcp", "google", "groq", "huggingface", "logfire", "mcp", "mistral", "openai", "retries", "temporal", "ui", "vertexai", "xai"] },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/42/3d/ae5bb713c81d8ffdd9400eebd765f8fba3f93cd49f5c1518e4b1e6f84408/pydantic_ai-1.47.0.tar.gz", hash = "sha256:e3a6c02f21d507b69476a618174dfda63ba2a87767c9c09c39f77e44614a5913", size = 11793, upload-time = "2026-01-24T00:44:38.392Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/11/5f/1dca9a73d4790a7a7dbd1994fc09ae7fdcb9d1748a706a3bce0b9d93601a/pydantic_ai-1.47.0-py3-none-any.whl", hash = "sha256:08cbc5142be7249973e044077ae85672b977620a82f72ae32f76dc07c95ffae0", size = 7221, upload-time = "2026-01-24T00:44:29.098Z" },
-]
-
-[[package]]
 name = "pydantic-ai-slim"
-version = "1.47.0"
+version = "2.31.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "anyio" },
     { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
     { name = "genai-prices" },
-    { name = "griffe" },
+    { name = "griffelib" },
     { name = "httpx" },
     { name = "opentelemetry-api" },
     { name = "pydantic" },
     { name = "pydantic-graph" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bb/71/d44ee4a2f5ce89dbefdc795340891e1d809419352996bb5f6aa76ce00e7c/pydantic_ai_slim-1.47.0.tar.gz", hash = "sha256:4961cadff4050e47bf67862336a19ab8181be23b3c4cf5fd442423b689127a40", size = 395376, upload-time = "2026-01-24T00:44:41.034Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/28/9d/a100fed1873151d930c45ed4e394647ba4d0bad5794d24d384b20dad3bad/pydantic_ai_slim-2.31.1.tar.gz", hash = "sha256:f04611e65e9a619b077732651240753cfb058bd844bd3c4e1eea549a48d38376", size = 1214403, upload-time = "2026-08-18T03:39:52.762Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2f/ad/b38f00643109872e8480ce0239abd95f1b2c2e7aae9a714d0e7cdce46f29/pydantic_ai_slim-1.47.0-py3-none-any.whl", hash = "sha256:b7f5779a83d6fbb6c432bca26578a562e351e1150b5bfd7cfdb06c01a486d0bf", size = 517677, upload-time = "2026-01-24T00:44:32.876Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/76/90841be18ff357a39c27d5bee5246af6bb71f13399b55ab318c4c32cc4c8/pydantic_ai_slim-2.31.1-py3-none-any.whl", hash = "sha256:4647d801c5febbd150203d130ddff6db2c481675626b648653e832f419609702", size = 1432432, upload-time = "2026-08-18T03:39:45.947Z" },
 ]
 
 [package.optional-dependencies]
-ag-ui = [
-    { name = "ag-ui-protocol" },
-    { name = "starlette" },
-]
-anthropic = [
-    { name = "anthropic" },
-]
-bedrock = [
-    { name = "boto3" },
-]
-cli = [
-    { name = "argcomplete" },
-    { name = "prompt-toolkit" },
-    { name = "pyperclip" },
-    { name = "rich" },
-]
-cohere = [
-    { name = "cohere", marker = "sys_platform != 'emscripten'" },
-]
-evals = [
-    { name = "pydantic-evals" },
-]
-fastmcp = [
-    { name = "fastmcp" },
-]
-google = [
-    { name = "google-genai" },
-]
-groq = [
-    { name = "groq" },
-]
-huggingface = [
-    { name = "huggingface-hub", extra = ["inference"] },
-]
-logfire = [
-    { name = "logfire", extra = ["httpx"] },
-]
-mcp = [
-    { name = "mcp" },
-]
-mistral = [
-    { name = "mistralai" },
-]
 openai = [
     { name = "openai" },
     { name = "tiktoken" },
-]
-retries = [
-    { name = "tenacity" },
-]
-temporal = [
-    { name = "temporalio" },
-]
-ui = [
-    { name = "starlette" },
-]
-vertexai = [
-    { name = "google-auth" },
-    { name = "requests" },
-]
-xai = [
-    { name = "xai-sdk" },
 ]
 
 [[package]]
@@ -6603,35 +5739,19 @@ wheels = [
 ]
 
 [[package]]
-name = "pydantic-evals"
-version = "1.47.0"
+name = "pydantic-graph"
+version = "2.31.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
-    { name = "logfire-api" },
-    { name = "pydantic" },
-    { name = "pydantic-ai-slim" },
-    { name = "pyyaml" },
-    { name = "rich" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/e9/e0/eb9108c102c69564183281cd4f3b2ce2801013f62f3f43d5698ed1f60cf3/pydantic_evals-1.47.0.tar.gz", hash = "sha256:db5b270c794524055011137c1cd44d172d42fe87a784990f44195c1e8291dd55", size = 47172, upload-time = "2026-01-24T00:44:42.432Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/79/1d/3cfabab8dbe50b87569ad690e80607bcffd444cc5e5b34e1493272c06411/pydantic_evals-1.47.0-py3-none-any.whl", hash = "sha256:8d4bc024245baf5535cca72ee425846ce5f1c127678caa5d1cd755716d6e48cc", size = 56347, upload-time = "2026-01-24T00:44:34.602Z" },
-]
-
-[[package]]
-name = "pydantic-graph"
-version = "1.47.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
     { name = "httpx" },
     { name = "logfire-api" },
     { name = "pydantic" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b2/e7/e419899a7e1942f4ce0cf3d5daa2d7410f9a04f3ed4cce2a54a4a3405d4c/pydantic_graph-1.47.0.tar.gz", hash = "sha256:59c904faba77e92efc0ed140dcabd429c333895ee22ec57f61bdd34a83530613", size = 58453, upload-time = "2026-01-24T00:44:43.6Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2e/40/da6b9b7ee8c77b5c5e910ecc49a7d4ed93422a9bddb1726ed876b6abbeea/pydantic_graph-2.31.1.tar.gz", hash = "sha256:ac5f34e7bbf518a18a9c22f1e33418c3343542a8ea269ee8ee58e637e3f4fd56", size = 45179, upload-time = "2026-08-18T03:39:54.732Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1c/34/075a5abb11f1c37730e329a77fc440e162097854efe536642d50c5fb8ae8/pydantic_graph-1.47.0-py3-none-any.whl", hash = "sha256:cbd3d60fb057bf4d51e62a6fb1383de560a18847107a843794efbdd5985fb6d1", size = 72326, upload-time = "2026-01-24T00:44:36.245Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/40/ca98101077f17c1773c1aad617d03f6a0666936a8c6aeb4aac4c3e61eb54/pydantic_graph-2.31.1-py3-none-any.whl", hash = "sha256:7a5a9a8143d52f509a917263eeb49b4466eda6caf5131d1e71143fc6e9710157", size = 52662, upload-time = "2026-08-18T03:39:49.133Z" },
 ]
 
 [[package]]
@@ -6646,30 +5766,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/43/4b/ac7e0aae12027748076d72a8764ff1c9d82ca75a7a52622e67ed3f765c54/pydantic_settings-2.12.0.tar.gz", hash = "sha256:005538ef951e3c2a68e1c08b292b5f2e71490def8589d4221b95dab00dafcfd0", size = 194184, upload-time = "2025-11-10T14:25:47.013Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c1/60/5d4751ba3f4a40a6891f24eec885f51afd78d208498268c734e256fb13c4/pydantic_settings-2.12.0-py3-none-any.whl", hash = "sha256:fddb9fd99a5b18da837b29710391e945b1e30c135477f484084ee513adb93809", size = 51880, upload-time = "2025-11-10T14:25:45.546Z" },
-]
-
-[[package]]
-name = "pydocket"
-version = "0.16.6"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "cloudpickle" },
-    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
-    { name = "fakeredis", extra = ["lua"] },
-    { name = "opentelemetry-api" },
-    { name = "opentelemetry-exporter-prometheus" },
-    { name = "opentelemetry-instrumentation" },
-    { name = "prometheus-client" },
-    { name = "py-key-value-aio", extra = ["memory", "redis"] },
-    { name = "python-json-logger" },
-    { name = "redis" },
-    { name = "rich" },
-    { name = "typer" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/72/00/26befe5f58df7cd1aeda4a8d10bc7d1908ffd86b80fd995e57a2a7b3f7bd/pydocket-0.16.6.tar.gz", hash = "sha256:b96c96ad7692827214ed4ff25fcf941ec38371314db5dcc1ae792b3e9d3a0294", size = 299054, upload-time = "2026-01-09T22:09:15.405Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/0a/3f/7483e5a6dc6326b6e0c640619b5c5bd1d6e3c20e54d58f5fb86267cef00e/pydocket-0.16.6-py3-none-any.whl", hash = "sha256:683d21e2e846aa5106274e7d59210331b242d7fb0dce5b08d3b82065663ed183", size = 67697, upload-time = "2026-01-09T22:09:13.436Z" },
 ]
 
 [[package]]
@@ -6706,15 +5802,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/1e/6c/9e370934bfa30e889d12e61d0dae009991294f40055c238980066a7fbd83/pymdown_extensions-10.20.1.tar.gz", hash = "sha256:e7e39c865727338d434b55f1dd8da51febcffcaebd6e1a0b9c836243f660740a", size = 852860, upload-time = "2026-01-24T05:56:56.758Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/40/6d/b6ee155462a0156b94312bdd82d2b92ea56e909740045a87ccb98bf52405/pymdown_extensions-10.20.1-py3-none-any.whl", hash = "sha256:24af7feacbca56504b313b7b418c4f5e1317bb5fea60f03d57be7fcc40912aa0", size = 268768, upload-time = "2026-01-24T05:56:54.537Z" },
-]
-
-[[package]]
-name = "pyparsing"
-version = "3.3.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f3/91/9c6ee907786a473bf81c5f53cf703ba0957b23ab84c264080fb5a450416f/pyparsing-3.3.2.tar.gz", hash = "sha256:c777f4d763f140633dcb6d8a3eda953bf7a214dc4eff598413c070bcdc117cbc", size = 6851574, upload-time = "2026-01-21T03:57:59.36Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl", hash = "sha256:850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d", size = 122781, upload-time = "2026-01-21T03:57:55.912Z" },
 ]
 
 [[package]]
@@ -6865,42 +5952,12 @@ wheels = [
 ]
 
 [[package]]
-name = "python-json-logger"
-version = "4.0.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/29/bf/eca6a3d43db1dae7070f70e160ab20b807627ba953663ba07928cdd3dc58/python_json_logger-4.0.0.tar.gz", hash = "sha256:f58e68eb46e1faed27e0f574a55a0455eecd7b8a5b88b85a784519ba3cff047f", size = 17683, upload-time = "2025-10-06T04:15:18.984Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/51/e5/fecf13f06e5e5f67e8837d777d1bc43fac0ed2b77a676804df5c34744727/python_json_logger-4.0.0-py3-none-any.whl", hash = "sha256:af09c9daf6a813aa4cc7180395f50f2a9e5fa056034c9953aec92e381c5ba1e2", size = 15548, upload-time = "2025-10-06T04:15:17.553Z" },
-]
-
-[[package]]
 name = "python-multipart"
-version = "0.0.22"
+version = "0.0.32"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/94/01/979e98d542a70714b0cb2b6728ed0b7c46792b695e3eaec3e20711271ca3/python_multipart-0.0.22.tar.gz", hash = "sha256:7340bef99a7e0032613f56dc36027b959fd3b30a787ed62d310e951f7c3a3a58", size = 37612, upload-time = "2026-01-25T10:15:56.219Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5b/42/55c32bb9b12693c092ad250a0e82edb5b31ddeda6eb772de5f308b3804ad/python_multipart-0.0.32.tar.gz", hash = "sha256:be54b7f3fa167bb83e4fcd936b887b708f4e57fe75911c02aebf53efaf8d938e", size = 46881, upload-time = "2026-06-04T16:18:58.647Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1b/d0/397f9626e711ff749a95d96b7af99b9c566a9bb5129b8e4c10fc4d100304/python_multipart-0.0.22-py3-none-any.whl", hash = "sha256:2b2cd894c83d21bf49d702499531c7bafd057d730c201782048f7945d82de155", size = 24579, upload-time = "2026-01-25T10:15:54.811Z" },
-]
-
-[[package]]
-name = "python-ulid"
-version = "3.1.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/40/7e/0d6c82b5ccc71e7c833aed43d9e8468e1f2ff0be1b3f657a6fcafbb8433d/python_ulid-3.1.0.tar.gz", hash = "sha256:ff0410a598bc5f6b01b602851a3296ede6f91389f913a5d5f8c496003836f636", size = 93175, upload-time = "2025-08-18T16:09:26.305Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/6c/a0/4ed6632b70a52de845df056654162acdebaf97c20e3212c559ac43e7216e/python_ulid-3.1.0-py3-none-any.whl", hash = "sha256:e2cdc979c8c877029b4b7a38a6fba3bc4578e4f109a308419ff4d3ccf0a46619", size = 11577, upload-time = "2025-08-18T16:09:25.047Z" },
-]
-
-[[package]]
-name = "pythonnet"
-version = "3.0.5"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "clr-loader", marker = "python_full_version < '3.14'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/9a/d6/1afd75edd932306ae9bd2c2d961d603dc2b52fcec51b04afea464f1f6646/pythonnet-3.0.5.tar.gz", hash = "sha256:48e43ca463941b3608b32b4e236db92d8d40db4c58a75ace902985f76dac21cf", size = 239212, upload-time = "2024-12-13T08:30:44.393Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/cd/f1/bfb6811df4745f92f14c47a29e50e89a36b1533130fcc56452d4660bd2d6/pythonnet-3.0.5-py3-none-any.whl", hash = "sha256:f6702d694d5d5b163c9f3f5cc34e0bed8d6857150237fae411fefb883a656d20", size = 297506, upload-time = "2024-12-13T08:30:40.661Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/04/e8135ebd1ad02c56ec633277529b2602ff99ff634be76cdba5744cf554fd/python_multipart-0.0.32-py3-none-any.whl", hash = "sha256:ff6d3f776f16878c894e52e107296ffc890e913c611b1a4ec6c44e2821fe2e23", size = 30042, upload-time = "2026-06-04T16:18:57.319Z" },
 ]
 
 [[package]]
@@ -7020,25 +6077,6 @@ wheels = [
 ]
 
 [[package]]
-name = "qdrant-client"
-version = "1.16.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "grpcio" },
-    { name = "httpx", extra = ["http2"] },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.4.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "portalocker" },
-    { name = "protobuf" },
-    { name = "pydantic" },
-    { name = "urllib3" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/ca/7d/3cd10e26ae97b35cf856ca1dc67576e42414ae39502c51165bb36bb1dff8/qdrant_client-1.16.2.tar.gz", hash = "sha256:ca4ef5f9be7b5eadeec89a085d96d5c723585a391eb8b2be8192919ab63185f0", size = 331112, upload-time = "2025-12-12T10:58:30.866Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/08/13/8ce16f808297e16968269de44a14f4fef19b64d9766be1d6ba5ba78b579d/qdrant_client-1.16.2-py3-none-any.whl", hash = "sha256:442c7ef32ae0f005e88b5d3c0783c63d4912b97ae756eb5e052523be682f17d3", size = 377186, upload-time = "2025-12-12T10:58:29.282Z" },
-]
-
-[[package]]
 name = "rapidfuzz"
 version = "3.14.3"
 source = { registry = "https://pypi.org/simple" }
@@ -7126,38 +6164,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/85/33/cd87d92b23f0b06e8914a61cea6850c6d495ca027f669fab7a379041827a/rapidfuzz-3.14.3-pp311-pypy311_pp73-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1faa0f8f76ba75fd7b142c984947c280ef6558b5067af2ae9b8729b0a0f99ede", size = 1352187, upload-time = "2025-11-01T11:54:45.518Z" },
     { url = "https://files.pythonhosted.org/packages/22/20/9d30b4a1ab26aac22fff17d21dec7e9089ccddfe25151d0a8bb57001dc3d/rapidfuzz-3.14.3-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1e6eefec45625c634926a9fd46c9e4f31118ac8f3156fff9494422cee45207e6", size = 3101472, upload-time = "2025-11-01T11:54:47.255Z" },
     { url = "https://files.pythonhosted.org/packages/b1/ad/fa2d3e5c29a04ead7eaa731c7cd1f30f9ec3c77b3a578fdf90280797cbcb/rapidfuzz-3.14.3-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:56fefb4382bb12250f164250240b9dd7772e41c5c8ae976fd598a32292449cc5", size = 1511361, upload-time = "2025-11-01T11:54:49.057Z" },
-]
-
-[[package]]
-name = "redis"
-version = "7.1.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "async-timeout", marker = "python_full_version < '3.11.3'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/43/c8/983d5c6579a411d8a99bc5823cc5712768859b5ce2c8afe1a65b37832c81/redis-7.1.0.tar.gz", hash = "sha256:b1cc3cfa5a2cb9c2ab3ba700864fb0ad75617b41f01352ce5779dabf6d5f9c3c", size = 4796669, upload-time = "2025-11-19T15:54:39.961Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/89/f0/8956f8a86b20d7bb9d6ac0187cf4cd54d8065bc9a1a09eb8011d4d326596/redis-7.1.0-py3-none-any.whl", hash = "sha256:23c52b208f92b56103e17c5d06bdc1a6c2c0b3106583985a76a18f83b265de2b", size = 354159, upload-time = "2025-11-19T15:54:38.064Z" },
-]
-
-[[package]]
-name = "redisvl"
-version = "0.14.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "jsonpath-ng" },
-    { name = "ml-dtypes" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.4.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "pydantic" },
-    { name = "python-ulid" },
-    { name = "pyyaml" },
-    { name = "redis" },
-    { name = "tenacity" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/21/45/1c5b308f68b01c4e33590a8e1445f43c51292917b28c2def8deaa5b3dc5b/redisvl-0.14.0.tar.gz", hash = "sha256:7a84c46858dbc86943e64ffe8590013684d03d79b72a634d10c02ce5d1c02335", size = 759829, upload-time = "2026-02-06T15:48:19.384Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/24/e9/264455caf42501b2b0747ac4819c7d0a2b458fad5e4e1f7610b6383d6d74/redisvl-0.14.0-py3-none-any.whl", hash = "sha256:85ec38f414427260da82ef20653a62d4c2626b97672c5c950616e5dde3cf0d0b", size = 196705, upload-time = "2026-02-06T15:48:17.636Z" },
 ]
 
 [[package]]
@@ -7496,18 +6502,6 @@ wheels = [
 ]
 
 [[package]]
-name = "rsa"
-version = "4.9.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pyasn1" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/da/8a/22b7beea3ee0d44b1916c0c1cb0ee3af23b700b6da9f04991899d0c555d4/rsa-4.9.1.tar.gz", hash = "sha256:e7bdbfdb5497da4c07dfd35530e1a902659db6ff241e39d9953cad06ebd0ae75", size = 29034, upload-time = "2025-04-16T09:51:18.218Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/64/8d/0133e4eb4beed9e425d9a98ed6e081a55d195481b7632472be1af08d2f6b/rsa-4.9.1-py3-none-any.whl", hash = "sha256:68635866661c6836b8d39430f97a996acbd61bfa49406748ea243539fe239762", size = 34696, upload-time = "2025-04-16T09:51:17.142Z" },
-]
-
-[[package]]
 name = "ruff"
 version = "0.14.14"
 source = { registry = "https://pypi.org/simple" }
@@ -7547,28 +6541,26 @@ wheels = [
 
 [[package]]
 name = "safetensors"
-version = "0.7.0"
+version = "0.8.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/29/9c/6e74567782559a63bd040a236edca26fd71bc7ba88de2ef35d75df3bca5e/safetensors-0.7.0.tar.gz", hash = "sha256:07663963b67e8bd9f0b8ad15bb9163606cd27cc5a1b96235a50d8369803b96b0", size = 200878, upload-time = "2025-11-19T15:18:43.199Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/45/06/f955dbbb1859e3bd23c8ac6141af5106e7ad5fedec4a3a6e3d60f94b7001/safetensors-0.8.0.tar.gz", hash = "sha256:fabaf3e0f18a6618d9b36560682562157f77c2b71fcffc7b432be2baed9d753d", size = 325846, upload-time = "2026-06-09T07:52:25.563Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fa/47/aef6c06649039accf914afef490268e1067ed82be62bcfa5b7e886ad15e8/safetensors-0.7.0-cp38-abi3-macosx_10_12_x86_64.whl", hash = "sha256:c82f4d474cf725255d9e6acf17252991c3c8aac038d6ef363a4bf8be2f6db517", size = 467781, upload-time = "2025-11-19T15:18:35.84Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/00/374c0c068e30cd31f1e1b46b4b5738168ec79e7689ca82ee93ddfea05109/safetensors-0.7.0-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:94fd4858284736bb67a897a41608b5b0c2496c9bdb3bf2af1fa3409127f20d57", size = 447058, upload-time = "2025-11-19T15:18:34.416Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/06/578ffed52c2296f93d7fd2d844cabfa92be51a587c38c8afbb8ae449ca89/safetensors-0.7.0-cp38-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e07d91d0c92a31200f25351f4acb2bc6aff7f48094e13ebb1d0fb995b54b6542", size = 491748, upload-time = "2025-11-19T15:18:09.79Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/33/1debbbb70e4791dde185edb9413d1fe01619255abb64b300157d7f15dddd/safetensors-0.7.0-cp38-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8469155f4cb518bafb4acf4865e8bb9d6804110d2d9bdcaa78564b9fd841e104", size = 503881, upload-time = "2025-11-19T15:18:16.145Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/1c/40c2ca924d60792c3be509833df711b553c60effbd91da6f5284a83f7122/safetensors-0.7.0-cp38-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:54bef08bf00a2bff599982f6b08e8770e09cc012d7bba00783fc7ea38f1fb37d", size = 623463, upload-time = "2025-11-19T15:18:21.11Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/3a/13784a9364bd43b0d61eef4bea2845039bc2030458b16594a1bd787ae26e/safetensors-0.7.0-cp38-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:42cb091236206bb2016d245c377ed383aa7f78691748f3bb6ee1bfa51ae2ce6a", size = 532855, upload-time = "2025-11-19T15:18:25.719Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/60/429e9b1cb3fc651937727befe258ea24122d9663e4d5709a48c9cbfceecb/safetensors-0.7.0-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dac7252938f0696ddea46f5e855dd3138444e82236e3be475f54929f0c510d48", size = 507152, upload-time = "2025-11-19T15:18:33.023Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/a8/4b45e4e059270d17af60359713ffd83f97900d45a6afa73aaa0d737d48b6/safetensors-0.7.0-cp38-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1d060c70284127fa805085d8f10fbd0962792aed71879d00864acda69dbab981", size = 541856, upload-time = "2025-11-19T15:18:31.075Z" },
-    { url = "https://files.pythonhosted.org/packages/06/87/d26d8407c44175d8ae164a95b5a62707fcc445f3c0c56108e37d98070a3d/safetensors-0.7.0-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:cdab83a366799fa730f90a4ebb563e494f28e9e92c4819e556152ad55e43591b", size = 674060, upload-time = "2025-11-19T15:18:37.211Z" },
-    { url = "https://files.pythonhosted.org/packages/11/f5/57644a2ff08dc6325816ba7217e5095f17269dada2554b658442c66aed51/safetensors-0.7.0-cp38-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:672132907fcad9f2aedcb705b2d7b3b93354a2aec1b2f706c4db852abe338f85", size = 771715, upload-time = "2025-11-19T15:18:38.689Z" },
-    { url = "https://files.pythonhosted.org/packages/86/31/17883e13a814bd278ae6e266b13282a01049b0c81341da7fd0e3e71a80a3/safetensors-0.7.0-cp38-abi3-musllinux_1_2_i686.whl", hash = "sha256:5d72abdb8a4d56d4020713724ba81dac065fedb7f3667151c4a637f1d3fb26c0", size = 714377, upload-time = "2025-11-19T15:18:40.162Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/d8/0c8a7dc9b41dcac53c4cbf9df2b9c83e0e0097203de8b37a712b345c0be5/safetensors-0.7.0-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b0f6d66c1c538d5a94a73aa9ddca8ccc4227e6c9ff555322ea40bdd142391dd4", size = 677368, upload-time = "2025-11-19T15:18:41.627Z" },
-    { url = "https://files.pythonhosted.org/packages/05/e5/cb4b713c8a93469e3c5be7c3f8d77d307e65fe89673e731f5c2bfd0a9237/safetensors-0.7.0-cp38-abi3-win32.whl", hash = "sha256:c74af94bf3ac15ac4d0f2a7c7b4663a15f8c2ab15ed0fc7531ca61d0835eccba", size = 326423, upload-time = "2025-11-19T15:18:45.74Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/e6/ec8471c8072382cb91233ba7267fd931219753bb43814cbc71757bfd4dab/safetensors-0.7.0-cp38-abi3-win_amd64.whl", hash = "sha256:d1239932053f56f3456f32eb9625590cc7582e905021f94636202a864d470755", size = 341380, upload-time = "2025-11-19T15:18:44.427Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/6a/4d08d89a6fcbe905c5ae68b8b34f0791850882fc19782d0d02c65abbdf3b/safetensors-0.7.0-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f4729811a6640d019a4b7ba8638ee2fd21fa5ca8c7e7bdf0fed62068fcaac737", size = 492430, upload-time = "2025-11-19T15:18:11.884Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/29/59ed8152b30f72c42d00d241e58eaca558ae9dbfa5695206e2e0f54c7063/safetensors-0.7.0-pp310-pypy310_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:12f49080303fa6bb424b362149a12949dfbbf1e06811a88f2307276b0c131afd", size = 503977, upload-time = "2025-11-19T15:18:17.523Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/0b/4811bfec67fa260e791369b16dab105e4bae82686120554cc484064e22b4/safetensors-0.7.0-pp310-pypy310_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0071bffba4150c2f46cae1432d31995d77acfd9f8db598b5d1a2ce67e8440ad2", size = 623890, upload-time = "2025-11-19T15:18:22.666Z" },
-    { url = "https://files.pythonhosted.org/packages/58/5b/632a58724221ef03d78ab65062e82a1010e1bef8e8e0b9d7c6d7b8044841/safetensors-0.7.0-pp310-pypy310_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:473b32699f4200e69801bf5abf93f1a4ecd432a70984df164fc22ccf39c4a6f3", size = 531885, upload-time = "2025-11-19T15:18:27.146Z" },
+    { url = "https://files.pythonhosted.org/packages/39/a0/f718cda65b05407d228f97602cf60dca269c979867aa5beb25410de26cd3/safetensors-0.8.0-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:c554f85858e05226d3c2828e32395e677434685d6d94594a41643361c5e837f0", size = 473568, upload-time = "2026-06-09T07:52:18.829Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/b1/fa7c600e7dceae12e9606c7578cbc9ff1e1ed55844883ee5c92205e86226/safetensors-0.8.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:c80201d22cbf405b80647a60ada77bba06c8fba2da2743ba1e89cdcc39a81f25", size = 484562, upload-time = "2026-06-09T07:52:17.518Z" },
+    { url = "https://files.pythonhosted.org/packages/09/7d/65a7de0af421317bb36a067241e4235fff194eed60b961ed6d3f59a3fc60/safetensors-0.8.0-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7a46e5ff292c356d6991e60942ba7f79817682d3a2cef0702136448cb9c4d235", size = 502844, upload-time = "2026-06-09T07:52:07.624Z" },
+    { url = "https://files.pythonhosted.org/packages/91/4f/3175c9d75634e0e0dda0082794193521035edd7c70a6f212bf33ca06ddf4/safetensors-0.8.0-cp310-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:4124502b78f03534117c848f87a39b8f31e577b15eff423bf8bfb95f2a8c30d0", size = 511823, upload-time = "2026-06-09T07:52:09.565Z" },
+    { url = "https://files.pythonhosted.org/packages/20/87/846c289e7aa2299eff406335717cf43ce8777194ece8aad75772e0411615/safetensors-0.8.0-cp310-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7bc0a787ba8a35be368ee3574edfa2b1ad389eebd0a72e482ae275490e3f6c98", size = 633461, upload-time = "2026-06-09T07:52:11.128Z" },
+    { url = "https://files.pythonhosted.org/packages/76/22/8d64d9df2c45d5ded401df889d0ad90882804ca172d79ec4f0df8f727fe0/safetensors-0.8.0-cp310-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:040070828e36dc8e122178bbbd5830ff9e97920affb84cbe0f46442497bed358", size = 545148, upload-time = "2026-06-09T07:52:13.603Z" },
+    { url = "https://files.pythonhosted.org/packages/28/50/f203ff3a3ddfe19308efc83c5a3a29ed02bf786732ec35e68bf9162f3365/safetensors-0.8.0-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fd6f3f93c9a0a7cc2788ee63fb763353d4bd2e89b0751bc78fcf7dda00bea774", size = 516040, upload-time = "2026-06-09T07:52:16.29Z" },
+    { url = "https://files.pythonhosted.org/packages/46/fb/cdaed17ceb2948784fd9c36b6fd3e951b608547cea81a48e8ee6f8cfdfcb/safetensors-0.8.0-cp310-abi3-manylinux_2_31_riscv64.whl", hash = "sha256:fcdd41ec4628fee5799f807c73c353629130fbd942aa23d83c623dd6c9d52d78", size = 513832, upload-time = "2026-06-09T07:52:12.37Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/49/1e15de264dcc3b77943d2d0c56a95809956883b1c2d6d585c792523f180b/safetensors-0.8.0-cp310-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:8e9f537aa183a38ace122d27303dcd986b26bd2a7591f9181d7f0c396f4677ca", size = 559930, upload-time = "2026-06-09T07:52:14.743Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/43/bf38443278eab4b1be1fce2931e2b012ad9cb7df52ada751d0aab8f7659a/safetensors-0.8.0-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:87eec7ffed2b809f05a398a8becb7d013f19f7837cd15d9748580d6cf30dbaf4", size = 678670, upload-time = "2026-06-09T07:52:20.032Z" },
+    { url = "https://files.pythonhosted.org/packages/72/e3/68cd3fa5b48488e84add63e04cb12f3bc28ae4638c06d4508c6e88823d0e/safetensors-0.8.0-cp310-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:4a95ae2b05d7726d751da4ebf626a2ca782b706e101bd894c95bc2450b1cffcc", size = 786679, upload-time = "2026-06-09T07:52:21.322Z" },
+    { url = "https://files.pythonhosted.org/packages/29/4b/1c19c509d56e01f4fbb3d0a2e597450f6cc04d1d56cf52defb0a62dfd715/safetensors-0.8.0-cp310-abi3-musllinux_1_2_i686.whl", hash = "sha256:3ae091f16662658bdc019a4ff6cb4c085bb7d725eb5978b183ffd265863b6d2d", size = 765683, upload-time = "2026-06-09T07:52:22.594Z" },
+    { url = "https://files.pythonhosted.org/packages/27/43/41c1621732edd934d868a00d1b891584c892a7b62a9aab82ea5a0a5623ee/safetensors-0.8.0-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:8e080062fcde23be189565e1c3305d16751a218ecf9412c8601e64204eb6f846", size = 722361, upload-time = "2026-06-09T07:52:23.924Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/3f/73ccf82579412b4a71c4ca673f10b5f1f888d7cf5af7fe24f27d30307be4/safetensors-0.8.0-cp310-abi3-win32.whl", hash = "sha256:2ddf52eac562eda224f99acfa7889d02968c1fd59a5b011ae7d8137c37e9c02d", size = 342401, upload-time = "2026-06-09T07:52:28.895Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/6d/3fba214c1e5e0f69991677ec3bc17023f0421776975e1de0c682dca475e2/safetensors-0.8.0-cp310-abi3-win_amd64.whl", hash = "sha256:096ec1a98435df7beb08853bb5aa9081a84f23d0adc67ed1a0a10550f608373f", size = 355540, upload-time = "2026-06-09T07:52:27.832Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/fc/7eedc3510d97878876e32774eebbeb61c43f148a96e915c84229a3e967aa/safetensors-0.8.0-cp310-abi3-win_arm64.whl", hash = "sha256:f7838e5135a406ad3e02efdcb8cf2e5397d368b0154537c4fec682dbc544d452", size = 340500, upload-time = "2026-06-09T07:52:26.745Z" },
 ]
 
 [[package]]
@@ -7579,10 +6571,10 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "joblib", marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "threadpoolctl", marker = "python_full_version < '3.11'" },
+    { name = "joblib" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" } },
+    { name = "threadpoolctl" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/98/c2/a7855e41c9d285dfe86dc50b250978105dce513d6e459ea66a6aeb0e1e0c/scikit_learn-1.7.2.tar.gz", hash = "sha256:20e9e49ecd130598f1ca38a1d85090e1a600147b9c02fa6f15d69cb53d968fda", size = 7193136, upload-time = "2025-09-09T08:21:29.075Z" }
 wheels = [
@@ -7629,10 +6621,10 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "joblib", marker = "python_full_version >= '3.11'" },
-    { name = "numpy", version = "2.4.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "scipy", version = "1.17.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "threadpoolctl", marker = "python_full_version >= '3.11'" },
+    { name = "joblib" },
+    { name = "numpy", version = "2.4.1", source = { registry = "https://pypi.org/simple" } },
+    { name = "scipy", version = "1.17.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "threadpoolctl" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0e/d4/40988bf3b8e34feec1d0e6a051446b1f66225f8529b9309becaeef62b6c4/scikit_learn-1.8.0.tar.gz", hash = "sha256:9bccbb3b40e3de10351f8f5068e105d0f4083b1a65fa07b6634fbc401a6287fd", size = 7335585, upload-time = "2025-12-10T07:08:53.618Z" }
 wheels = [
@@ -7682,7 +6674,7 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0f/37/6964b830433e654ec7485e45a00fc9a27cf868d622838f6b6d9c5ec0d532/scipy-1.15.3.tar.gz", hash = "sha256:eae3cf522bc7df64b42cad3925c876e1b0b6c35c1337c93e12c0f366f55b0eaf", size = 59419214, upload-time = "2025-05-08T16:13:05.955Z" }
 wheels = [
@@ -7744,7 +6736,7 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "numpy", version = "2.4.1", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/56/3e/9cca699f3486ce6bc12ff46dc2031f1ec8eb9ccc9a320fdaf925f1417426/scipy-1.17.0.tar.gz", hash = "sha256:2591060c8e648d8b96439e111ac41fd8342fdeff1876be2e19dea3fe8930454e", size = 30396830, upload-time = "2026-01-10T21:34:23.009Z" }
 wheels = [
@@ -7825,22 +6817,25 @@ wheels = [
 
 [[package]]
 name = "sentence-transformers"
-version = "5.2.0"
+version = "6.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "huggingface-hub" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "scikit-learn", version = "1.7.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "scikit-learn", version = "1.8.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "scipy", version = "1.17.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "tokenizers" },
     { name = "torch" },
     { name = "tqdm" },
     { name = "transformers" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a2/a1/64e7b111e753307ffb7c5b6d039c52d4a91a47fa32a7f5bc377a49b22402/sentence_transformers-5.2.0.tar.gz", hash = "sha256:acaeb38717de689f3dab45d5e5a02ebe2f75960a4764ea35fea65f58a4d3019f", size = 381004, upload-time = "2025-12-11T14:12:31.038Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d9/ef/87681678d0aa91a1e77f0ffdd2e5d900aaf358aac644dd14bead8d95ec4c/sentence_transformers-6.0.1.tar.gz", hash = "sha256:1c3b8d9403f87ad0c879638554f36cc85744f38a6a70d150fd7e964ca0e9935b", size = 575395, upload-time = "2026-08-31T07:50:43.518Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/40/d0/3b2897ef6a0c0c801e9fecca26bcc77081648e38e8c772885ebdd8d7d252/sentence_transformers-5.2.0-py3-none-any.whl", hash = "sha256:aa57180f053687d29b08206766ae7db549be5074f61849def7b17bf0b8025ca2", size = 493748, upload-time = "2025-12-11T14:12:29.516Z" },
+    { url = "https://files.pythonhosted.org/packages/31/ab/dc6031faf1b6bba08076fbf457b21a5c51ba7928a77916915e093c16b8c7/sentence_transformers-6.0.1-py3-none-any.whl", hash = "sha256:b8888d72c707ba33c63aa30845850702dd5acadf1dd0d051436380bcebe4fd0f", size = 739832, upload-time = "2026-08-31T07:50:41.635Z" },
 ]
 
 [[package]]
@@ -7966,15 +6961,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
-]
-
-[[package]]
-name = "sortedcontainers"
-version = "2.4.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88", size = 30594, upload-time = "2021-05-16T22:03:42.897Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575, upload-time = "2021-05-16T22:03:41.177Z" },
 ]
 
 [[package]]
@@ -8201,20 +7187,20 @@ wheels = [
 
 [[package]]
 name = "starlette"
-version = "0.50.0"
+version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ba/b8/73a0e6a6e079a9d9cfa64113d771e421640b6f679a52eeb9b32f72d871a1/starlette-0.50.0.tar.gz", hash = "sha256:a2a17b22203254bcbc2e1f926d2d55f3f9497f769416b3190768befe598fa3ca", size = 2646985, upload-time = "2025-11-01T15:25:27.516Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b5/b4/205b0d5241d934e8add0c38aa924c4f9fb7330834ff11e5444db964ec3f9/starlette-1.6.0.tar.gz", hash = "sha256:d4e3ac5e546444960c710297a3c9fc3f7ebae1b7e963f3d36173b49da535be9b", size = 2716969, upload-time = "2026-08-08T18:27:57.512Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d9/52/1064f510b141bd54025f9b55105e26d1fa970b9be67ad766380a3c9b74b0/starlette-0.50.0-py3-none-any.whl", hash = "sha256:9e5391843ec9b6e472eed1365a78c8098cfceb7a74bfd4d6b1c0c0095efb3bca", size = 74033, upload-time = "2025-11-01T15:25:25.461Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/cb/6a6a47d5b464bd08695d254f3da6e7986cc70c9fa5d778eda57538edfe56/starlette-1.6.0-py3-none-any.whl", hash = "sha256:a86dd39d14bb45f85a3d18525215a9ef0cfd1f192ac793220e72598c90335f0c", size = 75969, upload-time = "2026-08-08T18:27:56.196Z" },
 ]
 
 [[package]]
 name = "strands-agents"
-version = "1.52.0"
+version = "1.55.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "boto3" },
@@ -8231,9 +7217,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "watchdog" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/92/f5/7bcd5018b80dcc9eb70bb315ad42d0e8e1607473689a246bdbb763433f5a/strands_agents-1.52.0.tar.gz", hash = "sha256:e79f08527cf3b03ace3ead081f71ee43ee33de7285a4faa9ecafaef4618afeb0", size = 1333918, upload-time = "2026-08-12T18:52:03.743Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0d/80/f65af6df0300f1d09e5c0d0cc7ebb1e8183d3922829cec2c255c91188ec9/strands_agents-1.55.1.tar.gz", hash = "sha256:55dc609a9d7c75d61842304180456a815e60b34d00ce089c29362cedd274cd2a", size = 1622097, upload-time = "2026-09-09T21:24:37.159Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/32/28/6b1733dfb50ccf2b250d892ff9fdb0c987d0486febaf1305c5b6a904154b/strands_agents-1.52.0-py3-none-any.whl", hash = "sha256:768ff0e865df9f18154a2111f71e0c7683b8505e897704b89981cf7f11667bee", size = 687868, upload-time = "2026-08-12T18:52:01.538Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/a0/5d7dc1c6df4b4717d7be516c32e5c9383ef0676166fb06260b6d88c4c9ab/strands_agents-1.55.1-py3-none-any.whl", hash = "sha256:3b62a8ca6f34d14140789900e35205c0032fa4a92f6147c7f69a7fda149da7ab", size = 821393, upload-time = "2026-09-09T21:24:35.259Z" },
 ]
 
 [[package]]
@@ -8246,26 +7232,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/83/d3/803453b36afefb7c2bb238361cd4ae6125a569b4db67cd9e79846ba2d68c/sympy-1.14.0.tar.gz", hash = "sha256:d3d3fe8df1e5a0b42f0e7bdf50541697dbe7d23746e894990c030e2b05e72517", size = 7793921, upload-time = "2025-04-27T18:05:01.611Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a2/09/77d55d46fd61b4a135c444fc97158ef34a095e5681d0a6c10b75bf356191/sympy-1.14.0-py3-none-any.whl", hash = "sha256:e091cc3e99d2141a0ba2847328f5479b05d94a6635cb96148ccb3f34671bd8f5", size = 6299353, upload-time = "2025-04-27T18:04:59.103Z" },
-]
-
-[[package]]
-name = "temporalio"
-version = "1.20.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "nexus-rpc" },
-    { name = "protobuf" },
-    { name = "python-dateutil", marker = "python_full_version < '3.11'" },
-    { name = "types-protobuf" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/21/db/7d5118d28b0918888e1ec98f56f659fdb006351e06d95f30f4274962a76f/temporalio-1.20.0.tar.gz", hash = "sha256:5a6a85b7d298b7359bffa30025f7deac83c74ac095a4c6952fbf06c249a2a67c", size = 1850498, upload-time = "2025-11-25T21:25:20.225Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f4/1b/e69052aa6003eafe595529485d9c62d1382dd5e671108f1bddf544fb6032/temporalio-1.20.0-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:fba70314b4068f8b1994bddfa0e2ad742483f0ae714d2ef52e63013ccfd7042e", size = 12061638, upload-time = "2025-11-25T21:24:57.918Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/3b/3e8c67ed7f23bedfa231c6ac29a7a9c12b89881da7694732270f3ecd6b0c/temporalio-1.20.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:ffc5bb6cabc6ae67f0bfba44de6a9c121603134ae18784a2ff3a7f230ad99080", size = 11562603, upload-time = "2025-11-25T21:25:01.721Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/be/ed0cc11702210522a79e09703267ebeca06eb45832b873a58de3ca76b9d0/temporalio-1.20.0-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a1e80c1e4cdf88fa8277177f563edc91466fe4dc13c0322f26e55c76b6a219e6", size = 11824016, upload-time = "2025-11-25T21:25:06.771Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/97/09c5cafabc80139d97338a2bdd8ec22e08817dfd2949ab3e5b73565006eb/temporalio-1.20.0-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ba92d909188930860c9d89ca6d7a753bc5a67e4e9eac6cea351477c967355eed", size = 12189521, upload-time = "2025-11-25T21:25:12.091Z" },
-    { url = "https://files.pythonhosted.org/packages/11/23/5689c014a76aff3b744b3ee0d80815f63b1362637814f5fbb105244df09b/temporalio-1.20.0-cp310-abi3-win_amd64.whl", hash = "sha256:eacfd571b653e0a0f4aa6593f4d06fc628797898f0900d400e833a1f40cad03a", size = 12745027, upload-time = "2025-11-25T21:25:16.827Z" },
 ]
 
 [[package]]
@@ -8428,6 +7394,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/28/c0/3c7a39ff68022ddfd7d93f3337ad90389a342f761c4d71de99a3ccc57857/tiktoken-0.12.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:54c891b416a0e36b8e2045b12b33dd66fb34a4fe7965565f1b482da50da3e86a", size = 1194908, upload-time = "2025-10-06T20:22:32.073Z" },
     { url = "https://files.pythonhosted.org/packages/ab/0d/c1ad6f4016a3968c048545f5d9b8ffebf577774b2ede3e2e352553b685fe/tiktoken-0.12.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5edb8743b88d5be814b1a8a8854494719080c28faaa1ccbef02e87354fe71ef0", size = 1253706, upload-time = "2025-10-06T20:22:33.385Z" },
     { url = "https://files.pythonhosted.org/packages/af/df/c7891ef9d2712ad774777271d39fdef63941ffba0a9d59b7ad1fd2765e57/tiktoken-0.12.0-cp314-cp314t-win_amd64.whl", hash = "sha256:f61c0aea5565ac82e2ec50a05e02a6c44734e91b51c10510b084ea1b8e633a71", size = 920667, upload-time = "2025-10-06T20:22:34.444Z" },
+]
+
+[[package]]
+name = "tinytag"
+version = "2.3.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/38/0f/fae085b7f19fe0c67b68e6d70098ac6cd046cc498f253f5ee56a3dd03bbc/tinytag-2.3.2.tar.gz", hash = "sha256:021d711cdbdbf840d3b67b976cb34dadc58d2fcfd490eb74ef9602b37b991414", size = 47353, upload-time = "2026-09-07T17:46:08.886Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6b/54/d378858d14e5c5c7b921cb9ffccf27be3d34f3d6d010c57404ddd634685d/tinytag-2.3.2-py3-none-any.whl", hash = "sha256:ebaf957915266b9c20414a10f8c5170a345aa039a794650d39d66e7d6b96199f", size = 37171, upload-time = "2026-09-07T17:46:07.434Z" },
 ]
 
 [[package]]
@@ -8610,24 +7585,23 @@ wheels = [
 
 [[package]]
 name = "transformers"
-version = "4.57.6"
+version = "5.15.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "filelock" },
     { name = "huggingface-hub" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.4.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "packaging" },
     { name = "pyyaml" },
     { name = "regex" },
-    { name = "requests" },
     { name = "safetensors" },
     { name = "tokenizers" },
     { name = "tqdm" },
+    { name = "typer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c4/35/67252acc1b929dc88b6602e8c4a982e64f31e733b804c14bc24b47da35e6/transformers-4.57.6.tar.gz", hash = "sha256:55e44126ece9dc0a291521b7e5492b572e6ef2766338a610b9ab5afbb70689d3", size = 10134912, upload-time = "2026-01-16T10:38:39.284Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2a/92/c50c61da7046bbb59a4d011291aeadcfb4d7980ab36fdb31e93823a3fb93/transformers-5.15.1.tar.gz", hash = "sha256:27c996bd9075ddc82d40f8590dfdc81ea45f611bfca477e0db5d7fd257a482f7", size = 9378434, upload-time = "2026-08-19T11:28:20.33Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/03/b8/e484ef633af3887baeeb4b6ad12743363af7cce68ae51e938e00aaa0529d/transformers-4.57.6-py3-none-any.whl", hash = "sha256:4c9e9de11333ddfe5114bc872c9f370509198acf0b87a832a0ab9458e2bd0550", size = 11993498, upload-time = "2026-01-16T10:38:31.289Z" },
+    { url = "https://files.pythonhosted.org/packages/41/c4/a12e1d9b387fb0c40a57116db82b457e8c771cb419163cda29204d74a595/transformers-5.15.1-py3-none-any.whl", hash = "sha256:b7cdf238ff583e3a58dbc7fa34da1aaf091ce063141f65a30538160bd5afe93f", size = 11749582, upload-time = "2026-08-19T11:28:16.726Z" },
 ]
 
 [[package]]
@@ -8642,6 +7616,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/35/f8/9c66bfc55361ec6d0e4040a0337fb5924ceb23de4648b8a81ae9d33b2b38/triton-3.6.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d002e07d7180fd65e622134fbd980c9a3d4211fb85224b56a0a0efbd422ab72f", size = 188400296, upload-time = "2026-01-20T16:00:56.042Z" },
     { url = "https://files.pythonhosted.org/packages/df/3d/9e7eee57b37c80cec63322c0231bb6da3cfe535a91d7a4d64896fcb89357/triton-3.6.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a17a5d5985f0ac494ed8a8e54568f092f7057ef60e1b0fa09d3fd1512064e803", size = 188273063, upload-time = "2026-01-20T16:01:07.278Z" },
     { url = "https://files.pythonhosted.org/packages/f6/56/6113c23ff46c00aae423333eb58b3e60bdfe9179d542781955a5e1514cb3/triton-3.6.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:46bd1c1af4b6704e554cad2eeb3b0a6513a980d470ccfa63189737340c7746a7", size = 188397994, upload-time = "2026-01-20T16:01:14.236Z" },
+]
+
+[[package]]
+name = "truststore"
+version = "0.10.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169, upload-time = "2025-08-12T18:49:02.73Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660, upload-time = "2025-08-12T18:49:01.46Z" },
 ]
 
 [[package]]
@@ -8706,33 +7689,12 @@ wheels = [
 ]
 
 [[package]]
-name = "types-protobuf"
-version = "6.32.1.20251210"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c2/59/c743a842911887cd96d56aa8936522b0cd5f7a7f228c96e81b59fced45be/types_protobuf-6.32.1.20251210.tar.gz", hash = "sha256:c698bb3f020274b1a2798ae09dc773728ce3f75209a35187bd11916ebfde6763", size = 63900, upload-time = "2025-12-10T03:14:25.451Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/aa/43/58e75bac4219cbafee83179505ff44cae3153ec279be0e30583a73b8f108/types_protobuf-6.32.1.20251210-py3-none-any.whl", hash = "sha256:2641f78f3696822a048cfb8d0ff42ccd85c25f12f871fbebe86da63793692140", size = 77921, upload-time = "2025-12-10T03:14:24.477Z" },
-]
-
-[[package]]
 name = "types-pyyaml"
 version = "6.0.12.20260518"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b8/83/4a1afc3fbfcf5b8d46fc390cd95ed6b0dc9010a265f4e9f46314efffa37a/types_pyyaml-6.0.12.20260518.tar.gz", hash = "sha256:d917f83fb38462550338c1297faedd860b3ec83912b96b1e3d73255f7473e466", size = 17850, upload-time = "2026-05-18T06:01:58.675Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/06/a2/c01db32be2ae7d6a1689972f3c492b149ee4e164b12fdfd9f64b50888215/types_pyyaml-6.0.12.20260518-py3-none-any.whl", hash = "sha256:d2150f75a231c9fe9c7463bd29487d93e60bac90400287351384bc2284eba7cd", size = 20312, upload-time = "2026-05-18T06:01:57.368Z" },
-]
-
-[[package]]
-name = "types-requests"
-version = "2.32.4.20260107"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "urllib3" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/0f/f3/a0663907082280664d745929205a89d41dffb29e89a50f753af7d57d0a96/types_requests-2.32.4.20260107.tar.gz", hash = "sha256:018a11ac158f801bfa84857ddec1650750e393df8a004a8a9ae2a9bec6fcb24f", size = 23165, upload-time = "2026-01-07T03:20:54.091Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/1c/12/709ea261f2bf91ef0a26a9eed20f2623227a8ed85610c1e54c5805692ecb/types_requests-2.32.4.20260107-py3-none-any.whl", hash = "sha256:b703fe72f8ce5b31ef031264fe9395cac8f46a04661a79f7ed31a80fb308730d", size = 20676, upload-time = "2026-01-07T03:20:52.929Z" },
 ]
 
 [[package]]
@@ -8800,12 +7762,12 @@ wheels = [
 ]
 
 [[package]]
-name = "uritemplate"
-version = "4.2.0"
+name = "uncalled-for"
+version = "0.4.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/98/60/f174043244c5306c9988380d2cb10009f91563fc4b31293d27e17201af56/uritemplate-4.2.0.tar.gz", hash = "sha256:480c2ed180878955863323eea31b0ede668795de182617fef9c6ca09e6ec9d0e", size = 33267, upload-time = "2025-06-02T15:12:06.318Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6b/5a/92ce0b3ea5481915f55da994c2c2c5f7a3c09949afde196ee89f8ab961aa/uncalled_for-0.4.0.tar.gz", hash = "sha256:335b95bd2422332ec210d518f314a16e4c640921c39fc8bf2ad095bd3538f4af", size = 56979, upload-time = "2026-08-10T14:51:46.247Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a9/99/3ae339466c9183ea5b8ae87b34c0b897eda475d2aec2307cae60e5cd4f29/uritemplate-4.2.0-py3-none-any.whl", hash = "sha256:962201ba1c4edcab02e60f9a0d3821e82dfc5d2d6662a21abd533879bdb8a686", size = 11488, upload-time = "2025-06-02T15:12:03.405Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/40/97cec87c077eb3291fc7905e6633e08b7ca593c57d30238444bcb6bb3d53/uncalled_for-0.4.0-py3-none-any.whl", hash = "sha256:16c4bb3337532e4bd5569adc192285976f3ad5305402256d34c67a12b5c968bd", size = 15502, upload-time = "2026-08-10T14:51:45.068Z" },
 ]
 
 [[package]]
@@ -9113,15 +8075,6 @@ wheels = [
 ]
 
 [[package]]
-name = "wcwidth"
-version = "0.3.5"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/95/fc/44799c4a51ff0da0de0ff27e68c9dea3454f3d9bf15ffb606aeb6943e672/wcwidth-0.3.5.tar.gz", hash = "sha256:7c3463f312540cf21ddd527ea34f3ae95c057fa191aa7a9e043898d20d636e59", size = 234185, upload-time = "2026-01-25T04:37:23.942Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7a/86/7f461495625145a99d60f14cdac142a11db5d501c86d48aad165575d1e06/wcwidth-0.3.5-py3-none-any.whl", hash = "sha256:b0a0245130566939a24ab8432e625b38272fbc62ecbe5aecbdcb50b8f02ce993", size = 86681, upload-time = "2026-01-25T04:37:22.585Z" },
-]
-
-[[package]]
 name = "weasel"
 version = "0.4.3"
 source = { registry = "https://pypi.org/simple" }
@@ -9210,18 +8163,6 @@ wheels = [
 ]
 
 [[package]]
-name = "werkzeug"
-version = "3.1.5"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "markupsafe" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/5a/70/1469ef1d3542ae7c2c7b72bd5e3a4e6ee69d7978fa8a3af05a38eca5becf/werkzeug-3.1.5.tar.gz", hash = "sha256:6a548b0e88955dd07ccb25539d7d0cc97417ee9e179677d22c7041c8f078ce67", size = 864754, upload-time = "2026-01-08T17:49:23.247Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ad/e4/8d97cca767bcc1be76d16fb76951608305561c6e056811587f36cb1316a8/werkzeug-3.1.5-py3-none-any.whl", hash = "sha256:5111e36e91086ece91f93268bb39b4a35c1e6f1feac762c9c822ded0a4e322dc", size = 225025, upload-time = "2026-01-08T17:49:21.859Z" },
-]
-
-[[package]]
 name = "wrapt"
 version = "1.17.3"
 source = { registry = "https://pypi.org/simple" }
@@ -9291,21 +8232,199 @@ wheels = [
 ]
 
 [[package]]
-name = "xai-sdk"
-version = "1.5.0"
+name = "xxhash"
+version = "4.0.1"
 source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "aiohttp" },
-    { name = "grpcio" },
-    { name = "opentelemetry-sdk" },
-    { name = "packaging" },
-    { name = "protobuf" },
-    { name = "pydantic" },
-    { name = "requests" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/b9/54/378c681c2c4512de78b49b65af1b7aaea0e0740dfa4a3389535e65422f70/xai_sdk-1.5.0.tar.gz", hash = "sha256:f88529d844f962fbb24464351a5962cc21a7d080e088bf656709ca7856270c8c", size = 349692, upload-time = "2025-12-05T03:27:36.93Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/a5/1386f35da1475fcaeef42581deae73417c6d2a6a0b2d2e8914de18844dcd/xxhash-4.0.1.tar.gz", hash = "sha256:d55bf4ef10eb09b8b6866790e083d26d087d84caa3cc0946ba87c3ca7ecaf7b7", size = 101513, upload-time = "2026-08-17T08:24:08.557Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d6/34/cd3681e5f786e37fb2dbb195fa3d5eb2a5e2be9b20d3abf01b40c9aba839/xai_sdk-1.5.0-py3-none-any.whl", hash = "sha256:4dc56bec2d67811c67030a50b42c4a1bc60f43947d4baaa840acf0aef246e816", size = 204314, upload-time = "2025-12-05T03:27:35.67Z" },
+    { url = "https://files.pythonhosted.org/packages/19/de/6854b311cb468985de555e49717357ba1de8ffe4b08eda3f4c522a418fda/xxhash-4.0.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:3f68fe400ceec235f3e4a4b02a28c2fd2d283584a193223c921dd4c48f1d0754", size = 38470, upload-time = "2026-08-17T08:20:33.331Z" },
+    { url = "https://files.pythonhosted.org/packages/91/2a/7d79952633fccbf9c2a59cc1dfe9d073f9edfceb052ba9bff5075e31408d/xxhash-4.0.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:9b1dddc257279417d93c9e59420d49ef90aece90d7a01996db3aade74b0281b1", size = 36229, upload-time = "2026-08-17T08:20:10.259Z" },
+    { url = "https://files.pythonhosted.org/packages/70/6a/6a6f4220c39bae1636eb3f8ef217359b8afe268493ee858adf9002130257/xxhash-4.0.1-cp310-cp310-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:4972332c079d6aad69c4620a68d015a4ecb33141583f70d642cf9edf6a713763", size = 243168, upload-time = "2026-08-17T08:20:07.211Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/03/a1d745b324bede7af8a274d889d25b758402629695499a957375cc5fe994/xxhash-4.0.1-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f1b603d0686c99fa0879f104a74e7db58367634c6e50ba827bee9aa095e23205", size = 266061, upload-time = "2026-08-17T08:20:18.253Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/cd/55c7565db23d2d29a2e31ea9dd0001ad3f4729298f42ba32967dde7644ab/xxhash-4.0.1-cp310-cp310-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:33fd538191f47071deef6b1f676535e2aa770f1fd150ae4cc75a34c9e930be3d", size = 287357, upload-time = "2026-08-17T08:20:08.901Z" },
+    { url = "https://files.pythonhosted.org/packages/72/31/c967c98cbf151df6ae8756fc9821b1f78d1feffa8420ff2ad5645f27f98f/xxhash-4.0.1-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:33e270d302c95ec426dfa0f5a4e16bff2ab8d7b8a46faa4746affb05e684ac77", size = 270683, upload-time = "2026-08-17T08:20:10.943Z" },
+    { url = "https://files.pythonhosted.org/packages/70/98/df9f3c14bc2fb2712ed1497349dc7e8c0b0f20a1f353e2e146d83a1adef9/xxhash-4.0.1-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3fb1d30d4b6d6e2c4a08e5ac6fffdb2b572d2cfcca15a5509cf4e7a1350f955c", size = 497802, upload-time = "2026-08-17T08:20:17.217Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/3b/e5d20b4f602d15fc5fc066f601052a7d6f5a401a50d67fac92098a5829a5/xxhash-4.0.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7e27dbed5c4ba033919e4b4ed8dc14e029e91d14a93cd9f920d25277c7df6781", size = 249503, upload-time = "2026-08-17T08:20:40.14Z" },
+    { url = "https://files.pythonhosted.org/packages/39/98/4cd03fa7ba791657aa555d0655e89a0d66193b1331e4391114b50227f80f/xxhash-4.0.1-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:43bcf2a871f28f16135545415cab3ec43904d4c80425a64598a9e6cebfb2b5ba", size = 333384, upload-time = "2026-08-17T08:20:18.93Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/67/a0a076dbcecad2af0cceb873ba4f95475f3955fb81d82f9c5e9f97a12854/xxhash-4.0.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:5dc434c946012e6d8a72b10f970ea30755b718251dd7591dbfdabafd3bcb21bc", size = 262463, upload-time = "2026-08-17T08:20:08.719Z" },
+    { url = "https://files.pythonhosted.org/packages/48/94/767b68736250813923d74703ef628b0f57ff1c5bf690d7a6082928d1a14d/xxhash-4.0.1-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:0b1082fd0f089ce9098ed77aad8b777b5d156f8ac601c69cab73811822b8ef07", size = 289405, upload-time = "2026-08-17T08:20:35.493Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/61/69d9ec6e85f9933f26b39753b404f97ffd2fc3bfeeb5e26333752595e060/xxhash-4.0.1-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:dd649663ddeafbfd4734eb8abae921dd5baa1242f20bda54e8bc927369ccded4", size = 247989, upload-time = "2026-08-17T08:20:10.759Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/66/e6a033879893074bc441faec65587f9ef9cca49ee3cb99ef20c699b014cf/xxhash-4.0.1-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:97b455de3e8b1b0b1e4594cb61a468992563f03ca264062fbb0a66b393c01d90", size = 267987, upload-time = "2026-08-17T08:20:20.947Z" },
+    { url = "https://files.pythonhosted.org/packages/18/91/a99a412b010cf2cc2bd38a0a44043c894ffa80b46c8d4e1522e40d2ef401/xxhash-4.0.1-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:2194bf96d5f3d4e0cb65deba370ec83dda3edfba42155f9384190ed5e51ea5e2", size = 322541, upload-time = "2026-08-17T08:20:22.675Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/12/1a91408e66d1716bd278cf55529d4ba251d90c6b694ea78a09dcbd9d36c6/xxhash-4.0.1-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:84df5f8da574caadbc0cb1b8866ecc2368cc941f0cd05f677756c802f370dafa", size = 466264, upload-time = "2026-08-17T08:21:12.422Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/c8/8abd4c1b90962f794ed9b139767b0a971e5168e8393961ccf046956c0039/xxhash-4.0.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:c09ada495567c9c9a8156c5ebcfb93be7fece0755062d738c972dcbecd0d84b5", size = 246149, upload-time = "2026-08-17T08:20:23.385Z" },
+    { url = "https://files.pythonhosted.org/packages/22/3f/e020285d737a712bbfcf01dfdbbec7773c7c8289447a5373540caf2cdf5f/xxhash-4.0.1-cp310-cp310-win32.whl", hash = "sha256:85bdd40cb505a11e0ca04191711266c5fd696ed786ae83849955e457774edc96", size = 34630, upload-time = "2026-08-17T08:20:10.001Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/9b/4e8384b299b40664a225ce9deef54c42b3d59f5181a16d4a374ea3503f8f/xxhash-4.0.1-cp310-cp310-win_amd64.whl", hash = "sha256:8ec4777d92fd61a5c8fdeddab894fd65bea301a8092fb5419ec6472aa4d458d7", size = 37058, upload-time = "2026-08-17T08:21:05.846Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/e9/d73c870d9dd26f8d6782ecf716b31e836bb6269c888b6bb6e1fcf71eed36/xxhash-4.0.1-cp310-cp310-win_arm64.whl", hash = "sha256:03600a8987849b2bef7be795a60a6052b635c63fa98b718b08ca5ee823691cfc", size = 33289, upload-time = "2026-08-17T08:20:19.707Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/58/bc81e25cceab76ce4b400441e3a43312bf3887fedbb2e5f80cc5a7dd7f75/xxhash-4.0.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:8b4477edc03091f51f5309406d230851c23cf4822029e3bf40b8df53093fff1c", size = 38473, upload-time = "2026-08-17T08:20:34.303Z" },
+    { url = "https://files.pythonhosted.org/packages/64/8d/d95e810c9a2930906f1fbd0e38f77554abb8e042a190aa9cbb24da39e9a2/xxhash-4.0.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:04f9a24de11a6647666d5302fd73d6a5224ce50ddc965fb0bb44cee736e6bd7c", size = 36228, upload-time = "2026-08-17T08:20:36.641Z" },
+    { url = "https://files.pythonhosted.org/packages/72/be/ebcded2a32ba664a17a1737a91b6baa298bcda6942acdad81af81660b74c/xxhash-4.0.1-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:6a8c5ce76b94ba49f3be8a8f2611abc6564210702c72ac9e237ca2bebfd17794", size = 253292, upload-time = "2026-08-17T08:21:27.206Z" },
+    { url = "https://files.pythonhosted.org/packages/52/2a/72d31d787d988d1130253bc34d249c553f02c9387e7dda789b6d5aa7963b/xxhash-4.0.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b4c8842fb19d78b5e8c2a52baf4c8357658cc56c62bc822b86ce0f942f28e286", size = 276545, upload-time = "2026-08-17T08:20:26.726Z" },
+    { url = "https://files.pythonhosted.org/packages/39/ae/048f3b1f283a340bef3697fe5a9d4f10de1696a379af9af6b2352c24d82a/xxhash-4.0.1-cp311-cp311-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:a43418e1a90b4809a9caf64aeb8b0696e3e1f300a323acc1e6ee2f93ae319fcf", size = 296295, upload-time = "2026-08-17T08:20:15.759Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/43/e9a593c81445c8e8d669402edb8264144624e7e5e2406df7d33e3c164d90/xxhash-4.0.1-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:b3662719007e059abde7eddacf8517142ba076ddc7b30c807260e57d28c3c191", size = 279966, upload-time = "2026-08-17T08:21:22.217Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/4c/29da2b166955a300521c0abd498ad4481916c3743949b106192b781f58fc/xxhash-4.0.1-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:06d7fbd609503c3be5e65cdb6bb2f040d6a98574404e2e1d5c60815c97fff4aa", size = 509850, upload-time = "2026-08-17T08:20:32.731Z" },
+    { url = "https://files.pythonhosted.org/packages/40/ff/e39e1900179ce7f0f23e7000d9fc672471a8d05b6b2dc657cb496c8975d0/xxhash-4.0.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:101aa300de6ceef3d9c77569706330d8921fc45dd82bceed2084f1e9f2557a24", size = 261005, upload-time = "2026-08-17T08:20:40.735Z" },
+    { url = "https://files.pythonhosted.org/packages/89/79/76ee26720d13219458f4b2ec0b22f539fe2bcb1f83dc22a24be4cda4e285/xxhash-4.0.1-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e4296fcc790876a8b0f297edc83d3b088457b774d8f67b4636807f8a2ec69a79", size = 339620, upload-time = "2026-08-17T08:20:50.371Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/c7/56b53252d64ecb2f3a0d283b41033561b1bec9c268095150153b694c2e52/xxhash-4.0.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:57d7fa8f23908d173001c21a9e82bfc6ad997d1b6c270fb121812b7ed158891c", size = 272558, upload-time = "2026-08-17T08:21:33.883Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/76/83101a2f2ad3eb6b4b5d571e0aa394a576e3e23121707d507d80197ac385/xxhash-4.0.1-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:85e402dab0f9acd3604539747c6fcc57dc188a18af6ab07eb8189351cd32466c", size = 300417, upload-time = "2026-08-17T08:20:36.183Z" },
+    { url = "https://files.pythonhosted.org/packages/34/5d/5be1166ec4fc4bc896e508dc51189a2dad200b373269a430e214fb152693/xxhash-4.0.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:fb59a0dd61fb2ad481c03fda399d78ce57dab6bb62c2c8fdb446a7ba4754b89a", size = 259286, upload-time = "2026-08-17T08:20:21.51Z" },
+    { url = "https://files.pythonhosted.org/packages/77/6c/42f6201f13278787c58a6b3a1cd597b47e8665a7d4f68a3440d001c05a75/xxhash-4.0.1-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:0b20a06454b34f1531fc677c54efe2ecdec691ef9224f7fa919bf2c1363f7ff1", size = 278230, upload-time = "2026-08-17T08:21:47.62Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/37/3cb7f149a5a469c628604c33bec6d79764698b315700a4bbf1c6fb15622b/xxhash-4.0.1-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:f7db035447a0ac8959aa230c5d36545ecf9f547413eb1711c0ca6f0ba1418925", size = 329846, upload-time = "2026-08-17T08:35:10.922Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/ee/934eb1e11f4d0e95f3828825f8da4b6d59e338235d63edc3d929769262d2/xxhash-4.0.1-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:34ed93e20bfd98d722b902121643791eeb4b1641871e2dc63d0d4c2d93f187df", size = 477285, upload-time = "2026-08-17T08:20:46.297Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/0b/77835dcd7aec970db74f5724c94207ada83b3e2f5e1474ab44b9c8fe5ea5/xxhash-4.0.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:f6247f5e23ee94f2557ac9dab738a336f607c6ff476fcf66ca70c3aef5eee15a", size = 257552, upload-time = "2026-08-17T08:20:58.211Z" },
+    { url = "https://files.pythonhosted.org/packages/da/6c/a3ce7a1a9c4ec9ad8babba591a996a71c474ff9630c5fb04c8c9d8b995ca/xxhash-4.0.1-cp311-cp311-win32.whl", hash = "sha256:348c8f288dc961d6bbd1985c8152a3ed7a85c95df00e82320f0c5215d922a399", size = 34630, upload-time = "2026-08-17T08:21:53.323Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/58/60d2170e8cda0891aab25dcaa74797b420c3c6cde8a5bc8372f17b30c0cf/xxhash-4.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:ac0f291ab6485bd71f33941f9b92771318332a05d505460b41e893a549caadc0", size = 36992, upload-time = "2026-08-17T08:20:41.973Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/de/b229a39f9bbbe30cbcf9afaaa8993cb65286715c90a3b058c3769196ae02/xxhash-4.0.1-cp311-cp311-win_arm64.whl", hash = "sha256:72f34834518157a75e7090f328ee7a16c70c804cfc7c694fa069cc888e9fc03e", size = 33289, upload-time = "2026-08-17T08:20:32.176Z" },
+    { url = "https://files.pythonhosted.org/packages/26/6c/dc7cffeadd06336cd934947187cd38abb263103bbc552ca0f55fe4ff595a/xxhash-4.0.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:1ee523f51718e41753f04f7102bb4dc55a18d2ea5cbaceef8ec7ca08571bd428", size = 38444, upload-time = "2026-08-17T08:21:54.332Z" },
+    { url = "https://files.pythonhosted.org/packages/75/c9/cf736f6db8c3273af18925061572db0d4357818a9ce425f4b5fb0021918e/xxhash-4.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:515a822c73abbf6a0b7c70976d9662be342835c9d78b8dc7c023411f39c35dbc", size = 36195, upload-time = "2026-08-17T08:35:13.004Z" },
+    { url = "https://files.pythonhosted.org/packages/da/a2/ca1929354b6851529d0148f7f335b5e2b0281f83bab3e19f0896dc579796/xxhash-4.0.1-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:f5d031f35962e5483a613214e61f09fe24ab523062c3646d592dc16c4a217451", size = 253113, upload-time = "2026-08-17T08:20:52.152Z" },
+    { url = "https://files.pythonhosted.org/packages/de/bb/542005206af59518bc8d78a210f1e0172217bc53beb32f64a5b632e72b6b/xxhash-4.0.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:da0264844a09b538c894e5eff25313d941deb4dedec2131b98418a71a3c9944e", size = 276525, upload-time = "2026-08-17T08:21:01.886Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/df/607cff25dcb0f1d35c3b04493f6ad8471edb03fd4eacbdcc5ceddef1f3e9/xxhash-4.0.1-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:1642907941ee4b75aacc3db688af52ea02ca2305ab22af7ee686ed726b332684", size = 297703, upload-time = "2026-08-17T08:21:57.958Z" },
+    { url = "https://files.pythonhosted.org/packages/15/ba/9d2275eea0b9d9c6b02921be23f7588356c60df95c763b25f0e045894d43/xxhash-4.0.1-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:4af350bc3f329970c0e3a59af84a8a30998bf8a9167eb50cd48e59baaa1d7bec", size = 280252, upload-time = "2026-08-17T08:20:47.299Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/aa/2299d9f6369e550aef2abb64945e39daa34412725aa46a20d99b74d76f67/xxhash-4.0.1-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:8ba782ca3bf1e81492611152b9a0d5264971339e95e34d69de0ac2c926be496d", size = 511041, upload-time = "2026-08-17T08:20:36.771Z" },
+    { url = "https://files.pythonhosted.org/packages/83/97/31bd8b8279e6935a0719f6910ced15e9d5a2cd554b253f6027ce1b5a1c2c/xxhash-4.0.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:237b8f63a2a0fcfb1ffc06e21dad23add44e6d354b2b014364a1d41e419a4dee", size = 261812, upload-time = "2026-08-17T08:22:00.469Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/c1/d180a2da23c105d8e0b02d54f9f5841013fc81c233010ec781e31f1aee4c/xxhash-4.0.1-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:81507a68ba84c55241fb61cce1469f473a5da4205fc8ef6f698e5948eea8dd88", size = 339878, upload-time = "2026-08-17T08:35:17.626Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/3d/f584cd3172fe934f0f5a0a3917d0d7ce781f74d794fd43bb72be71c3ef6f/xxhash-4.0.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:5f1ea31d61bcd2cd2f3ec4ca80a64187bbd7948f490b63cf0dcbc6e717b4c1e9", size = 272871, upload-time = "2026-08-17T08:20:56.067Z" },
+    { url = "https://files.pythonhosted.org/packages/34/50/2c7956b2b551682e00b9aebce9ceb0a991a131d65f9850c09f5f9760be2e/xxhash-4.0.1-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:06713a5aaf1d0905c5579416c020c02e42b3ceb931e86c7d3b7fb85403dee3f3", size = 301440, upload-time = "2026-08-17T08:21:35.911Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/a2/0739f6482184a8026f4b022718f5f815d352059312e80696825433f0a8e7/xxhash-4.0.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:e8cda075b10bb3917b002c74a04f9e02b7d13b5bf732571404d51c52b11c7329", size = 260157, upload-time = "2026-08-17T08:22:01.416Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/25/b31a7bcf1d7d116842812e54f9b944843b4236ea4fa85634e8259f342212/xxhash-4.0.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:c10b9206753b64aa791b35b201485477525b26fdec5bf86e8364c388a03e2592", size = 278233, upload-time = "2026-08-17T08:21:15.674Z" },
+    { url = "https://files.pythonhosted.org/packages/db/e8/5293bae090fc6119dbc5fcf5c4cc0e1536394b52d73b7904d033836c73db/xxhash-4.0.1-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:f3e1a44af01b6692de0ec6caba5f0bf93ceb36896e02b7fc00952c6ea7ef39e1", size = 330270, upload-time = "2026-08-17T08:20:51.128Z" },
+    { url = "https://files.pythonhosted.org/packages/72/9e/e2ab12d40921f3f34c9317637d65e011aeababf8288356ea8d527de2c1d0/xxhash-4.0.1-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:c6fc415b5568bd9accc7187f1729a99707330c0a67a8b9f93c1149ed573ed75d", size = 478555, upload-time = "2026-08-17T08:22:04.183Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/32/c6148d39a49efa95f39b4cf0d41ef35a487f3b30f6fb1fc8fe8d8eab577e/xxhash-4.0.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:96d8de55029d42251945531f6aa7590c32b48163c66a43bf29d8657d7446a377", size = 258174, upload-time = "2026-08-17T08:35:21.18Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/fb/0b04b68d6c5bc71c7a2c344f1287327b67e607f28fbcfd937697caca64b6/xxhash-4.0.1-cp312-cp312-pyemscripten_2024_0_wasm32.whl", hash = "sha256:0163b5d259de23ae9e07b7eabf435ce4704f6f205589a2b154e6af4be985ce1b", size = 20767, upload-time = "2026-08-17T08:21:00.806Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/be/476092aba34d1fcd313e1613a3bb3bc692f253d167b54bc90049043b5034/xxhash-4.0.1-cp312-cp312-win32.whl", hash = "sha256:1216f7ba5683f17a89eb7dcb4bc50a0b743dfe1902278d7b3d0786f538118433", size = 34669, upload-time = "2026-08-17T08:21:49.486Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/02/f9413d94fae43cec6d1a74c4f12156c6f4a7f5fd50e1d34defebdee3dec9/xxhash-4.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:5c2d525a3afabcd8e3549d85fc7e111fde6bc302d06a1893fe73adb79823415e", size = 37073, upload-time = "2026-08-17T08:22:04.886Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/83/6fe93c1b95acf962bc61a246df09dc2dcce895ccfc1080c9f48d0b652b92/xxhash-4.0.1-cp312-cp312-win_arm64.whl", hash = "sha256:86b2b12bec60c678ed8f5cca0258ad93a8928ebddb6ca7732f0875afe1451d1a", size = 33299, upload-time = "2026-08-17T08:35:12.708Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/dd/c707286b527722f776e1fb81dd202c45623355ba1a2972337a2a26075b2b/xxhash-4.0.1-cp313-cp313-android_24_arm64_v8a.whl", hash = "sha256:8c9fe122444e129881afd1d4d1c7ac0d3ce2d91b68c2b40173b6025ff1c31f9a", size = 43639, upload-time = "2026-08-17T08:20:54.945Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/3b/bb71639a0f95635f61936a6f2653599c4261b645ddddd8d00f9dfe3613e2/xxhash-4.0.1-cp313-cp313-android_24_x86_64.whl", hash = "sha256:1f3346c5c287ac3c7f38b20380f55e8768230e7252af59fabcf3b87ab21e4256", size = 40657, upload-time = "2026-08-17T08:22:12.616Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/91/76f3f5385faa9886a36f21fcc603f40b4c0c40ce622382f133160c48b4d9/xxhash-4.0.1-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:4e5141543c7f7fe3087500bbb4ac2845cb528a980aa91f8f1e661e2292ff4a5d", size = 34708, upload-time = "2026-08-17T08:35:24.614Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/4a/f48f0e3e1b1ab072979fff2a5be899234e28090883e8b519d0b10215d708/xxhash-4.0.1-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:f09ee747e2a5f876cc5ad56947734811828335e13b403dd8ea1e06d77a9dd48d", size = 35650, upload-time = "2026-08-17T08:21:09.337Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/53/b73d7472b196101ad1f57ed0674af3af803ac3e9ec2feadd650a7b262562/xxhash-4.0.1-cp313-cp313-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:acf52474b2494ef66dc7e0fb6d5e2b50c18313039ad4d275fbf9f9907c804bc5", size = 37958, upload-time = "2026-08-17T08:22:10.616Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/f2/024946ad8fa532074af4e4380179da54b7ec9facc8bd0b279ec0fac4e63a/xxhash-4.0.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:1b3cccf75eeb5b01639b2feadb042a8e07889293b7ca72fa2985e7dcb64763cf", size = 38032, upload-time = "2026-08-17T08:22:09.535Z" },
+    { url = "https://files.pythonhosted.org/packages/da/e0/934af8d99bb5885711006bec30a691f728edd513d2c40f053f887d8e7577/xxhash-4.0.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:cd878d32f5c6cbce9783f8d6897561fb772211edba9dde49d85672b88ed45276", size = 35895, upload-time = "2026-08-17T08:35:16.53Z" },
+    { url = "https://files.pythonhosted.org/packages/20/5f/a8011f6a1558f7ca66d9077bb4f192b1871afcea62fbd5733605d2015755/xxhash-4.0.1-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:41e579025a6e13a99e6d71e39c9cfc621a0dcdbbf19106325e145fa858f2d794", size = 259464, upload-time = "2026-08-17T08:21:06.72Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/89/9665a44397547e7a3d58c0942425a976d58dcfd4b538f33220a312bf6912/xxhash-4.0.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:74379a577a9f3b6afbdedf1b90e5c7764467051977f18a326d7d607336d743bd", size = 283949, upload-time = "2026-08-17T08:22:17.003Z" },
+    { url = "https://files.pythonhosted.org/packages/34/2d/78774141266457468f29f3f5803092df4db87d8148ba74e4debd041649db/xxhash-4.0.1-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:acb31ecdd1a97fab5cd39a84ee9f515e727d319f796fec48703b8339b9998360", size = 303898, upload-time = "2026-08-17T08:35:27.951Z" },
+    { url = "https://files.pythonhosted.org/packages/59/48/d78d22de576b42528bff87c14207de50de4f0b888221a50ff7c9d675d670/xxhash-4.0.1-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:5b7875ac1a2edcb691f27642b8b94b904baa6bcecb7d79c72df2228ba8cb5c51", size = 287241, upload-time = "2026-08-17T08:21:13.042Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/de/7a1755a59c59fd46176f293bbdd99e399a6537ba9537fc723aa4d1bf6e27/xxhash-4.0.1-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:4751f1d7eecae6b2d2a773630f1a7248f125c9a92a456694d03c15bceffc9d68", size = 519856, upload-time = "2026-08-17T08:22:15.35Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/fb/76580c08e916507859b0f335393cb5fdc59452c4402edbc6bcca6e47e7df/xxhash-4.0.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9a51b061d54cda8b83e62c44458bfbf0dabbef9b975dd9649952ba5076b9f349", size = 268572, upload-time = "2026-08-17T08:22:14.533Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/2b/1abde3e07b8f2077a38b4fbfaf764115008bfe0ff03bc7756a52c9fd0607/xxhash-4.0.1-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:74a164e8b63f1e9cf35c9a7809d082b033d1a00e7375d5d814415436e7867e57", size = 344967, upload-time = "2026-08-17T08:35:23.569Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/15/80b6ddf0732eef48a8b5fe717398274794392bd6dbe82af38d189d214772/xxhash-4.0.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:4f5e5c6df4b703afcbe9352d238a51efd97c3b91fdc3a2052e40fdacb1e7505f", size = 279956, upload-time = "2026-08-17T08:21:24.97Z" },
+    { url = "https://files.pythonhosted.org/packages/77/e0/11cbc43c205bf81fad50d69c7319cd1b1ccc01a66cd4fb8766357126c43d/xxhash-4.0.1-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:d54b8ae068af532c8cdf56abb9e09a60fbe7b10792444c9c27987bb6d3b450fa", size = 307583, upload-time = "2026-08-17T08:22:22.541Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/11/cf0bc07feb2791045b6ac075d4bf64f1a5beedef2f46ae70d7104d63a19f/xxhash-4.0.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:1749f0688020209fe0d357ce1e1cd9ec9c6161ed0405ea949d24581c4c43fa91", size = 265848, upload-time = "2026-08-17T08:35:31.298Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/c4/7ada4bea2a2795073dfc42d96842930efbe7a0c1857ef4b522e4e90e5d83/xxhash-4.0.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:94ac8a6b8c47951173f0b67bf862bcb971bf24e493b9fbbdb0e010cbbc7d9f54", size = 284409, upload-time = "2026-08-17T08:21:23.156Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/f4/d8ce83dd6b99ccfbdadaf2db968ae40334d2e5f73a0297e593b9ddb3df39/xxhash-4.0.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:a33de7633c948ab2dc144af370a66e7e7af29b425dcd0f7e4f59689fb9391b53", size = 335921, upload-time = "2026-08-17T08:22:21.802Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/9f/f47d8724bd8bc45b395b06b7cacea2dae0d00031af1b707184a091161df6/xxhash-4.0.1-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:247ece770647c0aef080561fa996f9774b4dadce2d0c42eeb98229db7dcf820d", size = 487023, upload-time = "2026-08-17T08:22:19.729Z" },
+    { url = "https://files.pythonhosted.org/packages/57/54/2d87098f3371cc1e42dd04d2285ad56bca4c56667bc501bff02d2b9fd6b5/xxhash-4.0.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:a4553d36cc0b7fce1f35ba8a94dfd775aa3ed12f5eab2dc3b46ac75a0706b0bb", size = 264333, upload-time = "2026-08-17T08:35:27.001Z" },
+    { url = "https://files.pythonhosted.org/packages/27/b8/93795ca5898ec7d7d0455283ad261c0fc76b4f0c0a69e86233bd7badb0bd/xxhash-4.0.1-cp313-cp313-pyemscripten_2025_0_wasm32.whl", hash = "sha256:87aa309a93bd5ec13f14309a305ff4e9bf74c5363fc46c264c0a22edfd5b0670", size = 20581, upload-time = "2026-08-17T08:21:39.207Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/96/926f7335a0a1647952c00421e8da877f658094f61336306c7cadc335c94d/xxhash-4.0.1-cp313-cp313-win32.whl", hash = "sha256:cba763d84b06bda2c38d5185dee76f1b9dfdc0789e96e476d9e10005526d0788", size = 34449, upload-time = "2026-08-17T08:22:29.362Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/61/8a5aeb811de093bab3434e77eff0e9461624a1a56a6a93d315d080aab2aa/xxhash-4.0.1-cp313-cp313-win_amd64.whl", hash = "sha256:97b94fb29abf21f5f0bde15f7dbdd3a4aa2dc59f37026adc7b4bee8563b84375", size = 36520, upload-time = "2026-08-17T08:35:34.852Z" },
+    { url = "https://files.pythonhosted.org/packages/04/14/97f3c74000ca36955e9cb86f6d270dcd5848b5c65afa623453f5cf2d83d6/xxhash-4.0.1-cp313-cp313-win_arm64.whl", hash = "sha256:08ed8da18cd4fd0a6a5d6a444852d8fbd0e565388a74a4937085451b5f1a312a", size = 33428, upload-time = "2026-08-17T08:21:31.713Z" },
+    { url = "https://files.pythonhosted.org/packages/81/0e/ea406a02b561d3275232ccfdb3e29df80f7a65414940e3a15721c7bea40f/xxhash-4.0.1-cp314-cp314-android_24_arm64_v8a.whl", hash = "sha256:af05a3f650220a6c59fa0ad2410249f2d2470a05225807c378fb67458693f8df", size = 43747, upload-time = "2026-08-17T08:22:31.37Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/f0/b0c94d61ccf6b5d1f8847b58ef8f923125ac4919ed5bd0eb082750ca7cbd/xxhash-4.0.1-cp314-cp314-android_24_x86_64.whl", hash = "sha256:a6e3653df1a70b8ac4191216324242e4be2bca18c9a7c10934e1bd56dc7ca15e", size = 40749, upload-time = "2026-08-17T08:22:29.431Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/c5/8085881a538983be0fd1c865d5df236242fea496044e2c8ca32b9f2ba39c/xxhash-4.0.1-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:4528cf80ebbbf57d40edfb31521ae265daa6dd636d615b1cf0ac86209579e59d", size = 34734, upload-time = "2026-08-17T08:35:33.68Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/94/8803d13c968fc75ca434eea991d29ac5fd8a36b4afc9a6a9803c53933db4/xxhash-4.0.1-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:90cb2a1c9cc503a054a19612b48ff6e8e47805f618bdb3224a07568aad03a37e", size = 35671, upload-time = "2026-08-17T08:21:48.322Z" },
+    { url = "https://files.pythonhosted.org/packages/85/d5/ad91d7f0fd294190d37c08236fe661f5c4e3f83dcd1a121877a2e64681ce/xxhash-4.0.1-cp314-cp314-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:a949b072ea59c6eca0811ccd9e95133cc50d2afda8d464b5b077c78f78efa269", size = 38094, upload-time = "2026-08-17T08:22:39.763Z" },
+    { url = "https://files.pythonhosted.org/packages/89/f4/2b7ebdc1869caca5f02c4cba8379b631050d3c3d4adb9187e4dc1a6b8d3c/xxhash-4.0.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:79a3203aadf39637869dfea1185227d8452844d78b837e54fb1117b4d34ba5c3", size = 38244, upload-time = "2026-08-17T08:35:38.081Z" },
+    { url = "https://files.pythonhosted.org/packages/90/9d/f66cf6935f528e575f1ae4d6560d376e7587569747186f4fae8777cadc1b/xxhash-4.0.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:d9f3848ffaf010bdbabdbf4c25641fa258b6227ff27bc74a4d06edef521a4873", size = 35904, upload-time = "2026-08-17T08:21:37.358Z" },
+    { url = "https://files.pythonhosted.org/packages/07/29/34569d7b482f0dc060074faafd163c588f915cbc3e3e218f1ffd8a3ad340/xxhash-4.0.1-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:9283d9dd6b44acad35118e2976fc763a065509e4118debdb61916ec322ed17b9", size = 259595, upload-time = "2026-08-17T08:22:38.153Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/d2/a2370acfcd48732cf5c2b87f06cfbf7fa51c0ce0dd736bde42939eb9ebf7/xxhash-4.0.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1c7c642a0f79c3e3cf2965475507574d3d1a50ec71060039d60cb87358667cb2", size = 284279, upload-time = "2026-08-17T08:22:36.396Z" },
+    { url = "https://files.pythonhosted.org/packages/08/15/17d33c24e6c4a1c0b9ddc5584f0c25d51d48b34bacde1416a2235a19db4b/xxhash-4.0.1-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:96dedccfb09a73a25751053a183159b88f4ee75f388df8166040c152ac0531c6", size = 303973, upload-time = "2026-08-17T08:35:39.22Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/e0/4ec0d69ad5738729098a61e631b7ed2df22a922b0e03014b597c72bd863d/xxhash-4.0.1-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:81664268dba92e037b740ecf37fa02f1cab4a391f93f28e35792b3341c60648f", size = 287535, upload-time = "2026-08-17T08:21:52.158Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/8b/4f9b17e7a9eb71c65548ecddd9c18b84e3c18ca41c4d436ad2a3000d3f7b/xxhash-4.0.1-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:839f58c5bd9989875be0fd28446dbf32cace2c2cd8bf2f6762acdc38a95cd1aa", size = 519257, upload-time = "2026-08-17T08:22:43.272Z" },
+    { url = "https://files.pythonhosted.org/packages/68/35/3276b3e743b8ddbed9c3f71c76d9dd6a75d72aa4e678b1447b635cfd92e0/xxhash-4.0.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ffa44b4c7c5d0ffa31356b4428659516c0e47647825c74079a296b3857b6d99d", size = 268190, upload-time = "2026-08-17T08:35:44.985Z" },
+    { url = "https://files.pythonhosted.org/packages/08/d4/f1555de3c96721320930dbb7988c8482d82b85970076aba1a8d40e83ad43/xxhash-4.0.1-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e681a6fc7e4f715252b9b5acfb30536ec7dd1f75033a32dc617e6fa95af1a3fd", size = 345553, upload-time = "2026-08-17T08:21:41.025Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/98/c28908f27007087b61139d290f908dd827ffd40b88af0c43f9e1a1a7ffd5/xxhash-4.0.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:c6301d92545c591ad31c3e050aa40a5f8a4c16413f1f9e6f9322c6f0f9d2b736", size = 280499, upload-time = "2026-08-17T08:22:52.236Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/76/3ef57622c65816348f8196273485baab4752aae064959901e85cd867e067/xxhash-4.0.1-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:6efb8f21cc136c79b3e5bb747c8682d37916fb202cdbbc32182de5c4e47f821f", size = 307211, upload-time = "2026-08-17T08:22:40.815Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/4c/5804504bbc808968e57d6a50286dd8f8cc06e0ddd6e4ab4b1dc89ae42f35/xxhash-4.0.1-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:760de77279e9cf9c81d012ce0705cba13afccee9b09c480f17d778c8c5cefae8", size = 265865, upload-time = "2026-08-17T08:35:42.727Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/ee/8572fdfd70e7aaaf150af899871c2cc0bb88c3295ca82172a31e04ca5168/xxhash-4.0.1-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:a16a3fa6936e36bb1414d16a6bd012c9033e5161b68b426805b61d895392437d", size = 284545, upload-time = "2026-08-17T08:21:56.965Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/f8/6eadcca0904660c848b466524e82a233d16c9d2d5258433aaf3546142d86/xxhash-4.0.1-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:9c3c4b9aa9a27196b921197f7daf9e6c1412739df06a99cfa6e923879362eff6", size = 336022, upload-time = "2026-08-17T08:22:46.346Z" },
+    { url = "https://files.pythonhosted.org/packages/27/df/4aa107b81602d6d6d09ab5a607c530d2d3a6b28e2e9a59b01875bd877c54/xxhash-4.0.1-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:863f3d3b44110f7243e86cf994aa5c5d88f2348b6e84ab4402fadadfbf9f7da7", size = 486671, upload-time = "2026-08-17T08:35:49.016Z" },
+    { url = "https://files.pythonhosted.org/packages/45/b7/b2bf9b5301e9cd5f2e335fea8da0f5cf209a6594cb1fe77754774ad4a6fd/xxhash-4.0.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:63aa52659bc32bb9bd7cb5caf523b4d14429a477762cfac886132d687c1f80fc", size = 263744, upload-time = "2026-08-17T08:21:56.165Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/96/35b1c02177ae26234892c2310fb4822ba62411acccbf425ab8f9fd99354a/xxhash-4.0.1-cp314-cp314-pyemscripten_2026_0_wasm32.whl", hash = "sha256:67e57b834e07ed973cee7b6da1548ff28a56458d77696fd2a5f397f340694848", size = 20563, upload-time = "2026-08-17T08:35:11.924Z" },
+    { url = "https://files.pythonhosted.org/packages/51/c2/a06300b165fbd6b0cb4a9742987f2e997a9f447ce3bf7c6ac97b862ce62a/xxhash-4.0.1-cp314-cp314-win32.whl", hash = "sha256:b6c1f9c59bbe593f88a0aad30be4150f15bd57bd64efb95feeabcb8e563f1ecd", size = 35151, upload-time = "2026-08-17T08:22:44.283Z" },
+    { url = "https://files.pythonhosted.org/packages/06/96/c5b37296b78f80fc97124c0fee0c7bbd1bdb6f3b18bcd8748bb113b2d8fc/xxhash-4.0.1-cp314-cp314-win_amd64.whl", hash = "sha256:da544672efd9ad76077928a3e6c5d894e52ce82d3bf14002db4a1bf17d1a36a2", size = 37156, upload-time = "2026-08-17T08:35:46.551Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/5e/248f9cd169c2fb62236bedfba246d213bce728f74901e99047e3f3c55875/xxhash-4.0.1-cp314-cp314-win_arm64.whl", hash = "sha256:d0d24a4f3fb63852cd09af46ae4b7a4d00cc8b8615a046dca543786e728d1056", size = 34379, upload-time = "2026-08-17T08:21:59.446Z" },
+    { url = "https://files.pythonhosted.org/packages/58/c8/db1d37c0da0324d0298f6abd931ca1d4736e049d9f2081230a8421da74d2/xxhash-4.0.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:349775ac30372b344d2338b2a168c0a1312a644194da25b8bec476d55761a128", size = 38656, upload-time = "2026-08-17T08:22:49.119Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/8e/e18998ec465fb977bc74272e5bf3c2e886c13b014cbef916cd607802c709/xxhash-4.0.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:43e5f9169e73d0f0db33b5f6b8554bcce69ac278c966daf83d5eb4eb2f13829f", size = 36306, upload-time = "2026-08-17T08:35:52.853Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/1a/b83f86f8a987a3cbcb7e005a6824ff64aecae35abc1395a0d44ee16c3319/xxhash-4.0.1-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:4a252fb862b0ae2590587e625f47a0e03da05cf0205e8830b67b6596c06038b1", size = 273729, upload-time = "2026-08-17T08:21:58.833Z" },
+    { url = "https://files.pythonhosted.org/packages/02/4e/2db15aa8508e0cd5b632927a53b98234f24039ea65377e6cf996c06d2d4f/xxhash-4.0.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2df3ca8757dc381e75e90a4d7995a6324f58a923c7145220a7b2c0231f66fddc", size = 301083, upload-time = "2026-08-17T08:35:14.113Z" },
+    { url = "https://files.pythonhosted.org/packages/26/94/ed759787ffe802bd8e31cfcdad3755cbeca2dcdafd2f790cd6f25d195199/xxhash-4.0.1-cp314-cp314t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:bfed61996d618eb90d6eaae0178002e3466a28b06bfc557a7a3a7266378d8c5a", size = 312745, upload-time = "2026-08-17T08:22:52.232Z" },
+    { url = "https://files.pythonhosted.org/packages/45/7a/f64b4a4cc8b51e950709207f55f7f56ae9c5af6631dd31d7fb443312418c/xxhash-4.0.1-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:9761ff4a0ffa583fe850731ad24fe82c88cccb7a2294727db0955f3279a4cb3f", size = 301419, upload-time = "2026-08-17T08:35:50.143Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/71/bac313b8de073569b8db3152044a7cfcce87a3fa9698c18fe9f914dee6b1/xxhash-4.0.1-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:edccc2ec58435a580f96a48a3ccae8cd0a480824119165dd90108718ad81ae6e", size = 534485, upload-time = "2026-08-17T08:22:11.515Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/0c/16b5e419f24e59507ee05626d2bb0deafdb03f9f27783bc0785a9849602e/xxhash-4.0.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4741d42d59e4e5fa1a86c17ab9c27dc8ea459c700d91b6742fdb9138d9a516cb", size = 279605, upload-time = "2026-08-17T08:22:52.934Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/55/5787dd6e2d8d5b61256a5039f6b18c2193c7c1de4a2fd2413288d0d9c604/xxhash-4.0.1-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:440c401e146ce64bdb3beb8ff0c84677b6f21307c28a34779071cecee5d4d70c", size = 358924, upload-time = "2026-08-17T08:35:58.164Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/68/89be41991f3b0a2e91f940bdf3128852c3ed571cf560d98ad0f67024afe4/xxhash-4.0.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:5b7979f71d06ae45a769de0699900a246d8cb632db1e8bfdc79ec019063a503c", size = 295305, upload-time = "2026-08-17T08:22:13.683Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/5a/52ff0a0cc361aad393ff9a46ffe3aabbcf9c03d6c8f2612da7d553048276/xxhash-4.0.1-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:62198213fc3e0c56e567894b318ba45834e007d065f84ba6dc9165d21546fc56", size = 320228, upload-time = "2026-08-17T08:35:18.946Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/b5/91c60ff22c7f6cd5f6d7a5bad5a2cdcb4c33987dfa50bf13f0d856279b2e/xxhash-4.0.1-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:b3bece52127ac20044311ee73567f9f0893b5de64f9028aecc90cc740cfd525a", size = 279414, upload-time = "2026-08-17T08:23:03.212Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/94/9685954804d47d0390871a64bec606a0d536406382d71a784df3a5883fb4/xxhash-4.0.1-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:a865d2d470220e659220fdb59d5b6c4422802d8d6098e1324bc4d12444798914", size = 297594, upload-time = "2026-08-17T08:35:57.881Z" },
+    { url = "https://files.pythonhosted.org/packages/89/62/b67ac9412907b7a07a2a0c08c3440b9e4480231a7b3de0767e87011e4564/xxhash-4.0.1-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:8580aab306888224074c7edeec734de0c3c5ccde65b2da4e6c9a5e28f7c0a1bd", size = 348526, upload-time = "2026-08-17T08:22:18.571Z" },
+    { url = "https://files.pythonhosted.org/packages/37/ed/6723cc49a9f567d52d01fd7c1741b0f2e3a13e71d15f7ac49d753a20c115/xxhash-4.0.1-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:2d52dc7c33c1b83082b707f6b7814dc76d2faaa2ea62bd9c5fab4b36f83c087f", size = 499307, upload-time = "2026-08-17T08:22:56.52Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/2e/7b10e101ab988d93b791023be7191d7661271d6ab31ac082276b9091042a/xxhash-4.0.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6a9f98af872355e0c02439e48583958eee00e60b928bb20476460d9d40cb7b4e", size = 274989, upload-time = "2026-08-17T08:36:01.834Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/8d/7eabcc8d29cce40621443cff24c07d7306ef574b8956c47ac59f21098005/xxhash-4.0.1-cp314-cp314t-win32.whl", hash = "sha256:a14578102a6081465aec9cf73c76c3cd3f79f0709bdb3b8ae7ab0b54c9d8b089", size = 35482, upload-time = "2026-08-17T08:22:32.336Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/89/2a4268e1971f63038b79fb75e3b9c8de942cd77acabbb0c5625352a31940/xxhash-4.0.1-cp314-cp314t-win_amd64.whl", hash = "sha256:c57963970d359a72262f7fe6be88f945e2334d4bc41462b7f08c37b0abf35ca6", size = 37490, upload-time = "2026-08-17T08:35:22.475Z" },
+    { url = "https://files.pythonhosted.org/packages/90/7b/950ecab1fe4cf421d0a6211ddd9a0ac82e39e55c45a111ceb90953dc6c9a/xxhash-4.0.1-cp314-cp314t-win_arm64.whl", hash = "sha256:b659fad79c99b0238c7ad7e9d7dbf4eebfea9097c2dba65fa0a4d18a25b29a2f", size = 34596, upload-time = "2026-08-17T08:23:10.001Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/03/7dc3b85fac10751613bfedb0e120734e0e8710054abad3f931e9d3843a14/xxhash-4.0.1-cp315-cp315-android_24_arm64_v8a.whl", hash = "sha256:5adf927dca8c47fde7e683fe69efdd81bc865c4db1fb6bb00b391e2b6185207b", size = 43749, upload-time = "2026-08-17T08:36:00.47Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/55/bfac071c5b1c6d6a3d48ab1ab96a15e958a1d7061f4afc97804292d87264/xxhash-4.0.1-cp315-cp315-android_24_x86_64.whl", hash = "sha256:c30dd1af66a820820398b26e0d74e7a9aa43cae705924f23ed828cd8e5c26c3d", size = 40758, upload-time = "2026-08-17T08:22:30.209Z" },
+    { url = "https://files.pythonhosted.org/packages/79/87/49a260e685d1a74c56a69432a8ee0527ddcbd684a3c51f87edc3b75639c5/xxhash-4.0.1-cp315-cp315-ios_13_0_arm64_iphoneos.whl", hash = "sha256:1bc591533fc975614f7e13594daee76af96b8e1fbcf8de76c8773858fa9e7cea", size = 34788, upload-time = "2026-08-17T08:23:09.014Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/ef/50d72ed2170dae872e1c0fe333d0908e0a2afbffe74c5c9037d5406a4b89/xxhash-4.0.1-cp315-cp315-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:567cbc630302a46a8ecfd943b309ccf5372bb3718f1f3762d452df30f033bcf0", size = 35746, upload-time = "2026-08-17T08:36:05.557Z" },
+    { url = "https://files.pythonhosted.org/packages/66/f0/969deaa2bab3bfd5ad5b023442124d2255b9961eef6f797ec74eb8683bdf/xxhash-4.0.1-cp315-cp315-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:e998cb3685b92101ec5de0fb4d9485cf01e50bc418211955c55d98064664cf4c", size = 38098, upload-time = "2026-08-17T08:22:36.906Z" },
+    { url = "https://files.pythonhosted.org/packages/86/aa/45ed7d7b8d7b66202a47bf8ff3b77cea28d2ea54dfcdd202b4cfe043e3dc/xxhash-4.0.1-cp315-cp315-macosx_10_15_x86_64.whl", hash = "sha256:c3074db513c81f764053e3da079312ecf85a50d8350c71f4cc0105d9662a9e6c", size = 38251, upload-time = "2026-08-17T08:35:25.774Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/9d/45e7520a7856e13800a5dc8cd038d34c6372429465b163af0c5722f16918/xxhash-4.0.1-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:3088dadbffa33c29e0518578430a7dff2e901a212e487aefa5faaa0dc06dad34", size = 35986, upload-time = "2026-08-17T08:23:25.854Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/0e/5ad466e5fea18c9f9bdc5828c0506f62190061b4a1b0e688aa54969d0a9e/xxhash-4.0.1-cp315-cp315-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:1b50223d92df94d54e1a31469335a2c74b16692e6c1cb726f1e6949514458706", size = 264609, upload-time = "2026-08-17T08:36:04.229Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/cf/8f269f85217e3dbd45e31e25e46cc26f3aff0e159ef05d228b4b982c778c/xxhash-4.0.1-cp315-cp315-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:427b62d62d4f967fbb10b82a3813e4875c2a6e7e7634739f17265b650c7f65a6", size = 285910, upload-time = "2026-08-17T08:22:38.589Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/30/2fc1a16ee0f9501d074b798ebfae52e24fa602c7117f5c4b81de71eada72/xxhash-4.0.1-cp315-cp315-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:c6370189e8e66b7e608f533b939a9de092ddca6cce084ca0d3d414d2ed5b5d59", size = 306566, upload-time = "2026-08-17T08:23:16.895Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/a7/08375cf2b997e1903663fe7525c5973b1987a4f8ad2b8d47463e9143f2ee/xxhash-4.0.1-cp315-cp315-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ec1a470c6db94ac4589c203921e89ac1bc13e796a8b1784d8135e1893559cd3b", size = 287978, upload-time = "2026-08-17T08:36:09.296Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/e5/90a7b404c11add9e53a497d06236152852490c3b2f21e468d97a58f26afe/xxhash-4.0.1-cp315-cp315-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:37f667dee0f867c42894b34e2a6fe26bf195c0ea4683d9d2b713db023f242c3a", size = 520098, upload-time = "2026-08-17T08:22:41.565Z" },
+    { url = "https://files.pythonhosted.org/packages/11/02/7fba10b1b17eb46308f09cc0a4ed513d74dff16b1e22a1c439f011c77129/xxhash-4.0.1-cp315-cp315-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f18732adcc271741bd651c3e56fa519d8a237d2cccda01fe3afb226bf87f783b", size = 268273, upload-time = "2026-08-17T08:35:29.043Z" },
+    { url = "https://files.pythonhosted.org/packages/54/49/c21b228877357a3be43eeeaa22182ad1685796f415390ada475922c084e4/xxhash-4.0.1-cp315-cp315-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:0b42a5a26607e4b2409fea174773a66f2dff9dfdbf2c1a851bb7b804e2c97535", size = 350164, upload-time = "2026-08-17T08:23:29.494Z" },
+    { url = "https://files.pythonhosted.org/packages/00/3c/c15bb4aa33d94b78a5553b52e7fa1070565f0199925aeadec3871de20ce9/xxhash-4.0.1-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:99166cc98637e8bf550cda2aab07f4f1d5f899c45fbd721801aeabcc9d404824", size = 281975, upload-time = "2026-08-17T08:36:08.139Z" },
+    { url = "https://files.pythonhosted.org/packages/18/7a/b1d0388315fe7752b7725b68a912667526a1dd48ed492fcc031ac03f4b52/xxhash-4.0.1-cp315-cp315-musllinux_1_2_armv7l.whl", hash = "sha256:6cf633df84d80a1668fcf61e330791dae46825e395549e7d34f376411e75088a", size = 307872, upload-time = "2026-08-17T08:22:42.206Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/a1/037cb2dd8cf725c9565dfe3712b2915c0e0276a9154913dbfcbcecbeb672/xxhash-4.0.1-cp315-cp315-musllinux_1_2_i686.whl", hash = "sha256:e259bb7e1e2d8de6b35f430f5c7220b1c0ebf3962d1ba7ec7545980d5931edb8", size = 268241, upload-time = "2026-08-17T08:23:23.997Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/a9/67c44422d0ee082169b238ce24bd2796b82d7c21ed953471365df8c508d8/xxhash-4.0.1-cp315-cp315-musllinux_1_2_ppc64le.whl", hash = "sha256:704381264b36a18b9c62ecbabe2e71d0fc58c77c129c15355c989b10bf05b6b0", size = 284970, upload-time = "2026-08-17T08:36:13.476Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/d0/254a5f51c4014cacc77a26f321372338b924f54e89efb730164ee336d850/xxhash-4.0.1-cp315-cp315-musllinux_1_2_riscv64.whl", hash = "sha256:e90b4bcf1d9eb1010fdaee7c9209fb667e74c0684f3ba17f9032bd7319da90c9", size = 338074, upload-time = "2026-08-17T08:22:51.166Z" },
+    { url = "https://files.pythonhosted.org/packages/64/03/f21c4830118d72ef3a958ce8bf2152f49e0d4cf200907616c9be6caf372a/xxhash-4.0.1-cp315-cp315-musllinux_1_2_s390x.whl", hash = "sha256:a65785e653573fcd1e33062760ab4c3c3440e8e910765018e4b6ed4ad07b54a0", size = 487626, upload-time = "2026-08-17T08:35:32.768Z" },
+    { url = "https://files.pythonhosted.org/packages/45/1f/268a689d741d7da649317eb4ce41760140beb4179aaf43a7216fdbe8100c/xxhash-4.0.1-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:e3996ff9b6f99180357024336bf5749a8ad6476a9a2523e535c5212b995b12a2", size = 263852, upload-time = "2026-08-17T08:23:41.871Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/f5/adaf8101cd7f143191a0b390600294d83924b32cb13770fde8803dce27a2/xxhash-4.0.1-cp315-cp315-pyemscripten_2026_5_wasm32.whl", hash = "sha256:99054b838b74d8d3995ea0d410976ae967c46207ae22d6ddfc535e809197dab9", size = 20569, upload-time = "2026-08-17T08:36:11.952Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/2c/56a5eb8c993420fc07114c08f447a2b66ee996510b4764cb368b9b44c9f0/xxhash-4.0.1-cp315-cp315-win32.whl", hash = "sha256:6c45258a37fc22721395c09927cb982d3e7a83607cab15be7e2416501bd3a330", size = 35145, upload-time = "2026-08-17T08:22:50.038Z" },
+    { url = "https://files.pythonhosted.org/packages/67/c7/65f210db43e62157d0fef3b4d4d7b394821e7733c8bb4ece49f91410a725/xxhash-4.0.1-cp315-cp315-win_amd64.whl", hash = "sha256:0ab851b45c70d4992be7cdeeee16f97a0b677408c758c4b1efb1cfe8030bfd37", size = 37161, upload-time = "2026-08-17T08:23:32.438Z" },
+    { url = "https://files.pythonhosted.org/packages/33/ae/1a641d1d60ba219756d9ebe907ff0ecf4445adcf4fa96f6e3da57b91d439/xxhash-4.0.1-cp315-cp315-win_arm64.whl", hash = "sha256:a5b21b42a01a343096a1c018d35e9b7aec9c7065dda53ae8da071e37478b2cea", size = 34378, upload-time = "2026-08-17T08:36:15.912Z" },
+    { url = "https://files.pythonhosted.org/packages/48/7f/7698b320b251806d1249e513922a626f19027e104c829a611272250350eb/xxhash-4.0.1-cp315-cp315t-macosx_10_15_x86_64.whl", hash = "sha256:44ab12e8cd17d4f001769f00ad465208b4bcb897ed29e65f058f74466b57a98f", size = 38610, upload-time = "2026-08-17T08:22:55.203Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/3d/436497e775b647b3b3e9a4ffe8c76c59fa4aa7a9fab6447cb59acf1b50ea/xxhash-4.0.1-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:45e88111ebe331de478ef8d4293efbe88f3cf8b863386c9a2357136b838e1af0", size = 36378, upload-time = "2026-08-17T08:35:36.18Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/d8/17a4f8182b9257898aa2a77c2a45f70233eb8e50681a280e8e09d2ee76e9/xxhash-4.0.1-cp315-cp315t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:bf430c587f447a554c53768ad76b9846fe7c5632180ef6f69c4fce8b0552fbd0", size = 273559, upload-time = "2026-08-17T08:23:51.075Z" },
+    { url = "https://files.pythonhosted.org/packages/83/28/121bd5a5c5adb88e0da772c7bef61964cf9da92956a7a237c7d24c4351b8/xxhash-4.0.1-cp315-cp315t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:adbd48b30e3f82c89fb2b3e6a87cdd28d113b190a5ed0ee2dee286323ee9a621", size = 299133, upload-time = "2026-08-17T08:36:14.731Z" },
+    { url = "https://files.pythonhosted.org/packages/11/8f/57c7b6e04642ed738a0d08a31bed7fc63fdacb661d665f98739cc9751b62/xxhash-4.0.1-cp315-cp315t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:e71b34978e77868cbf2d18c5206a4603f9c644dd7181bec5643bd40141d3b8c5", size = 314527, upload-time = "2026-08-17T08:22:54.224Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/18/42793917dbab0ea1ff71458aea4875e17a7263f2797b798af048dc81e867/xxhash-4.0.1-cp315-cp315t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:488ca5c5e28ef56ec4bbb12f835b3f1cbecc5f3510062e70117bc6594851932a", size = 299199, upload-time = "2026-08-17T08:23:36.864Z" },
+    { url = "https://files.pythonhosted.org/packages/37/60/51dc92443923d8e908d5614f1145d8d696450f9d6c8f1abe243c6f2a0222/xxhash-4.0.1-cp315-cp315t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:421b94f3ba7067958d02e38960d987756347aa150df06df11aa68ae1af78c619", size = 531967, upload-time = "2026-08-17T08:36:18.66Z" },
+    { url = "https://files.pythonhosted.org/packages/88/c5/d0de77de09661fac71742c4155b1cd65e274f7cc277819d702b6c8ff2db5/xxhash-4.0.1-cp315-cp315t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f33cf0baa91eccd2cb7b62bf00f10c2264ef578b71dd33a12962e71a36eb4d32", size = 278764, upload-time = "2026-08-17T08:22:58.15Z" },
+    { url = "https://files.pythonhosted.org/packages/08/9a/589929c655aba1bfb2c41ee03e50eec1547c39c3042a66bda9c173a9614b/xxhash-4.0.1-cp315-cp315t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:23a4376b4a3183cb50d4d2a3179f887a7773cc695eb2c908e551bec3221b8c60", size = 359876, upload-time = "2026-08-17T08:35:40.35Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/a8/c1d8c94d54d91db2215565f4b4151c1593af3e6d27ac4c00fd1e8d714a02/xxhash-4.0.1-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:38c3d22129a6958846a3098d68bc8e661704461c0be4793ae28836e4690c8478", size = 293548, upload-time = "2026-08-17T08:23:54.951Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/67/85d8abca94508a4dd10561d9dea3e6e68843c6986dd6d9c1b3729c8622e4/xxhash-4.0.1-cp315-cp315t-musllinux_1_2_armv7l.whl", hash = "sha256:87cbdec1a7dd930079671a60b249f3ca4e773e6fbd0676e21e36fdc9dd0f3b00", size = 318780, upload-time = "2026-08-17T08:36:17.623Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/16/2b920ed456b9cdcfc99ddc20c3afe42f9f807ee5850773c12fd891f3c08d/xxhash-4.0.1-cp315-cp315t-musllinux_1_2_i686.whl", hash = "sha256:6cbf4e21ef0890804b5bb9ad25c48f9c127758d7f6c66bef374efcacc63c738a", size = 277582, upload-time = "2026-08-17T08:22:57.156Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/cc/5811b5997aebb8452047f5800d32fc50eaa29d0ba08d4e426f84450b9c2f/xxhash-4.0.1-cp315-cp315t-musllinux_1_2_ppc64le.whl", hash = "sha256:c101180495cb4ba3617b279a944345c53a5e73b0c150053d1fa8d8af32de9579", size = 295116, upload-time = "2026-08-17T08:23:40.868Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/dc/c2f3f9c2f4d6aadb79f17a9f1c9a7ee82638cc873680da044cf29537d2ee/xxhash-4.0.1-cp315-cp315t-musllinux_1_2_riscv64.whl", hash = "sha256:c0e6ccc2b19ec8a726b2e26062ac71ea63e15500d6bf85910e42481844fdffc1", size = 347065, upload-time = "2026-08-17T08:36:21.618Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/4c/750cc642c92252e10772ec09e1a1d995581ba4c3ceb24f6e2d57c7ce47ca/xxhash-4.0.1-cp315-cp315t-musllinux_1_2_s390x.whl", hash = "sha256:8bcba9456242ebf180a04d9443812fd85ffe6bd12bda464dd116fcece8886ff3", size = 497208, upload-time = "2026-08-17T08:23:17.88Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/2d/58693cb13d6395f39b6b9bb40c5e0db53a5df7c9fce805aa7e792f64a1a5/xxhash-4.0.1-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:83b8c2013edb5dc1f9e7268b6496130705bc48d79c86bb8817b3d210b81a5513", size = 274338, upload-time = "2026-08-17T08:35:44.062Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/08/9aa9787586d9b3e92d63343ce7dc24f0f445fd9e74ff5d6e85dd82233df5/xxhash-4.0.1-cp315-cp315t-win32.whl", hash = "sha256:aa6ccc7f31018484d652cf52db020003433f3c9fa83189c028bd807d2adde503", size = 35471, upload-time = "2026-08-17T08:24:05.795Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/ab/4615789c333bee331ac417885c50105715eeb8244bfc68d2bc37dcfd63ca/xxhash-4.0.1-cp315-cp315t-win_amd64.whl", hash = "sha256:daade8936c4deaaf7b01561324ce438ba4f885d717e9adc62b4d67212ad7d7bd", size = 37488, upload-time = "2026-08-17T08:36:19.929Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/81/49f718beb0c55d0411bc4bd90b50a3fbe5863a0e97a2f4d11682ba13d298/xxhash-4.0.1-cp315-cp315t-win_arm64.whl", hash = "sha256:f00330ac7e24769e2032203f2b01794d670916b0c1799fd261340f1af9499875", size = 34590, upload-time = "2026-08-17T08:23:19.597Z" },
+    { url = "https://files.pythonhosted.org/packages/86/79/9127ff42a887a348dc4ce3211cf1a962836887adee6f57078132bfba78b4/xxhash-4.0.1-graalpy312-graalpy250_312_native-macosx_10_13_x86_64.whl", hash = "sha256:ff48915bf1871a1f19f74c11834c6329443d306cedc0c05fe7fe617810422a80", size = 31836, upload-time = "2026-08-17T08:36:28.261Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/e6/f238693bfdd642adb59c99683964d46d9947fe721ff44d3bd850ae675407/xxhash-4.0.1-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:4a76345f5aceb4ec404918edf9c7f2b5507db864dc0d7455982009ac0890b57b", size = 34453, upload-time = "2026-08-17T08:23:49.795Z" },
+    { url = "https://files.pythonhosted.org/packages/40/4b/796ace33cdfb75c91ba6d11615c3bd436355b9f3103e05865bbee9abce57/xxhash-4.0.1-graalpy312-graalpy250_312_native-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:31d86f9e81f3e84e00131ac7c54caf5119ae4ddd82c09c31cff597c813ce1ee2", size = 38488, upload-time = "2026-08-17T08:23:59.901Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/23/2d549e5d5d7759eaf9ac2d2d2ab81ff60f1bb2b52cdaae8e5ec5c6524354/xxhash-4.0.1-graalpy312-graalpy250_312_native-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:deca2a30d983d240b8375ec2ee0a4288e72042827fc61df2f7671f8467e4cb2f", size = 38206, upload-time = "2026-08-17T08:36:32.193Z" },
+    { url = "https://files.pythonhosted.org/packages/79/98/1ee576b27f78e6107ee4ea8ac03e8a52888dff256e57d560f8282c195563/xxhash-4.0.1-graalpy312-graalpy250_312_native-win_amd64.whl", hash = "sha256:7c343ee174d417a44d0c3355602c0cbbfa52a04d1bbbf1723378c7d2c8f60626", size = 37127, upload-time = "2026-08-17T08:23:42.705Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/c5/8b528f4a394a1eabfd5d8b4271f24fff67fa1aebe58bdd3c64967662e6fe/xxhash-4.0.1-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:26fe6238c2d5b11ed5063b9bf4eb290624b004fd074688da6bb079bd564f10d7", size = 36450, upload-time = "2026-08-17T08:35:59.217Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/03/909926dcedb64ceee629e18d8dffa758f9d3fdbe01e25530ce2bf0eaf9d0/xxhash-4.0.1-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:e53926e76131a74e79cc0b39fa712c227875f180afc68646bd1e1d8a17e60313", size = 33467, upload-time = "2026-08-17T08:24:12.924Z" },
+    { url = "https://files.pythonhosted.org/packages/13/b5/ad50456fbfed07f29169bc3fd34e70cbee306a88c17d1a1141a7638de0ee/xxhash-4.0.1-pp310-pypy310_pp73-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:0718ad66f4ded2411f8e62bdba549ee71e313a2d26ef5060ca3fdbf29897dd3c", size = 48048, upload-time = "2026-08-17T08:36:30.847Z" },
+    { url = "https://files.pythonhosted.org/packages/33/c4/83cfe6b591a3067ab3f1339931c91211a8b3864d0ea76ad8184f0c1b0515/xxhash-4.0.1-pp310-pypy310_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1c2200b98a805351cb3142ae4e1fdcc9e91b5e20f5d30d4862b0b96f92558f4e", size = 42719, upload-time = "2026-08-17T08:23:53.581Z" },
+    { url = "https://files.pythonhosted.org/packages/20/2e/0f654f2831abba09d502751e38816759086dd92749501b128b7c3676ea87/xxhash-4.0.1-pp310-pypy310_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ea5ecf800b45bdb34afe05a1d0dae1f8ea02a290e50636dccd399063f6b180f8", size = 39477, upload-time = "2026-08-17T08:24:03.735Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/d4/375b9e4b719ee70e0a6d9e98e2b60aab09efd59f46c7871a112a2e6b0fcb/xxhash-4.0.1-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:ce6d5cc94a50291d080259a126cbf1e9ba4ac861e6429d2f3cdbb1474f51945d", size = 37244, upload-time = "2026-08-17T08:36:35.452Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/4f/e0648288a17d0d1084ca4f7bef206097831988fc86af74aa1dff8f1fbd68/xxhash-4.0.1-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:554f87034635bcec47c5d72447bf3db7e02da1bf493a0ada010db28a76f891c6", size = 36333, upload-time = "2026-08-17T08:23:52.913Z" },
+    { url = "https://files.pythonhosted.org/packages/22/15/34b7f72e9b5a8bfd7e6178de9e1e342bc3de9f07111a5ae26c00506d9edf/xxhash-4.0.1-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:3c2445edafc300cc40feb6a25a8356a971c30cd0bf47b5349c2ad74c508343b1", size = 33519, upload-time = "2026-08-17T08:36:03.04Z" },
+    { url = "https://files.pythonhosted.org/packages/06/4b/e0af324ccf701bf84a7a060bef11c915d45d9e3c5b9caf5b94d62ecb040b/xxhash-4.0.1-pp311-pypy311_pp73-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:bdd16718b63aa3ebd68aabb79021a40e47c81374852d41a306b9453141bbcbee", size = 47995, upload-time = "2026-08-17T08:24:14.335Z" },
+    { url = "https://files.pythonhosted.org/packages/59/46/cc7130e6ca6b41ab72eb6a03177b933c7c74145545c99a8610ecc208c449/xxhash-4.0.1-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8b99ebaf9e816ac5069423b1367ee7e8078fbcebcf62545506bb0608d2f4f468", size = 42725, upload-time = "2026-08-17T08:36:34.144Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/24/4f26ff9a7dd0998f6d1036bdddef7ce3e78972a74f7fffa7967e7bc3b7e4/xxhash-4.0.1-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f484ed57bb3e4142f9d6439568658c38be5f94b702ba00a1ff32c69783b6c66d", size = 39532, upload-time = "2026-08-17T08:23:57.556Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/f3/1ac078fc8fceadcf066469acecacb35d2821cbfaf7d6fc5ac2107c7a314d/xxhash-4.0.1-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:fac4832b638000106207bc44e44b9616a6a416aaee56c62b01d61f3705e49f58", size = 37252, upload-time = "2026-08-17T08:24:06.652Z" },
 ]
 
 [[package]]


### PR DESCRIPTION


Library prerequisites for the examples modernization (Phase 1 of the examples review). Every framework adapter now targets the major that is current in September 2026, and four bugs the examples tripped over are fixed. All changes are covered by the unit suite (1794 passing) and the integration suites for each adapter.

Framework adapters and extras
- PydanticAI 2.x: `[pydantic-ai]` is now `pydantic-ai-slim[openai]>=2.0,<3` (the meta package conflicts with the fastmcp pin). MemoryDependency, create_memory_tools, nams_memory_tools and record_agent_trace use the 2.x toolset/RunContext API; trace outcomes were always "Completed".
- Google ADK 2.x: `google-adk>=2.0,<3` + `google-genai>=1.0`. Neo4jMemoryService implements the 2.x BaseMemoryService contract (SearchMemoryResponse of MemoryEntry with types.Content); agent turns are no longer dropped on ingest. NAMS compatibility from #130 kept.
- Microsoft Agent Framework GA: `[microsoft-agent]` is `agent-framework-core>=1.13,<2`; BaseContextProvider/BaseHistoryProvider renamed to ContextProvider/HistoryProvider; MIN_VERSION bumped.
- LangChain 1.x: `langchain-core>=1.0,<2` plus a new `[langchain-agents]` extra (`langchain>=1.0,<2`). Neo4jAgentMemory previously imitated a BaseMemory class that langchain-core 1.x does not ship; it is now a real BaseChatMessageHistory, Neo4jMemoryRetriever a real BaseRetriever, and a create_agent middleware (before_model/after_model) is added. Two async deadlocks in the adapters are fixed; NotSupportedError is tolerated on NAMS.
- Strands 1.52+: `strands-agents>=1.52,<2`; session manager re-verified against the multi-agent/bidi hooks; Bedrock model ids in integrations/strands/config.py moved to inference-profile ids.
- FastMCP 4 / MCP Python SDK 2: `[mcp]` is `fastmcp>=4.0,<5`. Server, tools, resources and prompts ported (keyword-only constructor, snake_case ToolAnnotations keys, Streamable HTTP). `mcp serve --transport sse` remains as a deprecated alias for streamable-http.
- OpenAI `>=2.0,<4`, Anthropic `>=1.0,<2` (temperature/top_p/top_k are no longer sent; structured output kept), sentence-transformers `>=3.0,<7`, crewai `>=1.0,<2`, llama-index-core `>=0.14,<1`, google-cloud-aiplatform `>=2.0,<3` + google-genai `>=1.66`.

Bug fixes
- Vertex AI embeddings: `text-embedding-004` was shut down on 2026-01-14 and was still the default. Default is now `gemini-embedding-001` with `output_dimensionality` defaulting to 768 so existing vector indexes keep their dimensions; retired models raise a clear error (embeddings/vertex_models.py). Docs, tests and the examples README convention updated.
- Enrichment results never reached `entity.metadata`; the enrichment node properties and JSON blob are now folded into metadata (enriched_description, wikipedia_url, wikidata_id, image_url, enriched_at) and BackgroundEnrichmentService also SETs the URL properties it previously only selected.
- ExactMatchResolver reported match_type="exact" on its no-match path; it now reports "none".
- LongTermProtocol.wait_for_extraction accepts the NAMS keyword signature so client.long_term type-checks on both backends.

Docs: how-to and tutorial pages for each adapter, the MCP tutorial and tool reference, the CLI and configuration references, and the TypeScript how-to pages updated to the new APIs.

Dev dependency group gains python-dotenv and respx (used by the example smoke tests that follow in later commits).

BREAKING: extras floors above; VertexAIEmbedder default model and dimension behaviour; LangChain adapter base classes; MCP transport names