### PR TITLE
fix(long-term): stop silent data loss in the entity write path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `expected_names` / `min_results` / `predicate` / `timeout` / `interval`, so
   portable code calling it through `client.long_term` failed `mypy --strict`. All
   parameters are keyword-only and optional; bolt still returns `True` immediately.
+- **Entity aliases are now readable by alias.** `add_entity` wrote `aliases`
+  into the JSON `metadata` blob while `get_entity_by_name` looks for a top-level
+  `aliases` property, so an entity was never findable by an alias passed to
+  `add_entity`. `aliases` is now a top-level list property everywhere, matching
+  what `MERGE_ENTITIES` already wrote; rows written earlier still read back via
+  the `metadata` fallback.
+- **`add_relationship` no longer acknowledges a write that matched nothing.**
+  The query `MATCH`es both endpoints before `MERGE`ing the edge, so ids that
+  address no node wrote zero rows and returned a relationship the graph did not
+  contain. It now raises `NotFoundError` naming both ids, and on a re-add it
+  returns the stored id instead of a newly minted one.
+- **`add_entity` returns the id the graph stored.** The `MERGE` is keyed on
+  `(name, type)`, so a repeat add hits `ON MATCH`, keeps the original `id` and
+  discards the freshly minted one — the returned entity then addressed no node,
+  and every later write keyed on it (`add_relationship`,
+  `link_entity_to_message`) silently did nothing.
+- **`merge_duplicate_entities` no longer orphans edges.** It migrated only
+  `MENTIONS` and `SAME_AS`, so a merge dropped the entity's `RELATED_TO` edges
+  (both directions) and both provenance edges (`EXTRACTED_FROM`,
+  `EXTRACTED_BY`), plus the v0.2 `APPLIES_TO` and `TOUCHED` audit edges. All of
+  them are now copied onto the surviving entity and tagged `migrated_from`; the
+  merged-away entity keeps its own edges so the merge stays reversible.
 - **`add_messages_batch` now accepts `user_identifier`**, enforcing `multi_tenant`
   and linking the conversation to its `:User`; previously the bulk path silently
   wrote unscoped, unlinked conversations — so a bulk write that used to succeed

--- a/src/neo4j_agent_memory/graph/queries.py
+++ b/src/neo4j_agent_memory/graph/queries.py
@@ -351,7 +351,14 @@ ON CREATE SET
     r.valid_from = $valid_from,
     r.valid_until = $valid_until,
     r.created_at = datetime()
-RETURN r
+// Project the properties rather than ``RETURN r``: the client reads results
+// via ``Result.data()``, which serializes a relationship as a
+// ``(start_props, type, end_props)`` tuple and drops its own properties.
+// Callers need ``r.id`` to report the id the graph actually stored — on a
+// re-add ``ON CREATE`` did not run, so the pre-existing id wins.
+RETURN r.id AS id,
+       r.description AS description,
+       r.confidence AS confidence
 """
 
 GET_FACTS_BY_SUBJECT = """
@@ -1019,6 +1026,81 @@ CALL (source, target) {
         created_at: datetime()
     }]-(other)
     RETURN count(*) AS sameAsTransferred
+}
+// Transfer outgoing RELATED_TO edges. Without this the merged-away node keeps
+// the only copy of the edge and the surviving entity loses it.
+CALL (source, target) {
+    MATCH (source)-[r:RELATED_TO]->(other:Entity)
+    WHERE other <> target AND NOT (target)-[:RELATED_TO {type: r.type}]->(other)
+    MERGE (target)-[nr:RELATED_TO {type: r.type}]->(other)
+    ON CREATE SET
+        nr.id = r.id,
+        nr.description = r.description,
+        nr.confidence = r.confidence,
+        nr.valid_from = r.valid_from,
+        nr.valid_until = r.valid_until,
+        nr.created_at = r.created_at,
+        nr.migrated_from = source.id
+    RETURN count(*) AS relatedOutTransferred
+}
+// Transfer incoming RELATED_TO edges
+CALL (source, target) {
+    MATCH (other:Entity)-[r:RELATED_TO]->(source)
+    WHERE other <> target AND NOT (other)-[:RELATED_TO {type: r.type}]->(target)
+    MERGE (other)-[nr:RELATED_TO {type: r.type}]->(target)
+    ON CREATE SET
+        nr.id = r.id,
+        nr.description = r.description,
+        nr.confidence = r.confidence,
+        nr.valid_from = r.valid_from,
+        nr.valid_until = r.valid_until,
+        nr.created_at = r.created_at,
+        nr.migrated_from = source.id
+    RETURN count(*) AS relatedInTransferred
+}
+// Transfer provenance: which messages the entity was extracted from
+CALL (source, target) {
+    MATCH (source)-[r:EXTRACTED_FROM]->(m:Message)
+    WHERE NOT (target)-[:EXTRACTED_FROM]->(m)
+    MERGE (target)-[nr:EXTRACTED_FROM]->(m)
+    ON CREATE SET
+        nr.confidence = r.confidence,
+        nr.start_pos = r.start_pos,
+        nr.end_pos = r.end_pos,
+        nr.context = r.context,
+        nr.created_at = r.created_at,
+        nr.migrated_from = source.id
+    RETURN count(*) AS extractedFromTransferred
+}
+// Transfer provenance: which extractors produced the entity
+CALL (source, target) {
+    MATCH (source)-[r:EXTRACTED_BY]->(ex:Extractor)
+    WHERE NOT (target)-[:EXTRACTED_BY]->(ex)
+    MERGE (target)-[nr:EXTRACTED_BY]->(ex)
+    ON CREATE SET
+        nr.confidence = r.confidence,
+        nr.extraction_time_ms = r.extraction_time_ms,
+        nr.created_at = r.created_at,
+        nr.migrated_from = source.id
+    RETURN count(*) AS extractedByTransferred
+}
+// Transfer inbound preference scoping (v0.2 APPLIES_TO edges)
+CALL (source, target) {
+    MATCH (p:Preference)-[r:APPLIES_TO]->(source)
+    WHERE NOT (p)-[:APPLIES_TO]->(target)
+    MERGE (p)-[nr:APPLIES_TO]->(target)
+    ON CREATE SET nr.migrated_from = source.id
+    RETURN count(*) AS appliesToTransferred
+}
+// Transfer inbound reasoning audit edges (v0.2 TOUCHED edges)
+CALL (source, target) {
+    MATCH (s:ReasoningStep)-[r:TOUCHED]->(source)
+    WHERE NOT (s)-[:TOUCHED]->(target)
+    MERGE (s)-[nr:TOUCHED]->(target)
+    ON CREATE SET
+        nr.recorded_at = r.recorded_at,
+        nr.migrated_from = source.id
+    RETURN count(*) AS touchedTransferred
 }
 // Mark source as merged
 SET source.merged_into = target.id,

--- a/src/neo4j_agent_memory/graph/query_builder.py
+++ b/src/neo4j_agent_memory/graph/query_builder.py
@@ -235,7 +235,11 @@ def build_label_set_clause(entity_type: str, subtype: str | None, node_var: str 
 
 
 def build_create_entity_query(
-    entity_type: str, subtype: str | None, *, include_location: bool = False
+    entity_type: str,
+    subtype: str | None,
+    *,
+    include_location: bool = False,
+    include_aliases: bool = False,
 ) -> str:
     """Build the CREATE_ENTITY query with dynamic type/subtype labels.
 
@@ -246,6 +250,12 @@ def build_create_entity_query(
         entity_type: The entity type (e.g., "PERSON", "OBJECT")
         subtype: Optional subtype (e.g., "VEHICLE", "ADDRESS")
         include_location: If True, include location Point property (for LOCATION entities)
+        include_aliases: If True, include the top-level ``aliases`` list property.
+            Callers that set this must pass an ``aliases`` parameter when
+            running the query — Cypher errors on a referenced-but-absent
+            parameter. Off by default so that queries built by hand with their
+            own parameter dict keep working unchanged; ``LongTermMemory.add_entity``
+            opts in.
 
     Returns:
         Complete Cypher query string with dynamic labels
@@ -256,6 +266,9 @@ def build_create_entity_query(
 
         >>> query = build_create_entity_query("LOCATION", "CITY", include_location=True)
         >>> # Returns query that also sets e.location = $location
+
+        >>> query = build_create_entity_query("PERSON", None, include_aliases=True)
+        >>> # Returns query that also sets e.aliases = $aliases
     """
     label_set_clause = build_label_set_clause(entity_type, subtype)
 
@@ -267,6 +280,22 @@ def build_create_entity_query(
         location_on_create = ",\n    e.location = CASE WHEN $location IS NOT NULL THEN point({latitude: $location.latitude, longitude: $location.longitude}) ELSE null END"
         location_on_match = ",\n    e.location = CASE WHEN $location IS NOT NULL THEN point({latitude: $location.latitude, longitude: $location.longitude}) ELSE e.location END"
 
+    # Build aliases clause. ``aliases`` is a top-level list property (not
+    # buried in the JSON ``metadata`` string) so that name lookups —
+    # ``GET_ENTITY_BY_NAME`` reads ``$name IN e.aliases`` — and
+    # ``MERGE_ENTITIES``, which appends the merged-away name to
+    # ``target.aliases``, all agree on one location. ON MATCH appends only
+    # aliases not already present, atomically, so concurrent writers cannot
+    # clobber each other's list.
+    aliases_on_create = ""
+    aliases_on_match = ""
+    if include_aliases:
+        aliases_on_create = ",\n    e.aliases = coalesce($aliases, [])"
+        aliases_on_match = (
+            ",\n    e.aliases = coalesce(e.aliases, [])"
+            " + [a IN coalesce($aliases, []) WHERE NOT a IN coalesce(e.aliases, [])]"
+        )
+
     query = f"""MERGE (e:Entity {{name: $name, type: $type}})
 ON CREATE SET
     e.id = $id,
@@ -276,13 +305,13 @@ ON CREATE SET
     e.embedding = $embedding,
     e.confidence = $confidence,
     e.created_at = datetime(),
-    e.metadata = $metadata{location_on_create}
+    e.metadata = $metadata{aliases_on_create}{location_on_create}
 ON MATCH SET
     e.subtype = COALESCE($subtype, e.subtype),
     e.canonical_name = COALESCE($canonical_name, e.canonical_name),
     e.description = COALESCE($description, e.description),
     e.embedding = COALESCE($embedding, e.embedding),
-    e.updated_at = datetime(){location_on_match}"""
+    e.updated_at = datetime(){aliases_on_match}{location_on_match}"""
 
     # Add label SET clause if we have valid labels
     if label_set_clause:

--- a/src/neo4j_agent_memory/memory/long_term.py
+++ b/src/neo4j_agent_memory/memory/long_term.py
@@ -12,7 +12,7 @@ from uuid import UUID, uuid4
 
 from pydantic import Field
 
-from neo4j_agent_memory.core.exceptions import NotSupportedError
+from neo4j_agent_memory.core.exceptions import NotFoundError, NotSupportedError
 from neo4j_agent_memory.core.memory import BaseMemory, MemoryEntry
 from neo4j_agent_memory.core.protocols import LongTermProtocol
 from neo4j_agent_memory.graph import queries
@@ -574,16 +574,16 @@ class LongTermMemory(BaseMemory[Entity], LongTermProtocol):
         if location_point is not None:
             entity.attributes["coordinates"] = location_point
 
-        # Merge attributes into metadata for storage
+        # Merge attributes into metadata for storage. ``aliases`` is written as
+        # a top-level list property instead, so that ``GET_ENTITY_BY_NAME``
+        # (``$name IN e.aliases``) can actually find the entity by alias.
         storage_metadata = {**entity.metadata}
         if entity.attributes:
             storage_metadata["attributes"] = entity.attributes
-        if entity.aliases:
-            storage_metadata["aliases"] = entity.aliases
 
         # Store entity with dynamic labels for type/subtype
-        create_query = build_create_entity_query(entity.type, entity.subtype)
-        await self._client.execute_write(
+        create_query = build_create_entity_query(entity.type, entity.subtype, include_aliases=True)
+        results = await self._client.execute_write(
             create_query,
             {
                 "id": str(entity.id),
@@ -594,10 +594,25 @@ class LongTermMemory(BaseMemory[Entity], LongTermProtocol):
                 "description": entity.description,
                 "embedding": entity.embedding,
                 "confidence": entity.confidence,
+                "aliases": entity.aliases or [],
                 "metadata": _serialize_metadata(storage_metadata) if storage_metadata else None,
                 "location": location_point,  # Neo4j Point for LOCATION entities
             },
         )
+
+        # The query MERGEs on (name, type): when a node with that name+type
+        # already exists, ``ON MATCH`` keeps its original ``id`` (and any
+        # property it already had) and discards the freshly minted one. Adopt
+        # what the database actually holds, otherwise callers get an entity
+        # whose id matches no node, and every later write keyed on that id —
+        # ``add_relationship``, ``link_entity_to_message`` — silently does
+        # nothing.
+        #
+        # The ``id`` check keeps a node written by something other than this
+        # library (no ``id`` property) from turning into a KeyError inside
+        # ``_parse_entity`` on the write path. Such a node is left as-is.
+        if results and results[0].get("e") and results[0]["e"].get("id"):
+            entity = self._parse_entity(dict(results[0]["e"]))
 
         # If flagged for review, create SAME_AS relationship
         if dedup_result.action == "flagged" and dedup_result.matched_entity_id:
@@ -1027,7 +1042,7 @@ class LongTermMemory(BaseMemory[Entity], LongTermProtocol):
             attributes=attributes or {},
         )
 
-        await self._client.execute_write(
+        results = await self._client.execute_write(
             queries.CREATE_ENTITY_RELATIONSHIP,
             {
                 "id": str(relationship.id),
@@ -1040,6 +1055,45 @@ class LongTermMemory(BaseMemory[Entity], LongTermProtocol):
                 "valid_until": valid_until.isoformat() if valid_until else None,
             },
         )
+
+        # ``CREATE_ENTITY_RELATIONSHIP`` MATCHes both endpoints *before* it
+        # MERGEs the edge, so ids that match no node — a stale id, or the
+        # client-minted id ``add_entity`` used to hand back for an existing
+        # node (see #79) — write zero rows without raising. Report that rather
+        # than returning a relationship the graph does not contain.
+        if not results:
+            raise NotFoundError(
+                f"Cannot create {relationship_type!r} relationship: no :Entity node "
+                f"found for source {source_id} or target {target_id}. Use the ids "
+                "stored on the nodes (e.g. the result of add_entity / "
+                "get_entity_by_name), not ids minted client-side."
+            )
+
+        # The MERGE key is (endpoints, relation type), so re-adding an existing
+        # relationship keeps its original id: ``ON CREATE`` did not run, and the
+        # fresh uuid above addresses no edge. Report what the graph holds
+        # instead of echoing the arguments, which would hand back a ghost id.
+        # The query projects these as aliases because ``Result.data()``
+        # flattens a bare ``RETURN r`` to a ``(start, type, end)`` tuple.
+        stored = results[0]
+        stored_id = stored.get("id")
+        if stored_id is not None:
+            stored_confidence = stored.get("confidence")
+            relationship = Relationship(
+                id=UUID(str(stored_id)),
+                source_id=source_id,
+                target_id=target_id,
+                type=relationship_type,
+                # ``description`` falls back to the argument because writing
+                # ``null`` on create is indistinguishable from never having set
+                # it. ``valid_from`` / ``valid_until`` are stored as ISO strings
+                # but read back as ``datetime`` fields, so they stay as passed.
+                description=stored.get("description") or description,
+                confidence=(stored_confidence if stored_confidence is not None else confidence),
+                valid_from=valid_from,
+                valid_until=valid_until,
+                attributes=relationship.attributes,
+            )
 
         return relationship
 
@@ -1440,35 +1494,27 @@ class LongTermMemory(BaseMemory[Entity], LongTermProtocol):
     async def _add_alias_to_entity(self, entity_id: UUID, alias: str) -> None:
         """Add an alias to an existing entity.
 
+        Appends to the entity's top-level ``aliases`` list property in a
+        single write (no read-modify-write of the whole ``metadata`` blob), so
+        two concurrent callers cannot drop each other's alias.
+
         Args:
             entity_id: Entity UUID
             alias: Alias to add
         """
-        # Get current entity
-        entity = await self._get_entity_by_id(entity_id)
-        if entity is None:
-            return
-
-        # Update aliases in metadata
-        current_aliases = entity.aliases or []
-        if alias not in current_aliases:
-            current_aliases.append(alias)
-
-        # Update in database
-        storage_metadata = {**entity.metadata}
-        storage_metadata["aliases"] = current_aliases
-        if entity.attributes:
-            storage_metadata["attributes"] = entity.attributes
-
         await self._client.execute_write(
             """
             MATCH (e:Entity {id: $id})
-            SET e.metadata = $metadata
+            SET e.aliases = CASE
+                WHEN e.aliases IS NULL THEN [$alias]
+                WHEN NOT $alias IN e.aliases THEN e.aliases + $alias
+                ELSE e.aliases
+            END
             RETURN e
             """,
             {
                 "id": str(entity_id),
-                "metadata": _serialize_metadata(storage_metadata),
+                "alias": alias,
             },
         )
 
@@ -1518,8 +1564,24 @@ class LongTermMemory(BaseMemory[Entity], LongTermProtocol):
     ) -> tuple[Entity, Entity] | None:
         """Merge two entities, keeping the target and marking source as merged.
 
-        The source entity's name is added as an alias to the target.
-        Any relationships pointing to the source are transferred to the target.
+        The source entity's name is added to the target's ``aliases``, and every
+        edge the source carries is copied onto the target so the surviving
+        entity does not lose graph context:
+
+        * ``MENTIONS`` (inbound, from ``Message``)
+        * ``RELATED_TO`` (both directions)
+        * ``SAME_AS``
+        * ``EXTRACTED_FROM`` (outbound provenance to ``Message``)
+        * ``EXTRACTED_BY`` (outbound provenance to ``Extractor``)
+        * ``APPLIES_TO`` (inbound, from ``Preference``)
+        * ``TOUCHED`` (inbound, from ``ReasoningStep``)
+
+        Edges are *copied*, not moved: the merged-away source keeps its own
+        edges so the merge stays reversible and auditable, and the source is
+        marked with ``merged_into`` / ``merged_at`` to exclude it from
+        deduplication candidate scans. A copied edge keeps the source edge's
+        ``id`` and gains ``migrated_from``, so the pair is identifiable — the
+        two share an id, and nothing looks a ``RELATED_TO`` edge up by it.
 
         Args:
             source_id: ID of entity to merge from (will be marked as merged)
@@ -2154,7 +2216,14 @@ class LongTermMemory(BaseMemory[Entity], LongTermProtocol):
         """Parse entity from database result."""
         metadata = _deserialize_metadata(data.get("metadata"))
         attributes = metadata.pop("attributes", {})
-        aliases = metadata.pop("aliases", [])
+        # ``aliases`` lives as a top-level list property. Nodes written before
+        # that became the case kept them inside the ``metadata`` JSON blob, so
+        # fall back to that location for rows that have no top-level list.
+        aliases = data.get("aliases")
+        if isinstance(aliases, list) and aliases:
+            metadata.pop("aliases", None)
+        else:
+            aliases = metadata.pop("aliases", [])
         # Surface background-enrichment results (stored as node properties)
         # through ``entity.metadata`` — see CLAUDE.md implementation note 22.
         metadata.update(_enrichment_metadata(data))

--- a/tests/integration/test_long_term_write_integrity.py
+++ b/tests/integration/test_long_term_write_integrity.py
@@ -1,0 +1,520 @@
+"""Integration tests for long-term write-path integrity against a real Neo4j.
+
+These exercise the failure modes that only show up once a real MERGE, a real
+``ON MATCH`` branch and a real relationship write are involved:
+
+* ``aliases`` written into the ``metadata`` blob while alias lookup read a
+  top-level property;
+* ``add_entity`` returning an id that no node carries;
+* ``add_relationship`` acknowledging a write that matched nothing;
+* ``merge_duplicate_entities`` orphaning the merged-away entity's edges.
+"""
+
+from uuid import UUID, uuid4
+
+import pytest
+
+from neo4j_agent_memory.core.exceptions import NotFoundError
+
+pytestmark = [pytest.mark.integration, pytest.mark.asyncio]
+
+
+async def _edges(neo4j_client, query: str, **params) -> list[dict]:
+    return await neo4j_client.execute_read(query, params)
+
+
+class TestAliasesRoundTrip:
+    """``add_entity(aliases=...)`` must be findable by that alias."""
+
+    async def test_entity_is_findable_by_alias(self, clean_memory_client):
+        entity, _ = await clean_memory_client.long_term.add_entity(
+            "Jonathan Smith",
+            "PERSON",
+            aliases=["Jon Smith", "J. Smith"],
+            resolve=False,
+            generate_embedding=False,
+        )
+
+        found = await clean_memory_client.long_term.get_entity_by_name("Jon Smith")
+
+        assert found is not None
+        assert found.id == entity.id
+        assert "Jon Smith" in found.aliases
+
+    async def test_aliases_survive_a_round_trip(self, clean_memory_client):
+        await clean_memory_client.long_term.add_entity(
+            "Jonathan Smith",
+            "PERSON",
+            aliases=["Jon Smith"],
+            resolve=False,
+            generate_embedding=False,
+        )
+
+        found = await clean_memory_client.long_term.get_entity_by_name("Jonathan Smith")
+
+        assert found is not None
+        assert found.aliases == ["Jon Smith"]
+
+    async def test_alias_is_not_duplicated_into_metadata(self, clean_memory_client):
+        entity, _ = await clean_memory_client.long_term.add_entity(
+            "Jonathan Smith",
+            "PERSON",
+            aliases=["Jon Smith"],
+            metadata={"source": "test"},
+            resolve=False,
+            generate_embedding=False,
+        )
+
+        assert "aliases" not in (entity.metadata or {})
+        assert entity.metadata.get("source") == "test"
+
+    async def test_adding_the_same_alias_twice_does_not_duplicate_it(self, clean_memory_client):
+        entity, _ = await clean_memory_client.long_term.add_entity(
+            "Jonathan Smith", "PERSON", resolve=False, generate_embedding=False
+        )
+
+        await clean_memory_client.long_term._add_alias_to_entity(entity.id, "Jon Smith")
+        await clean_memory_client.long_term._add_alias_to_entity(entity.id, "Jon Smith")
+
+        found = await clean_memory_client.long_term.get_entity_by_name("Jonathan Smith")
+        assert found is not None
+        assert found.aliases == ["Jon Smith"]
+
+    async def test_legacy_row_with_metadata_aliases_still_reads_back(self, clean_memory_client):
+        """Rows written before the move to a property must keep working."""
+        entity_id = str(uuid4())
+        await clean_memory_client.graph.execute_write(
+            """
+            MERGE (e:Entity {name: $name, type: $type})
+            ON CREATE SET e.id = $id,
+                          e.metadata = $metadata,
+                          e.created_at = datetime()
+            """,
+            {
+                "id": entity_id,
+                "name": "Legacy Person",
+                "type": "PERSON",
+                "metadata": '{"aliases": ["Old Alias"], "attributes": {}}',
+            },
+        )
+
+        found = await clean_memory_client.long_term._get_entity_by_id(UUID(entity_id))
+
+        assert found is not None
+        assert found.aliases == ["Old Alias"]
+        assert "aliases" not in (found.metadata or {})
+
+
+class TestAddEntityReturnsStoredId:
+    """Every id ``add_entity`` hands back must address a real node."""
+
+    async def test_re_add_returns_the_id_the_graph_kept(self, clean_memory_client):
+        first, _ = await clean_memory_client.long_term.add_entity(
+            "John Smith", "PERSON", resolve=False, generate_embedding=False
+        )
+        second, _ = await clean_memory_client.long_term.add_entity(
+            "John Smith", "PERSON", resolve=False, generate_embedding=False
+        )
+
+        # The MERGE matched, so ON CREATE did not run and the original id won.
+        assert second.id == first.id
+
+    async def test_returned_id_is_backed_by_a_node(self, clean_memory_client):
+        entity, _ = await clean_memory_client.long_term.add_entity(
+            "John Smith", "PERSON", resolve=False, generate_embedding=False
+        )
+        # Force the ON MATCH branch on the next call.
+        re_added, _ = await clean_memory_client.long_term.add_entity(
+            "John Smith", "PERSON", resolve=False, generate_embedding=False
+        )
+
+        rows = await _edges(
+            clean_memory_client.graph,
+            "MATCH (e:Entity {id: $id}) RETURN count(e) AS n",
+            id=str(re_added.id),
+        )
+
+        assert rows[0]["n"] == 1
+        assert re_added.id == entity.id
+
+    async def test_relationship_between_returned_ids_actually_lands(self, clean_memory_client):
+        """The reported symptom: the edge is silently never created."""
+        source, _ = await clean_memory_client.long_term.add_entity(
+            "Alice", "PERSON", resolve=False, generate_embedding=False
+        )
+        target, _ = await clean_memory_client.long_term.add_entity(
+            "Bob", "PERSON", resolve=False, generate_embedding=False
+        )
+
+        await clean_memory_client.long_term.add_relationship(source.id, target.id, "KNOWS")
+
+        rows = await _edges(
+            clean_memory_client.graph,
+            """
+            MATCH (a:Entity {id: $source})-[r:RELATED_TO]->(b:Entity {id: $target})
+            RETURN r.type AS relation_type
+            """,
+            source=str(source.id),
+            target=str(target.id),
+        )
+
+        assert len(rows) == 1
+        assert rows[0]["relation_type"] == "KNOWS"
+
+    async def test_relationship_survives_an_on_match_re_add(self, clean_memory_client):
+        """Ids captured before a repeat add must still address the node."""
+        source, _ = await clean_memory_client.long_term.add_entity(
+            "Alice", "PERSON", resolve=False, generate_embedding=False
+        )
+        target, _ = await clean_memory_client.long_term.add_entity(
+            "Bob", "PERSON", resolve=False, generate_embedding=False
+        )
+        await clean_memory_client.long_term.add_entity(
+            "Alice", "PERSON", resolve=False, generate_embedding=False
+        )
+
+        await clean_memory_client.long_term.add_relationship(source.id, target.id, "KNOWS")
+
+        rows = await _edges(
+            clean_memory_client.graph,
+            "MATCH (:Entity {id: $source})-[:RELATED_TO]->(:Entity {id: $target}) "
+            "RETURN count(*) AS n",
+            source=str(source.id),
+            target=str(target.id),
+        )
+
+        assert rows[0]["n"] == 1
+
+
+class TestAddRelationshipSurfacesFailure:
+    """A relationship write that matches no node is an error, not a success."""
+
+    async def test_missing_source_raises_and_writes_nothing(self, clean_memory_client):
+        target, _ = await clean_memory_client.long_term.add_entity(
+            "Bob", "PERSON", resolve=False, generate_embedding=False
+        )
+
+        with pytest.raises(NotFoundError):
+            await clean_memory_client.long_term.add_relationship(uuid4(), target.id, "KNOWS")
+
+        rows = await _edges(
+            clean_memory_client.graph,
+            "MATCH ()-[r:RELATED_TO]->() RETURN count(r) AS n",
+        )
+        assert rows[0]["n"] == 0
+
+    async def test_missing_target_raises(self, clean_memory_client):
+        source, _ = await clean_memory_client.long_term.add_entity(
+            "Alice", "PERSON", resolve=False, generate_embedding=False
+        )
+
+        with pytest.raises(NotFoundError):
+            await clean_memory_client.long_term.add_relationship(source.id, uuid4(), "KNOWS")
+
+    async def test_both_endpoints_missing_raises(self, clean_memory_client):
+        with pytest.raises(NotFoundError):
+            await clean_memory_client.long_term.add_relationship(uuid4(), uuid4(), "KNOWS")
+
+    async def test_re_adding_an_edge_is_idempotent(self, clean_memory_client):
+        source, _ = await clean_memory_client.long_term.add_entity(
+            "Alice", "PERSON", resolve=False, generate_embedding=False
+        )
+        target, _ = await clean_memory_client.long_term.add_entity(
+            "Bob", "PERSON", resolve=False, generate_embedding=False
+        )
+
+        first = await clean_memory_client.long_term.add_relationship(
+            source.id, target.id, "KNOWS", confidence=0.9
+        )
+        second = await clean_memory_client.long_term.add_relationship(
+            source.id, target.id, "KNOWS", confidence=0.2
+        )
+
+        assert second.id == first.id
+        # ON CREATE kept the original confidence; the retry did not overwrite it.
+        assert second.confidence == first.confidence
+
+        rows = await _edges(
+            clean_memory_client.graph,
+            "MATCH (:Entity {id: $s})-[r:RELATED_TO]->(:Entity {id: $t}) RETURN count(r) AS n",
+            s=str(source.id),
+            t=str(target.id),
+        )
+        assert rows[0]["n"] == 1
+
+
+class TestMergeMigratesEdges:
+    """The surviving entity must inherit the merged-away entity's context."""
+
+    async def test_related_to_edges_are_copied_in_both_directions(self, clean_memory_client):
+        long_term = clean_memory_client.long_term
+        source, _ = await long_term.add_entity(
+            "Jon Smith", "PERSON", resolve=False, generate_embedding=False
+        )
+        target, _ = await long_term.add_entity(
+            "John Smith", "PERSON", resolve=False, generate_embedding=False
+        )
+        outgoing, _ = await long_term.add_entity(
+            "Acme Corp", "ORGANIZATION", resolve=False, generate_embedding=False
+        )
+        incoming, _ = await long_term.add_entity(
+            "Bob", "PERSON", resolve=False, generate_embedding=False
+        )
+        await long_term.add_relationship(source.id, outgoing.id, "WORKS_AT", confidence=0.8)
+        await long_term.add_relationship(incoming.id, source.id, "KNOWS", confidence=0.7)
+
+        merged = await long_term.merge_duplicate_entities(source.id, target.id)
+        assert merged is not None
+
+        out_rows = await _edges(
+            clean_memory_client.graph,
+            "MATCH (:Entity {id: $t})-[r:RELATED_TO]->(:Entity {id: $o}) "
+            "RETURN r.type AS relation_type, r.confidence AS confidence, "
+            "       r.migrated_from AS migrated_from",
+            t=str(target.id),
+            o=str(outgoing.id),
+        )
+        assert len(out_rows) == 1
+        assert out_rows[0]["relation_type"] == "WORKS_AT"
+        assert out_rows[0]["confidence"] == 0.8
+        assert out_rows[0]["migrated_from"] == str(source.id)
+
+        in_rows = await _edges(
+            clean_memory_client.graph,
+            "MATCH (:Entity {id: $i})-[r:RELATED_TO]->(:Entity {id: $t}) "
+            "RETURN r.type AS relation_type",
+            i=str(incoming.id),
+            t=str(target.id),
+        )
+        assert len(in_rows) == 1
+        assert in_rows[0]["relation_type"] == "KNOWS"
+
+    async def test_mentions_are_copied(self, clean_memory_client):
+        long_term = clean_memory_client.long_term
+        source, _ = await long_term.add_entity(
+            "Jon Smith", "PERSON", resolve=False, generate_embedding=False
+        )
+        target, _ = await long_term.add_entity(
+            "John Smith", "PERSON", resolve=False, generate_embedding=False
+        )
+        # MENTIONS is written by the short-term extraction path, not by
+        # link_entity_to_message (which writes EXTRACTED_FROM), so create it
+        # the way a real extraction would.
+        message = await clean_memory_client.short_term.add_message(
+            f"session-{uuid4()}", "user", "Jon Smith was here.", extract_entities=False
+        )
+        await clean_memory_client.graph.execute_write(
+            "MATCH (m:Message {id: $m}), (e:Entity {id: $e}) MERGE (m)-[:MENTIONS]->(e)",
+            {"m": str(message.id), "e": str(source.id)},
+        )
+
+        await long_term.merge_duplicate_entities(source.id, target.id)
+
+        rows = await _edges(
+            clean_memory_client.graph,
+            "MATCH (m:Message {id: $m})-[:MENTIONS]->(e:Entity {id: $t}) RETURN count(*) AS n",
+            m=str(message.id),
+            t=str(target.id),
+        )
+        assert rows[0]["n"] == 1
+
+    async def test_provenance_edges_are_copied(self, clean_memory_client):
+        long_term = clean_memory_client.long_term
+        source, _ = await long_term.add_entity(
+            "Jon Smith", "PERSON", resolve=False, generate_embedding=False
+        )
+        target, _ = await long_term.add_entity(
+            "John Smith", "PERSON", resolve=False, generate_embedding=False
+        )
+        message = await clean_memory_client.short_term.add_message(
+            f"session-{uuid4()}", "user", "Jon Smith was here.", extract_entities=False
+        )
+        await long_term.link_entity_to_message(source, message.id, confidence=0.9, context="ctx")
+        await long_term.register_extractor("TestExtractor", version="1.0.0")
+        await long_term.link_entity_to_extractor(source, "TestExtractor", confidence=0.9)
+
+        await long_term.merge_duplicate_entities(source.id, target.id)
+
+        provenance = await long_term.get_entity_provenance(target)
+        assert any(s["message_id"] == str(message.id) for s in provenance["sources"])
+        assert any(e["name"] == "TestExtractor" for e in provenance["extractors"])
+
+    async def test_merge_is_idempotent(self, clean_memory_client):
+        long_term = clean_memory_client.long_term
+        source, _ = await long_term.add_entity(
+            "Jon Smith", "PERSON", resolve=False, generate_embedding=False
+        )
+        target, _ = await long_term.add_entity(
+            "John Smith", "PERSON", resolve=False, generate_embedding=False
+        )
+        other, _ = await long_term.add_entity(
+            "Acme Corp", "ORGANIZATION", resolve=False, generate_embedding=False
+        )
+        await long_term.add_relationship(source.id, other.id, "WORKS_AT")
+
+        await long_term.merge_duplicate_entities(source.id, target.id)
+        await long_term.merge_duplicate_entities(source.id, target.id)
+
+        rows = await _edges(
+            clean_memory_client.graph,
+            "MATCH (:Entity {id: $t})-[r:RELATED_TO]->(:Entity {id: $o}) RETURN count(r) AS n",
+            t=str(target.id),
+            o=str(other.id),
+        )
+        assert rows[0]["n"] == 1
+
+    async def test_source_keeps_its_own_edges_for_audit(self, clean_memory_client):
+        """Edges are copied, not moved, so the merge stays reversible."""
+        long_term = clean_memory_client.long_term
+        source, _ = await long_term.add_entity(
+            "Jon Smith", "PERSON", resolve=False, generate_embedding=False
+        )
+        target, _ = await long_term.add_entity(
+            "John Smith", "PERSON", resolve=False, generate_embedding=False
+        )
+        other, _ = await long_term.add_entity(
+            "Acme Corp", "ORGANIZATION", resolve=False, generate_embedding=False
+        )
+        await long_term.add_relationship(source.id, other.id, "WORKS_AT")
+
+        await long_term.merge_duplicate_entities(source.id, target.id)
+
+        rows = await _edges(
+            clean_memory_client.graph,
+            "MATCH (:Entity {id: $s})-[:RELATED_TO]->(:Entity {id: $o}) RETURN count(*) AS n",
+            s=str(source.id),
+            o=str(other.id),
+        )
+        assert rows[0]["n"] == 1
+
+    async def test_source_name_becomes_a_findable_alias(self, clean_memory_client):
+        long_term = clean_memory_client.long_term
+        source, _ = await long_term.add_entity(
+            "Jon Smith", "PERSON", resolve=False, generate_embedding=False
+        )
+        target, _ = await long_term.add_entity(
+            "John Smith", "PERSON", resolve=False, generate_embedding=False
+        )
+
+        await long_term.merge_duplicate_entities(source.id, target.id)
+
+        found = await long_term.get_entity_by_name("Jon Smith")
+        assert found is not None
+        assert found.id == target.id
+
+    async def test_source_is_marked_as_merged(self, clean_memory_client):
+        long_term = clean_memory_client.long_term
+        source, _ = await long_term.add_entity(
+            "Jon Smith", "PERSON", resolve=False, generate_embedding=False
+        )
+        target, _ = await long_term.add_entity(
+            "John Smith", "PERSON", resolve=False, generate_embedding=False
+        )
+
+        await long_term.merge_duplicate_entities(source.id, target.id)
+
+        rows = await _edges(
+            clean_memory_client.graph,
+            "MATCH (e:Entity {id: $id}) RETURN e.merged_into AS merged_into, "
+            "       e.merged_at AS merged_at",
+            id=str(source.id),
+        )
+        assert rows[0]["merged_into"] == str(target.id)
+        assert rows[0]["merged_at"] is not None
+
+
+class TestIssue79:
+    """Reproduces https://github.com/neo4j-labs/agent-memory/issues/79.
+
+    The report's sequence, in library terms: an entity exists, and a later
+    write links *to* it by calling ``add_entity`` for the target with
+    ``deduplicate=False, resolve=False`` — which is what the reporting bridge
+    does. On the pre-fix code that call returns an id no node carries, so the
+    following ``add_relationship`` writes zero rows and returns silently:
+    ``{"status": "stored"}`` with no edge in the graph.
+
+    The report describes the returned id as "a new ghost entity". There is no
+    second node — the ``MERGE`` is keyed on ``(name, type)`` and reuses the
+    existing one — which is why the fix belongs in ``add_entity``'s return
+    value rather than in a bridge-side name lookup.
+    """
+
+    async def test_relationship_to_an_existing_entity_lands(self, clean_memory_client):
+        long_term = clean_memory_client.long_term
+
+        # 1. The entity that already exists.
+        await long_term.add_entity(
+            "Charles Brubaker",
+            "PERSON",
+            deduplicate=False,
+            resolve=False,
+            generate_embedding=False,
+        )
+
+        # 2. A new entity carrying a relationship to it.
+        scout, _ = await long_term.add_entity(
+            "Scout",
+            "OBJECT",
+            deduplicate=False,
+            resolve=False,
+            generate_embedding=False,
+        )
+
+        # The bridge's target lookup: add_entity again, dedup and resolution off.
+        target, _ = await long_term.add_entity(
+            "Charles Brubaker",
+            "PERSON",
+            deduplicate=False,
+            resolve=False,
+            generate_embedding=False,
+        )
+
+        await long_term.add_relationship(scout, target, "AUTHORED_BY")
+
+        rows = await _edges(
+            clean_memory_client.graph,
+            "MATCH ()-[r:RELATED_TO]->() RETURN count(r) AS n",
+        )
+        assert rows[0]["n"] == 1
+
+    async def test_the_relationship_connects_the_two_real_nodes(self, clean_memory_client):
+        """Not just an edge — an edge between the nodes the caller meant."""
+        long_term = clean_memory_client.long_term
+
+        stored, _ = await long_term.add_entity(
+            "Charles Brubaker",
+            "PERSON",
+            deduplicate=False,
+            resolve=False,
+            generate_embedding=False,
+        )
+        scout, _ = await long_term.add_entity(
+            "Scout",
+            "OBJECT",
+            deduplicate=False,
+            resolve=False,
+            generate_embedding=False,
+        )
+        # Re-add, exactly as the bridge does for a relationship target.
+        target, _ = await long_term.add_entity(
+            "Charles Brubaker",
+            "PERSON",
+            deduplicate=False,
+            resolve=False,
+            generate_embedding=False,
+        )
+
+        await long_term.add_relationship(scout, target, "AUTHORED_BY")
+
+        rows = await _edges(
+            clean_memory_client.graph,
+            """
+            MATCH (a:Entity {id: $source})-[r:RELATED_TO]->(b:Entity {id: $target})
+            RETURN b.name AS target_name, r.type AS rel_type
+            """,
+            source=str(scout.id),
+            target=str(stored.id),
+        )
+        assert len(rows) == 1
+        assert rows[0]["target_name"] == "Charles Brubaker"
+        assert rows[0]["rel_type"] == "AUTHORED_BY"

--- a/tests/unit/test_long_term_write_integrity.py
+++ b/tests/unit/test_long_term_write_integrity.py
@@ -1,0 +1,448 @@
+"""Tests for long-term write-path integrity.
+
+Covers the cases where a successful-looking call left the graph without the
+data the caller believed it had written:
+
+* aliases were stored inside the ``metadata`` JSON blob while alias lookup
+  read a top-level ``aliases`` property, so ``get_entity_by_name`` could
+  never find an entity by its aliases;
+* ``add_entity`` returned a client-minted id instead of the id the MERGE
+  actually stored, so ids handed to ``add_relationship`` matched no node;
+* ``add_relationship`` reported success after writing zero rows;
+* ``merge_duplicate_entities`` dropped the merged-away entity's edges.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock
+from uuid import UUID, uuid4
+
+import pytest
+
+from neo4j_agent_memory.core.exceptions import NotFoundError
+from neo4j_agent_memory.graph import queries
+from neo4j_agent_memory.graph.query_builder import build_create_entity_query
+from neo4j_agent_memory.memory.long_term import (
+    DeduplicationConfig,
+    LongTermMemory,
+)
+
+# Edge types that merge_duplicate_entities documents (and must therefore
+# migrate) for an entity.
+MERGED_EDGE_TYPES = {
+    "MENTIONS",
+    "RELATED_TO",
+    "SAME_AS",
+    "EXTRACTED_FROM",
+    "EXTRACTED_BY",
+    "APPLIES_TO",
+    "TOUCHED",
+}
+
+
+def stored_node(**overrides: object) -> dict[str, object]:
+    """Build a node payload as ``execute_write`` returns it (``RETURN e``)."""
+    node: dict[str, object] = {
+        "id": str(uuid4()),
+        "name": "John Smith",
+        "canonical_name": "John Smith",
+        "type": "PERSON",
+        "subtype": None,
+        "description": None,
+        "embedding": [0.1] * 384,
+        "confidence": 1.0,
+        "metadata": None,
+    }
+    node.update(overrides)
+    return node
+
+
+@pytest.fixture
+def mock_client() -> MagicMock:
+    client = MagicMock()
+    client.execute_read = AsyncMock(return_value=[])
+    client.execute_write = AsyncMock(return_value=[])
+    return client
+
+
+@pytest.fixture
+def mock_embedder() -> MagicMock:
+    embedder = MagicMock()
+    embedder.embed = AsyncMock(return_value=[0.1] * 384)
+    return embedder
+
+
+@pytest.fixture
+def memory(mock_client: MagicMock, mock_embedder: MagicMock) -> LongTermMemory:
+    return LongTermMemory(
+        client=mock_client,
+        embedder=mock_embedder,
+        deduplication=DeduplicationConfig(),
+    )
+
+
+@pytest.fixture
+def memory_unique(mock_client: MagicMock, mock_embedder: MagicMock) -> LongTermMemory:
+    """Deduplication off, so ``add_entity`` always runs the create path."""
+    return LongTermMemory(
+        client=mock_client,
+        embedder=mock_embedder,
+        deduplication=DeduplicationConfig(enabled=False),
+    )
+
+
+class TestAliasesAreTopLevel:
+    """``aliases`` must live where the alias lookup query reads it."""
+
+    def test_create_query_writes_top_level_aliases(self) -> None:
+        query = build_create_entity_query("PERSON", None, include_aliases=True)
+
+        assert "e.aliases = coalesce($aliases, [])" in query
+        # ON MATCH appends only aliases not already present, atomically.
+        assert "e.aliases = coalesce(e.aliases, [])" in query
+
+    def test_aliases_are_opt_in_so_hand_built_params_keep_working(self) -> None:
+        """The builder gained a parameter; existing callers must not break.
+
+        Cypher errors on a referenced-but-absent parameter, so a query built
+        without opting in must not mention ``$aliases`` at all — otherwise
+        every caller supplying its own parameter dict starts failing with
+        ``ParameterMissing``.
+        """
+        assert "$aliases" not in build_create_entity_query("PERSON", None)
+        assert "e.aliases" not in build_create_entity_query("PERSON", None)
+
+    def test_alias_lookup_reads_the_same_property_the_writer_sets(self) -> None:
+        """Guard against the write path and the lookup drifting apart again."""
+        assert "e.aliases" in queries.GET_ENTITY_BY_NAME
+        assert "e.aliases" in build_create_entity_query("PERSON", None, include_aliases=True)
+
+    def test_merge_entities_writes_the_same_property(self) -> None:
+        assert "target.aliases" in queries.MERGE_ENTITIES
+
+    @pytest.mark.asyncio
+    async def test_add_entity_passes_aliases_as_a_parameter(
+        self, memory_unique: LongTermMemory, mock_client: MagicMock
+    ) -> None:
+        await memory_unique.add_entity("John Smith", "PERSON", aliases=["Jon Smith"])
+
+        params = mock_client.execute_write.call_args[0][1]
+        assert params["aliases"] == ["Jon Smith"]
+        # Not buried in the metadata blob — that is the split being fixed.
+        stored_metadata = json.loads(params["metadata"]) if params["metadata"] else {}
+        assert "aliases" not in stored_metadata
+
+    @pytest.mark.asyncio
+    async def test_add_entity_without_aliases_sends_an_empty_list(
+        self, memory_unique: LongTermMemory, mock_client: MagicMock
+    ) -> None:
+        await memory_unique.add_entity("John Smith", "PERSON")
+
+        assert mock_client.execute_write.call_args[0][1]["aliases"] == []
+
+    def test_parse_entity_reads_top_level_aliases(self, memory: LongTermMemory) -> None:
+        entity = memory._parse_entity(
+            stored_node(
+                aliases=["Jon Smith", "J. Smith"], metadata='{"attributes": {"role": "ceo"}}'
+            )
+        )
+
+        assert entity.aliases == ["Jon Smith", "J. Smith"]
+        assert entity.attributes == {"role": "ceo"}
+        # Aliases must not be duplicated into metadata.
+        assert "aliases" not in entity.metadata
+
+    def test_parse_entity_falls_back_to_legacy_metadata_aliases(
+        self, memory: LongTermMemory
+    ) -> None:
+        """Rows written before aliases moved to a property still read back."""
+        entity = memory._parse_entity(
+            stored_node(metadata='{"aliases": ["Jon Smith"], "attributes": {}}')
+        )
+
+        assert entity.aliases == ["Jon Smith"]
+        assert "aliases" not in entity.metadata
+
+    @pytest.mark.asyncio
+    async def test_add_alias_appends_without_reading_metadata_back(
+        self, memory: LongTermMemory, mock_client: MagicMock
+    ) -> None:
+        entity_id = uuid4()
+
+        await memory._add_alias_to_entity(entity_id, "Jon Smith")
+
+        # A single write, and no read-modify-write of the metadata blob.
+        mock_client.execute_read.assert_not_called()
+        assert mock_client.execute_write.call_count == 1
+        query, params = mock_client.execute_write.call_args[0]
+        assert "e.aliases" in query
+        assert "e.metadata" not in query
+        assert params == {"id": str(entity_id), "alias": "Jon Smith"}
+
+
+class TestAddEntityReturnsStoredNode:
+    """``add_entity`` must return what the MERGE stored, not what it minted."""
+
+    @pytest.mark.asyncio
+    async def test_returns_the_stored_id_when_merge_matched_an_existing_node(
+        self, memory_unique: LongTermMemory, mock_client: MagicMock
+    ) -> None:
+        stored_id = str(uuid4())
+        # ON MATCH keeps the pre-existing node: its id and properties win.
+        mock_client.execute_write.return_value = [
+            {"e": stored_node(id=stored_id, name="John Smith", description="pre-existing")}
+        ]
+
+        entity, _ = await memory_unique.add_entity("John Smith", "PERSON")
+
+        assert entity.id == UUID(stored_id)
+        assert entity.description == "pre-existing"
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_the_local_entity_when_nothing_is_returned(
+        self, memory_unique: LongTermMemory
+    ) -> None:
+        """An empty result set (e.g. a stub client) must not break the call."""
+        entity, _ = await memory_unique.add_entity("John Smith", "PERSON")
+
+        assert isinstance(entity.id, UUID)
+        assert entity.name == "John Smith"
+
+    @pytest.mark.asyncio
+    async def test_node_without_an_id_does_not_break_the_write_path(
+        self, memory_unique: LongTermMemory, mock_client: MagicMock
+    ) -> None:
+        """A node written by another tool has no ``id``; don't KeyError on it."""
+        mock_client.execute_write.return_value = [{"e": {"name": "John Smith", "type": "PERSON"}}]
+
+        entity, _ = await memory_unique.add_entity("John Smith", "PERSON")
+
+        assert isinstance(entity.id, UUID)
+        assert entity.name == "John Smith"
+
+    @pytest.mark.asyncio
+    async def test_flagged_entity_still_writes_same_as_and_enrichment_after_readback(
+        self, mock_client: MagicMock, mock_embedder: MagicMock
+    ) -> None:
+        """Reading the node back must not skip the post-write steps."""
+        stored_id = str(uuid4())
+        matched_id = str(uuid4())
+        # Raw scores only, so the candidate lands inside the flag band.
+        memory = LongTermMemory(
+            client=mock_client,
+            embedder=mock_embedder,
+            deduplication=DeduplicationConfig(use_fuzzy_matching=False),
+        )
+        mock_client.execute_read.return_value = [
+            {
+                "e": {
+                    "id": matched_id,
+                    "name": "John Smith",
+                    "canonical_name": "John Smith",
+                    "type": "PERSON",
+                    "metadata": None,
+                },
+                "score": 0.90,
+            }
+        ]
+        mock_client.execute_write.return_value = [{"e": stored_node(id=stored_id)}]
+        enrichment = MagicMock()
+        enrichment.is_running = True
+        enrichment.enqueue = AsyncMock()
+        memory._enrichment_service = enrichment
+
+        entity, dedup_result = await memory.add_entity("Jon Smith", "PERSON", enrich=True)
+
+        assert dedup_result.action == "flagged"
+        assert entity.id == UUID(stored_id)
+
+        # The SAME_AS edge and the enrichment queue entry both still happen, and
+        # the edge is keyed on the id the graph stored.
+        relationship_writes = [
+            call
+            for call in mock_client.execute_write.call_args_list
+            if call[0][0] == queries.CREATE_SAME_AS_RELATIONSHIP
+        ]
+        assert len(relationship_writes) == 1
+        assert relationship_writes[0][0][1]["source_id"] == stored_id
+        assert relationship_writes[0][0][1]["target_id"] == matched_id
+        enrichment.enqueue.assert_awaited_once()
+        assert enrichment.enqueue.call_args.kwargs["entity_id"] == UUID(stored_id)
+
+
+class TestAddRelationshipSurfacesFailure:
+    """A write that matched nothing is not a success."""
+
+    @pytest.mark.asyncio
+    async def test_raises_when_endpoints_do_not_exist(
+        self, memory: LongTermMemory, mock_client: MagicMock
+    ) -> None:
+        mock_client.execute_write.return_value = []  # both MATCH clauses missed
+
+        with pytest.raises(NotFoundError, match="no :Entity node"):
+            await memory.add_relationship(uuid4(), uuid4(), "KNOWS")
+
+    @pytest.mark.asyncio
+    async def test_error_names_both_endpoint_ids(
+        self, memory: LongTermMemory, mock_client: MagicMock
+    ) -> None:
+        mock_client.execute_write.return_value = []
+        source_id, target_id = uuid4(), uuid4()
+
+        with pytest.raises(NotFoundError) as excinfo:
+            await memory.add_relationship(source_id, target_id, "KNOWS")
+
+        message = str(excinfo.value)
+        assert str(source_id) in message
+        assert str(target_id) in message
+        assert "KNOWS" in message
+
+    @pytest.mark.asyncio
+    async def test_returns_the_stored_relationship_on_re_add(
+        self, memory: LongTermMemory, mock_client: MagicMock
+    ) -> None:
+        """Re-adding an edge keeps the original id/confidence, not the new ones."""
+        stored_id = str(uuid4())
+        # This is the shape the query projects; the driver's ``data()``
+        # flattens a bare ``RETURN r`` to a tuple with no properties.
+        mock_client.execute_write.return_value = [
+            {"id": stored_id, "description": "original", "confidence": 0.4}
+        ]
+        source_id, target_id = uuid4(), uuid4()
+
+        relationship = await memory.add_relationship(
+            source_id, target_id, "KNOWS", confidence=0.9, description="retry"
+        )
+
+        assert relationship.id == UUID(stored_id)
+        assert relationship.confidence == 0.4
+        assert relationship.description == "original"
+        assert relationship.source_id == source_id
+        assert relationship.target_id == target_id
+
+    @pytest.mark.asyncio
+    async def test_null_stored_confidence_falls_back_to_the_argument(
+        self, memory: LongTermMemory, mock_client: MagicMock
+    ) -> None:
+        """Edges written before confidence was recorded must not yield None."""
+        mock_client.execute_write.return_value = [
+            {"id": str(uuid4()), "description": None, "confidence": None}
+        ]
+
+        relationship = await memory.add_relationship(uuid4(), uuid4(), "KNOWS", confidence=0.9)
+
+        assert relationship.confidence == 0.9
+        assert relationship.description is None
+
+    @pytest.mark.asyncio
+    async def test_keeps_the_local_id_when_the_query_projects_nothing(
+        self, memory: LongTermMemory, mock_client: MagicMock
+    ) -> None:
+        """A zero-row/no-projection result must not crash or drop the edge type."""
+        mock_client.execute_write.return_value = [{}]
+
+        relationship = await memory.add_relationship(uuid4(), uuid4(), "KNOWS")
+
+        assert isinstance(relationship.id, UUID)
+        assert relationship.type == "KNOWS"
+
+    @pytest.mark.asyncio
+    async def test_accepts_entity_objects_and_passes_through_attributes(
+        self, memory: LongTermMemory, mock_client: MagicMock
+    ) -> None:
+        mock_client.execute_write.return_value = [{"id": str(uuid4())}]
+        entity_a, _ = await self._entities()
+
+        relationship = await memory.add_relationship(
+            entity_a, uuid4(), "KNOWS", attributes={"source": "extraction"}
+        )
+
+        assert relationship.attributes == {"source": "extraction"}
+
+    @staticmethod
+    async def _entities() -> tuple[object, object]:
+        from neo4j_agent_memory.memory.long_term import Entity
+
+        return Entity(id=uuid4(), name="A", type="PERSON"), Entity(
+            id=uuid4(), name="B", type="PERSON"
+        )
+
+
+class TestMergeMigratesEntityEdges:
+    """``merge_duplicate_entities`` must not orphan the source's edges."""
+
+    @pytest.mark.parametrize("edge_type", sorted(MERGED_EDGE_TYPES))
+    def test_merge_query_migrates_each_documented_edge_type(self, edge_type: str) -> None:
+        assert edge_type in queries.MERGE_ENTITIES
+
+    def test_merge_query_migrates_related_to_in_both_directions(self) -> None:
+        query = queries.MERGE_ENTITIES.replace(" ", "")
+
+        # Outgoing: (source)-[:RELATED_TO]->(other)
+        assert "(source)-[r:RELATED_TO]->(other:Entity)" in query
+        # Incoming: (other)-[:RELATED_TO]->(source)
+        assert "(other:Entity)-[r:RELATED_TO]->(source)" in query
+
+    def test_still_adds_the_source_name_as_an_alias(self) -> None:
+        assert "target.aliases" in queries.MERGE_ENTITIES
+
+    def test_still_marks_the_source_as_merged(self) -> None:
+        assert "source.merged_into = target.id" in queries.MERGE_ENTITIES
+        assert "source.merged_at" in queries.MERGE_ENTITIES
+
+    def test_documented_edge_list_matches_the_query(self) -> None:
+        """The docstring enumerates what migrates; keep it honest."""
+        doc = LongTermMemory.merge_duplicate_entities.__doc__ or ""
+        documented = set()
+        for line in doc.splitlines():
+            stripped = line.strip()
+            if stripped.startswith("* ") and "``" in stripped:
+                documented.add(stripped.split("``")[1])
+            elif stripped.startswith("* ") and "`" in stripped:
+                documented.add(stripped.split("`")[1])
+
+        assert documented == MERGED_EDGE_TYPES
+
+    def test_migrated_edges_are_tagged_with_their_origin(self) -> None:
+        """Every copied edge carries where it came from, so the merge is auditable."""
+        assert queries.MERGE_ENTITIES.count("nr.migrated_from = source.id") == 6
+
+    def test_edge_properties_survive_the_copy(self) -> None:
+        """A bare MERGE would silently strip the edge's own properties."""
+        query = queries.MERGE_ENTITIES
+        assert "nr.type = r.type" not in query  # type is the merge key, not copied
+        assert "nr.recorded_at = r.recorded_at" in query  # TOUCHED
+        assert "nr.context = r.context" in query  # EXTRACTED_FROM
+        assert "nr.extraction_time_ms = r.extraction_time_ms" in query  # EXTRACTED_BY
+        assert "nr.valid_until = r.valid_until" in query  # RELATED_TO bi-temporality
+
+    @pytest.mark.asyncio
+    async def test_merge_returns_the_stored_node_pair(
+        self, memory: LongTermMemory, mock_client: MagicMock
+    ) -> None:
+        source_id, target_id = uuid4(), uuid4()
+        mock_client.execute_write.return_value = [
+            {
+                "source": stored_node(
+                    id=str(source_id), name="Jon Smith", metadata='{"merged_into": "x"}'
+                ),
+                "target": stored_node(id=str(target_id), name="John Smith", aliases=["Jon Smith"]),
+            }
+        ]
+
+        result = await memory.merge_duplicate_entities(source_id, target_id)
+
+        assert result is not None
+        source, target = result
+        assert source.id == source_id
+        assert target.id == target_id
+        assert target.aliases == ["Jon Smith"]
+
+    @pytest.mark.asyncio
+    async def test_merge_returns_none_when_entities_are_missing(
+        self, memory: LongTermMemory, mock_client: MagicMock
+    ) -> None:
+        mock_client.execute_write.return_value = []
+
+        assert await memory.merge_duplicate_entities(uuid4(), uuid4()) is None


### PR DESCRIPTION
Four defects where a call reported success while the graph did not hold what the caller was told it held. They compound: add_entity hands out an id that addresses no node, and add_relationship then acknowledges the write that id was used for, so the failure only surfaces as missing data much later.

Fixes #79.

* aliases are written where the alias lookup does not read. add_entity stored them inside the JSON metadata blob while GET_ENTITY_BY_NAME reads a top-level `aliases` property — which is what MERGE_ENTITIES already wrote to target.aliases — so an entity was never findable by an alias passed to add_entity. `aliases` is now a top-level list property everywhere; ON MATCH appends only aliases not already present, in one statement, and _add_alias_to_entity drops its read-modify-write of the whole metadata blob. Rows written earlier still read back through a metadata fallback in _parse_entity.

  build_create_entity_query is public and callers do drive it with their own parameter dicts, so the new $aliases reference is opt-in (include_aliases=False, following the include_location precedent) — an unconditional one broke six existing tests with ParameterMissing.

* add_entity returned an id that addressed no node. The query MERGEs on (name, type), so a repeat add hits ON MATCH, keeps the pre-existing node's id and discards the freshly minted one — which was returned anyway. The returned entity now adopts what the query stored.

  This is issue #79's root cause. The report describes the returned id as a "ghost entity"; no second node is created, which is why the fix belongs in the return value and not in a caller-side name lookup. With it, the reporting bridge's existing add_entity/add_relationship sequence works unmodified.

* add_relationship acknowledged a write that matched nothing. CREATE_ENTITY_RELATIONSHIP MATCHes both endpoints before MERGEing the edge, so ids addressing no node write zero rows and the method still returned a Relationship. It now raises NotFoundError naming both ids. Re-adding an existing edge also returned a freshly minted uuid and the arguments rather than the stored values; the query now projects r.id/r.description/r.confidence, because Result.data() flattens a bare RETURN r to a (start_props, type, end_props) tuple and drops the relationship's own properties.

* merge_duplicate_entities orphaned most of the entity's edges. The docstring said relationships were transferred; the query carried subqueries for MENTIONS and SAME_AS only, so a merge silently dropped RELATED_TO (both directions), both provenance edges (EXTRACTED_FROM, EXTRACTED_BY) and the v0.2 APPLIES_TO / TOUCHED audit edges. All are now copied onto the surviving entity, each tagged migrated_from. Edges are copied rather than moved so the merge stays reversible.

Bolt backend only. NAMS is unaffected: its add_relationship raises NotSupportedError, and its add_entity already follows `merged_into` and asserts the canonical id, so #79's defect does not exist there.

Tests: tests/unit/test_long_term_write_integrity.py (34) and tests/integration/test_long_term_write_integrity.py (22, including TestIssue79 reproducing the report's own sequence). Every defect here is invisible to a mocked client — the mechanism is a real MERGE/ON MATCH branch — and the integration suite caught two bugs in this patch, including the Result.data() flattening above. 12 of the 22 fail against the pre-fix code (8c29880) and all 22 pass against this commit; the other 10 assert behaviour that did not change.